### PR TITLE
Set explicitly output path for `simulate_prod`

### DIFF
--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -48,7 +48,9 @@
     run (int, required)
         Run number (actual run number will be 'start_run' + 'run').
     data_directory (str, optional)
-        The location of the output directories corsika-data and simtel-data
+        The location of the output directories corsika-data and simtel-data.
+        the label is added to the data_directory, such that the output
+        will be written to `data_directory/label/simtel-data`.
     pack_for_grid_register (bool, optional)
         Set whether to prepare a tarball for registering the output files on the grid.
         The files are written to the `output_path/directory_for_grid_upload` directory.
@@ -67,8 +69,11 @@
         --start_run 0 --run 1
 
     By default the configuration is saved in simtools-output/test-production
-    and the output in corsika-data and simtel-data. The location of the latter directories
-    can be set to a different location via the option --data_directory.
+    together with the actual simulation output in corsika-data and simtel-data within.
+    The location of the latter directories can be set
+    to a different location via the option --data_directory,
+    but the label is always added to the data_directory, such that the output
+    will be written to `data_directory/label/simtel-data`.
 
     Expected final print-out message:
 
@@ -187,7 +192,11 @@ def _parse(description=None):
     )
     config.parser.add_argument(
         "--data_directory",
-        help="The directory where to save the corsika-data and simtel-data output directories.",
+        help=(
+            "The directory where to save the corsika-data and simtel-data output directories."
+            "the label is added to the data_directory, such that the output"
+            "will be written to `data_directory/label/simtel-data`."
+        ),
         type=str.lower,
         required=False,
         default="./simtools-output/",

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -233,13 +233,12 @@ def main():
     config_data["common"]["zenith"] = args_dict["zenith_angle"]
     config_data["common"]["phi"] = args_dict["azimuth_angle"]
     label = config_data["common"].pop("label", "test-production")
+    config_data["common"]["data_directory"] = Path(args_dict["data_directory"]) / label
 
     if args_dict["nshow"] is not None:
         config_data["showers"]["nshow"] = args_dict["nshow"]
     if args_dict["label"] is not None:
         label = args_dict["label"]
-    if "data_directory" in args_dict:
-        config_data["common"]["data_directory"] = Path(args_dict["data_directory"]) / label
 
     simulator = Simulator(
         label=label,

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -49,6 +49,9 @@
         Run number (actual run number will be 'start_run' + 'run').
     data_directory (str, optional)
         The location of the output directories corsika-data and simtel-data
+    pack_for_grid_register (bool, optional)
+        Set whether to prepare a tarball for registering the output files on the grid.
+        The files are written to the `output_path/directory_for_grid_upload` directory.
     log_level (str, optional)
         Log level to print.
 
@@ -61,7 +64,7 @@
         simtools-simulate-prod \
         --production_config tests/resources/prod_multi_config_test.yml --model_version Prod5 \
         --site north --primary gamma --azimuth_angle north --zenith_angle 20 \
-         --start_run 0 --run 1
+        --start_run 0 --run 1
 
     By default the configuration is saved in simtools-output/test-production
     and the output in corsika-data and simtel-data. The location of the latter directories
@@ -187,7 +190,7 @@ def _parse(description=None):
         help="The directory where to save the corsika-data and simtel-data output directories.",
         type=str.lower,
         required=False,
-        default="./",
+        default="./simtools-output/",
     )
     config.parser.add_argument(
         "--pack_for_grid_register",
@@ -227,7 +230,7 @@ def main():
     if args_dict["label"] is not None:
         label = args_dict["label"]
     if "data_directory" in args_dict:
-        config_data["common"]["data_directory"] = args_dict["data_directory"]
+        config_data["common"]["data_directory"] = Path(args_dict["data_directory"]) / label
 
     simulator = Simulator(
         label=label,
@@ -258,7 +261,7 @@ def main():
             files_to_tar = log_files[:1] + histogram_files[:1]
             for file_to_tar in files_to_tar:
                 tar.add(file_to_tar, arcname=Path(file_to_tar).name)
-        directory_for_grid_upload = Path(args_dict.get("output_path", "./")).joinpath(
+        directory_for_grid_upload = Path(args_dict.get("output_path")).joinpath(
             "directory_for_grid_upload"
         )
         directory_for_grid_upload.mkdir(parents=True, exist_ok=True)

--- a/simtools/io_operations/io_handler.py
+++ b/simtools/io_operations/io_handler.py
@@ -90,13 +90,16 @@ class IOHandler(metaclass=IOHandlerSingleton):
         if self.use_plain_output_path:
             path = Path(self.output_path)
         else:
-            try:
-                output_directory_prefix = Path(self.output_path).joinpath(
-                    re.sub(r"\-result$", "", dir_type) + "-output"
-                )
-            except TypeError:
-                self._logger.error(f"Error creating output directory name from {dir_type}")
-                raise
+            if str(self.output_path).endswith("-output"):
+                output_directory_prefix = Path(self.output_path)
+            else:
+                try:
+                    output_directory_prefix = Path(self.output_path).joinpath(
+                        re.sub(r"\-result$", "", dir_type) + "-output"
+                    )
+                except TypeError:
+                    self._logger.error(f"Error creating output directory name from {dir_type}")
+                    raise
             label_dir = label if label is not None else "d-" + str(datetime.date.today())
             path = output_directory_prefix.joinpath(label_dir)
         if sub_dir is not None:

--- a/tests/integration_tests/test_applications.py
+++ b/tests/integration_tests/test_applications.py
@@ -639,7 +639,7 @@ APP_LIST = {
             "--data_directory",
             "TESTOUTPUTDIR/",
             "--output_path",
-            "./",
+            "TESTOUTPUTDIR/",
         ]
     ],
     "simulate_prod::gamma_20_deg_pack_for_grid": [


### PR DESCRIPTION
Closes #680

Output paths are set explicitly for `simulate_prod`. Allows to run "cleaner" integration tests without spurious files leftover. 

Requires to add `--output_path ./` to obtain original behavior (meaning: writing the production configuration into the current directory).
