### PR TITLE
Add pylint to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,9 +22,21 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        args:
+          [
+            "-rn",  # Only display messages
+            "-sn",  # Don't display the score
+          ]
   # https://github.com/HunterMcGushion/docstr_coverage
   - repo: https://github.com/HunterMcGushion/docstr_coverage
-    rev: v2.3.0 # most recent docstr-coverage release or commit sha
+    rev: v2.3.0  # most recent docstr-coverage release or commit sha
     hooks:
       - id: docstr-coverage
         args: ["--verbose", "2", "--fail-under", "70.", "simtools"]

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy
   - numpydoc
   - pre-commit
+  - pylint
   - pymongo
   - pyproj
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
 ]
 "dev" = [
     "flake8",
+    "pylint",
     "pre-commit",
 ]
 "doc" = [

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -81,7 +81,7 @@ class JobManager:
         Parameters
         ----------
         run_script: str
-            Shell script descring the job to be submitted.
+            Shell script describing the job to be submitted.
         run_out_file: str or Path
             Redirect output/error/job stream to this file (out,err,job suffix).
         log_file: str or Path


### PR DESCRIPTION
The title should be clear.

Note that this works only with a local installation of pylint (see [here](https://pylint.pycqa.org/en/latest/user_guide/installation/pre-commit-integration.html)). This is why I've added pylint as a package to be installed.

Please try it out. A single file takes for me 3-6s to lint with pylint, which is quite slow but probably still accessible.