### PR TITLE
Update Ubuntu version to 23.04

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,26 +1,24 @@
-From ghcr.io/gammasim/simtools-corsika_sim_telarray
+FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
+    python3-venv \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    rm -f get-pip.py
-
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
+    python3 -m venv env && \
+    source env/bin/activate && \
     pip install toml-to-requirements && \
-    toml-to-req --toml-file pyproject.toml --include-optional
-
-RUN cd /workdir/ && \
-    pip install -r requirements.txt
+    toml-to-req --toml-file pyproject.toml --include-optional && \
+    pip uninstall -y toml-to-requirements && \
+    pip install --no-cache-dir -r requirements.txt
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
+ENV PATH="/workdir/simtools/env/bin/:$PATH"
 SHELL ["/bin/bash", "-c"]
 
 WORKDIR /workdir/external

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -1,24 +1,23 @@
-From ghcr.io/gammasim/simtools-corsika_sim_telarray
+FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
+    python3-venv \
     wget && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://bootstrap.pypa.io/get-pip.py && \
-    python3 get-pip.py && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    rm -f get-pip.py
-
-RUN git clone https://github.com/gammasim/simtools.git
-
-ENV SIMTEL_PATH="/workdir/sim_telarray/"
-SHELL ["/bin/bash", "-c"]
-
-RUN cd /workdir/simtools && \
+RUN git clone -b main https://github.com/gammasim/simtools.git --depth 1
+RUN cd /workdir/ && \
+    python3 -m venv env && \
+    source env/bin/activate && \
+    cd /workdir/simtools/ && \
     pip install --no-cache-dir .
 
-WORKDIR /workdir/
+ENV SIMTEL_PATH="/workdir/sim_telarray/"
+ENV PATH="/workdir/env/bin/:$PATH"
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /workdir

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -5,8 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     git \
     python3-pip \
-    python3-venv \
-    wget && \
+    python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN git clone -b main https://github.com/gammasim/simtools.git --depth 1

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -29,7 +29,7 @@ RUN cd sim_telarray && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
 
-From ubuntu:22.10
+From ubuntu:23.04
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,4 +1,4 @@
-From ubuntu:22.10 as build_image
+From ubuntu:23.04 as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,43 +1,44 @@
-FROM almalinux:9.2 as build_image
+From ubuntu:23.04 as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN yum install -y \
+RUN apt-get update && apt-get install -y \
     bash \
+    build-essential \
+    bzip2 \
     csh \
-    gcc \
-    gcc-c++ \
     gfortran \
-    gsl-devel \
-    krb5-workstation \
+    gcc \
+    g++ \
+    libgsl-dev \
+    krb5-user \
+    libpam-krb5 \
     make \
-    unzip \
-    wget \
-    yum clean all && rm -rf /var/cache/yum
+    unzip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# corsika and sim_telarray
 RUN mkdir sim_telarray
-COPY corsika7.7_simtelarray.tar.gz sim_telarray/
+COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
     tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
 
-FROM almalinux:9.2
+From ubuntu:23.04
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
-
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
-RUN yum install -y \
+RUN apt-get update && apt-get install -y \
     bc \
-    gcc \
-    gcc-c++ \
+    bzip2 \
     gfortran \
-    gsl-devel \
+    libgsl-dev \
     unzip \
     zstd && \
-    yum clean all && rm -rf /var/cache/yum
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,47 +1,43 @@
-From ubuntu:23.04 as build_image
+FROM almalinux:9.2 as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN yum install -y \
     bash \
-    build-essential \
-    bzip2 \
     csh \
-    gfortran \
     gcc \
-    g++ \
-    git \
-    libgsl-dev \
-    krb5-user \
-    libpam-krb5 \
+    gcc-c++ \
+    gfortran \
+    gsl-devel \
+    krb5-workstation \
     make \
     unzip \
-    vim \
-    wget && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    wget \
+    yum clean all && rm -rf /var/cache/yum
 
-# corsika and sim_telarray
 RUN mkdir sim_telarray
-COPY corsika7.7_simtelarray.tar.gz sim_telarray
+COPY corsika7.7_simtelarray.tar.gz sim_telarray/
 RUN cd sim_telarray && \
     tar -xvf corsika7.7_simtelarray.tar.gz && \
     ./build_all prod5 qgs2 gsl && \
     find . -name "*.tar.gz" -exec rm -f {} \; && \
     cd ..
 
-From ubuntu:23.04
+FROM almalinux:9.2
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
+
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
-RUN apt-get update && apt-get install -y \
+RUN yum install -y \
     bc \
-    bzip2 \
+    gcc \
+    gcc-c++ \
     gfortran \
-    libgsl-dev \
+    gsl-devel \
     unzip \
     zstd && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    yum clean all && rm -rf /var/cache/yum
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -11,8 +11,6 @@ RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     libgsl-dev \
-    krb5-user \
-    libpam-krb5 \
     make \
     unzip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,17 +25,16 @@ Prepare a file for the simulation model database access (see simtools documentat
 To run the container in bash
 
 ```bash
-docker run --rm -it --env-file .dotenv -v "$(pwd):/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
+docker run --rm -it --env-file .env -v "$(pwd):/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
 ```
 
 In the container, simtools applications are installed and can be called directly (e.g., `simtools-print-array-elements -h`).
 This example uses the docker syntax to mount your local directory.
 
-
 The following example runs an application inside the container and writes the output into a directory of the local files system,
 
 ```bash
-docker run --rm -it --env-file .dotenv \
+docker run --rm -it --env-file .env \
     -v "$(pwd):/workdir/external" \
     ghcr.io/gammasim/simtools-prod:latest \
     simtools-print-array-elements \
@@ -82,6 +81,7 @@ To download and run a prepared container in bash:
 
 ```bash
 docker run --rm -it -v "$(pwd)/:/workdir/external" ghcr.io/gammasim/simtools-dev:latest bash -c "cd /workdir/external/simtools && pip install -e . && bash"
+docker run --rm -it -v "$(pwd)/:/workdir/external" ghcr.io/gammasim/simtools-dev:latest bash -c "source /workdir/env/bin/activate && cd /workdir/external/simtools && pip install -e . && bash"
 ```
 
 Remember you need to `docker login` to the GitHub package repository with a personal token in order to download an image (follow [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)).


### PR DESCRIPTION
Used until now 22.10, which has some known vulnerabilities. This version is also no consistently building with some errors release to RELEASE files.

Change therefore the Ubuntu 23.04: this is one of the recent stable releases.

Note that this required some changes how pip is used (the usage of pip without virtual env is not allowed anymore, see e.g., [here](https://askubuntu.com/questions/1465218/pip-error-on-ubuntu-externally-managed-environment-%C3%97-this-environment-is-extern).

The latter requires a change in how simtools-dev is called: 

```
docker run --rm -it -v "$(pwd)/:/workdir/external" ghcr.io/gammasim/simtools-dev:latest bash -c "source /workdir/env/bin/activate && cd /workdir/external/simtools && pip install -e . && bash"
```

(not nice; but the command line was already too long, so this adds only a little bit...)

