### PR TITLE
simplify and fix building of corsika / simtel image

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -3,6 +3,15 @@ name: docker-corsika-simtelarray
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  release:
+    types: [published]
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
 
-  build-simtools-container:
+  corsika-simtelarray-container:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -10,23 +10,7 @@ env:
 
 jobs:
 
-  corsikasimtelpackage:
-    runs-on: ubuntu-latest
-    steps:
-      - name: download corsikasimtelpackage
-        run: |
-          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL }}/download
-          mv download corsika7.7_simtelarray.tar.gz
-
-      - name: Publish Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: corsika7.7_simtelarray.tar.gz
-          path: corsika7.7_simtelarray.tar.gz
-          retention-days: 1
-
   build-simtools-container:
-    needs: corsikasimtelpackage
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,14 +20,13 @@ jobs:
         type: ['simtelarray']
 
     steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: corsika7.7_simtelarray.tar.gz
-          path: corsika7.7_simtelarray.tar.gz
-
       - name: Checkout repository
         uses: actions/checkout@v3
+
+      - name: download corsikasimtelpackage
+        run: |
+          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL }}/download
+          mv download ./docker/corsika7.7_simtelarray.tar.gz
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -26,7 +26,7 @@ jobs:
       - name: download corsikasimtelpackage
         run: |
           wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL }}/download
-          mv download ./docker/corsika7.7_simtelarray.tar.gz
+          mv download corsika7.7_simtelarray.tar.gz
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
This PR fixes the corsika / simtelarray container generation (also simplifies it, as it is now a separate step).

Although strictly not necessary, this workflow is executed for each merge to main (but not for each pull request).  Main reason is to have it appear in the `package` on the right column of the simtools main repository page (arghh). 

Note to myself: when moving container files from other repositories, make sure that the package right are set correctly and that this one has write permissions.

Tests are successful as new packages appear here: https://github.com/gammasim/containers/pkgs/container/simtools-simtelarray and the action here: https://github.com/gammasim/simtools/actions/runs/5903392923/job/16061510040