### PR TITLE
remove unused functions from simulator

### DIFF
--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -1,12 +1,10 @@
 import copy
 import logging
 
-import matplotlib.pyplot as plt
 import numpy as np
 from ctapipe.io import write_table
 from eventio import EventIOFile, Histograms
 from eventio.search_utils import yield_toplevel_of_type
-from matplotlib.backends.backend_pdf import PdfPages
 
 from simtools import version
 from simtools.io_operations.hdf5_handler import fill_hdf5_table
@@ -43,18 +41,6 @@ class SimtelHistograms:
         self._is_test = test
         self.combined_hists = None
         self.__meta_dict = None
-
-    def plot_and_save_figures(self, fig_name):
-        """
-        Plot all histograms and save a single pdf file.
-
-        Parameters
-        ----------
-        fig_name: str
-            Name of the output figure file.
-        """
-        self.combine_histogram_files()
-        self._plot_combined_histograms(fig_name)
 
     @property
     def number_of_histograms(self):
@@ -123,37 +109,6 @@ class SimtelHistograms:
                     n_files += int(count_file)
 
         self._logger.debug(f"End of reading {n_files} files")
-
-    def _plot_combined_histograms(self, fig_name):
-        """
-        Plot all histograms into pdf pages and save the figure as a pdf file.
-
-        Parameters
-        ----------
-        fig_name: str
-            Name of the output figure file.
-        """
-
-        pdf_pages = PdfPages(fig_name)
-        for i_hist, histo in enumerate(self.combined_hists):
-            # Test case: processing only 1/10 of the histograms
-            if self._is_test and i_hist % 10 != 0:
-                self._logger.debug(f"Skipping (test=True): {histo['title']}")
-                continue
-
-            self._logger.debug(f"Processing: {histo['title']}")
-
-            fig = plt.figure(figsize=(8, 6))
-            ax = plt.gca()
-
-            self.plot_one_histogram(i_hist, ax)
-
-            plt.tight_layout()
-            pdf_pages.savefig(fig)
-            plt.close()
-
-        if pdf_pages.get_pagecount() > 0:
-            pdf_pages.close()
 
     def plot_one_histogram(self, i_hist, ax):
         """

--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -68,7 +68,8 @@ class SimtelHistograms:
         return self.combined_hists[i_hist]["title"]
 
     def combine_histogram_files(self):
-        """Combine histograms from all files into one single list of histograms."""
+        """Add the values of the same type of histogram from the various lists into a single
+        histogram list."""
         # Processing and combining histograms from multiple files
         self.combined_hists = []
         n_files = 0

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -13,7 +13,6 @@ from simtools.corsika_simtel.corsika_simtel_runner import CorsikaSimtelRunner
 from simtools.io_operations import io_handler
 from simtools.job_execution.job_manager import JobManager
 from simtools.model.array_model import ArrayModel
-from simtools.simtel.simtel_histograms import SimtelHistograms
 from simtools.simtel.simtel_runner_array import SimtelRunnerArray
 from simtools.utils import names
 
@@ -592,34 +591,6 @@ class Simulator:
             self._results["input"].append(None)
             self._results["hist"].append(None)
             self._results["log"].append(None)
-
-    def print_histograms(self, input_file_list=None):
-        """
-        Print histograms and save a pdf file.
-
-        Parameters
-        ----------
-        input_file_list: str or list of str
-            Single file or list of files of shower simulations.
-
-        Returns
-        -------
-        path
-            Path of the pdf file.
-        """
-
-        fig_name = None
-
-        if self.simulator in ["simtel", "corsika_simtel"]:
-            if len(self._results["hist"]) == 0 and input_file_list is not None:
-                self._fill_results_without_run(input_file_list)
-
-            fig_name = self._output_directory.joinpath("histograms.pdf")
-            hist_file_list = self.get_list_of_histogram_files()
-            simtel_histograms = SimtelHistograms(hist_file_list)
-            simtel_histograms.plot_and_save_figures(fig_name)
-
-        return fig_name
 
     def get_list_of_output_files(self, run_list=None, run_range=None):
         """

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -45,3 +45,33 @@ def test_export_histograms(simtel_array_histograms_instance, io_handler):
     assert len(list_of_tables) == 144
     for table in list_of_tables:
         assert isinstance(table, Table)
+
+
+def test_number_of_histograms(simtel_array_histograms_instance):
+    assert (
+        len(simtel_array_histograms_instance.combined_hists)
+        == simtel_array_histograms_instance.number_of_histograms
+    )
+
+
+def test_get_histogram_title(simtel_array_histograms_instance):
+    assert (
+        simtel_array_histograms_instance.get_histogram_title(0)
+        == "Events, without weights (Ra, log10(E))"
+    )
+
+
+def test_combine_histogram_files(simtel_array_histograms_file):
+    # Reading one histogram file
+    instance_alone = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
+    instance_alone.combine_histogram_files()
+
+    # Passing the same file twice
+    instance_all = SimtelHistograms(
+        histogram_files=[simtel_array_histograms_file, simtel_array_histograms_file], test=True
+    )
+    instance_all.combine_histogram_files()
+
+    assert (
+        2 * instance_alone.combined_hists[0]["data"] == instance_all.combined_hists[0]["data"]
+    ).all()

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -49,23 +49,30 @@ def test_export_histograms(simtel_array_histograms_instance, io_handler):
         assert isinstance(table, Table)
 
 
