### PR TITLE
Package push trigger

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -67,8 +67,10 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push:
-            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+          push: |
+            github.event_name == 'release' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -67,10 +67,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push: |
-            github.event_name == 'release' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
+          push:
+            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -65,10 +65,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push: |
-            ${{ github.event_name == 'release' ||
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
+          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
+          push:
+            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -65,8 +65,10 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          push:
-            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+          push: |
+            github.event_name == 'release' ||
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -66,9 +66,9 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push: |
-            github.event_name == 'release' ||
+            ${{ github.event_name == 'release' ||
             github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
+            (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
Packages where pushed to the repository each time a pull request is issued or updated, but not after a merge to main.

Changed this so that only successfully merged pull request result in a package push (other triggers for push are not changed: manual and release).

This does not change when this workflows are triggered; only the 'package push' conditions are changed.

(and I didn't find an easier expression for successful merge to main)