### PR TITLE
Switch Current to released

### DIFF
--- a/simtools/applications/get_parameter.py
+++ b/simtools/applications/get_parameter.py
@@ -6,7 +6,7 @@
     Get a parameter entry from DB for a specific telescope or a site.
     The application receives a parameter name, a site, a telescope (if applicable) and \
     optionally a version. It then prints out the parameter entry.
-    If no version is provided, the value of the current model is printed..
+    If no version is provided, the value of the released model is printed..
 
     Command line arguments
     ----------------------
@@ -64,7 +64,7 @@ def main():
             "Get a parameter entry from DB for a specific telescope or a site. "
             "The application receives a parameter name a site, a telescope (if applicable), "
             " and optionally a version. It then prints out the parameter entry. "
-            "If no version is provided, the value of the current model is printed. "
+            "If no version is provided, the value of the released model is printed. "
         )
     )
     config.parser.add_argument("--parameter", help="Parameter name", type=str, required=True)

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -22,7 +22,7 @@
     telescope (str, required)
         Telescope model name (e.g. LST-1, SST-D, ...)
     model_version (str, optional)
-        Model version (default='Current')
+        Model version (default='Released')
     zenith_angle (float, optional)
         Zenith angle in degrees (between 0 and 180).
     azimuth_angle (float, optional)

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -245,7 +245,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 "--model_version",
                 help="model version",
                 type=str,
-                default="Current",
+                default="Released",
             )
 
     @staticmethod

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -1309,24 +1309,24 @@ class DatabaseHandler:
 
     def _convert_version_to_tagged(self, model_version, db_name):
         """Convert to tagged version, if needed."""
-        if model_version in ["Current", "Latest"]:
+        if model_version in ["Released", "Latest"]:
             return self._get_tagged_version(db_name, model_version)
 
         return model_version
 
     @staticmethod
-    def _get_tagged_version(db_name, version="Current"):
+    def _get_tagged_version(db_name, version="Released"):
         """
-        Get the tag of the "Current" or "Latest" version of the MC Model.
-        The "Current" is the latest stable MC Model,
-        the latest is the latest tag (not necessarily stable, but can be equivalent to "Current").
+        Get the tag of the "Released" or "Latest" version of the MC Model.
+        The "Released" is the latest stable MC Model,
+        the latest is the latest tag (not necessarily stable, but can be equivalent to "Released").
 
         Parameters
         ----------
         db_name: str
             the name of the DB
         version: str
-            Can be "Current" or "Latest" (default: "Current").
+            Can be "Released" or "Latest" (default: "Released").
 
         Returns
         -------
@@ -1336,12 +1336,12 @@ class DatabaseHandler:
         Raises
         ------
         ValueError
-            if version not valid. Valid versions are: 'Current' and 'Latest'.
+            if version not valid. Valid versions are: 'Released' and 'Latest'.
 
         """
 
-        if version not in ["Current", "Latest"]:
-            raise ValueError('The only default versions are "Current" or "Latest"')
+        if version not in ["Released", "Latest"]:
+            raise ValueError('The only default versions are "Released" or "Latest"')
 
         collection = DatabaseHandler.db_client[db_name].metadata
         query = {"Entry": "Simulation-Model-Tags"}

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -215,7 +215,7 @@ class ArrayLayout:
 
         db = db_handler.DatabaseHandler(mongo_db_config=self.mongo_db_config)
         self._logger.debug("Reading site parameters from DB")
-        _site_pars = db.get_site_parameters(self.site, "Current", only_applicable=True)
+        _site_pars = db.get_site_parameters(self.site, "Released", only_applicable=True)
         corsika_dict["corsika_obs_level"] = _site_pars["altitude"]["Value"] * u.Unit(
             _site_pars["altitude"]["units"]
         )
