### PR TITLE
Configure applications from configuration file

### DIFF
--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -100,7 +100,7 @@ def _parse(label=None, description=None):
     config.parser.add_argument(
         "--input",
         help="list of array element positions",
-        required=True,
+        required=False,
     )
     config.parser.add_argument(
         "--input_meta",
@@ -144,7 +144,7 @@ def _parse(label=None, description=None):
         default=None,
         nargs="+",
     )
-    return config.initialize(output=True)
+    return config.initialize(output=True, require_command_line=True)
 
 
 def main():

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -32,7 +32,7 @@ class Configurator:
     - configuration dict when calling the class
     - environmental variables
 
-    Assigns unique ACIVITY_ID to this configuration (uuid).
+    Assigns unique ACTIVITY_ID to this configuration (uuid).
 
     Configuration parameter names are converted always to lower case.
 
@@ -97,6 +97,7 @@ class Configurator:
 
     def initialize(
         self,
+        require_command_line=True,
         paths=True,
         output=False,
         telescope_model=False,
@@ -116,6 +117,8 @@ class Configurator:
 
         Parameters
         ----------
+        require_command_line: bool
+            Require at least one command line argument.
         paths: bool
             Add path configuration to list of args.
         output: bool
@@ -149,7 +152,7 @@ class Configurator:
             job_submission=job_submission,
         )
 
-        self._fill_from_command_line()
+        self._fill_from_command_line(require_command_line=require_command_line)
         try:
             self._fill_from_config_file(self.config["config"])
         except KeyError:
@@ -169,14 +172,30 @@ class Configurator:
 
         return self.config, _db_dict
 
-    def _fill_from_command_line(self, arg_list=None):
+    def _fill_from_command_line(self, arg_list=None, require_command_line=True):
         """
         Fill configuration parameters from command line arguments.
+
+        Parameters
+        ----------
+        arg_list: list
+            List of arguments.
+        require_command_line: bool
+            Require at least one command line argument.
+
+        Raises
+        ------
+        InvalidConfigurationParameter
+              invalid configuration.
 
         """
 
         if arg_list is None:
             arg_list = sys.argv[1:]
+
+        if require_command_line and len(arg_list) == 0:
+            self._logger.debug("No command line arguments given, printing help.")
+            arg_list = ["--help"]
 
         self._fill_config(arg_list)
 

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -5,11 +5,11 @@ import sys
 import uuid
 
 import astropy.units as u
-import yaml
 from dotenv import load_dotenv
 
 import simtools.configuration.commandline_parser as argparser
 from simtools.io_operations import io_handler
+from simtools.utils import general as gen
 
 __all__ = [
     "Configurator",
@@ -153,10 +153,7 @@ class Configurator:
         )
 
         self._fill_from_command_line(require_command_line=require_command_line)
-        try:
-            self._fill_from_config_file(self.config["config"])
-        except KeyError:
-            pass
+        self._fill_from_config_file(self.config.get("config", None))
         self._fill_from_config_dict(self.config_class_init)
         self._fill_from_environmental_variables()
 
@@ -175,6 +172,8 @@ class Configurator:
     def _fill_from_command_line(self, arg_list=None, require_command_line=True):
         """
         Fill configuration parameters from command line arguments.
+        Triggers a print of the help if no command line arguments are given and
+        require_command_line is set.
 
         Parameters
         ----------
@@ -199,21 +198,24 @@ class Configurator:
 
         self._fill_config(arg_list)
 
-    def _fill_from_config_dict(self, _input_dict):
+    def _fill_from_config_dict(self, input_dict, overwrite=False):
         """
         Fill configuration parameters from dictionary. Enforce that configuration parameter names\
          are lower case.
 
         Parameters
         ----------
-        _input_dict: dict
+        input_dict: dict
             dictionary with configuration parameters.
+        overwrite: bool
+            overwrite existing configuration parameters.
 
         """
         _tmp_config = {}
         try:
-            for key, value in _input_dict.items():
-                self._check_parameter_configuration_status(key, value)
+            for key, value in input_dict.items():
+                if not overwrite:
+                    self._check_parameter_configuration_status(key, value)
                 _tmp_config[key.lower()] = value
         except AttributeError:
             pass
@@ -268,25 +270,33 @@ class Configurator:
 
         try:
             self._logger.debug(f"Reading configuration from {config_file}")
-            with open(config_file, "r", encoding="utf-8") as stream:
-                _config_dict = yaml.safe_load(stream)
-            if "CTASIMPIPE" in _config_dict:
+            _config_dict = gen.collect_data_from_yaml_or_dict(
+                in_yaml=config_file, in_dict=None, allow_empty=True
+            )
+            if "CTA_SIMPIPE" in _config_dict:
                 try:
-                    self._fill_from_config_dict(_config_dict["CTASIMPIPE"]["CONFIGURATION"])
+                    self._fill_from_config_dict(
+                        input_dict=gen.change_dict_keys_case(
+                            _config_dict["CTA_SIMPIPE"]["CONFIGURATION"]
+                        ),
+                        overwrite=True,
+                    )
                 except KeyError:
-                    self._logger.info(f"No CTASIMPIPE:CONFIGURATION dict found in {config_file}.")
+                    self._logger.info(f"No CTA_SIMPIPE:CONFIGURATION dict found in {config_file}.")
             else:
-                self._fill_from_config_dict(_config_dict)
+                self._fill_from_config_dict(
+                    input_dict=gen.change_dict_keys_case(_config_dict), overwrite=True
+                )
         # TypeError is raised for config_file=None
         except TypeError:
             pass
-        except FileNotFoundError:
+        except gen.InvalidConfigData:
             self._logger.error(f"Configuration file not found: {config_file}")
             raise
 
     def _fill_from_environmental_variables(self):
         """
