### PR TITLE
Plot simtel histograms missing file lists

### DIFF
--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -23,7 +23,8 @@
     .. code-block:: console
 
         simtools-plot-simtel-histograms \
-            --file_lists list_test1.txt list_test2.txt --figure_name histograms_comparison
+            --file_lists tests/resources/simtel_histograms_file_list.txt
+            --figure_name histograms
 
 """
 

--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -51,7 +51,7 @@ class SimtelHistograms:
     @property
     def number_of_histograms(self):
         """Returns number of histograms."""
-        if not hasattr(self, "combined_hists"):
+        if self.combined_hists is None:
             self._combine_histogram_files()
         return len(self.combined_hists)
 
@@ -69,7 +69,7 @@ class SimtelHistograms:
         str
             Histogram title.
         """
-        if not hasattr(self, "combined_hists"):
+        if self.combined_hists is None:
             self._combine_histogram_files()
         return self.combined_hists[i_hist]["title"]
 
@@ -77,7 +77,6 @@ class SimtelHistograms:
         """Combine histograms from all files into one single list of histograms."""
         # Processing and combining histograms from multiple files
         self.combined_hists = []
-
         n_files = 0
         for file in self._histogram_files:
             count_file = True

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -225,9 +225,9 @@ APP_LIST = {
     "plot_simtel_histograms": [
         [
             "--file_lists",
-            "tests/resources/simtel_histograms_file_list.txt",
+            "./tests/resources/simtel_histograms_file_list.txt",
             "--figure_name",
-            "test_figure_name",
+            "TESTOUTPUTDIR/test_figure_name",
         ]
     ],
     # Layout

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -227,7 +227,7 @@ APP_LIST = {
             "--file_lists",
             "tests/resources/simtel_histograms_file_list.txt",
             "--figure_name",
-            "test_figure_name.png",
+            "test_figure_name",
         ]
     ],
     # Layout

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -222,9 +222,12 @@ APP_LIST = {
             "TESTOUTPUTDIR/",
         ]
     ],
-    "plot_simtel_histograms::help": [
+    "plot_simtel_histograms": [
         [
-            "--help",
+            "--file_lists",
+            "tests/resources/simtel_histograms_file_list.txt",
+            "--figure_name",
+            "test_figure_name.png",
         ]
     ],
     # Layout

--- a/tests/resources/simtel_histograms_file_list.txt
+++ b/tests/resources/simtel_histograms_file_list.txt
@@ -1,0 +1,1 @@
+/workdir/external/simtools/tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst

--- a/tests/resources/simtel_histograms_file_list.txt
+++ b/tests/resources/simtel_histograms_file_list.txt
@@ -1,1 +1,1 @@
-/workdir/external/simtools/tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst
+./tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst


### PR DESCRIPTION
Closes #648, #647.

Review #650 first please. This is built on top of that.

This implements an integration test for Plot simtel histograms and also includes a new file to the resources pointing to a histogram file list which contains a histogram file.