### PR TITLE
Add pytest-xdist

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pre-commit
   - pytest
   - pytest-cov
+  - pytest-xdist
   - scipy
   - pymongo
   - numpydoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 "tests" = [
     "pytest",
     "pytest-cov",
+    "pytest-xdist",
 ]
 "dev" = [
     "pre-commit",


### PR DESCRIPTION
Allows to run tests in parallel on all available core in your local environment. This significantly accelerates testing. This is for developers only.

Use with `pytest -n auto tests/unit_tests`.

More info at https://pytest-xdist.readthedocs.io/en/latest/