### PR TITLE
Switch to alma container

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -2,16 +2,17 @@ FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN microdnf update -y && microdnf install -y \
     git \
     python3-pip \
-    python3-venv \
+    python3-devel \
     wget && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    microdnf clean all
 
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
     python3 -m venv env && \
     source env/bin/activate && \
+    pip install -U pip && \
     pip install toml-to-requirements && \
     toml-to-req --toml-file pyproject.toml --include-optional && \
     pip uninstall -y toml-to-requirements && \

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -2,11 +2,11 @@ FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+RUN microdnf update -y && microdnf install -y \
     git \
     python3-pip \
-    python3-venv && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    python3-devel && \
+    microdnf clean all
 
 RUN git clone -b main https://github.com/gammasim/simtools.git --depth 1
 RUN cd /workdir/ && \

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,23 +1,17 @@
-From ubuntu:23.04 as build_image
+From almalinux as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
-    bash \
-    build-essential \
-    bzip2 \
+RUN yum update -y && yum install -y \
     csh \
-    gfortran \
-    gcc \
-    g++ \
-    libgsl-dev \
-    make \
-    unzip && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    perl \
+    which \
+    gcc-fortran \
+    gsl-devel \
+    && \
+    yum clean all
 
 # corsika and sim_telarray
-# (corsika source code is removed to follow
-# the corsika non-distribution policy)
 RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
@@ -25,23 +19,25 @@ RUN cd sim_telarray && \
     ./build_all prod5 qgs2 gsl
 
 RUN find sim_telarray/ -name "*.tar.gz" -exec rm -f {} \;
-RUN rm -f sim_telarray/corsika-run && \
-    mv sim_telarray/corsika-77*/run sim_telarray/corsika-run && \
-    rm -rf sim_telarray/corsika-77*
 
-From ubuntu:23.04
+# corsika source code is removed to follow
+# the corsika non-distribution policy.
+RUN rm -f sim_telarray/corsika-run && \
+   mv sim_telarray/corsika-77*/run sim_telarray/corsika-run && \
+   rm -rf sim_telarray/corsika-77*
+
+From almalinux/9-minimal
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
-RUN apt-get update && apt-get install -y \
+RUN microdnf update -y && microdnf install -y \
     bc \
-    bzip2 \
-    gfortran \
-    libgsl-dev \
-    unzip \
-    zstd && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+    zstd \
+    gsl-devel \
+    gcc-fortran \
+    && \
+    microdnf clean all
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 


### PR DESCRIPTION
In the end, after installing all of the stuff for simtools, the container is unfortunately 1.7 GB (the simtools ubuntu based container is 1.9 GB). So we only save 200 MB with this change, which is not as much as I had hoped since the minimal almalinux container is about 1 GB smaller than the ubuntu one we've been using. 
Either way, it's a necessary change probably, so that we are in line with the production environment.

My local tests all worked, hopefully no one runs into any other changes.

Fixes #621.