### PR TITLE
Random state set to none

### DIFF
--- a/simtools/corsika_simtel/corsika_simtel_runner.py
+++ b/simtools/corsika_simtel/corsika_simtel_runner.py
@@ -156,7 +156,7 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         command += super()._config_option(
             "output_file", self.get_file_name("output", **info_for_file_name)
         )
-        command += super()._config_option("random_state", "auto")
+        command += super()._config_option("random_state", "none")
         command += super()._config_option("show", "all")
         command += f" {kwargs['input_file']}"
         command += f" | gzip > {self.get_file_name('log', **info_for_file_name)} 2>&1 || exit"

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -274,7 +274,7 @@ class SimtelRunnerArray(SimtelRunner):
         command += super()._config_option("power_law", "2.5")
         command += super()._config_option("histogram_file", histogram_file)
         command += super()._config_option("output_file", output_file)
-        command += super()._config_option("random_state", "auto")
+        command += super()._config_option("random_state", "none")
         command += super()._config_option("show", "all")
         command += f" {kwargs['input_file']}"
         command += f" > {self._log_file} 2>&1 || exit"

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -164,6 +164,7 @@ class SimtelRunnerRayTracing(SimtelRunner):
         command += f" -c {self.telescope_model.get_config_file()}"
         command += " -I../cfg/CTA"
         command += f" -I{self.telescope_model.get_config_directory()}"
+        command += super()._config_option("random_state", "none")
         command += super()._config_option("IMAGING_LIST", str(self._photons_file))
         command += super()._config_option("stars", str(self._stars_file))
         command += super()._config_option(


### PR DESCRIPTION
Set the random state to "none" in order to reduce the number of `telarray_rand.conf.used` files to just one.
Fixes #645.