### PR TITLE
Any pull requests should trigger CI tests

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -11,7 +11,6 @@ env:
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize]
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -10,7 +10,6 @@ env:
 
 on:
   pull_request:
-    branches: [main]
     types: [opened, synchronize]
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
Any pull request should trigger the unit and integration tests. Before this change, only pull requests to main did this. This PR removes this requirement.