### PR TITLE
Remove  running of CI on push to main

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -13,9 +13,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
-  push:
-    branches:
-      - main
 
 jobs:
 

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -13,6 +13,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -12,9 +12,6 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
-  push:
-    branches:
-      - main
 
 jobs:
 


### PR DESCRIPTION
Reduce the number of github action processes running by remove running the CI actions on push to main.

(see discussions on mattermost)