### PR TITLE
Add `skip_output_validation` flag to allow writing without validation against a schema file.

### DIFF
--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -145,6 +145,13 @@ class CommandLineParser(argparse.ArgumentParser):
             default="ecsv",
             required=False,
         )
+        _job_group.add_argument(
+            "--skip_output_validation",
+            help="skip output data validation against schema",
+            default=False,
+            required=False,
+            action="store_true",
+        )
 
     def initialize_application_execution_arguments(self):
         """

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -17,17 +17,26 @@ class ModelDataWriter:
 
     Parameters
     ----------
+    product_data_file: str
+        Name of output file.
+    product_data_format: str
+        Format of output file.
     args_dict: Dictionary
         Dictionary with configuration parameters.
     """
 
-    def __init__(self, product_data_file=None, product_data_format=None):
+    def __init__(self, product_data_file=None, product_data_format=None, args_dict=None):
         """
         Initialize model data writer.
         """
 
         self._logger = logging.getLogger(__name__)
         self.io_handler = io_handler.IOHandler()
+        if args_dict is not None:
+            self.io_handler.set_paths(
+                output_path=args_dict.get("output_path", None),
+                use_plain_output_path=args_dict.get("use_plain_output_path", False),
+            )
         try:
             self.product_data_file = self.io_handler.get_output_file(
                 file_name=product_data_file, dir_type="simtools-result"
@@ -37,7 +46,7 @@ class ModelDataWriter:
         self.product_data_format = self._astropy_data_format(product_data_format)
 
     @staticmethod
-    def dump(args_dict, metadata=None, product_data=None, validate_schema_file=False):
+    def dump(args_dict, metadata=None, product_data=None, validate_schema_file=None):
         """
         Write model data and metadata (as static method).
 
@@ -57,8 +66,9 @@ class ModelDataWriter:
         writer = ModelDataWriter(
             product_data_file=args_dict.get("output_file", None),
             product_data_format=args_dict.get("output_file_format", "ascii.ecsv"),
+            args_dict=args_dict,
         )
-        if validate_schema_file and not args_dict.get("skip_output_validation", True):
+        if validate_schema_file is not None and not args_dict.get("skip_output_validation", True):
             product_data = writer.validate_and_transform(
                 product_data=product_data,
                 validate_schema_file=validate_schema_file,

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -58,7 +58,7 @@ class ModelDataWriter:
             product_data_file=args_dict.get("output_file", None),
             product_data_format=args_dict.get("output_file_format", "ascii.ecsv"),
         )
-        if validate_schema_file:
+        if validate_schema_file and not args_dict.get("skip_output_validation", True):
             product_data = writer.validate_and_transform(
                 product_data=product_data,
                 validate_schema_file=validate_schema_file,

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -79,7 +79,7 @@ class Simulator:
     simulator: choices: [simtel, corsika]
         implemented are sim_telarray and CORSIKA
     simulator_source_path: str or Path
-        Location of exectutables for simulation software \
+        Location of executables for simulation software \
             (e.g. path with CORSIKA or sim_telarray)
     label: str
         Instance label.

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -679,16 +679,17 @@ APP_LIST = {
             "TESTOUTPUTDIR/",
         ],
     ],
-    #    "print_array_elements::export_utm": [
-    #        [
-    #            "--input",
-    #            "tests/resources/telescope_positions-South-4MST.ecsv",
-    #            "--export",
-    #            "utm",
-    #            "--output_path",
-    #            "TESTOUTPUTDIR/",
-    #        ],
-    #    ],
+    "print_array_elements::export_utm": [
+        [
+            "--input",
+            "tests/resources/telescope_positions-South-4MST.ecsv",
+            "--export",
+            "utm",
+            "--output_path",
+            "TESTOUTPUTDIR/",
+            "--skip_output_validation",
+        ],
+    ],
     "print_array_elements::export_corsika": [
         [
             "--input",


### PR DESCRIPTION
Closes #717 

Coordinate transformations from corsika to utm were broken due to the strict introduction of output validation using a schema file. The schema for UTM coordinates is not yet defined.

Added with this pull request a flag in the `output` group to be able to skip the output validation at the stage of writing (flag is `--skip_output_validation`).

This feature will be useful on the long term, however we need to prepare the schemas for all input / outputs (this is anyway an ongoing effort and I therefore don't open an issue on this point).

