### PR TITLE
explicit setting of output path

### DIFF
--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -106,9 +106,9 @@ class CommandLineParser(argparse.ArgumentParser):
             required=False,
         )
         _job_group.add_argument(
-            "--no_simtools_output_path_naming",
-            help="do not add date and tool name to output path",
-            action="store_false",
+            "--plain_output_path",
+            help="use plain output path (without adding the tool name and dates)",
+            action="store_true",
             required=False,
         )
         _job_group.add_argument(

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -106,7 +106,7 @@ class CommandLineParser(argparse.ArgumentParser):
             required=False,
         )
         _job_group.add_argument(
-            "--plain_output_path",
+            "--_use_plain_output_path",
             help="use plain output path (without adding the tool name and dates)",
             action="store_true",
             required=False,

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -106,6 +106,12 @@ class CommandLineParser(argparse.ArgumentParser):
             required=False,
         )
         _job_group.add_argument(
+            "--no_simtools_output_path_naming",
+            help="do not add date and tool name to output path",
+            action="store_false",
+            required=False,
+        )
+        _job_group.add_argument(
             "--model_path",
             help="path pointing towards simulation model file directory",
             type=Path,

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -282,6 +282,7 @@ class Configurator:
         _io_handler = io_handler.IOHandler()
         _io_handler.set_paths(
             output_path=self.config.get("output_path", None),
+            output_path_simtools_naming=self.config.get("no_simtools_output_path_naming", True),
             data_path=self.config.get("data_path", None),
             model_path=self.config.get("model_path", None),
         )

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -282,7 +282,7 @@ class Configurator:
         _io_handler = io_handler.IOHandler()
         _io_handler.set_paths(
             output_path=self.config.get("output_path", None),
-            plain_output_path=self.config.get("plain_output_path", False),
+            use_plain_output_path=self.config.get("use_plain_output_path", False),
             data_path=self.config.get("data_path", None),
             model_path=self.config.get("model_path", None),
         )

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -282,7 +282,7 @@ class Configurator:
         _io_handler = io_handler.IOHandler()
         _io_handler.set_paths(
             output_path=self.config.get("output_path", None),
-            output_path_simtools_naming=self.config.get("no_simtools_output_path_naming", True),
+            plain_output_path=self.config.get("plain_output_path", False),
             data_path=self.config.get("data_path", None),
             model_path=self.config.get("model_path", None),
         )

--- a/simtools/io_handler.py
+++ b/simtools/io_handler.py
@@ -32,7 +32,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
         self._logger.debug("Init IOHandler")
 
         self.output_path = None
-        self.output_path_simtools_naming = True
+        self.plain_output_path = False
         self.data_path = None
         self.model_path = None
 
@@ -40,7 +40,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
                   output_path=None,
                   data_path=None,
                   model_path=None,
-                  output_path_simtools_naming=True):
+                  plain_output_path=False):
         """
         Set paths for input and output.
 
@@ -55,7 +55,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
 
         """
         self.output_path = output_path
-        self.output_path_simtools_naming = output_path_simtools_naming
+        self.plain_output_path = plain_output_path
         self.data_path = data_path
         self.model_path = model_path
 
@@ -82,7 +82,9 @@ class IOHandler(metaclass=IOHandlerSingleton):
             if error creating directory
         """
 
-        if self.output_path_simtools_naming:
+        if self.plain_output_path:
+            path = Path(self.output_path)
+        else:
             if test:
                 output_directory_prefix = Path(self.output_path).joinpath("test-output")
             else:
@@ -93,8 +95,6 @@ class IOHandler(metaclass=IOHandlerSingleton):
             path = output_directory_prefix.joinpath(label_dir)
             if dir_type is not None:
                 path = path.joinpath(dir_type)
-        else:
-            path = Path(self.output_path)
 
         try:
             path.mkdir(parents=True, exist_ok=True)

--- a/simtools/io_handler.py
+++ b/simtools/io_handler.py
@@ -32,10 +32,15 @@ class IOHandler(metaclass=IOHandlerSingleton):
         self._logger.debug("Init IOHandler")
 
         self.output_path = None
+        self.output_path_simtools_naming = True
         self.data_path = None
         self.model_path = None
 
-    def set_paths(self, output_path=None, data_path=None, model_path=None):
+    def set_paths(self,
+                  output_path=None,
+                  data_path=None,
+                  model_path=None,
+                  output_path_simtools_naming=True):
         """
         Set paths for input and output.
 
