### PR TITLE
Remove uploading of code coverage report (XML) format as artefact

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -104,9 +104,3 @@ jobs:
         if: contains(matrix.extra-args, 'codecov')
         with:
           token: ${{ secrets.CODECOV_SIMTOOLS_TOKEN }}
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
-        with:
-          name: code-coverage-report
-          path: coverage.xml


### PR DESCRIPTION
Code coverage reports in XML format are archived as artefact for each run of the unit tests, see e.g., the artefact on the lower part of [this page](https://github.com/gammasim/simtools/actions/runs/7246859654).

This is a leftover from earlier times and we do not use this anymore (the codecov action workflow is executed in the step before). I therefore removed this workflow step.