### PR TITLE
Build on merge / push to main

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -4,6 +4,8 @@ name: docker-simtools
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
   pull_request:


### PR DESCRIPTION
New simtools container (simtools-dev and simtools-prod) should be build when merging a pull request to main.

Packages are then available from here: https://github.com/orgs/gammasim/packages?repo_name=simtools