### PR TITLE
Docker images for simtools-dev and simtools-prod should not be pushed on "pull request"

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -94,7 +94,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'pull_request' || github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+            ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
Docker images  for simtools-dev and simtools-prod  are currently pushed to the package repository each time a pull request is issued.

This is inconsistent, as `docker pull simtools-dev:latest` might result in an image generated from a pull request under review (possible with bugs). 

Removed the event "pull_request" from the push command, meaning that the image is still built but not pushed.