-def test_number_of_histograms(simtel_array_histograms_instance):
+def test_number_of_histograms(simtel_array_histograms_file):
+    instance_alone = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
+    # If combined_hists is None
+    assert instance_alone.combined_hists is None
+    assert instance_alone.number_of_histograms == 145
     assert (
         len(simtel_array_histograms_instance.combined_hists)
         == simtel_array_histograms_instance.number_of_histograms
     )
 
 
-def test_get_histogram_title(simtel_array_histograms_instance):
-    assert (
-        simtel_array_histograms_instance.get_histogram_title(0)
-        == "Events, without weights (Ra, log10(E))"
-    )
+def test_get_histogram_title(simtel_array_histograms_file, simtel_array_histograms_instance):
+    instance_alone = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
+    # If combined_hists is None
+    assert instance_alone.combined_hists is None
+    assert instance_alone.number_of_histograms == 145
+    for instance in [instance_alone, simtel_array_histograms_instance]:
+        assert instance.get_histogram_title(0) == "Events, without weights (Ra, log10(E))"
 
 
 def test_combine_histogram_files(simtel_array_histograms_file):
     # Reading one histogram file
     instance_alone = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
+
     instance_alone.combine_histogram_files()
 
     # Passing the same file twice

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -49,7 +49,7 @@ def test_export_histograms(simtel_array_histograms_instance, io_handler):
         assert isinstance(table, Table)
 
 
-def test_number_of_histograms(simtel_array_histograms_file):
+def test_number_of_histograms(simtel_array_histograms_file, simtel_array_histograms_instance):
     instance_alone = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
     # If combined_hists is None
     assert instance_alone.combined_hists is None

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -27,26 +27,6 @@ def simtel_array_histograms_instance(simtel_array_histograms_file):
     return instance
 
 
-def test_histograms(io_handler, simtel_array_histograms_file):
-    histogram_files = list()
-    histogram_files.append(simtel_array_histograms_file)
-    histogram_files.append(
-        io_handler.get_input_data_file(
-            file_name="run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
-            test=True,
-        )
-    )
-
-    hists = SimtelHistograms(histogram_files=histogram_files, test=True)
-
-    fig_name = io_handler.get_output_file(
-        file_name="simtel_histograms.pdf", sub_dir="plots", dir_type="test"
-    )
-    hists.plot_and_save_figures(fig_name=fig_name)
-
-    assert fig_name.exists()
-
-
 def test_meta_dict(simtel_array_histograms_instance):
     assert "simtools_version" in simtel_array_histograms_instance._meta_dict
 

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -2,8 +2,10 @@
 
 import logging
 
+import matplotlib.pyplot as plt
 import pytest
 from astropy.table import Table
+from matplotlib.collections import QuadMesh
 
 from simtools.io_operations.hdf5_handler import read_hdf5
 from simtools.simtel.simtel_histograms import SimtelHistograms
@@ -75,3 +77,18 @@ def test_combine_histogram_files(simtel_array_histograms_file):
     assert (
         2 * instance_alone.combined_hists[0]["data"] == instance_all.combined_hists[0]["data"]
     ).all()
+
+
+def test_plot_one_histogram(simtel_array_histograms_instance):
+    """
+    Plot all histograms into pdf pages and save the figure as a pdf file.
+    Parameters
+    ----------
+    fig_name: str
+        Name of the output figure file.
+    """
+
+    fig, ax = plt.subplots()
+    simtel_array_histograms_instance.plot_one_histogram(0, ax)
+    quadmesh = ax.collections[0]
+    assert isinstance(quadmesh, QuadMesh)

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -283,28 +283,6 @@ def test_fill_results(array_simulator, shower_simulator, shower_array_simulator,
     assert shower_simulator.get_list_of_histogram_files()[1] is None
 
 
-def test_print_histograms(
-    array_config_data, shower_simulator, input_file_list, db_config, simtel_path
-):
-    _array_simulator = Simulator(
-        label="simtel_test",
-        simulator="simtel",
-        simulator_source_path=simtel_path,
-        config_data=array_config_data,
-        mongo_db_config=db_config,
-    )
-
-    assert len(str(_array_simulator.print_histograms())) > 0
-
-    _array_simulator._results["hist"] = list()
-    assert len(str(_array_simulator.print_histograms(input_file_list=None))) > 0
-
-    with pytest.raises(FileNotFoundError):
-        _array_simulator.print_histograms(input_file_list=input_file_list)
-
-    assert shower_simulator.print_histograms() is None
-
-
 def test_get_list_of_files(shower_simulator):
     assert len(shower_simulator.get_list_of_output_files()) == len(shower_simulator.runs)
     assert len(shower_simulator.get_list_of_output_files(run_list=[2, 5, 7])) == 10


### PR DESCRIPTION
Closes #728.

In this PR, I clean up `simulator.py` and `simtel_histograms` given that the deleted functions were not being used. I also add some tests.
All functions are tested, more lines are tested but the coverage seems to decrease. I would not give much attention to the codecov report here