### PR TITLE
Remove duplications in application default arguments printing

### DIFF
--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -23,7 +23,7 @@
         The DB to insert the files to. \
         The choices are either the default CTA simulation DB or a sandbox for testing.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/compare_cumulative_psf.py
+++ b/simtools/applications/compare_cumulative_psf.py
@@ -30,11 +30,11 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...).
     model_version (str, optional)
-        Model version (default=prod4).
+        Model version.
     src_distance (float, optional)
-        Source distance in km (default=10).
+        Source distance in km.
     zenith (float, optional)
-        Zenith angle in deg (default=20).
+        Zenith angle in deg.
     data (str, optional)
         Name of the data file with the measured cumulative PSF.
     pars (str, optional)
@@ -42,7 +42,7 @@
     test (activation mode, optional)
         If activated, application will be faster by simulating fewer photons.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------
@@ -117,12 +117,12 @@ def main():
     )
     config.parser.add_argument(
         "--src_distance",
-        help="Source distance in km (default=10)",
+        help="Source distance in km",
         type=float,
         default=10,
     )
     config.parser.add_argument(
-        "--zenith", help="Zenith angle in deg (default=20)", type=float, default=20.0
+        "--zenith", help="Zenith angle in deg", type=float, default=20.0
     )
     config.parser.add_argument(
         "--data", help="Data file name with the measured PSF vs radius [cm]", type=str

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -68,7 +68,7 @@
     telescope (str, required)
         Telescope name (e.g. North-LST-1, South-SST-D, ...)
     model_version (str, optional)
-        Model version (default='Current')
+        Model version
     psf_measurement (str, optional)
         Table with results from PSF measurements for each mirror panel spot size
     psf_measurement_containment_mean (float, required)
@@ -76,7 +76,7 @@
     psf_measurement_containment_sigma (float, optional)
         Std dev of measured containment diameter [cm]
     containment_fraction (float, required)
-        Containment fraction for diameter calculation (default: 0.8)
+        Containment fraction for diameter calculation
     rnda (float, optional)
         Starting value of mirror_reflection_random_angle [deg]. If not given, the value from the \
         default model is read from the simulation model database.
@@ -93,7 +93,7 @@
     test (activation mode, optional)
         If activated, application will be faster by simulating only few mirrors.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/generate_simtel_array_histograms.py
+++ b/simtools/applications/generate_simtel_array_histograms.py
@@ -31,7 +31,7 @@
         associated to `hdf5` will be overwritten. The remaining tables, if any, will stay
         untouched.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Raises
     ------

--- a/simtools/applications/get_file_from_db.py
+++ b/simtools/applications/get_file_from_db.py
@@ -18,7 +18,7 @@
         Name of the local output directory where to save the files.
         Default it $CWD.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/get_parameter.py
+++ b/simtools/applications/get_parameter.py
@@ -20,7 +20,7 @@
         Telescope model name (e.g. LST-1, SST-D, ...)
 
     log_level (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Raises
     ------

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -13,7 +13,7 @@
     Command line arguments
     ----------------------
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/plot_layout_array.py
+++ b/simtools/applications/plot_layout_array.py
@@ -26,7 +26,7 @@
     show_tel_label (bool, optional)
         Shows the telescope labels in the plot.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/produce_array_config.py
+++ b/simtools/applications/produce_array_config.py
@@ -65,7 +65,7 @@
     array_config (str, required)
         Path to a yaml file with the array config data.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/production.py
+++ b/simtools/applications/production.py
@@ -45,7 +45,7 @@
     data_directory (str, optional)
         The location of the output directories corsika-data and simtel-data
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/sim_showers_for_trigger_rates.py
+++ b/simtools/applications/sim_showers_for_trigger_rates.py
@@ -25,13 +25,13 @@
     primary (str, required)
         Name of the primary particle (proton, helium ...).
     nruns (int, optional)
-        Number of runs to be simulated (default=100).
+        Number of runs to be simulated.
     nevents (int, optional)
-        Number of events simulated per run (default=100000).
+        Number of events simulated per run.
     zenith (float, optional)
-        Zenith angle in deg (default=20).
+        Zenith angle in deg.
     azimuth (float, optional)
-        Azimuth angle in deg (default=0).
+        Azimuth angle in deg.
     output (str, optional)
         Path of the directory to store the output simulations. By default, \
         the standard output directory defined by config will be used.
@@ -39,7 +39,7 @@
         If activated, no job will be submitted. Instead, an example of the \
         run script will be printed.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------
@@ -106,16 +106,16 @@ def _parse(label=None, description=None):
         required=True,
     )
     config.parser.add_argument(
-        "--nruns", help="Number of runs (default=100)", type=int, default=100
+        "--nruns", help="Number of runs", type=int, default=100
     )
     config.parser.add_argument(
-        "--nevents", help="Number of events/run (default=100)", type=int, default=100000
+        "--nevents", help="Number of events/run", type=int, default=100000
     )
     config.parser.add_argument(
-        "--zenith", help="Zenith angle in deg (default=20)", type=float, default=20
+        "--zenith", help="Zenith angle in deg", type=float, default=20
     )
     config.parser.add_argument(
-        "--azimuth", help="Azimuth angle in deg (default=0)", type=float, default=0
+        "--azimuth", help="Azimuth angle in deg", type=float, default=0
     )
     # TODO confusing with output_path?
     config.parser.add_argument(

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -50,7 +50,7 @@
     data_directory (str, optional)
         The location of the output directories corsika-data and simtel-data
     log_level (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------

--- a/simtools/applications/tune_psf.py
+++ b/simtools/applications/tune_psf.py
@@ -37,11 +37,11 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...).
     model_version (str, optional)
-        Model version (default="Current").
+        Model version.
     src_distance (float, optional)
-        Source distance in km (default=10).
+        Source distance in km.
     zenith (float, optional)
-        Zenith angle in deg (default=20).
+        Zenith angle in deg.
     data (str, optional)
         Name of the data file with the measured cumulative PSF.
     plot_all (activation mode, optional)
@@ -51,7 +51,7 @@
     test (activation mode, optional)
         If activated, application will be faster by simulating fewer photons.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------
@@ -127,12 +127,12 @@ def main():
     )
     config.parser.add_argument(
         "--src_distance",
-        help="Source distance in km (default=10)",
+        help="Source distance in km",
         type=float,
         default=10,
     )
     config.parser.add_argument(
-        "--zenith", help="Zenith angle in deg (default=20)", type=float, default=20
+        "--zenith", help="Zenith angle in deg", type=float, default=20
     )
     config.parser.add_argument(
         "--data", help="Data file name with the measured PSF vs radius [cm]", type=str

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -22,9 +22,9 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...)
     model_version (str, optional)
-        Model version (default='Current')
+        Model version
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print
 
     Example
     -------

--- a/simtools/applications/validate_camera_fov.py
+++ b/simtools/applications/validate_camera_fov.py
@@ -20,16 +20,16 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...)
     model_version (str, optional)
