### PR TITLE
Improved handling of non-initialized IOHandler

### DIFF
--- a/simtools/io_operations/io_handler.py
+++ b/simtools/io_operations/io_handler.py
@@ -6,6 +6,10 @@ from pathlib import Path
 __all__ = ["IOHandlerSingleton", "IOHandler"]
 
 
+class IncompleteIOHandlerInit(Exception):
+    """Exception raised when IOHandler is not initialized"""
+
+
 class IOHandlerSingleton(type):
     """
     Singleton base class
@@ -161,6 +165,8 @@ class IOHandler(metaclass=IOHandlerSingleton):
 
         if test:
             file_prefix = Path("tests/resources/")
-        else:
+        elif self.data_path is not None:
             file_prefix = Path(self.data_path).joinpath(parent_dir)
+        else:
+            raise IncompleteIOHandlerInit
         return file_prefix.joinpath(file_name).absolute()

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -174,9 +174,14 @@ class ArrayLayout:
             If file_name does not exist.
         """
         if file_name is None:
-            corsika_parameters_dict = collect_data_from_yaml_or_dict(
-                self.io_handler.get_input_data_file("parameters", "corsika_parameters.yml"), None
-            )
+            try:
+                corsika_parameters_dict = collect_data_from_yaml_or_dict(
+                    self.io_handler.get_input_data_file("parameters", "corsika_parameters.yml"),
+                    None,
+                )
+            except io_handler.IncompleteIOHandlerInit:
+                self._logger.info("Error reading CORSIKA parameters from file")
+                return {}
         else:
             if not isinstance(file_name, Path):
                 file_name = Path(file_name)

--- a/tests/unit_tests/io_operations/test_io_handler.py
+++ b/tests/unit_tests/io_operations/test_io_handler.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+import simtools.io_operations.io_handler as io_handler_module
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
@@ -112,3 +114,7 @@ def test_get_data_file(args_dict, io_handler):
         io_handler.get_input_data_file(file_name="test-file.txt", test=True)
         == Path("tests/resources/test-file.txt").absolute()
     )
+
+    io_handler.data_path = None
+    with pytest.raises(io_handler_module.IncompleteIOHandlerInit):
+        io_handler.get_input_data_file(file_name="test-file.txt")

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -68,6 +68,11 @@ def array_layout_south_four_LST_instance(
     return layout
 
 
+def test_array_layout_empty():
+    layout = ArrayLayout()
+    assert layout.get_number_of_telescopes() == 0
+
+
 def test_from_array_layout_name(io_handler, db_config):
     layout = ArrayLayout.from_array_layout_name(
         mongo_db_config=db_config, array_layout_name="South-TestLayout"


### PR DESCRIPTION
Closes #623

Added an exception to io_handler (IncompleteIOHandlerInit) to be able to catch in a controlled way when the IOHandler class is used without proper initialization (especially if no paths are set).

Additions to unit tests to catch this.