@@ -838,7 +838,7 @@ class ArrayLayout:
 
     def print_telescope_list(self, compact_printing="", corsika_z=False):
         """
-        Print list of telescopes in current layout.
+        Print list of telescopes in latest released layout.
 
         Parameters
         ----------

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -95,8 +95,8 @@ class ArrayModel:
             "model_version" not in array_config_data.keys()
             or array_config_data["model_version"] is None
         ):
-            self._logger.warning("model_version not given in array_config_data - using current")
-            self.model_version = "current"
+            self._logger.warning("model_version not given in array_config_data - using 'Released'")
+            self.model_version = "Released"
         else:
             self.model_version = names.validate_model_version_name(
                 array_config_data["model_version"]

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -48,7 +48,7 @@ class TelescopeModel:
         site,
         telescope_model_name,
         mongo_db_config,
-        model_version="Current",
+        model_version="Released",
         label=None,
     ):
         """

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -83,7 +83,7 @@ all_model_version_names = {
     "2020-06-28": ["prod5"],
     "prod4-prototype": [""],
     "default": [],
-    "Current": [],
+    "Released": [],
     "Latest": [],
 }
 

--- a/tests/resources/CTA-North-LST-1-Released_test-telescope-model.cfg
+++ b/tests/resources/CTA-North-LST-1-Released_test-telescope-model.cfg
@@ -1,0 +1,107 @@
+%==================================================
+% TELESCOPE CONFIGURATION FILE
+% Site: North
+% ModelVersion: Released
+% TelescopeModelName: LST-1
+% Label: test-telescope-model
+%==================================================
+%
+#ifdef TELESCOPE
+   echo Configuration for LST-1 - TELESCOPE $(TELESCOPE)
+#endif
+
+asum_clipping = 9999.0
+asum_offset = 0.0
+asum_shaping_file = none
+asum_threshold = 270.0
+camera_body_diameter = 348.0
+camera_body_shape = 2
+camera_config_file = camera_CTA-LST-234_analogsum21_v2020-04-14.dat
+camera_config_name = LST
+camera_config_version = 2020-06-28
+camera_filter = transmission_lst_window_No7-10_ave.dat
+camera_pixels = 1855
+camera_transmission = 1.0
+default_trigger = AnalogSum
+disc_bins = 68
+discriminator_amplitude = 6.5
+discriminator_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat
+disc_start = 3
+dish_shape_length = 2800.0
+effective_focal_length = 2930.57
+fadc_amplitude = 25.0
+fadc_bins = 75
+fadc_err_pedestal = 0.5
+fadc_lg_amplitude = 1.28
+fadc_lg_err_pedestal = 0.3
+fadc_lg_max_signal = 4288
+fadc_lg_noise = 5.7
+fadc_lg_pedestal = 400.0
+fadc_lg_var_pedestal = 0.4
+fadc_max_signal = 4249
+fadc_max_sum = 16777215
+fadc_mhz = 1024.0
+fadc_noise = 6.7
+fadc_pedestal = 400.0
+fadc_pulse_shape = pulse_LST_8dynode_pix6_20200204.dat
+fadc_sum_bins = 40
+fadc_sum_offset = 9
+fadc_var_pedestal = 0.4
+fadc_var_sensitivity = 0.01416
+focal_length = 2800.0
+focus_offset = 6.55 28 0 0
+gain_variation = 0.0187
+min_photoelectrons = 25
+min_photons = 300.0
+mirror_align_random_distance = 0.0
+mirror_align_random_horizontal = 0.0039 28 0 0
+mirror_align_random_vertical = 0.0039 28 0 0
+mirror_focal_length = 0.0
+mirror_list = mirror_CTA-S-LST_v2020-04-07.dat
+mirror_offset = 93.25
+mirror_reflection_random_angle = 0.0075 0.125 0.037
+mirror_reflectivity = ref_LST_2020-04-23.dat
+nightsky_background = all: 0.25307
+num_gains = 2
+optics_config_name = LST
+optics_config_version = 2020-04-29
+output_format = 1
+parabolic_dish = 1
+photon_delay = 19
+pixel_cells = 0
+pm_average_gain = 40000.0
+pm_collection_efficiency = 1.0
+pm_gain_index = 3.92
+pm_photoelectron_spectrum = spe_LST_2020-05-09_AP2.0e-4.dat
+pm_transit_time = 20.89 9 350 1135
+pm_voltage_variation = 0.03
+pulse_analysis = -30
+qe_variation = 0.03
+quantum_efficiency = qe_lst2-4_20200318_high+low.dat
+random_focal_length = all: 0
+store_photoelectrons = 20
+sum_after_peak = 4
+sum_before_peak = 3
+tailcut_scale = 2.6
+telescope_random_angle = 0.0
+telescope_random_error = 0.0
+telescope_transmission = 0.969 0 0 0 0 0
+transit_time_jitter = 0.7
+trigger_current_limit = 20.0
+trigger_delay_compensation = all: 0
+trigger_telescopes = 1
+discriminator_threshold = 99999.0
+dsum_threshold = 0.0
+multiplicity_offset = -0.5
+teltrig_min_sigsum = 7.8
+teltrig_min_time = 0.5
+trigger_pixels = 3
+array_window = 1000.0
+convergent_depth = 0.0
+iobuf_maximum = 1000000000
+iobuf_output_maximum = 400000000
+nsb_scaling_factor = 1.0
+only_triggered_telescopes = 1
+altitude = 2158.0
+atmospheric_transmission = atm_trans_2158_1_3_2_0_0_0.1_0.1.dat
+array_triggers = array_trigger_prod5_lapalma_extended.dat

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 from astropy import units as u
 
