### PR TITLE
no need for logger.error before raise(mscg)

### DIFF
--- a/simtools/util/names.py
+++ b/simtools/util/names.py
@@ -264,7 +264,6 @@ def validate_name(name, all_names):
 
     if not is_valid_name(name, all_names):
         msg = f"Invalid name {name}"
-        _logger.error(msg)
         raise ValueError(msg)
     for main_name, list_of_names in all_names.items():
         if name.lower() in list_of_names + [main_name.lower()]:


### PR DESCRIPTION
names.validate_name() prints and error messages, even when the exception is caught in a try...except ValueError.

Removed here the `_logger.error(msg)`, having a `raise ValueError(msg)` is enough.

This has been noticed while running `simtools/applications/submit_data_from_external.py`. There shouldn't be error messages without an error.