### PR TITLE
Strip comments from env

### DIFF
--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -277,6 +277,10 @@ class Configurator:
                 env_variable_to_read = f"SIMTOOLS_{key.upper()}"
                 if value is None:
                     _env_dict[key] = os.environ.get(env_variable_to_read)
+                if key in _env_dict and _env_dict[key] is not None:
+                    _env_dict[key] = (
+                        _env_dict[key].split("#")[0].strip().replace(" ", "").replace("'", "")
+                    )
         except AttributeError:
             pass
 

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -276,11 +276,12 @@ class Configurator:
                 # environmental variables for simtools should always start with SIMTOOLS_
                 env_variable_to_read = f"SIMTOOLS_{key.upper()}"
                 if value is None:
-                    _env_dict[key] = os.environ.get(env_variable_to_read)
-                if key in _env_dict and _env_dict[key] is not None:
-                    _env_dict[key] = (
-                        _env_dict[key].split("#")[0].strip().replace(" ", "").replace("'", "")
-                    )
+                    env_value = os.environ.get(env_variable_to_read)
+                    if env_value is not None:
+                        env_value = (
+                            env_value.split("#")[0].strip().replace('"', "").replace("'", "")
+                        )
+                    _env_dict[key] = env_value
         except AttributeError:
             pass
 

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -185,6 +185,7 @@ def test_initialize_output(configurator):
 
 def test_fill_from_environmental_variables(configurator):
     configurator.parser.initialize_output_arguments()
+    configurator.parser.initialize_db_config_arguments()
     configurator._fill_from_command_line(arg_list=[])
 
     _config_save = copy(configurator.config)
@@ -210,6 +211,19 @@ def test_fill_from_environmental_variables(configurator):
     assert configurator.config["config"] == "test_config_file"
     if "SIMTOOLS_CONFIG" in os.environ:
         del os.environ["SIMTOOLS_CONFIG"]
+
+    # using .dotenv files with docker: comments are not removed by docker
+    os.environ["SIMTOOLS_DB_API_PORT"] = "27017 #Port on the MongoDB server"
+    os.environ["SIMTOOLS_DB_SERVER"] = "'abc@def.de' # MongoDB server"
+    configurator.config["db_api_port"] = None
+    configurator.config["db_server"] = None
+    configurator._fill_from_environmental_variables()
+    assert configurator.config["db_api_port"] == 27017
+    assert configurator.config["db_server"] == "abc@def.de"
+    if "SIMTOOLS_DB_API_PORT" in os.environ:
+        del os.environ["SIMTOOLS_DB_API_PORT"]
+    if "SIMTOOLS_DB_SERVER" in os.environ:
+        del os.environ["SIMTOOLS_DB_SERVER"]
 
 
 def test_fill_from_environmental_variables_with_dotenv_file(configurator, tmp_test_directory):


### PR DESCRIPTION
Strip comments, spaces, and '' from env variables.
This is relevant when using docker with the `--env-file`
option.

I've tested that this works by building a docker container locally and running ` simtools-get-file-from-db --file_name mirror_CTA-N-LST1_v2019-03-31.dat`

Review after pull request #603.

Addresses issue #605 