### PR TITLE
Address issues with pyflakes and use flake8 instead

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -1,6 +1,6 @@
 ---
 name: CI-unittests
-# Execute unit tests - pyflakes and pytest
+# Execute unit tests - flake8 and pytest
 #
 env:
   SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
@@ -101,9 +101,9 @@ jobs:
           python --version
           pip install '.[tests,dev,doc]'
 
-      - name: pyflakes liniting
+      - name: flake8
         run: |
-          pyflakes .
+          flake8 --max-line-length 100 --per-file-ignores="_version.py:F401 E501" .
 
       - name: Unit tests
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -8,12 +8,12 @@ dependencies:
   - boost-histogram
   - ctapipe
   - eventio
+  - flake8
   - jsonschema
   - matplotlib-base
   - numpy
   - numpydoc
   - pre-commit
-  - pyflakes
   - pymongo
   - pyproj
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ dependencies = [
     "pytest-xdist",
 ]
 "dev" = [
+    "flake8",
     "pre-commit",
-    "pyflakes",
 ]
 "doc" = [
     "numpydoc",

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -13,7 +13,7 @@
     This application derives the value of the simulation model parameter \
     *mirror_reflection_random_angle* using measurements of the focal length \
     and PSF of individual mirror panels.
-     
+
     PSF measurements are provided by one of the following options:
 
     * mean and sigma value obtained from the measurement of containment diameters of a number of \

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -134,23 +134,23 @@ def test_check_data_for_duplicates():
 def test_interval_check_allow_range():
     data_validator = validate_data.DataValidator()
 
-    assert data_validator._interval_check((0.1, 0.9), (0.0, 1.0), "allowed_range") == True
-    assert data_validator._interval_check((0.0, 1.0), (0.0, 1.0), "allowed_range") == True
+    assert data_validator._interval_check((0.1, 0.9), (0.0, 1.0), "allowed_range")
+    assert data_validator._interval_check((0.0, 1.0), (0.0, 1.0), "allowed_range")
 
-    assert data_validator._interval_check((-1.0, 0.9), (0.0, 1.0), "allowed_range") == False
-    assert data_validator._interval_check((0.0, 1.1), (0.0, 1.0), "allowed_range") == False
-    assert data_validator._interval_check((-1.0, 1.1), (0.0, 1.0), "allowed_range") == False
+    assert not data_validator._interval_check((-1.0, 0.9), (0.0, 1.0), "allowed_range")
+    assert not data_validator._interval_check((0.0, 1.1), (0.0, 1.0), "allowed_range")
+    assert not data_validator._interval_check((-1.0, 1.1), (0.0, 1.0), "allowed_range")
 
 
 def test_interval_check_required_range():
     data_validator = validate_data.DataValidator()
 
-    assert data_validator._interval_check((250.0, 700.0), (300.0, 600), "required_range") == True
-    assert data_validator._interval_check((300.0, 600.0), (300.0, 600), "required_range") == True
+    assert data_validator._interval_check((250.0, 700.0), (300.0, 600), "required_range")
+    assert data_validator._interval_check((300.0, 600.0), (300.0, 600), "required_range")
 
-    assert data_validator._interval_check((350.0, 700.0), (300.0, 600), "required_range") == False
-    assert data_validator._interval_check((300.0, 500.0), (300.0, 600), "required_range") == False
-    assert data_validator._interval_check((350.0, 500.0), (300.0, 600), "required_range") == False
+    assert not data_validator._interval_check((350.0, 700.0), (300.0, 600), "required_range")
+    assert not data_validator._interval_check((300.0, 500.0), (300.0, 600), "required_range")
+    assert not data_validator._interval_check((350.0, 500.0), (300.0, 600), "required_range")
 
 
 def test_check_range():
@@ -231,8 +231,8 @@ def test_get_reference_data_column():
     with pytest.raises(IndexError):
         data_validator._get_reference_data_column("wrong_column")
 
-    assert data_validator._get_reference_data_column("wavelength", status_test=True) == True
-    assert data_validator._get_reference_data_column("wrong_column", status_test=True) == False
+    assert data_validator._get_reference_data_column("wavelength", status_test=True)
+    assert not data_validator._get_reference_data_column("wrong_column", status_test=True)
 
     data_validator._reference_data_columns = get_reference_columns_name_colx()
 
@@ -241,7 +241,7 @@ def test_get_reference_data_column():
     with pytest.raises(IndexError):
         data_validator._get_reference_data_column("col3")
 
-    assert data_validator._get_reference_data_column("col1", status_test=True) == True
+    assert data_validator._get_reference_data_column("col1", status_test=True)
 
     assert data_validator._get_reference_data_column("col1") == {"name": "col1"}
 
@@ -266,11 +266,10 @@ def test_check_for_not_a_number():
     data_validator = validate_data.DataValidator()
     data_validator._reference_data_columns = get_reference_columns()
 
-    assert (
+    assert not (
         data_validator._check_for_not_a_number(
             Column([300.0, 350.0, 315.0], dtype="float32", name="wavelength")
         )
-        == False
     )
 
     # wavelenght does not allow for nan
@@ -288,23 +287,20 @@ def test_check_for_not_a_number():
         )
 
     # pos_x allows for nan
-    assert (
+    assert not (
         data_validator._check_for_not_a_number(
             Column([300.0, 350.0, 315.0], dtype="float32", name="pos_x")
         )
-        == False
     )
     assert (
         data_validator._check_for_not_a_number(
             Column([np.nan, 350.0, 315.0], dtype="float32", name="pos_x")
         )
-        == True
     )
     assert (
         data_validator._check_for_not_a_number(
             Column([333.0, np.inf, 315.0], dtype="float32", name="pos_x")
         )
-        == True
     )
 
 

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -96,7 +96,7 @@ def test_ray_tracing_single_mirror_mode(simtel_path, io_handler, telescope_model
 
     assert ray.config.zenith_angle == 30
     assert len(ray.config.off_axis_angle) == 2
-    assert ray.config.single_mirror_mode == True
+    assert ray.config.single_mirror_mode
     assert "Single mirror mode is activated" in caplog.text
 
 


### PR DESCRIPTION
This addresses issues with pyflakes for files generated by setuptools (e.g. ./simtools/_version.py), see e.g., the failed tests [pyflakes runs here](https://github.com/gammasim/simtools/actions/runs/6273528145/job/17037966050#step:9:21).

pyflakes unfortunately doesn't allow a lot of configuration. Decided to replace it by flake8 (which is a wrapper for several tools, among them pyflakes) and configure the workflow such that the relevant issues with _version.py are ignored.

This pull requests also includes several issues noted by flake8 (but not pyflakes).

Note that `conda env update -f environment.yml` (with flak8 replacing pyflakes) did not result in a working environment for me and I had to remove it and start again.