### PR TITLE
fix zero padding in old production tool

### DIFF
--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -354,8 +354,8 @@ class CorsikaRunner:
             zenith = self.corsika_config.get_user_parameter("THETAP")[0]
             azimuth = self.corsika_config.get_user_parameter("AZM")[0]
             file_name = (
-                f"corsika_run{kwargs['run']:06}_{kwargs['primary']}_"
-                f"za{round(zenith):03}deg_azm{round(azimuth):03}deg_"
+                f"corsika_run{kwargs['run']}_{kwargs['primary']}_"
+                f"za{round(zenith)}deg_azm{round(azimuth)}deg_"
                 f"{kwargs['site']}_{kwargs['array_name']}{file_label}"
             )
             run_dir = self._get_run_directory(kwargs["run"])

--- a/simtools/corsika_simtel/corsika_simtel_runner.py
+++ b/simtools/corsika_simtel/corsika_simtel_runner.py
@@ -156,7 +156,7 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         command += super()._config_option(
             "output_file", self.get_file_name("output", **info_for_file_name)
         )
-        command += super()._config_option("random_state", "auto")
+        command += super()._config_option("random_state", "none")
         command += super()._config_option("show", "all")
         command += f" {kwargs['input_file']}"
         command += f" | gzip > {self.get_file_name('log', **info_for_file_name)} 2>&1 || exit"

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -274,7 +274,7 @@ class SimtelRunnerArray(SimtelRunner):
         command += super()._config_option("power_law", "2.5")
         command += super()._config_option("histogram_file", histogram_file)
         command += super()._config_option("output_file", output_file)
-        command += super()._config_option("random_state", "auto")
+        command += super()._config_option("random_state", "none")
         command += super()._config_option("show", "all")
         command += f" {kwargs['input_file']}"
         command += f" > {self._log_file} 2>&1 || exit"

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -133,7 +133,7 @@ def test_get_file_name(corsika_runner, io_handler):
     )
 
     file_name_for_output = (
-        "corsika_run000001_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
+        "corsika_run1_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
     )
     assert corsika_runner.get_file_name(
         "output", **info_for_file_name
@@ -165,7 +165,7 @@ def test_has_file(corsika_runner, corsika_file):
     shutil.copy(
         corsika_file,
         output_directory.joinpath(
-            "corsika_run000001_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
+            "corsika_run1_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
         ),
     )
     assert corsika_runner.has_file(file_type="output", run_number=1)

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -133,7 +133,7 @@ def test_get_file_name(corsika_runner, io_handler):
     )
 
     file_name_for_output = (
-        "corsika_run1_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
+        "corsika_run1_gamma_za20deg_azm0deg_South_TestLayout_test-corsika-runner.zst"
     )
     assert corsika_runner.get_file_name(
         "output", **info_for_file_name
@@ -165,7 +165,7 @@ def test_has_file(corsika_runner, corsika_file):
     shutil.copy(
         corsika_file,
         output_directory.joinpath(
-            "corsika_run1_gamma_za020deg_azm000deg_South_TestLayout_test-corsika-runner.zst"
+            "corsika_run1_gamma_za20deg_azm0deg_South_TestLayout_test-corsika-runner.zst"
         ),
     )
     assert corsika_runner.has_file(file_type="output", run_number=1)


### PR DESCRIPTION
Closes #646, #645.

Related to [660](https://github.com/gammasim/simtools/issues/660). For some time the old production tool was not working due to mismatches in the names of the files produced by CORSIKA.

It looks like a simple solution but it took me some time. First I wanted to keep the zero padding, but it was not possible to add the zero padding to the .zst file being saved by the corsika runner. There is a mess with directories, env variables and functions with the same name in the config and runner scripts. Instead, I removed the zero padding from the .zst file being read by simtel_runner. Hopefully that does not break anything in the new production tool.

To review (the test that I was doing locally): 
run the shower and then the array simulator. Check log files and more specifically the zst files in the data directories
```
mkdir test_sim_telarray
simtools-production --task simulate --productionconfig prod_config_test.yml --submit_command local --primary gamma --showers_only --output_path test_sim_telarray/
```

```
simtools-production --task simulate --productionconfig prod_config_test.yml --submit_command local --primary gamma --array_only --use_plain_output_path --output_path test_sim_telarray/
```

Edit: This is also closing #645. Now a bunch of files from the random_generator will not be written locally but only a single  file! That is already much better than before.