### PR TITLE
Change help message to new names for command line tools

### DIFF
--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -31,7 +31,7 @@
 
     .. code-block:: console
 
-        python applications/add_file_to_db.py --file_name test_application.dat --db test-data
+        simtools-add-file-to-db --file_name test_application.dat --db test-data
 
     Expected final print-out message:
 

--- a/simtools/applications/compare_cumulative_psf.py
+++ b/simtools/applications/compare_cumulative_psf.py
@@ -54,13 +54,13 @@
 
     .. code-block:: console
 
-        python applications/get_file_from_db.py --file_name PSFcurve_data_v2.txt
+        simtools-get-file-from-db --file_name PSFcurve_data_v2.txt
 
     Run the application:
 
     .. code-block:: console
 
-        python applications/compare_cumulative_psf.py --site North --telescope LST-1 \
+        simtools-compare-cumulative-psf --site North --telescope LST-1 \
             --model_version prod5 --data PSFcurve_data_v2.txt
 
     The output is saved in simtools-output/compare_cumulative_psf

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -85,13 +85,13 @@
 
      .. code-block:: console
 
-        python applications/get_file_from_db.py --file_name MLTdata-preproduction.ecsv
+        simtools-get-file-from-db --file_name MLTdata-preproduction.ecsv
 
     Run the application. Runtime about 4 min.
 
     .. code-block:: console
 
-        python applications/derive_mirror_rnda.py --site North --telescope MST-FlashCam-D \
+        simtools-derive-mirror-rnda --site North --telescope MST-FlashCam-D \
             --containment_fraction 0.8 --mirror_list MLTdata-preproduction.ecsv
             --psf_measurement MLTdata-preproduction.ecsv --rnda 0.0063 --test
 

--- a/simtools/applications/get_file_from_db.py
+++ b/simtools/applications/get_file_from_db.py
@@ -26,7 +26,7 @@
 
     .. code-block:: console
 
-        python applications/get_file_from_db.py --file_name mirror_CTA-N-LST1_v2019-03-31.dat
+        simtools-get-file-from-db --file_name mirror_CTA-N-LST1_v2019-03-31.dat
 
     Expected final print-out message:
 

--- a/simtools/applications/get_parameter.py
+++ b/simtools/applications/get_parameter.py
@@ -32,7 +32,7 @@
 
     .. code-block:: console
 
-        python applications/get_parameter.py --parameter mirror_list --site North --telescope LST-1\
+        simtools-get-parameter --parameter mirror_list --site North --telescope LST-1\
          --model_version prod5
 
     Expected final print-out message:

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -21,7 +21,7 @@
 
     .. code-block:: console
 
-        python applications/make_regular_arrays.py
+        simtools-make-regular-arrays
 
     The output is saved in simtools-output/make_regular_arrays.
 

--- a/simtools/applications/plot_layout_array.py
+++ b/simtools/applications/plot_layout_array.py
@@ -32,7 +32,7 @@
     -------
     .. code-block:: console
 
-        python applications/plot_layout_array.py --figure_name northern_array_alpha \
+        simtools-plot-layout-array --figure_name northern_array_alpha \
         --layout_array_name North-TestLayout
 
 """

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -22,7 +22,7 @@
     -------
     .. code-block:: console
 
-        python applications/plot_simtel_histograms.py \
+        simtools-plot-simtel-histograms \
             --file_lists list_test1.txt list_test2.txt --figure_name histograms_comparison
 
 """

--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -33,7 +33,7 @@
 
     .. code-block:: console
 
-        python applications/print_array_elements.py \
+        simtools-print-array-elements \
             --array_element_list tests/resources/telescope_positions-South-4MST.ecsv \
             --compact corsika
 

--- a/simtools/applications/produce_array_config.py
+++ b/simtools/applications/produce_array_config.py
@@ -81,7 +81,7 @@
 
     .. code-block:: console
 
-        python applications/produce_array_config.py --label test --array_config \
+        simtools-produce-array-config --label test --array_config \
         array_config_test.yml
 
     The output is saved in simtools-output/test/model.

