### PR TITLE
Fix fixture interdependence in test_corsika_config

### DIFF
--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -83,7 +83,7 @@ def test_export_input_file_multipipe(corsika_config):
         assert "TELFIL |" in f.read()
 
 
-def test_wrong_par_in_config_data(corsika_config_data, db_config):
+def test_wrong_par_in_config_data(corsika_config, corsika_config_data, db_config):
     logger.info("test_wrong_primary_name")
     new_config_data = copy(corsika_config_data)
     new_config_data["wrong_par"] = 20 * u.m
@@ -98,7 +98,7 @@ def test_wrong_par_in_config_data(corsika_config_data, db_config):
         corsika_test_Config.print_user_parameters()
 
 
-def test_units_of_config_data(corsika_config_data, db_config):
+def test_units_of_config_data(corsika_config, corsika_config_data, db_config):
     logger.info("test_units_of_config_data")
     new_config_data = copy(corsika_config_data)
     new_config_data["zenith"] = 20 * u.m
@@ -113,7 +113,7 @@ def test_units_of_config_data(corsika_config_data, db_config):
         corsika_test_Config.print_user_parameters()
 
 
-def test_len_of_config_data(corsika_config_data, db_config):
+def test_len_of_config_data(corsika_config, corsika_config_data, db_config):
     logger.info("test_len_of_config_data")
     new_config_data = copy(corsika_config_data)
     new_config_data["erange"] = [20 * u.TeV]
@@ -128,7 +128,7 @@ def test_len_of_config_data(corsika_config_data, db_config):
         corsika_test_Config.print_user_parameters()
 
 
-def test_wrong_primary_name(corsika_config_data, db_config):
+def test_wrong_primary_name(corsika_config, corsika_config_data, db_config):
     logger.info("test_wrong_primary_name")
     new_config_data = copy(corsika_config_data)
     new_config_data["primary"] = "rock"
@@ -143,7 +143,7 @@ def test_wrong_primary_name(corsika_config_data, db_config):
         corsika_test_Config.print_user_parameters()
 
 
-def test_missing_input(corsika_config_data, db_config):
+def test_missing_input(corsika_config, corsika_config_data, db_config):
     logger.info("test_missing_input")
     new_config_data = copy(corsika_config_data)
     new_config_data.pop("primary")


### PR DESCRIPTION
Units tests fail for `tests/unit_tests/corsika/test_corsika_config.py` when run with `pytest -n 8`. 

This indicated previously unknown interdependence between the tests. The issue is that `data_path` is set when calling CorsikaConfig, so I've added this fixture call to all test functions.