### PR TITLE
Set tests to run on main

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -4,7 +4,7 @@ name: CI-docs
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, closed, synchronize]
 
 jobs:

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -11,11 +11,11 @@ env:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize]
   push:
     branches:
-    - master
+    - main
 
 jobs:
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -10,11 +10,11 @@ env:
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize]
   push:
     branches:
-    - master
+    - main
 
 jobs:
 


### PR DESCRIPTION
With the switch to main instead of master, we need to tell the workflows to run on main instead of master.