### PR TITLE
Move docker files from container repository to simtools repository

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,0 +1,32 @@
+From ghcr.io/gammasim/simtools-simtelarray
+WORKDIR /workdir
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    bc \
+    bzip2 \
+    gfortran \
+    git \
+    libgsl-dev \
+    python3-pip \
+    unzip \
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -f get-pip.py
+
+RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
+    pip install toml-to-requirements && \
+    toml-to-req --toml-file pyproject.toml --include-optional
+
+RUN cd /workdir/ && \
+    pip install -r requirements.txt
+
+ENV SIMTEL_PATH="/workdir/sim_telarray/"
+SHELL ["/bin/bash", "-c"]
+
+
+WORKDIR /workdir/external

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -1,0 +1,29 @@
+From ghcr.io/gammasim/simtools-simtelarray
+WORKDIR /workdir
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    bc \
+    bzip2 \
+    gfortran \
+    git \
+    libgsl-dev \
+    python3-pip \
+    unzip \
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    rm -f get-pip.py
+
+RUN git clone https://github.com/gammasim/simtools.git
+
+ENV SIMTEL_PATH="/workdir/sim_telarray/"
+SHELL ["/bin/bash", "-c"]
+
+RUN cd /workdir/simtools && \
+    pip install --no-cache-dir .
+
+WORKDIR /workdir/

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,0 +1,49 @@
+From ubuntu:22.10 as build_image
+WORKDIR /workdir
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    bash \
+    build-essential \
+    bzip2 \
+    csh \
+    gfortran \
+    gcc \
+    g++ \
+    git \
+    libgsl-dev \
+    krb5-user \
+    libpam-krb5 \
+    make \
+    unzip \
+    vim \
+    wget && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# corsika and sim_telarray
+RUN mkdir sim_telarray
+COPY corsika7.7_simtelarray.tar.gz sim_telarray
+RUN cd sim_telarray && \
+    tar -xvf corsika7.7_simtelarray.tar.gz && \
+    ./build_all prod5 qgs2 gsl && \
+    find . -name "*.tar.gz" -exec rm -f {} \; && \
+    cd ..
+
+From ubuntu:22.10
+WORKDIR /workdir
+ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
+
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    gfortran \
+    libgsl-dev \
+    krb5-user \
+    libpam-krb5 \
+    unzip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV SIMTEL_PATH="/workdir/sim_telarray/"
+
+SHELL ["/bin/bash", "-c"]
+WORKDIR /workdir/

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,15 +2,64 @@
 
 Docker files for [simtools](https://github.com/gammasim/simtools) development and applications.
 
-[Docker](https://www.docker.com/community-edition#/download) or any compatible software are required to run these images.
+[Docker](https://www.docker.com/community-edition#/download) or any compatible software are required to run or build these images.
 
 Types of dockerfiles and containers available:
 
 - simtools users: [Dockerfile-prod](./Dockerfile-prod) provides a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
-- simtools development: [Dockerfile-dev](./Dockerfile-dev) provides a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
-- sim\_telarray: [Dockerfile-simtelarray](./Dockerfile-simtelarray) provides a container with the CORSIKA and sim\_telarray installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-simtelarray:latest`
+- simtools developers: [Dockerfile-dev](./Dockerfile-dev) provides a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
+- sim\_telarray: [Dockerfile-simtelarray](./Dockerfile-simtelarray) provides a container with the CORSIKA and sim\_telarray installed. This provides the base image for the previously listed containers. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-simtelarray:latest`
 
-The CORSIKA / sim\_telarray packages can be downloaded from MPIK (authentication required).
+## Container for simtools users
+
+## Container for simtools developers
+
+Provide a container for testing and development of simtools. This container is not optimised for size, but for completeness of development tools.
+
+Container includes installation of:
+
+- corsika and sim\_telarray
+- packages required by simtools (from pyproject.toml)
+
+The container does not include the simtools code, which should be cloned in the ./external directory (see below).
+
+There are two options on how to use this container:
+
+1. Download from [simtools container repository](https://github.com/gammasim/containers/pkgs/container/simtools-dev) **TODO**
+2. Build a new container from the available Dockerfile (requires access to sim\_telarray package)
+
+### Run a container using the prepared Docker image available from repository
+
+Packages are available from the [simtools container repository](https://github.com/gammasim/containers/pkgs/container/simtools-dev)**TODO**
+
+**Preparation:**
+
+Create a new directory for your development and clone simtools into a subdirectory:
+
+```bash
+mkdir -p simtools-dev && simtools-dev
+git clone git@github.com:gammasim/simtools.git
+```
+
+To download and run a prepared container in bash:
+
+```bash
+docker run --rm -it -v "$(pwd)/:/workdir/external" ghcr.io/gammasim/simtools-dev:latest bash -c "$(cat ./simtools/docker/entrypoint.sh) && bash"
+```
+
+This additionally executes the `entrypoint.sh` script (e.g., for pip install or set the database environment).
+
+Remember you need to `docker login` to the GitHub package repository with a personal token in order to download an image (follow [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)).
+
+### Build a new developers container locally
+
+To build a new container locally run:
+
+```bash
+docker build -f Dockerfile-dev -t simtools-dev .
+```
+
+Use the docker container in the same way as above, replacing `ghcr.io/gammasim/simtools-dev:latest` by `simtools-dev`.
 
 ## Container for simulation software CORSIKA / sim\_telarray
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,55 @@
+# Docker files for simtools
+
+Docker files for [simtools](https://github.com/gammasim/simtools) development and applications.
+
+[Docker](https://www.docker.com/community-edition#/download) or any compatible software are required to run these images.
+
+Types of dockerfiles and containers available:
+
+- simtools users: [Dockerfile-prod](./Dockerfile-prod) provides a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
+- simtools development: [Dockerfile-dev](./Dockerfile-dev) provides a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
+- sim\_telarray: [Dockerfile-simtelarray](./Dockerfile-simtelarray) provides a container with the CORSIKA and sim\_telarray installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-simtelarray:latest`
+
+The CORSIKA / sim\_telarray packages can be downloaded from MPIK (authentication required).
+
+## Container for simulation software CORSIKA / sim\_telarray
+
+Provide a container including the following the CORSIKA and sim\_telarray simulation software packages.
+
+There are two options on how to use this container:
+
+1. Download from [simtools container repository](https://github.com/gammasim/containers/pkgs/container/simtools-simtel)
+2. Build a new container from the available [Dockerfile](./Dockerfile-simtelarray) (requires access to sim\_telarray package)
+
+### Download from simtools container repository
+
+Packages are available from the [simtools container repository](https://github.com/gammasim/containers/pkgs/container/simtools-simtel).
+
+To download and run a prepared container in bash:
+
+```bash
+docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/simtools-simtelarray:latest bash
+```
+
+## Build a new container locally
+
+To build a new container locally run:
+
+```bash
+docker build -f Dockerfile-simtelarray  -t sim_telarray .
+```
+
+Building expects that a tar ball of corsika/sim\_telarray (named corsika7.7\_simtelarray.tar.gz) is available in the building directory.
+Download the tar package from the MPIK website (password applies) with
+
+```bash
+./download_simulationsoftware.sh
+```
+
+Run the newly build container:
+
+```bash
+docker run --rm -it -v "$(pwd)/external:/workdir/external" simtelarray bash
+```
+
+__Apple silicon users, notice you should add --platform=linux/amd64 to the run command above.__

--- a/docker/download_simulationsoftware.sh
+++ b/docker/download_simulationsoftware.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# download CORSIKA / sim_telarray package from
+# MPIK page
+#
+# requires CTA user name / password
+#
+
+VERSION="7.7"
+
+curl -u CTA -O https://www.mpi-hd.mpg.de/hfm/CTA/MC/Software/Testing/corsika${VERSION}_simtelarray.tar.gz

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# entrypoint script to configure development environment
+
+cd /workdir/external/simtools
+pip install -e .
+
+if [[ -e "set_DB_environ.sh" ]]; then
+    source ./set_DB_environ.sh
+fi


### PR DESCRIPTION
This PR is a follow up on the discussion in issue #516 and moves Dockerfiles from the [gammasim/containers](https://github.com/gammasim/containers) repository in a [./docker](./docker) directory.

Changes with respect to the implementation in containers:
- prod and dev containers are using as base images now the simtelarray image (so no need to recompile CORSIKA/sim_telarray all the time); this significantly reduces as well the building of these images.
- ...

TODO:
- [ ] add CI files