### PR TITLE
Increase unit test coverage for simtools/configuration/configurator.py

### DIFF
--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -341,7 +341,7 @@ class CommandLineParser(argparse.ArgumentParser):
 
         Parameters
         ----------
-        angle: float
+        angle: float, str, astropy.Quantity
             zenith angle to verify
 
         Returns
@@ -416,8 +416,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 "Will check if it is an astropy.Quantity instead"
             )
         try:
-            fangle = u.Quantity(angle).to("deg")
-            return fangle.to("deg")
+            return u.Quantity(angle).to("deg")
         except TypeError:
             logger.debug(
                 "The azimuth angle provided is not a valid astropy.Quantity. "

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -360,17 +360,20 @@ class CommandLineParser(argparse.ArgumentParser):
         logger = logging.getLogger(__name__)
 
         try:
-            fangle = float(angle)
+            fangle = float(angle) * u.deg
         except ValueError:
-            logger.error("The zenith angle provided is not a valid numeric value.")
-            raise
-        if fangle < 0.0 or fangle > 180.0:
+            fangle = u.Quantity(angle).to("deg")
+        except TypeError:
+            logger.error(
+                "The zenith angle provided is not a valid numerical or astropy.Quantity value."
+            )
+        if fangle < 0.0 * u.deg or fangle > 180.0 * u.deg:
             raise argparse.ArgumentTypeError(
                 f"The provided zenith angle, {angle:.1f}, "
                 "is outside of the allowed [0, 180] interval"
             )
 
-        return fangle * u.deg
+        return fangle
 
     @staticmethod
     def azimuth_angle(angle):
@@ -387,7 +390,7 @@ class CommandLineParser(argparse.ArgumentParser):
         Returns
         -------
         Astropy.Quantity
-            Validated/Converted aziumth angle in degrees
+            Validated/Converted azimuth angle in degrees
 
         Raises
         ------
@@ -410,6 +413,14 @@ class CommandLineParser(argparse.ArgumentParser):
         except ValueError:
             logger.debug(
                 "The azimuth angle provided is not a valid numeric value. "
+                "Will check if it is an astropy.Quantity instead"
+            )
+        try:
+            fangle = u.Quantity(angle).to("deg")
+            return fangle.to("deg")
+        except TypeError:
+            logger.debug(
+                "The azimuth angle provided is not a valid astropy.Quantity. "
                 "Will check if it is (north, south, east, west) instead"
             )
         if isinstance(angle, str):

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -360,13 +360,15 @@ class CommandLineParser(argparse.ArgumentParser):
         logger = logging.getLogger(__name__)
 
         try:
-            fangle = float(angle) * u.deg
-        except ValueError:
-            fangle = u.Quantity(angle).to("deg")
-        except TypeError:
+            try:
+                fangle = float(angle) * u.deg
+            except ValueError:
+                fangle = u.Quantity(angle).to("deg")
+        except TypeError as exc:
             logger.error(
                 "The zenith angle provided is not a valid numerical or astropy.Quantity value."
             )
+            raise exc
         if fangle < 0.0 * u.deg or fangle > 180.0 * u.deg:
             raise argparse.ArgumentTypeError(
                 f"The provided zenith angle, {angle:.1f}, "

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -352,7 +352,7 @@ class Configurator:
                     _list_args += value
                 elif isinstance(value, u.Quantity):
                     _list_args.append("--" + key)
-                    _list_args.append(str(value.value))
+                    _list_args.append(str(value))
                 elif not isinstance(value, bool) and value is not None and len(str(value)) > 0:
                     _list_args.append("--" + key)
                     _list_args.append(str(value))

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -48,6 +48,9 @@ def test_zenith_angle(caplog):
     assert parser.CommandLineParser.zenith_angle(45).value == pytest.approx(45.0)
     assert parser.CommandLineParser.zenith_angle(90).value == pytest.approx(90.0)
     assert isinstance(parser.CommandLineParser.zenith_angle(0), u.Quantity)
+    assert parser.CommandLineParser.zenith_angle("0 deg").value == pytest.approx(0.0)
+    assert parser.CommandLineParser.zenith_angle("45 deg").value == pytest.approx(45.0)
+    assert parser.CommandLineParser.zenith_angle("90 deg").value == pytest.approx(90.0)
 
     with pytest.raises(
         argparse.ArgumentTypeError,
@@ -59,7 +62,7 @@ def test_zenith_angle(caplog):
         match=r"The provided zenith angle, 190.0, is outside of the allowed \[0, 180\] interval",
     ):
         parser.CommandLineParser.zenith_angle(190)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         parser.CommandLineParser.zenith_angle("North")
         assert "The zenith angle provided is not a valid numeric value" in caplog.text
 
@@ -69,6 +72,9 @@ def test_azimuth_angle(caplog):
     assert parser.CommandLineParser.azimuth_angle(45).value == pytest.approx(45.0)
     assert parser.CommandLineParser.azimuth_angle(90).value == pytest.approx(90.0)
     assert isinstance(parser.CommandLineParser.azimuth_angle(0), u.Quantity)
+    assert parser.CommandLineParser.azimuth_angle("0 deg").value == pytest.approx(0.0)
+    assert parser.CommandLineParser.azimuth_angle("45 deg").value == pytest.approx(45.0)
+    assert parser.CommandLineParser.azimuth_angle("90 deg").value == pytest.approx(90.0)
 
     assert parser.CommandLineParser.azimuth_angle("North").value == pytest.approx(0.0)
     assert parser.CommandLineParser.azimuth_angle("South").value == pytest.approx(180.0)

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -62,6 +62,7 @@ def test_zenith_angle(caplog):
         match=r"The provided zenith angle, 190.0, is outside of the allowed \[0, 180\] interval",
     ):
         parser.CommandLineParser.zenith_angle(190)
+
     with pytest.raises(TypeError):
         parser.CommandLineParser.zenith_angle("North")
         assert "The zenith angle provided is not a valid numeric value" in caplog.text

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -20,7 +20,6 @@ logger.setLevel(logging.DEBUG)
 
 
 def test_fill_from_command_line(configurator, args_dict):
-    
     configurator._fill_from_command_line(arg_list=[])
     assert args_dict == configurator.config
 
@@ -107,7 +106,6 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
                 _tmp_config[key] = value
     assert _tmp_config == configurator.config
 
-
     # test that no KeyError is raised for "CTASIMPIPE:NO_CONFIGURATION"
     _tmp_dict_workflow = {"CTASIMPIPE": {"NO_CONFIGURATION": _tmp_dict}}
     _workflow_file = tmp_test_directory / "configuration-test-2.yml"
@@ -120,9 +118,7 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
     configurator._fill_from_config_file(_workflow_file)
 
 
-
 def test_initialize_io_handler(configurator, tmp_test_directory):
-
     # io_handler is a Singleton, so configurator changes should
     # be reflected in the io_handler
     _io_handler = io_handler.IOHandler()
@@ -153,11 +149,19 @@ def test_check_parameter_configuration_status(configurator, args_dict, tmp_test_
 
 
 def test_arglist_from_config():
-    _tmp_dict = {"a": 1.0, "b": None, "c": True, "d": ["d1", "d2", "d3"], "e": 5.*u.m}
+    _tmp_dict = {"a": 1.0, "b": None, "c": True, "d": ["d1", "d2", "d3"], "e": 5.0 * u.m}
 
     assert [
-        "--a", "1.0", "--c", "--d", "d1", "d2", "d3", "--e", "5.0 m",
-        ] == Configurator._arglist_from_config(_tmp_dict)
+        "--a",
+        "1.0",
+        "--c",
+        "--d",
+        "d1",
+        "d2",
+        "d3",
+        "--e",
+        "5.0 m",
+    ] == Configurator._arglist_from_config(_tmp_dict)
 
     assert [] == Configurator._arglist_from_config({})
 
@@ -215,7 +219,7 @@ def test_initialize_output(configurator):
 
     # output is not configured (but activity_id)
     configurator.config["activity_id"] = "A-ID"
-    configurator.config["label"] = "test_label" 
+    configurator.config["label"] = "test_label"
     configurator._initialize_output()
     assert configurator.config["output_file"] == "A-ID-test_label.ecsv"
 
@@ -296,28 +300,28 @@ def test_get_db_parameters():
     configurator.default_config(add_db_config=True)
     db_params = configurator._get_db_parameters()
     assert db_params == {
-        'db_api_port': None, 
-        'db_api_pw': None, 
-        'db_api_user': None, 
-        'db_server': None
-        }
+        "db_api_port": None,
+        "db_api_pw": None,
+        "db_api_user": None,
+        "db_server": None,
+    }
 
     # filled config
     configurator = Configurator()
     configurator.default_config(add_db_config=True)
     configurator.config = {
-            "db_api_user": "user", 
-            "db_api_pw": "password", 
-            "db_api_port": 1234, 
-            "db_server": "localhost"
-            }
-        
+        "db_api_user": "user",
+        "db_api_pw": "password",
+        "db_api_port": 1234,
+        "db_server": "localhost",
+    }
+
     db_params = configurator._get_db_parameters()
     assert db_params == {
-        "db_api_user": "user", 
-        "db_api_pw": "password", 
-        "db_api_port": 1234, 
-        "db_server": "localhost"
+        "db_api_user": "user",
+        "db_api_pw": "password",
+        "db_api_port": 1234,
+        "db_server": "localhost",
     }
 
     # empty config


### PR DESCRIPTION
Test coverage for `simtools/configuration/configurator.py` was with 72% a bit low for such a central module.

Added and improved unit tests.

Fixes also bug in reading of astro.units.Quantity from configuration config, see issue #706 