### PR TITLE
Sort dependencies alphabetical

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,24 +4,24 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - pyyaml
-  - numpy
   - astropy
+  - boost-histogram
+  - eventio
+  - jsonschema
   - matplotlib-base
+  - numpy
+  - numpydoc
   - pre-commit
+  - pyflakes
+  - pymongo
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-xdist
+  - pyyaml
   - scipy
-  - pymongo
-  - numpydoc
   - sphinx
   - sphinx_rtd_theme
-  - pyproj
-  - pyflakes
-  - eventio
-  - boost-histogram
-  - jsonschema
 
 # cheatsheet
 # create: conda env create -f environment.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
     "jsonschema",
     "matplotlib",
     "numpy",
-    "pyyaml",
     "pymongo",
     "pyproj",
+    "pyyaml",
     "scipy",
     "zstandard",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "pyproj",
     "pyyaml",
     "scipy",
-    "zstandard",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Micro-change and cosmetical - simply sorting the dependencies alphabetical for improved readability.

(with the exception of python; this seems to be a general way of doing it and putting this first makes sense).

There is one actually change: zstandard dependency is removed in pyproject.toml (implicit dependency through pyeventio; no need to list it explicitly)