@@ -50,6 +55,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
 
         """
         self.output_path = output_path
+        self.output_path_simtools_naming = output_path_simtools_naming
         self.data_path = data_path
         self.model_path = model_path
 
@@ -76,16 +82,20 @@ class IOHandler(metaclass=IOHandlerSingleton):
             if error creating directory
         """
 
-        if test:
-            output_directory_prefix = Path(self.output_path).joinpath("test-output")
-        else:
-            output_directory_prefix = Path(self.output_path).joinpath("simtools-output")
+        if self.output_path_simtools_naming:
+            if test:
+                output_directory_prefix = Path(self.output_path).joinpath("test-output")
+            else:
+                output_directory_prefix = Path(self.output_path).joinpath("simtools-output")
 
-        today = datetime.date.today()
-        label_dir = label if label is not None else "d-" + str(today)
-        path = output_directory_prefix.joinpath(label_dir)
-        if dir_type is not None:
-            path = path.joinpath(dir_type)
+            today = datetime.date.today()
+            label_dir = label if label is not None else "d-" + str(today)
+            path = output_directory_prefix.joinpath(label_dir)
+            if dir_type is not None:
+                path = path.joinpath(dir_type)
+        else:
+            path = Path(self.output_path)
+
         try:
             path.mkdir(parents=True, exist_ok=True)
         except FileNotFoundError:

--- a/simtools/io_handler.py
+++ b/simtools/io_handler.py
@@ -32,7 +32,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
         self._logger.debug("Init IOHandler")
 
         self.output_path = None
-        self.plain_output_path = False
+        self.use_plain_output_path = False
         self.data_path = None
         self.model_path = None
 
@@ -40,7 +40,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
                   output_path=None,
                   data_path=None,
                   model_path=None,
-                  plain_output_path=False):
+                  use_plain_output_path=False):
         """
         Set paths for input and output.
 
@@ -52,10 +52,12 @@ class IOHandler(metaclass=IOHandlerSingleton):
             Parent path of the data files.
         model_path: str or Path
             Parent path of the output files created by this class.
+        use_plain_output_path: bool
+            Use plain output path without adding tool name and date
 
         """
         self.output_path = output_path
-        self.plain_output_path = plain_output_path
+        self.use_plain_output_path = use_plain_output_path
         self.data_path = data_path
         self.model_path = model_path
 
@@ -82,7 +84,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
             if error creating directory
         """
 
-        if self.plain_output_path:
+        if self.use_plain_output_path:
             path = Path(self.output_path)
         else:
             if test:

--- a/tests/unit_tests/test_io_handler.py
+++ b/tests/unit_tests/test_io_handler.py
@@ -25,6 +25,20 @@ def test_get_output_directory(args_dict, io_handler):
         label="test-io-handler", dir_type="model", test=True
     ) == Path(f"{args_dict['output_path']}/output/test-output/test-io-handler/model")
 
+    io_handler.output_path_simtools_naming = False
+
+    assert io_handler.get_output_directory(label="test-io-handler") == Path(
+        f"{args_dict['output_path']}/output"
+    )
+
+    assert io_handler.get_output_directory(label="test-io-handler", test=True) == Path(
+        f"{args_dict['output_path']}/output"
+    )
+
+    assert io_handler.get_output_directory(label="test-io-handler", dir_type="model") == Path(
+        f"{args_dict['output_path']}/output"
+    )
+
 
 def test_get_output_file(args_dict, io_handler):
 

--- a/tests/unit_tests/test_io_handler.py
+++ b/tests/unit_tests/test_io_handler.py
@@ -25,7 +25,7 @@ def test_get_output_directory(args_dict, io_handler):
         label="test-io-handler", dir_type="model", test=True
     ) == Path(f"{args_dict['output_path']}/output/test-output/test-io-handler/model")
 
-    io_handler.output_path_simtools_naming = False
+    io_handler.plain_output_path = True
 
     assert io_handler.get_output_directory(label="test-io-handler") == Path(
         f"{args_dict['output_path']}/output"

--- a/tests/unit_tests/test_io_handler.py
+++ b/tests/unit_tests/test_io_handler.py
@@ -25,7 +25,7 @@ def test_get_output_directory(args_dict, io_handler):
         label="test-io-handler", dir_type="model", test=True
     ) == Path(f"{args_dict['output_path']}/output/test-output/test-io-handler/model")
 
-    io_handler.plain_output_path = True
+    io_handler.use_plain_output_path = True
 
     assert io_handler.get_output_directory(label="test-io-handler") == Path(
         f"{args_dict['output_path']}/output"


### PR DESCRIPTION
This PR addresses issue #463: add a command line flag to explicitly set the `output_path` without adding simtools tool name and date. The name of the command line flag is `--plain_output_path`.