-import simtools.utils.general as gen
 from simtools.model.telescope_model import InvalidParameter, TelescopeModel
 
 logger = logging.getLogger()
@@ -15,18 +14,9 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
-def lst_config_file(db, io_handler):
-    test_file_name = "CTA-North-LST-1-Current_test-telescope-model.cfg"
-    db.export_file_db(
-        db_name="test-data",
-        dest=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
-        file_name=test_file_name,
-    )
-
-    cfg_file = gen.find_file(
-        test_file_name, io_handler.get_output_directory(sub_dir="model", dir_type="test")
-    )
-    return cfg_file
+def lst_config_file():
+    """Return the path to test config file for LST-1"""
+    return "tests/resources/CTA-North-LST-1-Released_test-telescope-model.cfg"
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -15,7 +15,7 @@ logger.setLevel(logging.DEBUG)
 def simtel_config_writer():
     simtel_config_writer = SimtelConfigWriter(
         site="North",
-        model_version="Current",
+        model_version="Released",
         label="test-simtel-config-writer",
         telescope_model_name="test_telecope",
     )
@@ -30,7 +30,7 @@ def layout(io_handler, db_config):
     return layout
 
 
-# @pytest.mark.skip(reason="TODO :test_write_array_config_file - KeyError: 'Current'")
+# @pytest.mark.skip(reason="TODO :test_write_array_config_file - KeyError: 'Released'")
 def test_write_array_config_file(
     simtel_config_writer, layout, telescope_model_lst, io_handler, file_has_text
 ):

--- a/tests/unit_tests/test_db_handler.py
+++ b/tests/unit_tests/test_db_handler.py
@@ -36,7 +36,7 @@ def db_cleanup_file_sandbox(db_no_config_file, random_id):
 def test_reading_db_lst(db):
     logger.info("----Testing reading LST-----")
     assert 1 == 1
-    pars = db.get_model_parameters("north", "lst-1", "Current")
+    pars = db.get_model_parameters("north", "lst-1", "Released")
     if db.mongo_db_config:
         assert pars["parabolic_dish"]["Value"] == 1
         assert pars["camera_pixels"]["Value"] == 1855
@@ -47,7 +47,7 @@ def test_reading_db_lst(db):
 
 def test_reading_db_mst_nc(db):
     logger.info("----Testing reading MST-NectarCam-----")
-    pars = db.get_model_parameters("north", "mst-NectarCam-D", "Current")
+    pars = db.get_model_parameters("north", "mst-NectarCam-D", "Released")
     if db.mongo_db_config:
         assert pars["camera_pixels"]["Value"] == 1855
     else:
