### PR TITLE
Set branch for simtools-prod testing

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
-          build-args: "${GITHUB_REF#refs/heads/}"
+          build-args: "BUILD_BRANCH=${GITHUB_REF#refs/heads/}"
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
-          build-args: "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          build-args: "${GITHUB_REF#refs/heads/}"
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
-          build-args: "BUILD_BRANCH=${GITHUB_REF#refs/heads/}"
+          build-args: BUILD_BRANCH=${GITHUB_REF#refs/heads/}
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Set build arguments
         run: |
-          echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-
+          echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,8 +34,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-#        type: ['dev', 'prod']
-        type: ['prod']
+        type: ['dev', 'prod']
 
     steps:
       - name: Checkout repository
@@ -44,7 +43,6 @@ jobs:
       - name: Set build arguments
         run: |
           echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-          echo "Branch name is ${{ env.BUILD_BRANCH }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -76,7 +74,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
-          build-args: BUILD_BRANCH= ${{ env.BUILD_BRANCH }}
+          build-args: BUILD_BRANCH=${{ env.BUILD_BRANCH }}
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -70,6 +70,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
+          build-args: "${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,11 +34,17 @@ jobs:
       packages: write
     strategy:
       matrix:
-        type: ['dev', 'prod']
+#        type: ['dev', 'prod']
+        type: ['prod']
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set build arguments
+        run: |
+          echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          echo "Branch name is ${{ env.BUILD_BRANCH }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -70,7 +76,7 @@ jobs:
         if: matrix.type == 'prod'
         with:
           context: .
-          build-args: BUILD_BRANCH=${GITHUB_REF#refs/heads/}
+          build-args: BUILD_BRANCH= ${{ env.BUILD_BRANCH }}
           load: true
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ env.TEST_TAG }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -42,7 +42,11 @@ jobs:
 
       - name: Set build arguments
         run: |
-          echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+            echo "BUILD_BRANCH=${GITHUB_HEAD_REF}" >> "$GITHUB_ENV"
+          else
+            echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
+          fi
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -1,6 +1,7 @@
 FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
+ARG BUILD_BRANCH=main
 
 RUN microdnf update -y && microdnf install -y \
     git \
@@ -8,7 +9,7 @@ RUN microdnf update -y && microdnf install -y \
     python3.11-devel && \
     microdnf clean all
 
-RUN git clone -b main https://github.com/gammasim/simtools.git --depth 1
+RUN git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1
 RUN cd /workdir/ && \
     python3.11 -m venv env && \
     source env/bin/activate && \


### PR DESCRIPTION
Addresses issue #755 

For testing, the container simtools-prod used until always the main branch, even if another branch should be tested. This merge request introduces a build arg for the container building which is set in the github workflow to the current branch.