### PR TITLE
Bug fix in determination of reference coordinate system

### DIFF
--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -493,23 +493,19 @@ class TelescopePosition:
         if _crs_from is None:
             return
 
-        try:
-            for _crs_to_name, _crs_to in self.crs.items():
-                if _crs_to_name == _crs_from_name:
-                    continue
-                if not self.has_coordinates(_crs_to_name) and _crs_to["crs"] is not None:
-                    _x, _y = self._convert(
-                        crs_from=_crs_from["crs"],
-                        crs_to=_crs_to["crs"],
-                        xx=_crs_from["xx"]["value"],
-                        yy=_crs_from["yy"]["value"],
+        for _crs_to_name, _crs_to in self.crs.items():
+            if _crs_to_name == _crs_from_name:
+                continue
+            if not self.has_coordinates(_crs_to_name) and _crs_to["crs"] is not None:
+                _x, _y = self._convert(
+                    crs_from=_crs_from["crs"],
+                    crs_to=_crs_to["crs"],
+                    xx=_crs_from["xx"]["value"],
+                    yy=_crs_from["yy"]["value"],
+                )
+                self.set_coordinates(
+                    _crs_to_name, _x, _y, _crs_from["zz"]["value"] * _crs_from["zz"]["unit"]
                     )
-                    self.set_coordinates(
-                        _crs_to_name, _x, _y, _crs_from["zz"]["value"] * _crs_from["zz"]["unit"]
-                    )
-        except (InvalidCoordSystem, TypeError) as e:
-            self._logger.error("No reference coordinate system defined")
-            raise MissingInputForConvertion from e
 
     @staticmethod
     def _default_coordinate_system_definition():

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -4,15 +4,11 @@ import astropy.units as u
 import numpy as np
 import pyproj
 
-__all__ = ["InvalidCoordSystem", "MissingInputForConvertion", "TelescopePosition"]
+__all__ = ["InvalidCoordSystem", "TelescopePosition"]
 
 
 class InvalidCoordSystem(Exception):
     """Exception for invalid coordinate system."""
-
-
-class MissingInputForConvertion(Exception):
-    """Exception for missing input for convertion."""
 
 
 class TelescopePosition:
@@ -479,10 +475,6 @@ class TelescopePosition:
         crs_utm: pyproj.crs.crs.CRS
             Pyproj CRS of the utm coordinate system.
 
-        Raises
-        ------
-        MissingInputForConvertion
-            if the coordinate system is invalid.
         """
 
         self._set_coordinate_system("corsika", crs_local)

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -350,10 +350,12 @@ class TelescopePosition:
             raise InvalidCoordSystem from e
 
         return (
-            self.crs[crs_name]["xx"]["value"] is not np.nan
-            and self.crs[crs_name]["yy"]["value"] is not np.nan
-            and self.crs[crs_name]["xx"]["value"] is not None
-            and self.crs[crs_name]["yy"]["value"] is not None
+            np.all(np.isfinite(
+                    np.array(
+                        [self.crs[crs_name]["xx"]["value"], self.crs[crs_name]["yy"]["value"]],
+                        dtype=float)
+                )
+            )
         )
 
     def has_altitude(self, crs_name=None):
@@ -488,6 +490,8 @@ class TelescopePosition:
         self._set_coordinate_system("mercator", crs_wgs84)
 
         _crs_from_name, _crs_from = self._get_reference_system_from()
+        if _crs_from is None:
+            return
 
         try:
             for _crs_to_name, _crs_to in self.crs.items():

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -10,7 +10,6 @@ import pytest
 
 from simtools.layout.telescope_position import (
     InvalidCoordSystem,
-    MissingInputForConvertion,
     TelescopePosition,
 )
 

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -291,9 +291,6 @@ def test_convert_all(crs_wgs84, crs_local, crs_utm):
 
     tel = TelescopePosition(name="LST-01")
 
-    with pytest.raises(MissingInputForConvertion):
-        tel.convert_all(crs_wgs84=crs_wgs84, crs_local=crs_local, crs_utm=crs_utm)
-
     tel.set_coordinates("corsika", 0.0, 0.0, 2158.0 * u.m)
     tel.convert_all(crs_wgs84=crs_wgs84, crs_local=crs_local, crs_utm=crs_utm)
 
@@ -303,3 +300,11 @@ def test_convert_all(crs_wgs84, crs_local, crs_utm):
     assert 217609.2270142641 == pytest.approx(tel.crs["utm"]["xx"]["value"], 1.0e-9)
     assert 3185067.2783240844 == pytest.approx(tel.crs["utm"]["yy"]["value"], 1.0e-9)
     assert 2158.0 == pytest.approx(tel.crs["utm"]["zz"]["value"], 1.0e-9)
+
+    tel_nan = TelescopePosition(name="LST-02")
+    tel_nan.set_coordinates("corsika", np.nan, np.nan, 2158.0 * u.m)
+    tel_nan.convert_all(crs_wgs84=crs_wgs84, crs_local=crs_local, crs_utm=crs_utm)
+    assert np.isnan(tel_nan.crs["mercator"]["xx"]["value"])
+    assert np.isnan(tel_nan.crs["mercator"]["yy"]["value"])
+    assert np.isnan(tel_nan.crs["utm"]["xx"]["value"])
+    assert np.isnan(tel_nan.crs["utm"]["yy"]["value"])


### PR DESCRIPTION
The coordinate transformation code for the array layouts tries to find the `reference` coordinate system, meaning the `from system` for all coordinate transformation.

This did not work correctly and in the test cases always the crs_local (corsika system) was chosen, even if the array centre coordinates where all `np.nan`.

The logic to determine if a system has coordinates corrected and simplified with this PR.
