### PR TITLE
improve / fix application help messages

### DIFF
--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -69,13 +69,11 @@ def _user_confirm():
 
 
 def main():
-
     _db_tmp = db_handler.DatabaseHandler(mongo_db_config=None)
 
     config = configurator.Configurator(
-        label="Add file to the DB.",
-        description="python applications/add_file_to_db.py --file_name test_application.dat --db \
-         test-data",
+        description="Add file to the DB.",
+        usage="simtools-add-file-to-db --file_name test_application.dat --db test-data",
     )
     group = config.parser.add_mutually_exclusive_group(required=True)
     group.add_argument(

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -137,7 +137,9 @@ def _parse(label):
     Parse command line configuration
     """
 
-    config = configurator.Configurator(label=label)
+    config = configurator.Configurator(
+        description="Derive mirror random reflection angle.", label=label
+    )
     psf_group = config.parser.add_mutually_exclusive_group()
     psf_group.add_argument(
         "--psf_measurement_containment_mean",
@@ -317,7 +319,6 @@ def _get_psf_containment(logger, args_dict):
 
 
 def main():
-
     label = Path(__file__).stem
 
     args_dict, db_config = _parse(label)

--- a/simtools/applications/get_file_from_db.py
+++ b/simtools/applications/get_file_from_db.py
@@ -45,11 +45,9 @@ from simtools.configuration import configurator
 
 
 def main():
-
     config = configurator.Configurator(
-        label="Get file(s) from the DB.",
-        description="python applications/get_file_from_db.py "
-        " --file_name mirror_CTA-S-LST_v2020-04-07.dat",
+        description="Get file(s) from the DB.",
+        usage="simtools-get-file-from-db --file_name mirror_CTA-S-LST_v2020-04-07.dat",
     )
 
     config.parser.add_argument(

--- a/simtools/applications/submit_data_from_external.py
+++ b/simtools/applications/submit_data_from_external.py
@@ -52,7 +52,7 @@ from simtools.data_model import validate_data
 from simtools.data_model.workflow_description import WorkflowDescription
 
 
-def _parse(label, description, usage):
+def _parse(label, description):
     """
     Parse command line configuration
 
@@ -62,8 +62,6 @@ def _parse(label, description, usage):
         Label describing application.
     description: str
         Description of application.
-    usage: str
-        Example on how to use the application.
 
     Returns
     -------
@@ -72,7 +70,7 @@ def _parse(label, description, usage):
 
     """
 
-    config = configurator.Configurator(label=label, description=description, usage=usage)
+    config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(
         "--input_meta",
@@ -90,13 +88,10 @@ def _parse(label, description, usage):
 
 
 def main():
-
     label = Path(__file__).stem
     args_dict, _ = _parse(
         label,
         description="Submit model parameter (value, table) through an external interface.",
-        usage=" python applications/submit_data_from_external.py "
-        "--workflow_config <workflow configuration file>",
     )
 
     logger = logging.getLogger()


### PR DESCRIPTION
Improve help messages:

- help messages should reflect how users of simtools would run the tools (`simtools-...`; and not `python simtools/applications/....`)
- some had description / usages mixed up
