### PR TITLE
Remove TODOs and FIXMEs

### DIFF
--- a/simtools/applications/compare_cumulative_psf.py
+++ b/simtools/applications/compare_cumulative_psf.py
@@ -71,9 +71,6 @@
 
         d80 in cm = 3.3662565358159013
 
-    .. todo::
-
-        * Change default model to default (after this feature is implemented in db_handler)
 """
 
 import logging

--- a/simtools/applications/sim_showers_for_trigger_rates.py
+++ b/simtools/applications/sim_showers_for_trigger_rates.py
@@ -32,9 +32,10 @@
         Zenith angle in deg.
     azimuth (float, optional)
         Azimuth angle in deg.
-    output (str, optional)
-        Path of the directory to store the output simulations. By default, \
-        the standard output directory defined by config will be used.
+    data_directory (str, optional)
+        The location of the output directories corsika-data.
+        the label is added to the data_directory, such that the output
+        will be written to `data_directory/label/corsika-data`.
     test (activation mode, optional)
         If activated, no job will be submitted. Instead, an example of the \
         run script will be printed.
@@ -109,12 +110,16 @@ def _parse(label=None, description=None):
     config.parser.add_argument("--nevents", help="Number of events/run", type=int, default=100000)
     config.parser.add_argument("--zenith", help="Zenith angle in deg", type=float, default=20)
     config.parser.add_argument("--azimuth", help="Azimuth angle in deg", type=float, default=0)
-    # TODO confusing with output_path?
     config.parser.add_argument(
-        "--output",
-        help="Path of the output directory where the simulations will be saved.",
-        type=str,
-        default=None,
+        "--data_directory",
+        help=(
+            "The directory where to save the corsika-data output directories."
+            "the label is added to the data_directory, such that the output"
+            "will be written to `data_directory/label/corsika-data`."
+        ),
+        type=str.lower,
+        required=False,
+        default="./simtools-output/",
     )
     return config.initialize(telescope_model=True, job_submission=True, db_config=True)
 
@@ -131,9 +136,8 @@ def main():
     # Output directory to save files related directly to this app
     _io_handler = io_handler.IOHandler()
     output_dir = _io_handler.get_output_directory(label, sub_dir="application-plots")
-    print(output_dir)
     shower_config_data = {
-        "data_directory": args_dict["output"],
+        "data_directory": Path(args_dict["data_directory"]) / label,
         "site": args_dict["site"],
         "layout_name": args_dict["array"],
         "run_range": [1, args_dict["nruns"] + 1],

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -10,8 +10,8 @@
 
     The entire simulation chain is performed, i.e., shower simulations with CORSIKA
     which are piped directly to sim_telarray using the sim_telarray multipipe mechanism.
-    This script assumes that all the necessary configuration files for CORSIKA and
-    sim_telarray are available. FIXME - This is not true at the moment, need to fix I guess.
+    This script produces all the necessary configuration files for CORSIKA and
+    sim_telarray before running simulation.
     The multipipe scripts will be produced as part of this script.
 
     This script does not provide a mechanism to submit jobs to a batch system like others

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -61,10 +61,6 @@
         simtools/simtools-output/validate_camera_efficiency/application-plots/validate_camera\
         _efficiency_MST-NectarCam-D_nsb
 
-    .. todo::
-
-        * Change default model to default (after this feature is implemented in db_handler)
-        * Fix the set_style. For some reason, sphinx cannot built docs with it on.
 """
 
 import logging

--- a/simtools/applications/validate_camera_fov.py
+++ b/simtools/applications/validate_camera_fov.py
@@ -49,10 +49,6 @@
         Saved camera plot in /workdir/external/simtools/simtools-output/validate_camera_fov\
         /application-plots/validate_camera_fov_LST-1_pixel_layout.png
 
-    .. todo::
-
-        * Change default model to default (after this feature is implemented in db_handler)
-        * Fix the set_style. For some reason, sphinx cannot built docs with it on.
 """
 
 import logging

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -3,7 +3,6 @@ import re
 from collections import defaultdict
 
 import astropy.io.ascii
-import matplotlib.pyplot as plt
 import numpy as np
 from astropy.table import Table
 
@@ -457,37 +456,6 @@ class CameraEfficiency:
             / nsb_integral
         )
         return nsb_rate_provided_spectrum, nsb_rate_ref_conditions
-
-    def plot(self, key, **kwargs):  # FIXME - remove this function, probably not needed
-        """
-        Plot key vs wavelength.
-
-        Parameters
-        ----------
-        key: str
-            cherenkov or nsb
-        **kwargs:
-            kwargs for plt.plot
-
-        Raises
-        ------
-        KeyError
-            If key is not among the valid options.
-        """
-        if key not in ["cherenkov", "nsb"]:
-            msg = "Invalid key to plot"
-            self._logger.error(msg)
-            raise KeyError(msg)
-
-        ax = plt.gca()
-        first_letter = "C" if key == "cherenkov" else "N"
-        for par in ["1", "2", "3", "4", "4x"]:
-            ax.plot(
-                self._results["wl"],
-                self._results[first_letter + par],
-                label=first_letter + par,
-                **kwargs,
-            )
 
     def plot_cherenkov_efficiency(self):
         """

--- a/simtools/corsika_simtel/corsika_simtel_runner.py
+++ b/simtools/corsika_simtel/corsika_simtel_runner.py
@@ -139,7 +139,6 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         info_for_file_name = SimtelRunnerArray.get_info_for_file_name(self, kwargs["run_number"])
         weak_pointing = any(pointing in self.label for pointing in ["divergent", "convergent"])
 
-        # TODO: Think how to create multiple run commands for various pipes (e.g., NSB levels)
         command = str(self._simtel_source_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {self.array_model.get_config_file()}"
         command += f" -I{self.array_model.get_config_directory()}"

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -151,7 +151,9 @@ class MetadataCollector:
         """
         Append association metadata set through configurator.
 
-        TODO - this function might go in future, as instrument
+        Note
+        ----
+        This function might go in future, as instrument
         information will not be given via command line.
 
         Parameters
@@ -279,7 +281,6 @@ class MetadataCollector:
         product_dict["data"]["category"] = "SIM"
         product_dict["data"]["level"] = "R1"
         product_dict["data"]["type"] = "service"
-        # TODO - introduce consistent naming of DL3 data model and model parameter schema files
         try:
             product_dict["data"]["association"] = self.schema_dict["instrument"]["class"]
         except KeyError:

--- a/simtools/model/mirrors.py
+++ b/simtools/model/mirrors.py
@@ -153,7 +153,6 @@ class Mirrors:
 
     def plot_mirror_layout(self):
         """
-        Plot the mirror layout.
-
-        TODO
+        Plot the mirror layout (not implemented yet).
         """
+        raise NotImplementedError

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -132,8 +132,9 @@ class TelescopeModel:
 
         Notes
         -----
-        Todo: Dealing with ifdef/indef etc. By now it just keeps the last version of the parameters
-        in the file.
+        This function does not deal with ifdef/indef etc., it just keeps the last version
+        of the parameters in the file. This is fine for now since we do not
+        expect to read from sim_telarray config files in the future.
 
         Parameters
         ----------


### PR DESCRIPTION
Most removals were trivial and only one required opening an issue (but it is quite broad). 

A few were removed because it is anyway planned to implement the functionality mentioned. 

In one case a note was added to the function instead to mention that it might be removed in the future. If anyone has a better idea how to do it, I am happy to hear it (I thought about marking it as deprecated, but it seems premature to do it here).

One TODO is left in the code but it should be fixed in #718.

Fixes #715.