### PR TITLE
Important: remove temporary link to json schema

### DIFF
--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -655,7 +655,9 @@ def test_applications(application, io_handler, monkeypatch, db):
 
     prepare_one_file("PSFcurve_data_v2.txt")
     prepare_one_file("MLTdata-preproduction.ecsv")
-    download_file("https://github.com/gammasim/workflows/blob/main/schemas/jsonschema.yml")
+    download_file(
+        "https://raw.githubusercontent.com/gammasim/workflows/main/schemas/jsonschema.yml"
+    )
 
     def make_command(app, args):
         if app.find("simtools-") < 0:

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -655,10 +655,7 @@ def test_applications(application, io_handler, monkeypatch, db):
 
     prepare_one_file("PSFcurve_data_v2.txt")
     prepare_one_file("MLTdata-preproduction.ecsv")
-    # TODO - temporary path until workflows/documentation PR is merged
-    download_file(
-        "https://raw.githubusercontent.com/gammasim/workflows/documentation/schemas/jsonschema.yml"
-    )
+    download_file("https://github.com/gammasim/workflows/blob/main/schemas/jsonschema.yml")
 
     def make_command(app, args):
         if app.find("simtools-") < 0:


### PR DESCRIPTION
Remote temporary link to json schema in workflows repository.

Note that integration tests in all branches are failing right now. This issue resolves this.