### PR TITLE
Ensure latitude calculation required for local coordinate calculation

### DIFF
--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -306,15 +306,9 @@ class LayoutArray:
         self._array_center.set_coordinates("corsika", 0.0 * u.m, 0.0 * u.m, 0.0 * u.m)
         self._set_array_center_mercator(center_dict)
         self._set_array_center_utm(center_dict)
-        try:
-            self._array_center.set_altitude(u.Quantity(center_dict.get("center_alt", np.nan * u.m)))
-        except TypeError:
-            pass
-        try:
-            _name = center_dict.get("array_name")
-            self.name = _name if _name is not None else self.name
-        except KeyError:
-            pass
+        self._array_center.set_altitude(u.Quantity(center_dict.get("center_alt", np.nan * u.m)))
+        _name = center_dict.get("array_name")
+        self.name = _name if _name is not None else self.name
 
         self._array_center.convert_all(
             crs_local=self.geo_coordinates.crs_local(self._array_center),

--- a/simtools/layout/layout_array.py
+++ b/simtools/layout/layout_array.py
@@ -284,6 +284,8 @@ class LayoutArray:
     def _initialize_coordinate_systems(self, center_dict=None):
         """
         Initialize array center and coordinate systems.
+        By definition, the array center is at (0,0,0) in
+        the CORSIKA coordinate system.
 
         Parameters
         ----------
@@ -297,30 +299,15 @@ class LayoutArray:
 
         """
 
+        center_dict = {} if center_dict is None else center_dict
+
         self._array_center = TelescopePosition()
         self._array_center.name = "array_center"
         self._array_center.set_coordinates("corsika", 0.0 * u.m, 0.0 * u.m, 0.0 * u.m)
-
-        center_dict = {} if center_dict is None else center_dict
+        self._set_array_center_mercator(center_dict)
+        self._set_array_center_utm(center_dict)
         try:
-            self._array_center.set_coordinates(
-                "mercator",
-                u.Quantity(center_dict.get("center_lat", np.nan * u.deg)),
-                u.Quantity(center_dict.get("center_lon", np.nan * u.deg)),
-            )
-        except TypeError:
-            pass
-        try:
-            self._epsg = center_dict.get("EPSG", None)
-            self._array_center.set_coordinates(
-                "utm",
-                u.Quantity(center_dict.get("center_easting", np.nan * u.m)),
-                u.Quantity(center_dict.get("center_northing", np.nan * u.m)),
-            )
-        except TypeError:
-            pass
-        try:
-            self._array_center.set_altitude(u.Quantity(center_dict.get("center_alt", 0.0 * u.m)))
+            self._array_center.set_altitude(u.Quantity(center_dict.get("center_alt", np.nan * u.m)))
         except TypeError:
             pass
         try:
@@ -334,6 +321,44 @@ class LayoutArray:
             crs_wgs84=self.geo_coordinates.crs_wgs84(),
             crs_utm=self.geo_coordinates.crs_utm(self._epsg),
         )
+
+    def _set_array_center_mercator(self, center_dict):
+        """
+        Set array center coordinates in mercator system.
+
+        """
+
+        try:
+            self._array_center.set_coordinates(
+                "mercator",
+                u.Quantity(center_dict.get("center_lat", np.nan * u.deg)),
+                u.Quantity(center_dict.get("center_lon", np.nan * u.deg)),
+            )
+        except TypeError:
+            pass
+
+    def _set_array_center_utm(self, center_dict):
+        """
+        Set array center coordinates in UTM system.
+        Convert array center position to WGS84 system
+        (as latitudes are required for the definition
+        for the definition of the CORSIKA coordinate system)
+
+        """
+        try:
+            self._epsg = center_dict.get("EPSG", None)
+            self._array_center.set_coordinates(
+                "utm",
+                u.Quantity(center_dict.get("center_easting", np.nan * u.m)),
+                u.Quantity(center_dict.get("center_northing", np.nan * u.m)),
+            )
+            self._array_center.convert_all(
+                crs_local=None,
+                crs_wgs84=self.geo_coordinates.crs_wgs84(),
+                crs_utm=self.geo_coordinates.crs_utm(self._epsg),
+            )
+        except TypeError:
+            pass
 
     def _altitude_from_corsika_z(self, pos_z=None, altitude=None, tel_name=None):
         """
@@ -619,8 +644,8 @@ class LayoutArray:
 
     def _get_export_metadata(self, export_corsika_meta=False):
         """
-        File metadata for export of array element list to file. Included array center definiton,\
-        CORSIKA telescope parameters, and EPSG centre
+        File metadata for export of array element list to file. Included array center definition,\
+        CORSIKA telescope parameters, and EPSG center
 
         Parameters
         ----------

