### PR TITLE
Application to validate schema files

### DIFF
--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -141,3 +141,9 @@ validate_optics
 
 .. automodule:: validate_optics
    :members:
+
+validate_schema_files
+=====================
+
+.. automodule:: validate_schema_files
+   :members:

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pyflakes
   - eventio
   - boost-histogram
+  - jsonschema
 
 # cheatsheet
 # create: conda env create -f environment.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "astropy",
     "boost-histogram",
     "eventio",
+    "jsonschema",
     "matplotlib",
     "numpy",
     "pyyaml",
@@ -77,4 +78,5 @@ simtools-tune-psf = "simtools.applications.tune_psf:main"
 simtools-validate-camera-efficiency = "simtools.applications.validate_camera_efficiency:main"
 simtools-validate-camera-fov = "simtools.applications.validate_camera_fov:main"
 simtools-validate-optics = "simtools.applications.validate_optics:main"
+simtools-validate-schema-files = "simtools.applications.validate_schema_files:main"
 [tool.setuptools.packages.find]

--- a/simtools/applications/validate_schema_files.py
+++ b/simtools/applications/validate_schema_files.py
@@ -6,7 +6,7 @@
 
     Command line arguments
     ----------------------
-    file-name (str)
+    file_name (str)
       input file to be validated
     schema (str)
       schema file (jsonschema format) used for validation
@@ -17,7 +17,7 @@
     .. code-block:: console
 
         simtools-validate-schema-file \
-         --file-name tests/resources/MST_mirror_2f_measurements.schema.yml \
+         --file_name tests/resources/MST_mirror_2f_measurements.schema.yml \
          --schema jsonschema.yml
 
 """

--- a/simtools/applications/validate_schema_files.py
+++ b/simtools/applications/validate_schema_files.py
@@ -51,8 +51,8 @@ def _parse(label, description):
     """
 
     config = configurator.Configurator(label=label, description=description)
-    config.parser.add_argument("-f", "--file_name", help="file to be validated", required=True)
-    config.parser.add_argument("-s", "--schema", help="json schema file", required=True)
+    config.parser.add_argument("--file_name", help="file to be validated", required=True)
+    config.parser.add_argument("--schema", help="json schema file", required=True)
     return config.initialize()
 
 
@@ -87,7 +87,7 @@ def load_schema(schema_file):
     return parameter_schema
 
 
-def validate_schema_file(input_file, schema):
+def validate_schema_file(input_file, schema, logger):
     """
     Validate parameter file against schema.
 
@@ -109,25 +109,26 @@ def validate_schema_file(input_file, schema):
         with open(input_file, "r", encoding="utf-8") as file:
             data = yaml.safe_load(file)
     except FileNotFoundError:
-        logging.error(f"Input file {input_file} not found")
+        logger.error(f"Input file {input_file} not found")
         raise
 
     try:
         jsonschema.validate(data, schema=schema)
     except jsonschema.exceptions.ValidationError:
-        logging.error(f"Schema validation failed for {input_file} using {schema}")
+        logger.error(f"Schema validation failed for {input_file} using {schema}")
         raise
 
-    print(f"Schema validation successful for {input_file}")
+    logger.info(f"Schema validation successful for {input_file}")
 
 
 def main():
     label = Path(__file__).stem
     args_dict, _ = _parse(label, description="Parameter file schema checking")
+
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 
-    validate_schema_file(args_dict["file_name"], load_schema(args_dict["schema"]))
+    validate_schema_file(args_dict["file_name"], load_schema(args_dict["schema"]), logger)
 
 
 if __name__ == "__main__":

--- a/simtools/applications/validate_schema_files.py
+++ b/simtools/applications/validate_schema_files.py
@@ -70,6 +70,11 @@ def load_schema(schema_file):
     parameter_schema (dict)
         parameter schema
 
+    Raises
+    ------
+    FileNotFoundError
+        if schema file is not found
+
     """
 
     try:
@@ -85,6 +90,18 @@ def load_schema(schema_file):
 def validate_schema_file(input_file, schema):
     """
     Validate parameter file against schema.
+
+    Parameters
+    ----------
+    input_file (str)
+        input file to be validated
+    schema (dict)
+        schema used for validation
+
+    Raises
+    ------
+    FileNotFoundError
+        if input file is not found
 
     """
 
@@ -106,7 +123,7 @@ def validate_schema_file(input_file, schema):
 
 def main():
     label = Path(__file__).stem
-    args_dict, _ = _parse(label, description=("Parameter file schema checking"))
+    args_dict, _ = _parse(label, description="Parameter file schema checking")
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 

