### PR TITLE
Use command line tools for integration tests on pip installation

### DIFF
--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-import subprocess
+import shutil
 from io import StringIO
 
 import pytest
@@ -420,11 +420,9 @@ def test_applications(application, io_handler, monkeypatch, db):
         """
 
         # check if conda is installed on this machine
-        try:
-            subprocess.check_output(["conda", "--version"])
+
+        if shutil.which("conda") is not None:
             return app.partition("::")[0]
-        except FileNotFoundError:
-            pass
 
         app_name = app.partition("::")[0]
         return "simtools-" + app_name.replace("_", "-")


### PR DESCRIPTION
Use `simtools-...` to run integration tests for pip installation.

Integration test checks if conda is installed. If not, it uses to `simtools-...` to call integration tests (this should work on the GithHub action environment; but will not work locally in case you have conda installed. In this case, integration tests will call `python simtools/applications/...`).

