### PR TITLE
Add pytest-random-order to development environment. 

### DIFF
--- a/docs/source/developer_guidelines.rst
+++ b/docs/source/developer_guidelines.rst
@@ -77,6 +77,9 @@ This should be used to avoid duplication.
 The `pytest-xdist <https://pytest-xdist.readthedocs.io/en/latest/>`_ plugin is part of the developer environment
 and can be used to run unit and integration tests in parallel (e.g., ``pytest -n 4`` to run on four cores in parallel).
 
+Tests might pass just because they run after an unrelated test. In order to test the independence of unit tests, use the
+`pytest-random-order <https://pypi.org/project/pytest-random-order/>`_ plugin with ``pytest --random-order``.
+
 Check the test coverage with ``pytest -vv -n auto tests/unit_tests/ tests/integration_tests/ --cov``.
 Add the ``--cov-report html`` option to generate a coverage report in HTML format.
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,8 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - toml
+  - pip:
+      - pytest-random-order
 
 # cheatsheet
 # create: conda env create -f environment.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "pytest",
     "pytest-cov",
     "pytest-xdist",
+    "pytest-random-order",
 ]
 "dev" = [
     "flake8",


### PR DESCRIPTION
This is very useful to find hidden dependencies in unit test (e.g., right now #711 is passing tests in order, but not in random order).

Run `pytest --random-order -s --no-cov tests/unit_tests/test_db_handler.py` to see the mess.