-        Fill any unconfigured configuration parameters (i.e., parameter is None)
+        Fill any configuration parameters which is not already configured (i.e., parameter is None)
         from environmental variables or from file (default: ".env").
 
         """

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -395,6 +395,7 @@ def collect_data_from_yaml_or_dict(in_yaml, in_dict, allow_empty=False):
         _logger.debug(msg)
         return None
 
+    _logger.debug(msg)
     raise InvalidConfigData(msg)
 
 

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -395,7 +395,6 @@ def collect_data_from_yaml_or_dict(in_yaml, in_dict, allow_empty=False):
         _logger.debug(msg)
         return None
 
-    _logger.error(msg)
     raise InvalidConfigData(msg)
 
 

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -20,8 +20,11 @@ logger.setLevel(logging.DEBUG)
 
 
 def test_fill_from_command_line(configurator, args_dict):
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
     assert args_dict == configurator.config
+
+    with pytest.raises(SystemExit):
+        configurator._fill_from_command_line(arg_list=[], require_command_line=True)
 
     configurator._fill_from_command_line(arg_list=["--data_path", Path("abc")])
     _tmp_config = copy(dict(args_dict))

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -37,7 +37,7 @@ def test_fill_from_command_line(configurator, args_dict):
 
 def test_fill_from_config_dict(configurator, args_dict):
     # _fill_from_environmental_variables() is always called after _fill_from_command_line()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
 
     configurator._fill_from_config_dict({})
     assert args_dict == configurator.config
@@ -55,7 +55,7 @@ def test_fill_from_config_dict(configurator, args_dict):
 
 def test_fill_from_config_file_not_existing_file(configurator):
     # _fill_from_config_file() is always called after _fill_from_command_line()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
 
     # config_file not found raises FileNotFoundError
     with pytest.raises(FileNotFoundError):
@@ -92,7 +92,7 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
         "output_path": "./abc/",
         "test": True,
     }
-    _tmp_dict_workflow = {"CTASIMPIPE": {"CONFIGURATION": _tmp_dict}}
+    _tmp_dict_workflow = {"CTA_SIMPIPE": {"CONFIGURATION": _tmp_dict}}
     _workflow_file = tmp_test_directory / "configuration-test.yml"
     with open(_workflow_file, "w") as output:
         yaml.safe_dump(_tmp_dict_workflow, output, sort_keys=False)
@@ -109,8 +109,8 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
                 _tmp_config[key] = value
     assert _tmp_config == configurator.config
 
-    # test that no KeyError is raised for "CTASIMPIPE:NO_CONFIGURATION"
-    _tmp_dict_workflow = {"CTASIMPIPE": {"NO_CONFIGURATION": _tmp_dict}}
+    # test that no KeyError is raised for "CTA_SIMPIPE:NO_CONFIGURATION"
+    _tmp_dict_workflow = {"CTA_SIMPIPE": {"NO_CONFIGURATION": _tmp_dict}}
     _workflow_file = tmp_test_directory / "configuration-test-2.yml"
     with open(_workflow_file, "w") as output:
         yaml.safe_dump(_tmp_dict_workflow, output, sort_keys=False)
@@ -133,7 +133,7 @@ def test_initialize_io_handler(configurator, tmp_test_directory):
 
 
 def test_check_parameter_configuration_status(configurator, args_dict, tmp_test_directory):
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
     configurator.config["output_path"] = Path(tmp_test_directory)
 
     # default value (no change)
@@ -193,7 +193,7 @@ def test_convert_stringnone_to_none():
 
 def test_get_db_parameters_from_env(configurator, args_dict):
     configurator.parser.initialize_db_config_arguments()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
     configurator._fill_from_environmental_variables()
 
     args_dict["db_api_user"] = "db_user"
@@ -207,7 +207,7 @@ def test_get_db_parameters_from_env(configurator, args_dict):
 
 def test_initialize_output(configurator):
     configurator.parser.initialize_output_arguments()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
 
     # outputfile for testing
     configurator.config["test"] = True
@@ -236,7 +236,7 @@ def test_initialize_output(configurator):
 def test_fill_from_environmental_variables(configurator):
     configurator.parser.initialize_output_arguments()
     configurator.parser.initialize_db_config_arguments()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
 
     _config_save = copy(configurator.config)
 
@@ -282,7 +282,7 @@ def test_fill_from_environmental_variables(configurator):
 
 def test_fill_from_environmental_variables_with_dotenv_file(configurator, tmp_test_directory):
     configurator.parser.initialize_output_arguments()
-    configurator._fill_from_command_line(arg_list=[])
+    configurator._fill_from_command_line(arg_list=[], require_command_line=False)
 
     # write a temporary file into tmp_test_directory with the environmental variables
     _env_file = tmp_test_directory / "test_env_file"


### PR DESCRIPTION
Fix the existing functionality of configuring simtools using a configuration file, e.g., 

```
python simtools/applications/print_array_elements.py --config config.yml
```

With configurations listed in this example as

```
INPUT: ./tests/resources/telescope_positions-North-utm.ecsv
EXPORT: corsika
USE_CORSIKA_TELESCOPE_HEIGHT: True
OUTPUT_PATH: simtools-tests
SELECT_ASSETS:
  - LSTN
  - MSTN
```

Important to note that our configuration class is powerful, but with limits:

- configuration is allowed through command line, configuration file, environmental variables, and direct pass of a dictionary from the application
- difficult to determine priorities (as configuration parameters also have default values)

Also introduced a new parameter for Configurator::initialize(..., require_command_line=True/False, ...)` which means that this tools requires at least one command line parameter. If none is given, help is printed.