-        Model version (default='Current')
+        Model version
     camera_in_sky_coor (bool, optional)
         Plot the camera layout in sky coordinates akin to looking at it from behind for single \
-         mirror telescopes (default=False)
+         mirror telescopes
     print_pixels_id (bool, optional)
-        Up to which pixel ID to print (default=50). To suppress printing of pixel IDs, set to zero\
+        Up to which pixel ID to print. To suppress printing of pixel IDs, set to zero\
          (--print_pixels_id 0). To print all pixels, set to 'All'."
 
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print
 
     Example
     -------
@@ -84,7 +84,7 @@ def main():
     config.parser.add_argument(
         "--print_pixels_id",
         help=(
-            "Up to which pixel ID to print (default: 50). "
+            "Up to which pixel ID to print. "
             "To suppress printing of pixel IDs, set to zero (--print_pixels_id 0). "
             "To print all pixels, set to 'All'."
         ),

--- a/simtools/applications/validate_optics.py
+++ b/simtools/applications/validate_optics.py
@@ -32,21 +32,21 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...).
     model_version (str, optional)
-        Model version (default='Current').
+        Model version.
     src_distance (float, optional)
-        Source distance in km (default=10).
+        Source distance in km.
     zenith (float, optional)
-        Zenith angle in deg (default=20).
+        Zenith angle in deg.
     max_offset (float, optional)
-        Maximum offset angle in deg (default=4).
+        Maximum offset angle in deg.
     offset_steps (float, optional)
-        Offset angle step size (default=0.25 deg)
+        Offset angle step size.
     plot_images (activation mode, optional)
         Produce a multiple pages pdf file with the image plots.
     test (activation mode, optional)
         If activated, application will be faster by simulating fewer photons.
     verbosity (str, optional)
-        Log level to print (default=INFO).
+        Log level to print.
 
     Example
     -------
@@ -99,22 +99,22 @@ def _parse(label):
 
     config.parser.add_argument(
         "--src_distance",
-        help="Source distance in km (default=10)",
+        help="Source distance in km",
         type=float,
         default=10,
     )
     config.parser.add_argument(
-        "--zenith", help="Zenith angle in deg (default=20)", type=float, default=20
+        "--zenith", help="Zenith angle in deg", type=float, default=20
     )
     config.parser.add_argument(
         "--max_offset",
-        help="Maximum offset angle in deg (default=4)",
+        help="Maximum offset angle in deg",
         type=float,
         default=4,
     )
     config.parser.add_argument(
         "--offset_steps",
-        help="Offset angle step size (default=0.25 deg)",
+        help="Offset angle step size",
         type=float,
         default=0.25,
     )

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -167,7 +167,7 @@ class CommandLineParser(argparse.ArgumentParser):
             "--log_level",
             action="store",
             default="info",
-            help="log level to print (default is INFO)",
+            help="log level to print",
             required=False,
         )
         _job_group.add_argument(
@@ -188,7 +188,7 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         _job_group.add_argument(
             "--db_api_authentication_database",
-            help="database  with user info (optional, default is 'admin')",
+            help="database  with user info (optional)",
             type=str,
             required=False,
             default="admin",

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import sys
@@ -61,7 +62,9 @@ class Configurator:
         self.label = label
         self.config = {}
         self.parser = argparser.CommandLineParser(
-            prog=self.label, usage=usage, description=description, epilog=epilog
+            prog=self.label, usage=usage, description=description,
+            epilog=epilog,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         )
 
     def default_config(self, arg_list=None, add_db_config=False):


### PR DESCRIPTION
This pull requests deals with how we list default configuration parameters and helps to avoid mistakes by documenting "by hand" default values to docstrings and printouts:

- argparser is now configured with `formatter_class=argparse.ArgumentDefaultsHelpFormatter`, meaning the default values given for each parameters are listed when running an application with `--help`
- removed all statements about default from the description of each parameter
- removed all description of defaults in the docstrings of the applications. This is duplication and leads to mismatches.
