### PR TITLE
Remove workflow dispatch for docker push

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -102,7 +102,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+            ${{ github.event_name == 'release' || github.event.pull_request.merged == true }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
Do not push to package repository for 'workflow_dispatch' (this is used for testing; so those images should not be in the package repository).