### PR TITLE
Automatic version setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,3 +78,6 @@ simtools-validate-camera-efficiency = "simtools.applications.validate_camera_eff
 simtools-validate-camera-fov = "simtools.applications.validate_camera_fov:main"
 simtools-validate-optics = "simtools.applications.validate_optics:main"
 [tool.setuptools.packages.find]
+
+[tool.setuptools_scm]
+write_to = "simtools/_version.py"

--- a/simtools/__init__.py
+++ b/simtools/__init__.py
@@ -1,4 +1,8 @@
 import logging
 
+from .version import __version__
+
 logging.basicConfig(format="%(levelname)s::%(module)s(l%(lineno)s)::%(funcName)s::%(message)s")
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
+
+__all__ = ["__version__"]

--- a/simtools/_dev_version/__init__.py
+++ b/simtools/_dev_version/__init__.py
@@ -1,0 +1,11 @@
+# Try to use setuptools_scm to get the current version; this is only used
+# in development installations from the git repository.
+# Copied from astropy, see simtools/version.py for details
+import os.path as pth
+
+try:
+    from setuptools_scm import get_version
+
+    version = get_version(root=pth.join("..", ".."), relative_to=__file__)
+except Exception as e:
+    raise ImportError(f"setuptools_scm broken or not installed: {e}")

--- a/simtools/version.py
+++ b/simtools/version.py
@@ -1,5 +1,5 @@
-# this is adaped from https://github.com/cta-observatory/ctapipe/blob/main/ctapipe/version.py
-# this is adapted from https://github.com/astropy/astropy/blob/master/astropy/version.py
+# this is adapted from https://github.com/cta-observatory/ctapipe/blob/main/ctapipe/version.py
+# which is adapted from https://github.com/astropy/astropy/blob/master/astropy/version.py
 # see https://github.com/astropy/astropy/pull/10774 for a discussion on why this needed.
 
 try:

--- a/simtools/version.py
+++ b/simtools/version.py
@@ -1,5 +1,17 @@
-# preliminary simtools versioning; should be replaced by
-# cleaner way of automatically retrieve the version. e.g.,
-# https://github.com/cta-observatory/ctapipe/blob/master/ctapipe/version.py
+# this is adaped from https://github.com/cta-observatory/ctapipe/blob/main/ctapipe/version.py
+# this is adapted from https://github.com/astropy/astropy/blob/master/astropy/version.py
+# see https://github.com/astropy/astropy/pull/10774 for a discussion on why this needed.
 
-__version__ = "0.4.0-dev"
+try:
+    try:
+        from ._dev_version import version
+    except ImportError:
+        from ._version import version
+except Exception:
+    import warnings
+
+    warnings.warn("Could not determine simtools version; this indicates a broken installation.")
+    del warnings
+    version = "0.0.0"
+
+__version__ = version


### PR DESCRIPTION
Addresses #223 

Automatic version setting using the same approach as in astropy (which is also used in ctapipe).

Note that for the development, this includes the full git hash:
```
simtools-plot-simtel-histograms --version
plot_simtel_histograms 0.4.1.dev4027+g18da645b
```

I did not understand why it says `0.4.1`. The last release is `0.4.0`, it seems it adds a micro version, but I can't see where this happens.