@@ -56,7 +56,7 @@ def test_reading_db_mst_nc(db):
 
 def test_reading_db_mst_fc(db):
     logger.info("----Testing reading MST-FlashCam-----")
-    pars = db.get_model_parameters("north", "mst-FlashCam-D", "Current")
+    pars = db.get_model_parameters("north", "mst-FlashCam-D", "Released")
     if db.mongo_db_config:
         assert pars["camera_pixels"]["Value"] == 1764
     else:
@@ -65,7 +65,7 @@ def test_reading_db_mst_fc(db):
 
 def test_reading_db_sst(db):
     logger.info("----Testing reading SST-----")
-    pars = db.get_model_parameters("south", "sst-D", "Current")
+    pars = db.get_model_parameters("south", "sst-D", "Released")
     if db.mongo_db_config:
         assert pars["camera_pixels"]["Value"] == 2048
     else:
@@ -91,7 +91,7 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler):
     db.copy_telescope(
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
-        version_to_copy="Current",
+        version_to_copy="Released",
         new_tel_name="North-LST-Test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
@@ -107,7 +107,7 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler):
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
         telescope_model_name_db="North-LST-Test",
-        model_version="Current",
+        model_version="Released",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
         write_files=False,
@@ -126,7 +126,7 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler):
         db.read_mongo_db(
             db_name=f"sandbox_{random_id}",
             telescope_model_name_db="North-LST-Test",
-            model_version="Current",
+            model_version="Released",
             run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
             collection_name="telescopes_" + random_id,
             write_files=False,
@@ -138,7 +138,7 @@ def test_adding_parameter_version_db(db, random_id, db_cleanup, io_handler):
     db.copy_telescope(
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
-        version_to_copy="Current",
+        version_to_copy="Released",
         new_tel_name="North-LST-Test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
@@ -168,7 +168,7 @@ def test_update_parameter_db(db, random_id, db_cleanup, io_handler):
     db.copy_telescope(
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
-        version_to_copy="Current",
+        version_to_copy="Released",
         new_tel_name="North-LST-Test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
@@ -206,7 +206,7 @@ def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler):
     db.copy_telescope(
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
-        version_to_copy="Current",
+        version_to_copy="Released",
         new_tel_name="North-LST-Test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
@@ -236,7 +236,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     db.copy_telescope(
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
-        version_to_copy="Current",
+        version_to_copy="Released",
         new_tel_name="North-LST-Test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
@@ -252,7 +252,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     db.update_parameter_field(
         db_name=f"sandbox_{random_id}",
         telescope="North-LST-Test",
-        version="Current",
+        version="Released",
         parameter="camera_pixels",
         field="Applicable",
         new_value=False,
@@ -261,7 +261,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
         telescope_model_name_db="North-LST-Test",
-        model_version="Current",
+        model_version="Released",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
         write_files=False,
@@ -271,14 +271,14 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
 
 def test_reading_db_sites(db):
     logger.info("----Testing reading La Palma parameters-----")
-    pars = db.get_site_parameters("North", "Current")
+    pars = db.get_site_parameters("North", "Released")
     if db.mongo_db_config:
         assert pars["altitude"]["Value"] == 2158
     else:
         assert pars["altitude"] == 2158
 
     logger.info("----Testing reading Paranal parameters-----")
-    pars = db.get_site_parameters("South", "Current")
+    pars = db.get_site_parameters("South", "Released")
     if db.mongo_db_config:
         assert pars["altitude"]["Value"] == 2147
     else:
@@ -287,7 +287,7 @@ def test_reading_db_sites(db):
 
 def test_separating_get_and_write(db, io_handler):
     logger.info("----Testing getting parameters and exporting model files-----")
-    pars = db.get_model_parameters("north", "lst-1", "Current")
+    pars = db.get_model_parameters("north", "lst-1", "Released")
 
     file_list = list()
     for par_now in pars.values():


### PR DESCRIPTION
This PR changes from the name "Current" for the latest "Released" telescope model to the name "Released" cause it's clearer. 
Fixes #416.