### PR TITLE
Remove unused parameter corsika_parameters_file in corsika_runner

### DIFF
--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -43,10 +43,6 @@ class CorsikaRunner:
             'cscat': [10, 1500 * u.m, 0]
         }
 
-    The remaining CORSIKA parameters can be set as a yaml file, using the argument \
-    corsika_parameters_file. When not given, corsika_parameters will be loaded from \
-    data/parameters/corsika_parameters.yml.
-
     The CORSIKA output directory must be set by the data_directory entry. The following directories\
     will be created to store the logs and input file:
     {data_directory}/corsika/$site/$primary/logs
@@ -70,8 +66,6 @@ class CorsikaRunner:
         Dict with CORSIKA config data.
     corsika_config_file: str or Path
         Path to yaml file containing CORSIKA config data.
-    corsika_parameters_file: str or Path
-        Path to yaml file containing CORSIKA parameters.
     """
 
     def __init__(
@@ -82,7 +76,6 @@ class CorsikaRunner:
         simtel_source_path,
         label=None,
         keep_seeds=False,
-        corsika_parameters_file=None,
         corsika_config_data=None,
         corsika_config_file=None,
         use_multipipe=False,

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -124,7 +124,6 @@ class Simulator:
         self._corsika_config_data = None
         self.site = None
         self.layout_name = None
-        self._corsika_parameters_file = None
         self.config = None
         self.array_model = None
         self._simulation_runner = None
@@ -216,10 +215,6 @@ class Simulator:
         self.runs = self._validate_run_list_and_range(
             self._corsika_config_data.pop("run_list", None),
             self._corsika_config_data.pop("run_range", None),
-        )
-
-        self._corsika_parameters_file = self._corsika_config_data.pop(
-            "corsika_parameters_file", None
         )
 
     def _load_sim_tel_config_and_model(self, config_data):
@@ -361,7 +356,6 @@ class Simulator:
             "mongo_db_config": self._mongo_db_config,
             "site": self.site,
             "layout_name": self.layout_name,
-            "corsika_parameters_file": self._corsika_parameters_file,
             "corsika_config_data": self._corsika_config_data,
         }
         if self.simulator in ["simtel", "corsika_simtel"]:

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -217,6 +217,10 @@ class Simulator:
             self._corsika_config_data.pop("run_range", None),
         )
 
+        self._corsika_parameters_file = self._corsika_config_data.pop(
+            "corsika_parameters_file", None
+        )
+
     def _load_sim_tel_config_and_model(self, config_data):
         """
         Load array model and configuration parameters for array simulations
@@ -356,6 +360,7 @@ class Simulator:
             "mongo_db_config": self._mongo_db_config,
             "site": self.site,
             "layout_name": self.layout_name,
+            "corsika_parameters_file": self._corsika_parameters_file,
             "corsika_config_data": self._corsika_config_data,
         }
         if self.simulator in ["simtel", "corsika_simtel"]:

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -361,7 +361,6 @@ class Simulator:
             "mongo_db_config": self._mongo_db_config,
             "site": self.site,
             "layout_name": self.layout_name,
-            "corsika_parameters_file": self._corsika_parameters_file,
             "corsika_config_data": self._corsika_config_data,
         }
         if self.simulator in ["simtel", "corsika_simtel"]:

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -124,6 +124,7 @@ class Simulator:
         self._corsika_config_data = None
         self.site = None
         self.layout_name = None
+        self._corsika_parameters_file = None
         self.config = None
         self.array_model = None
         self._simulation_runner = None


### PR DESCRIPTION
Carefully checked if `corsika_parameters_file` is used anywhere. It is indeed not used and safely be removed. 

closes #417 