--- a/simtools/applications/validate_schema_files.py
+++ b/simtools/applications/validate_schema_files.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+"""
+    Summary
+    -------
+    Validate parameter description files using a json schema file.
+
+    Command line arguments
+    ----------------------
+    file-name (str)
+      input file to be validated
+    schema (str)
+      schema file (jsonschema format) used for validation
+
+    Example
+    -------
+
+    .. code-block:: console
+
+        simtools-validate-schema-file \
+         --file-name tests/resources/MST_mirror_2f_measurements.schema.yml \
+         --schema jsonschema.yml
+
+"""
+
+import logging
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+import simtools.util.general as gen
+from simtools.configuration import configurator
+
+
+def _parse(label, description):
+    """
+    Parse command line configuration
+
+    Parameters
+    ----------
+    label (str)
+        application label
+    description (str)
+        application description
+
+    Returns
+    -------
+    config (Configurator)
+        application configuration
+
+    """
+
+    config = configurator.Configurator(label=label, description=description)
+    config.parser.add_argument("-f", "--file_name", help="file to be validated", required=True)
+    config.parser.add_argument("-s", "--schema", help="json schema file", required=True)
+    return config.initialize()
+
+
+def load_schema(schema_file):
+    """
+    Load parameter schema from file.
+
+    Parameters
+    ----------
+    schema_file (str)
+        schema file
+
+    Returns
+    -------
+    parameter_schema (dict)
+        parameter schema
+
+    """
+
+    try:
+        with open(schema_file, "r", encoding="utf-8") as file:
+            parameter_schema = yaml.safe_load(file)
+    except FileNotFoundError:
+        logging.error(f"Schema file {schema_file} not found")
+        raise
+
+    return parameter_schema
+
+
+def validate_schema_file(input_file, schema):
+    """
+    Validate parameter file against schema.
+
+    """
+
+    try:
+        with open(input_file, "r", encoding="utf-8") as file:
+            data = yaml.safe_load(file)
+    except FileNotFoundError:
+        logging.error(f"Input file {input_file} not found")
+        raise
+
+    try:
+        jsonschema.validate(data, schema=schema)
+    except jsonschema.exceptions.ValidationError:
+        logging.error(f"Schema validation failed for {input_file} using {schema}")
+        raise
+
+    print(f"Schema validation successful for {input_file}")
+
+
+def main():
+    label = Path(__file__).stem
+    args_dict, _ = _parse(label, description=("Parameter file schema checking"))
+    logger = logging.getLogger()
+    logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
+
+    validate_schema_file(args_dict["file_name"], load_schema(args_dict["schema"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -377,12 +377,20 @@ APP_LIST = {
             "--use_corsika_telescope_height",
         ],
     ],
+    # validate_schema_files
+    "validate_schema_files": [
+        [
+            "--schema",
+            "TESTMODELDIR/jsonschema.yml",
+            "--file_name",
+            "tests/resources/MST_mirror_2f_measurements.schema.yml",
+        ]
+    ],
 }
 
 
 @pytest.mark.parametrize("application", APP_LIST.keys())
 def test_applications(application, io_handler, monkeypatch, db):
-
     logger.info(f"Testing {application}")
 
     # The add_file_to_db.py application requires a user confirmation.
@@ -399,6 +407,7 @@ def test_applications(application, io_handler, monkeypatch, db):
 
     prepare_one_file("PSFcurve_data_v2.txt")
     prepare_one_file("MLTdata-preproduction.ecsv")
+    prepare_one_file("jsonschema.yml")
 
     def make_command(app, args):
         cmd = "python simtools/applications/" + app + ".py"

--- a/tests/resources/MST_mirror_2f_measurements.schema.yml
+++ b/tests/resources/MST_mirror_2f_measurements.schema.yml
@@ -1,0 +1,44 @@
+---
+# Follows schema https://github.com/gammasim/workflows/schema/jsonschema.yml
+title: Mirror panel 2F measurements description
+description: |-
+  Data description of mirror panel 2F measurements used as
+  input to SimPipe.
+name: simpipe-schema
+version: 0.1.0
+
+schema:
+
+  - name: mirror_2f_measurement
+    description: |-
+      Mirror panel 2F measurements determining
+      panel radius and panel PSF.
+    data:
+      - type: datatable
+        table_columns:
+          - name: mirror_panel_id
+            description: |-
+              Mirror panel ID.
+            required: true
+            units: dimensionless
+            type: string
+          - name: mirror_panel_radius
+            description: |-
+              Mirror panel radius.
+            required: true
+            units: cm
+            type: double
+          - name: psf
+            description: |-
+              Spot size of mirror panel PSF at nominal distance.
+            required: true
+            units: cm
+            type: double
+          - name: psf_opt
+            description: |-
+              Spot size of mirror panel PSF
+              (best value, not at nominal distance).
+            required: false
+            units: cm
+            type: double
+...


### PR DESCRIPTION
Add a small application using [json-schema](https://json-schema.org/) to validate schema files used to define input and parameter definitions to simtools applications.

- requires additional package jsonschema
- application without module; not sure about how to to unit tests in this case
- reference schema is in the [workflow](https://github.com/gammasim/workflows/blob/prototype-DeriveArrayElementCoordinates/schemas/jsonschema.yml) (still in a branch) repository; this file is needed as a schema in general for simtools