--- a/tests/unit_tests/layout/test_geo_coordinates.py
+++ b/tests/unit_tests/layout/test_geo_coordinates.py
@@ -107,3 +107,22 @@ def test_geocentric_radius():
 
     with pytest.raises(TypeError):
         _coord._geocentric_radius(0.0, None, _semi_minor_axis)
+
+
+def test_valid_reference_point():
+    geo_coords = GeoCoordinates()
+    reference_point = TelescopePosition(name="LaPalma")
+    reference_point.set_coordinates("mercator", 28.7621661, -17.8920302, 2177.0)
+    assert geo_coords._valid_reference_point(reference_point)
+
+    reference_point.set_coordinates("mercator", 28.7621661, -17.8920302, np.nan)
+    assert not geo_coords._valid_reference_point(reference_point)
+
+    reference_point.set_coordinates("mercator", np.nan, np.nan, 2177.0)
+    assert not geo_coords._valid_reference_point(reference_point)
+
+    reference_point.set_coordinates("mercator", np.nan, -17.8920302, 2177.0)
+    assert not geo_coords._valid_reference_point(reference_point)
+
+    reference_point.set_coordinates("mercator", 28.7621661, np.nan, 2177.0)
+    assert not geo_coords._valid_reference_point(reference_point)

--- a/tests/unit_tests/layout/test_layout_array.py
+++ b/tests/unit_tests/layout/test_layout_array.py
@@ -87,20 +87,22 @@ def test_initialize_coordinate_systems(
     def test_one_site(center_data_dict, instance, easting, northing):
         instance._initialize_coordinate_systems()
         _x, _y, _z = instance._array_center.get_coordinates("corsika")
-        assert _x == 0.0 * u.m and _y == 0.0 * u.m and _z == 0.0 * u.m
+        assert _x == 0.0 * u.m and _y == 0.0 * u.m
+        assert np.isnan(_z.value)
         _lat, _lon, _z = instance._array_center.get_coordinates("mercator")
         assert np.isnan(_lat) and np.isnan(_lon)
 
-        instance._initialize_coordinate_systems(center_data_dict)
-        _x, _y, _z = instance._array_center.get_coordinates("corsika")
-        assert _x == 0.0 * u.m and _y == 0.0 * u.m and _z == center_data_dict["center_alt"]
-        _lat, _lon, _z = instance._array_center.get_coordinates("mercator")
-        assert _lat.value == pytest.approx(center_data_dict["center_lat"].value, 1.0e-2)
-        assert _lon.value == pytest.approx(center_data_dict["center_lon"].value, 1.0e-2)
+        if center_data_dict is not None:
+            instance._initialize_coordinate_systems(center_data_dict)
+            _x, _y, _z = instance._array_center.get_coordinates("corsika")
+            assert _x == 0.0 * u.m and _y == 0.0 * u.m and _z == center_data_dict["center_alt"]
+            _lat, _lon, _z = instance._array_center.get_coordinates("mercator")
+            assert _lat.value == pytest.approx(center_data_dict["center_lat"].value, 1.0e-2)
+            assert _lon.value == pytest.approx(center_data_dict["center_lon"].value, 1.0e-2)
 
-        _E, _N, _z = instance._array_center.get_coordinates("utm")
-        assert _E.value == pytest.approx(easting, 1.0)
-        assert _N.value == pytest.approx(northing, 1.0)
+            _E, _N, _z = instance._array_center.get_coordinates("utm")
+            assert _E.value == pytest.approx(easting, 1.0)
+            assert _N.value == pytest.approx(northing, 1.0)
 
     test_one_site(
         north_layout_center_data_dict, layout_array_north_instance, 217611.227, 3185066.278
@@ -108,6 +110,7 @@ def test_initialize_coordinate_systems(
     test_one_site(
         south_layout_center_data_dict, layout_array_south_instance, 366822.017, 7269466.999
     )
+    test_one_site(None, layout_array_south_instance, 366822.017, 7269466.999)
 
 
 def test_initialize_corsika_telescope_from_file(


### PR DESCRIPTION
Telescope position files might have the array centre defined in UTM coordinates only (this is actually the default).

This PR ensures that the latitude is calculated before the definition of the CORSIKA / local coordinate system. This allows to calculate the height and latitude dependent scale factor correctly.

Changed also the default for the centre altitude to `np.nan` (from 0 m). Ensures that this value is set and we do not use by accident the sea level value.

Tests are not entirely complete and require to solve issue #623 . Both layout_array.py and telescope_position.py have a test coverage of 80-85% only, this should be improved in a future pull request.