### PR TITLE
Improve plot simtel histograms

### DIFF
--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -10,9 +10,13 @@
 
     Command line arguments
     ----------------------
-    file_lists (str, required)
-        Text file containing the list of sim_telarray histogram files to be plotted. \
+    file_lists (str, optional)
+        Text file containing the list of sim_telarray histogram files to be plotted.
         Multiple text files can be given.
+    c (str, optional)
+        Name of the histogram files to be plotted.
+        Either one of the arguments must be given: `file_lists` or `hist_names` and they are
+        mutually exclusive.
     figure_name (str, required)
         File name for the pdf output (without extension).
     verbosity (str, optional)

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -10,13 +10,10 @@
 
     Command line arguments
     ----------------------
-    file_lists (str, optional)
-        Text file containing the list of sim_telarray histogram files to be plotted.
-        Multiple text files can be given.
     hist_file_names (str, optional)
         Name of the histogram files to be plotted.
-        Either one of the arguments must be given: `file_lists` or `hist_file_names` and they are
-        mutually exclusive.
+        It can be given as the histogram file names (more than one option allowed) or as a text
+            file with the names of the histogram files in it.
     figure_name (str, required)
         File name for the pdf output (without extension).
     verbosity (str, optional)
@@ -26,8 +23,8 @@
     -------
     .. code-block:: console
 
-        simtools-plot-simtel-histograms \
-            --file_lists tests/resources/simtel_histograms_file_list.txt
+        simtools-plot-simtel-histograms --hist_file_names
+            ./tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst
             --figure_name histograms
 
 """
@@ -51,14 +48,9 @@ def main():
     input_group = config.parser.add_mutually_exclusive_group(required=True)
 
     input_group.add_argument(
-        "--file_lists",
-        help="File containing the list of histogram files to be plotted.",
-        nargs="+",
-        type=str,
-    )
-    input_group.add_argument(
         "--hist_file_names",
-        help="Name of the histogram files to be plotted.",
+        help="Name of the histogram files to be plotted or the text file containing the list of "
+        "histogram files.",
         nargs="+",
         type=str,
     )

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -48,12 +48,19 @@ def main():
         label=Path(__file__).stem,
         description=("Plots sim_telarray histograms."),
     )
-    config.parser.add_argument(
+    input_group = config.parser.add_mutually_exclusive_group(required=True)
+
+    input_group.add_argument(
         "--file_lists",
         help="File containing the list of histogram files to be plotted.",
         nargs="+",
         type=str,
-        required=True,
+    )
+    input_group.add_argument(
+        "--hist_names",
+        help="Name of the histogram files to be plotted.",
+        nargs="+",
+        type=str,
     )
     config.parser.add_argument(
         "--figure_name", help="File name for the pdf output.", type=str, required=True

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -13,9 +13,9 @@
     file_lists (str, optional)
         Text file containing the list of sim_telarray histogram files to be plotted.
         Multiple text files can be given.
-    c (str, optional)
+    hist_file_names (str, optional)
         Name of the histogram files to be plotted.
-        Either one of the arguments must be given: `file_lists` or `hist_names` and they are
+        Either one of the arguments must be given: `file_lists` or `hist_file_names` and they are
         mutually exclusive.
     figure_name (str, required)
         File name for the pdf output (without extension).
@@ -57,7 +57,7 @@ def main():
         type=str,
     )
     input_group.add_argument(
-        "--hist_names",
+        "--hist_file_names",
         help="Name of the histogram files to be plotted.",
         nargs="+",
         type=str,
@@ -83,7 +83,7 @@ def main():
                     histogram_files.append(line.replace("\n", ""))
             histogram_file_list.append(histogram_files)
     else:
-        histogram_file_list = [args_dict["hist_names"]]
+        histogram_file_list = [args_dict["hist_file_names"]]
         n_lists = 1
 
     simtel_histograms = []

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -71,22 +71,25 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 
+    histogram_file_list = []
     if args_dict["file_lists"]:
-        list_of_input = args_dict["file_lists"]
+        n_lists = len(args_dict["file_lists"])
+        for one_list in args_dict["file_lists"]:
+            # Collecting hist files
+            histogram_files = []
+            with open(one_list, encoding="utf-8") as file:
+                for line in file:
+                    # Removing '\n' from filename, in case it is left there.
+                    histogram_files.append(line.replace("\n", ""))
+            histogram_file_list.append(histogram_files)
     else:
-        list_of_input = args_dict["hist_names"]
-    n_lists = len(list_of_input)
-    simtel_histograms = []
-    for this_list_of_files in list_of_input:
-        # Collecting hist files
-        histogram_files = []
-        with open(this_list_of_files, encoding="utf-8") as file:
-            for line in file:
-                # Removing '\n' from filename, in case it is left there.
-                histogram_files.append(line.replace("\n", ""))
+        histogram_file_list = [args_dict["hist_names"]]
+        n_lists = 1
 
+    simtel_histograms = []
+    for i_file in range(n_lists):
         # Building SimtelHistograms
-        sh = SimtelHistograms(histogram_files)
+        sh = SimtelHistograms(histogram_file_list[i_file])
         simtel_histograms.append(sh)
 
     # Checking if number of histograms is consistent

--- a/simtools/applications/plot_simtel_histograms.py
+++ b/simtools/applications/plot_simtel_histograms.py
@@ -71,9 +71,13 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 
-    n_lists = len(args_dict["file_lists"])
+    if args_dict["file_lists"]:
+        list_of_input = args_dict["file_lists"]
+    else:
+        list_of_input = args_dict["hist_names"]
+    n_lists = len(list_of_input)
     simtel_histograms = []
-    for this_list_of_files in args_dict["file_lists"]:
+    for this_list_of_files in list_of_input:
         # Collecting hist files
         histogram_files = []
         with open(this_list_of_files, encoding="utf-8") as file:

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -224,7 +224,7 @@ APP_LIST = {
     ],
     "plot_simtel_histograms::file_lists": [
         [
-            "--file_lists",
+            "--hist_file_names",
             "./tests/resources/simtel_histograms_file_list.txt",
             "--figure_name",
             "TESTOUTPUTDIR/test_figure_name",

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -222,10 +222,18 @@ APP_LIST = {
             "TESTOUTPUTDIR/",
         ]
     ],
-    "plot_simtel_histograms": [
+    "plot_simtel_histograms::file_lists": [
         [
             "--file_lists",
             "./tests/resources/simtel_histograms_file_list.txt",
+            "--figure_name",
+            "TESTOUTPUTDIR/test_figure_name",
+        ]
+    ],
+    "plot_simtel_histograms::hist_file_names": [
+        [
+            "--hist_file_names",
+            "./tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst",
             "--figure_name",
             "TESTOUTPUTDIR/test_figure_name",
         ]


### PR DESCRIPTION
Closes #652.

Implemented the functionality that allows the plot simtel histograms application to receive a list of histograms (or one histogram) instead of only a text file with the histogram file names in it. It is more flexible now.