### PR TITLE
check for non-ascii characters in docs

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -26,6 +26,14 @@ jobs:
           python --version
           pip install '.[doc]'
 
+      - name: Check for non-ASCII characters
+        run: |
+          output=$(perl -ne 'print if /[^[:ascii:]]/' docs/source/*)
+          if [ -n "$output" ]; then
+            echo "Non-ASCII characters found in documentation."
+            exit 1
+          fi
+
       - name: Build docs
         shell: bash -l {0}
         run: |

--- a/docs/source/pull_requests.rst
+++ b/docs/source/pull_requests.rst
@@ -6,7 +6,7 @@ Pull requests
 Pull requests are one of our most important and powerful development tools.
 They help to obtain good quality, homogenous, and maintainable code.
 
-Both reviewing pull requests and addressing reviewers’ comments is hard.
+Both reviewing pull requests and addressing reviewers' comments is hard.
 The following thoughts might help to obtain an efficient and pleasant reviewing process.
 
 Before issuing a pull request
@@ -14,7 +14,7 @@ Before issuing a pull request
 
 - changes and new features shall be discussed with the team before implementation
 - all tests shall pass
-- no conflicts with ‘main’ (best to do a `merge main` before the pull request)
+- no conflicts with 'main' (best to do a `merge main` before the pull request)
 - self-review the changes made (e.g., by using the draft pull request feature)
 
 Issuing a pull request
@@ -36,10 +36,10 @@ Reviewing a pull request
 - seek to understand the purpose of the pull request; reach out to the author before reviewing if it is not clear which problem will be solved
 - if you reject the pull request or if you think another approach might be more efficient, request immediately (not after many other patches are implemented); if there is a major issue, focus on that first and indicate that detailed comments will come at a later point
 - indicate on the pull request page (or e.g., in the chat) that you have started reviewing to avoid duplicated reviews
-- propose solutions, not just disagreement; reviewer comments should lead to improvements of the pull request (e.g., a comment saying “I don’t like this” is not helping)
-- accept that there are different solutions (keeping the homogenity of the code in mind)
+- propose solutions, not just disagreement; reviewer comments should lead to improvements of the pull request (e.g., a comment saying "I don't like this" is not helping)
+- accept that there are different solutions (keeping the homogeneity of the code in mind)
 - focus on relevant points
-- discuss the code, not the coder (it is “the code is doing..”, not “you are doing….”). Often logic has been introduced earlier and there is no use of pointing fingers.
+- discuss the code, not the coder (it is "the code is doing..", not "you are doing.."). Often logic has been introduced earlier and there is no use of pointing fingers.
 - pull the code locally and execute the new code
 - limit the review to the changes in the pull request. Open an issue or a follow-up pull request for anything else.
 - clearly indicate if you have no time for a review (this is ok if it is known)


### PR DESCRIPTION
Deployment of github pages fails with non-ascii characters in the rst files (see #669)

Add a workflow step to check RST files and exit if there are non-ascii characters.