--- a/simtools/applications/production.py
+++ b/simtools/applications/production.py
@@ -49,13 +49,13 @@
 
     .. code-block:: console
 
-        python applications/get_file_from_db.py --file_name prod_config_test.yml
+        simtools-get-file-from_db --file_name prod_config_test.yml
 
     Run the application:
 
     .. code-block:: console
 
-        python applications/production.py --task simulate --productionconfig prod_config_test.yml \
+        simtools-production --task simulate --productionconfig prod_config_test.yml \
         --test --showers_only --submit_command local
 
     The output is saved in simtools-output/test-production.

--- a/simtools/applications/sim_showers_for_trigger_rates.py
+++ b/simtools/applications/sim_showers_for_trigger_rates.py
@@ -47,7 +47,7 @@
 
     .. code-block:: console
 
-        python applications/sim_showers_for_trigger_rates.py --array 4LST --site North --primary \
+        simtools-sim-showers-for-trigger_rates --array 4LST --site North --primary \
         proton --nruns 2 --nevents 10000 --test --submit_command local
 
     The output is saved in simtools-output/sim_showers_for_trigger_rates.

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -53,7 +53,7 @@
 
     .. code-block:: console
 
-        python applications/simulate_prod.py \
+        simtools-simulate-prod \
         --production_config tests/resources/prod_multi_config_test.yml --model_version Prod5 \
         --site north --primary gamma --from_azimuth_direction north --zenith_angle 20 \
          --start_run 0 --run 1

--- a/simtools/applications/submit_data_from_external.py
+++ b/simtools/applications/submit_data_from_external.py
@@ -21,14 +21,14 @@
 
     .. code-block:: console
 
-        python applications/get_file_from_DB.py --file_name \
+        simtools-get-file-from_DB --file_name \
         set_MST_mirror_2f_measurements_from_external.config.yml
 
     Run the application:
 
     .. code-block:: console
 
-        python applications/submit_data_from_external.py --workflow_config \
+        simtools-submit-data-from-external --workflow_config \
         set_MST_mirror_2f_measurements_from_external.config.yml
 
     The output is saved in simtools-output/submit_data_from_external.

--- a/simtools/applications/tune_psf.py
+++ b/simtools/applications/tune_psf.py
@@ -63,13 +63,13 @@
 
     .. code-block:: console
 
-        python applications/get_file_from_db.py --file_name PSFcurve_data_v2.txt
+        simtools-get-file-from_db --file_name PSFcurve_data_v2.txt
 
     Run the application:
 
     .. code-block:: console
 
-        python applications/tune_psf.py --site North --telescope LST-1 \
+        simtools-tune-psf --site North --telescope LST-1 \
             --model_version prod5 --data PSFcurve_data_v2.txt --plot_all --test
 
     The output is saved in simtools-output/tune_psf.

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -34,7 +34,7 @@
 
     .. code-block:: console
 
-        python applications/validate_camera_efficiency.py --site North \
+        simtools-validate-camera-efficiency --site North \
             --telescope MST-NectarCam-D --model_version prod5
 
     The output is saved in simtools-output/validate_camera_efficiency.

--- a/simtools/applications/validate_camera_fov.py
+++ b/simtools/applications/validate_camera_fov.py
@@ -37,7 +37,7 @@
 
     .. code-block:: console
 
-        python applications/validate_camera_fov.py --site North \
+        validate-camera-fov --site North \
             --telescope LST-1 --model_version prod5
 
     The output is saved in simtools-output/validate_camera_fov.

--- a/simtools/applications/validate_optics.py
+++ b/simtools/applications/validate_optics.py
@@ -54,7 +54,7 @@
 
     .. code-block:: console
 
-        python applications/validate_optics.py --site North --telescope LST-1 --max_offset 1.0 \
+        simtools-validate-optics --site North --telescope LST-1 --max_offset 1.0 \
         --zenith 20 --src_distance 11 --test
 
     The output is saved in simtools-output/validate_optics


### PR DESCRIPTION
Help messages of applications are changed to reflect the naming given to the command line tools in [pyproject.toml](pyproject.toml).