### PR TITLE
Improve CI by adding pip installation

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -15,17 +15,26 @@ on:
     types: [opened, synchronize]
   push:
     branches:
-    - main
+      - main
 
 jobs:
 
   integrationtests:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #        python-version: [3.8, 3.9, 3.10.4]
-        python-version: [3.9]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.9"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.9"
+            install-method: pip
+
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
 
     steps:
       - name: checkout
@@ -37,19 +46,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install conda dependencies
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
+        if: matrix.install-method == 'conda'
+        uses: mamba-org/provision-with-micromamba@v14
+
+      - name: Python setup
+        if: matrix.install-method == 'pip'
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+
+      - name: Python dependencies
         run: |
-          source $CONDA/etc/profile.d/conda.sh
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          # sed -i -e "s/- python/- python=$PYTHON_VERSION/g" environment.yml
-          conda env create -f environment.yml
-          conda activate simtools-dev
-          echo 'source $CONDA/etc/profile.d/conda.sh' >> ~/.bash_profile
-          echo 'conda activate simtools-dev' >> ~/.bash_profile
-          echo 'pip install -e .' >> ~/.bash_profile
           python --version
+          pip install '.[tests,dev,doc]'
 
       - name: simteldependencies
         run: |

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -74,11 +74,6 @@ jobs:
           python --version
           pip install '.[tests,dev,doc]'
 
-      - name: Install pyflakes for conda
-        if: matrix.install-method == 'conda'
-        run: |
-          mamba install -q pyflakes
-
       - name: pyflakes liniting
         run: |
           pyflakes .

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -54,18 +54,7 @@ jobs:
 
       - name: Install conda dependencies
         if: matrix.install-method == 'conda'
-        env:
-          PYTHON_VERSION: ${{ matrix.python-version }}
-        run: |
-          source $CONDA/etc/profile.d/conda.sh
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
-          conda env create -f environment.yml
-          conda activate simtools-dev
-          echo 'source $CONDA/etc/profile.d/conda.sh' >> ~/.bash_profile
-          echo 'conda activate simtools-dev' >> ~/.bash_profile
-          conda install -q pyflakes
+        uses: mamba-org/provision-with-micromamba@v14
 
       - name: Python setup
         if: matrix.install-method == 'pip'
@@ -84,6 +73,11 @@ jobs:
         run: |
           python --version
           pip install '.[tests,dev,doc]'
+
+      - name: Install pyflakes for conda
+        if: matrix.install-method == 'conda'
+        run: |
+          mamba install -q pyflakes
 
       - name: pyflakes liniting
         run: |

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -23,22 +23,21 @@ jobs:
     strategy:
       matrix:
         include:
-          - runs-on: ubuntu-latest
+          - os: ubuntu-latest
             python-version: "3.9"
             install-method: conda
 
-          - runs-on: ubuntu-latest
+          - os: ubuntu-latest
             python-version: "3.9"
             install-method: pip
 
-          - runs-on: macos-latest
+          - os: macos-latest
             python-version: "3.9"
             install-method: conda
 
-          - runs-on: macos-latest
+          - os: macos-latest
             python-version: "3.9"
             install-method: pip
-
 
     defaults:
       run:

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -14,7 +14,7 @@ on:
     types: [opened, synchronize]
   push:
     branches:
-    - main
+      - main
 
 jobs:
 
@@ -24,7 +24,16 @@ jobs:
     strategy:
       matrix:
         #        python-version: [3.8, 3.9, 3.10.4]
-        python-version: [3.9]
+        include:
+          - python-version: "3.9"
+            install-method: conda
+
+          - python-version: "3.9"
+            install-method: pip
+
+    default:
+      run:
+        shell: bash -leo pipefail {0}
 
     steps:
       - name: checkout
@@ -36,6 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install conda dependencies
+        if: matrix.install-method == 'conda'
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
@@ -47,13 +57,22 @@ jobs:
           conda activate simtools-dev
           echo 'source $CONDA/etc/profile.d/conda.sh' >> ~/.bash_profile
           echo 'conda activate simtools-dev' >> ~/.bash_profile
-          echo 'pip install -e .' >> ~/.bash_profile
+          conda install -q pyflakes
+
+      - name: Python setup
+        if: matrix.install-method == 'pip'
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          check-latest: true
+
+      - name: Python dependencies
+        run: |
           python --version
+          pip install '.[tests,dev,doc]'
 
       - name: pyflakes liniting
-        shell: bash -leo pipefail {0}
         run: |
-          conda install -q pyflakes
           pyflakes .
 
       - name: Unit tests

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -31,7 +31,7 @@ jobs:
           - python-version: "3.9"
             install-method: pip
 
-    default:
+    defaults:
       run:
         shell: bash -leo pipefail {0}
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -19,17 +19,26 @@ on:
 jobs:
 
   unittests:
-    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        #        python-version: [3.8, 3.9, 3.10.4]
         include:
-          - python-version: "3.9"
+          - runs-on: ubuntu-latest
+            python-version: "3.9"
             install-method: conda
 
-          - python-version: "3.9"
+          - runs-on: ubuntu-latest
+            python-version: "3.9"
             install-method: pip
+
+          - runs-on: macos-latest
+            python-version: "3.9"
+            install-method: conda
+
+          - runs-on: macos-latest
+            python-version: "3.9"
+            install-method: pip
+
 
     defaults:
       run:
@@ -52,7 +61,7 @@ jobs:
           source $CONDA/etc/profile.d/conda.sh
           conda config --set always_yes yes --set changeps1 no
           conda update -q conda
-          # sed -i -e "s/- python/- python=$PYTHON_VERSION/g" environment.yml
+          sed -i -e "s/- python=.*/- python=$PYTHON_VERSION/g" environment.yml
           conda env create -f environment.yml
           conda activate simtools-dev
           echo 'source $CONDA/etc/profile.d/conda.sh' >> ~/.bash_profile
@@ -65,6 +74,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           check-latest: true
+
+      - if: ${{ matrix.install-method == 'pip' && runner.os == 'macOS' }}
+        name: Fix Python PATH on macOS
+        # from https://github.com/cta-observatory/ctapipe/blob/cfacbe1eeb2d9a4634980e5f1ef39b944bca6a7a/.github/workflows/ci.yml#L100
+        run: |
+          tee -a ~/.bash_profile <<<'export PATH="$pythonLocation/bin:$PATH"'
 
       - name: Python dependencies
         run: |

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -39,6 +39,22 @@ jobs:
             python-version: "3.9"
             install-method: pip
 
+          - os: ubuntu-latest
+            python-version: "3.10"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.10"
+            install-method: pip
+
+          - os: ubuntu-latest
+            python-version: "3.11"
+            install-method: conda
+
+          - os: ubuntu-latest
+            python-version: "3.11"
+            install-method: pip
+
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
 
   unittests:
-
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Improve CI by adding running of unit tests on:
- pip and conda installation
- ubuntu-latest and macos-latest

Do we have a strong reason to add other python version (3.10, 3.11)?

Inspired by https://github.com/cta-observatory/ctapipe/blob/main/.github/workflows/ci.yml