### PR TITLE
Remove collect_dict_from_file function from general.py; Rename collect_data_from_yaml_or_dict

### DIFF
--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -66,7 +66,7 @@ def main():
 
     _io_handler = io_handler.IOHandler()
 
-    corsika_pars = gen.collect_data_from_yaml_or_dict(
+    corsika_pars = gen.collect_data_from_file_or_dict(
         _io_handler.get_input_data_file("parameters", "corsika_parameters.yml"), None
     )
 

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -66,7 +66,7 @@ def _validate_yaml_or_json_file(args_dict, logger):
     """
 
     try:
-        data = gen.collect_data_from_file_or_dict(in_yaml=args_dict["file_name"], in_dict=None)
+        data = gen.collect_data_from_file_or_dict(file_name=args_dict["file_name"], in_dict=None)
     except FileNotFoundError:
         logger.error(f"Input file {args_dict['file_name']} not found")
         raise

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -66,7 +66,7 @@ def _validate_yaml_or_json_file(args_dict, logger):
     """
 
     try:
-        data = gen.collect_data_from_yaml_or_dict(in_yaml=args_dict["file_name"], in_dict=None)
+        data = gen.collect_data_from_file_or_dict(in_yaml=args_dict["file_name"], in_dict=None)
     except FileNotFoundError:
         logger.error(f"Input file {args_dict['file_name']} not found")
         raise

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -66,13 +66,13 @@ class CameraEfficiency:
         self._results = None
         self._has_results = False
 
-        _config_data_in = gen.collect_data_from_yaml_or_dict(
+        _config_data_in = gen.collect_data_from_file_or_dict(
             config_file, config_data, allow_empty=True
         )
         _parameter_file = self.io_handler.get_input_data_file(
             "parameters", "camera-efficiency_parameters.yml"
         )
-        _parameters = gen.collect_data_from_yaml_or_dict(_parameter_file, None)
+        _parameters = gen.collect_data_from_file_or_dict(_parameter_file, None)
         self.config = gen.validate_config_data(_config_data_in, _parameters)
 
         self._load_files()

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -287,7 +287,7 @@ class Configurator:
 
         try:
             self._logger.debug(f"Reading configuration from {config_file}")
-            _config_dict = gen.collect_data_from_yaml_or_dict(
+            _config_dict = gen.collect_data_from_file_or_dict(
                 in_yaml=config_file, in_dict=None, allow_empty=True
             )
             # yaml parser adds \n in multiline strings, remove them

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -288,7 +288,7 @@ class Configurator:
         try:
             self._logger.debug(f"Reading configuration from {config_file}")
             _config_dict = gen.collect_data_from_file_or_dict(
-                in_yaml=config_file, in_dict=None, allow_empty=True
+                file_name=config_file, in_dict=None, allow_empty=True
             )
             # yaml parser adds \n in multiline strings, remove them
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -10,7 +10,7 @@ import simtools.utils.general as gen
 from simtools.io_operations import io_handler
 from simtools.layout.array_layout import ArrayLayout
 from simtools.utils import names
-from simtools.utils.general import collect_data_from_yaml_or_dict
+from simtools.utils.general import collect_data_from_file_or_dict
 
 __all__ = [
     "CorsikaConfig",
@@ -113,7 +113,7 @@ class CorsikaConfig:
 
         self._corsika_parameters = self.load_corsika_parameters_file(corsika_parameters_file)
 
-        corsika_config_data = collect_data_from_yaml_or_dict(
+        corsika_config_data = collect_data_from_file_or_dict(
             corsika_config_file, corsika_config_data
         )
         self.set_user_parameters(corsika_config_data)

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -17,7 +17,7 @@ from eventio import IACTFile
 from simtools import version
 from simtools.io_operations import io_handler
 from simtools.io_operations.hdf5_handler import fill_hdf5_table
-from simtools.utils.general import collect_data_from_yaml_or_dict
+from simtools.utils.general import collect_data_from_file_or_dict
 from simtools.utils.geometry import convert_2d_to_radial_distr, rotate
 from simtools.utils.names import sanitize_name
 
@@ -344,7 +344,7 @@ class CorsikaHistograms:
             input_dict = input_config
         else:
             input_yaml = input_config
-        self._hist_config = collect_data_from_yaml_or_dict(input_yaml, input_dict, allow_empty=True)
+        self._hist_config = collect_data_from_file_or_dict(input_yaml, input_dict, allow_empty=True)
 
     def hist_config_to_yaml(self, file_name=None):
         """

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -9,7 +9,7 @@ from simtools.corsika.corsika_config import (
 )
 from simtools.io_operations import io_handler
 from simtools.utils import names
-from simtools.utils.general import collect_data_from_yaml_or_dict
+from simtools.utils.general import collect_data_from_file_or_dict
 
 __all__ = ["CorsikaRunner", "MissingRequiredEntryInCorsikaConfig"]
 
@@ -107,7 +107,7 @@ class CorsikaRunner:
         self._logger.debug(f"Creating output dir {self._output_directory}, if needed,")
 
         self._corsika_parameters_file = corsika_parameters_file
-        corsika_config_data = collect_data_from_yaml_or_dict(
+        corsika_config_data = collect_data_from_file_or_dict(
             corsika_config_file, corsika_config_data
         )
         self._load_corsika_config_data(corsika_config_data)

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -139,7 +139,7 @@ class MetadataCollector:
         """
 
         try:
-            return gen.collect_data_from_yaml_or_dict(in_yaml=self.schema_file, in_dict=None)
+            return gen.collect_data_from_file_or_dict(in_yaml=self.schema_file, in_dict=None)
         except gen.InvalidConfigData:
             self._logger.debug(f"No valid schema file provided ({self.schema_file}).")
         return {}
@@ -272,7 +272,7 @@ class MetadataCollector:
         if Path(metadata_file_name).suffix == ".yml":
             try:
                 self._logger.debug("Reading meta data from %s", metadata_file_name)
-                _input_metadata = gen.collect_data_from_yaml_or_dict(
+                _input_metadata = gen.collect_data_from_file_or_dict(
                     in_yaml=metadata_file_name, in_dict=None
                 )
             except (gen.InvalidConfigData, FileNotFoundError):

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -139,7 +139,7 @@ class MetadataCollector:
         """
 
         try:
-            return gen.collect_data_from_file_or_dict(in_yaml=self.schema_file, in_dict=None)
+            return gen.collect_data_from_file_or_dict(file_name=self.schema_file, in_dict=None)
         except gen.InvalidConfigData:
             self._logger.debug(f"No valid schema file provided ({self.schema_file}).")
         return {}
@@ -273,7 +273,7 @@ class MetadataCollector:
             try:
                 self._logger.debug("Reading meta data from %s", metadata_file_name)
                 _input_metadata = gen.collect_data_from_file_or_dict(
-                    in_yaml=metadata_file_name, in_dict=None
+                    file_name=metadata_file_name, in_dict=None
                 )
             except (gen.InvalidConfigData, FileNotFoundError):
                 self._logger.error("Failed reading metadata from %s", metadata_file_name)

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -92,7 +92,7 @@ def _load_schema(schema_file=None):
     if schema_file is None:
         schema_file = files("simtools").joinpath(simtools.constants.METADATA_JSON_SCHEMA)
 
-    schema = gen.collect_data_from_yaml_or_dict(in_yaml=schema_file, in_dict=None)
+    schema = gen.collect_data_from_file_or_dict(in_yaml=schema_file, in_dict=None)
     _logger.debug(f"Loading schema from {schema_file}")
 
     return schema, schema_file

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -92,7 +92,7 @@ def _load_schema(schema_file=None):
     if schema_file is None:
         schema_file = files("simtools").joinpath(simtools.constants.METADATA_JSON_SCHEMA)
 
-    schema = gen.collect_data_from_file_or_dict(in_yaml=schema_file, in_dict=None)
+    schema = gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)
     _logger.debug(f"Loading schema from {schema_file}")
 
     return schema, schema_file

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -82,7 +82,7 @@ class DataValidator:
 
         try:
             if Path(self.data_file_name).suffix in (".yml", ".yaml"):
-                self.data = gen.collect_data_from_yaml_or_dict(self.data_file_name, None)
+                self.data = gen.collect_data_from_file_or_dict(self.data_file_name, None)
                 self._logger.info(f"Validating data from: {self.data_file_name}")
             else:
                 self.data_table = Table.read(self.data_file_name, guess=True, delimiter=r"\s")
@@ -490,15 +490,20 @@ class DataValidator:
         dict
            validation schema
 
+        Raises
+        ------
+        KeyError
+            if 'data' can not be read from dict in schema file
+
         """
 
         try:
             if Path(schema_file).is_dir():
-                return gen.collect_dict_from_file(
-                    file_path=schema_file,
-                    file_name=parameter + ".schema.yml",
+                return gen.collect_data_from_file_or_dict(
+                    in_yaml=Path(schema_file) / (parameter + ".schema.yml"),
+                    in_dict=None,
                 )["data"]
-            return gen.collect_dict_from_file(schema_file)["data"]
+            return gen.collect_data_from_file_or_dict(in_yaml=schema_file, in_dict=None)["data"]
         except KeyError:
             self._logger.error(f"Error reading validation schema from {schema_file}")
             raise

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -530,10 +530,10 @@ class DataValidator:
         try:
             if Path(schema_file).is_dir():
                 return gen.collect_data_from_file_or_dict(
-                    in_yaml=Path(schema_file) / (parameter + ".schema.yml"),
+                    file_name=Path(schema_file) / (parameter + ".schema.yml"),
                     in_dict=None,
                 )["data"]
-            return gen.collect_data_from_file_or_dict(in_yaml=schema_file, in_dict=None)["data"]
+            return gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)["data"]
         except KeyError:
             self._logger.error(f"Error reading validation schema from {schema_file}")
             raise

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -11,7 +11,7 @@ from simtools.io_operations import io_handler
 from simtools.layout.geo_coordinates import GeoCoordinates
 from simtools.layout.telescope_position import TelescopePosition
 from simtools.utils import names
-from simtools.utils.general import collect_data_from_yaml_or_dict
+from simtools.utils.general import collect_data_from_file_or_dict
 
 __all__ = ["InvalidTelescopeListFile", "ArrayLayout"]
 
@@ -182,7 +182,7 @@ class ArrayLayout:
         """
         if file_name is None:
             try:
-                corsika_parameters_dict = collect_data_from_yaml_or_dict(
+                corsika_parameters_dict = collect_data_from_file_or_dict(
                     self.io_handler.get_input_data_file("parameters", "corsika_parameters.yml"),
                     None,
                 )
@@ -193,7 +193,7 @@ class ArrayLayout:
             if not isinstance(file_name, Path):
                 file_name = Path(file_name)
             if file_name.exists():
-                corsika_parameters_dict = collect_data_from_yaml_or_dict(file_name, None)
+                corsika_parameters_dict = collect_data_from_file_or_dict(file_name, None)
             else:
                 raise FileNotFoundError
 

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -7,7 +7,7 @@ from simtools.layout.array_layout import ArrayLayout
 from simtools.model.telescope_model import TelescopeModel
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 from simtools.utils import names
-from simtools.utils.general import collect_data_from_yaml_or_dict
+from simtools.utils.general import collect_data_from_file_or_dict
 
 __all__ = ["ArrayModel", "InvalidArrayConfigData"]
 
@@ -47,7 +47,7 @@ class ArrayModel:
         self.model_version = None
         self._config_file_path = None
         self.io_handler = io_handler.IOHandler()
-        array_config_data = collect_data_from_yaml_or_dict(array_config_file, array_config_data)
+        array_config_data = collect_data_from_file_or_dict(array_config_file, array_config_data)
         self._load_array_data(array_config_data)
         self._set_config_file_directory()
         self._build_array_model()

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -71,7 +71,7 @@ class RayTracing:
         self._telescope_model = self._validate_telescope_model(telescope_model)
 
         self.config = gen.validate_config_data(
-            gen.collect_data_from_yaml_or_dict(config_file, config_data),
+            gen.collect_data_from_file_or_dict(config_file, config_data),
             SimtelRunnerRayTracing.ray_tracing_default_configuration(False),
         )
 

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -68,11 +68,11 @@ class SimtelRunnerArray(SimtelRunner):
         self._base_directory = self.io_handler.get_output_directory(self.label, "array-simulator")
 
         # Loading config_data
-        _config_data_in = gen.collect_data_from_yaml_or_dict(config_file, config_data)
+        _config_data_in = gen.collect_data_from_file_or_dict(config_file, config_data)
         _parameter_file = self.io_handler.get_input_data_file(
             "parameters", "simtel-runner-array_parameters.yml"
         )
-        _parameters = gen.collect_data_from_yaml_or_dict(_parameter_file, None)
+        _parameters = gen.collect_data_from_file_or_dict(_parameter_file, None)
         self.config = gen.validate_config_data(_config_data_in, _parameters)
 
         self._load_simtel_data_directories()

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -83,7 +83,7 @@ class SimtelRunnerRayTracing(SimtelRunner):
 
         # Loading config_data
         self.config = gen.validate_config_data(
-            gen.collect_data_from_yaml_or_dict(config_file, config_data),
+            gen.collect_data_from_file_or_dict(config_file, config_data),
             self.ray_tracing_default_configuration(True),
         )
 

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -177,7 +177,7 @@ class Simulator:
             Path to yaml file containing configurable data.
 
         """
-        simulator_config_data = gen.collect_data_from_yaml_or_dict(config_file, config_data)
+        simulator_config_data = gen.collect_data_from_file_or_dict(config_file, config_data)
         if self.simulator == "corsika":
             self._load_corsika_config_and_model(simulator_config_data)
         if self.simulator == "simtel":
@@ -236,7 +236,7 @@ class Simulator:
         _parameter_file = self.io_handler.get_input_data_file(
             "parameters", "array-simulator_parameters.yml"
         )
-        _parameters = gen.collect_data_from_yaml_or_dict(_parameter_file, None)
+        _parameters = gen.collect_data_from_file_or_dict(_parameter_file, None)
         self.config = gen.validate_config_data(_rest_config, _parameters, ignore_unidentified=True)
 
         self.array_model = ArrayModel(

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -369,13 +369,13 @@ def collect_data_from_http(url):
     return data
 
 
-def collect_data_from_file_or_dict(in_yaml, in_dict, allow_empty=False):
+def collect_data_from_file_or_dict(file_name, in_dict, allow_empty=False):
     """
     Collect input data that can be given either as a dict or as a yaml/json file.
 
     Parameters
     ----------
-    in_yaml: str
+    file_name: str
         Name of the yaml/json file.
     in_dict: dict
         Data as dict.
@@ -388,22 +388,22 @@ def collect_data_from_file_or_dict(in_yaml, in_dict, allow_empty=False):
         Data as dict.
     """
 
-    if in_yaml is not None:
+    if file_name is not None:
         if in_dict is not None:
-            _logger.warning("Both in_dict in_yaml were given - in_yaml will be used")
-        if is_url(str(in_yaml)):
-            data = collect_data_from_http(in_yaml)
-        elif Path(in_yaml).suffix.lower() == ".json":
-            with open(in_yaml, encoding="utf-8") as file:
+            _logger.warning("Both in_dict and file_name were given - file_name will be used")
+        if is_url(str(file_name)):
+            data = collect_data_from_http(file_name)
+        elif Path(file_name).suffix.lower() == ".json":
+            with open(file_name, encoding="utf-8") as file:
                 data = json.load(file)
         else:
-            with open(in_yaml, encoding="utf-8") as file:
+            with open(file_name, encoding="utf-8") as file:
                 data = yaml.load(file)
         return data
     if in_dict is not None:
         return dict(in_dict)
 
-    msg = "Input has not been provided (neither by yaml file, nor by dict)"
+    msg = "Input has not been provided (neither by file, nor by dict)"
     if allow_empty:
         _logger.debug(msg)
         return None

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -20,7 +20,7 @@ from astropy.io.misc import yaml
 
 __all__ = [
     "change_dict_keys_case",
-    "collect_data_from_yaml_or_dict",
+    "collect_data_from_file_or_dict",
     "collect_final_lines",
     "collect_kwargs",
     "InvalidConfigData",
@@ -369,7 +369,7 @@ def collect_data_from_http(url):
     return data
 
 
-def collect_data_from_yaml_or_dict(in_yaml, in_dict, allow_empty=False):
+def collect_data_from_file_or_dict(in_yaml, in_dict, allow_empty=False):
     """
     Collect input data that can be given either as a dict or as a yaml/json file.
 
@@ -410,42 +410,6 @@ def collect_data_from_yaml_or_dict(in_yaml, in_dict, allow_empty=False):
 
     _logger.debug(msg)
     raise InvalidConfigData(msg)
-
-
-def collect_dict_from_file(file_path, file_name=None):
-    """
-    Collect input data from a file.
-
-    File_path can be a yaml file name or a directory.
-    In the latter case, file_name is used to find the file.
-
-    Note that this method returns an empty dict if the file is not found
-    (while gen.collect_data_from_yaml_or_dict returns None).
-
-    Parameters
-    ----------
-    file_path: str
-        Name of the yaml file or directory.
-    file_name: str
-        Name of the file to be found in the directory.
-
-    """
-
-    _dict = {}
-    try:
-        _dict = (
-            collect_data_from_yaml_or_dict(in_yaml=file_path, in_dict=None, allow_empty=True) or {}
-        )
-    except IsADirectoryError:
-        try:
-            _file = Path(file_path).joinpath(file_name)
-            _dict = (
-                collect_data_from_yaml_or_dict(in_yaml=_file, in_dict=None, allow_empty=True) or {}
-            )
-        except (TypeError, KeyError):
-            pass
-
-    return _dict
 
 
 def collect_kwargs(label, in_kwargs):

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -74,7 +74,7 @@ def get_list_of_test_configurations(get_test_names=False):
         # remove new line characters from config - otherwise issues
         # with especially long file names
         _dict = gen.remove_substring_recursively_from_dict(
-            gen.collect_data_from_file_or_dict(in_yaml=config_file, in_dict=None), substring="\n"
+            gen.collect_data_from_file_or_dict(file_name=config_file, in_dict=None), substring="\n"
         )
         configs.append(_dict.get("CTA_SIMPIPE", None))
 

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -74,7 +74,7 @@ def get_list_of_test_configurations(get_test_names=False):
         # remove new line characters from config - otherwise issues
         # with especially long file names
         _dict = gen.remove_substring_recursively_from_dict(
-            gen.collect_data_from_yaml_or_dict(in_yaml=config_file, in_dict=None), substring="\n"
+            gen.collect_data_from_file_or_dict(in_yaml=config_file, in_dict=None), substring="\n"
         )
         configs.append(_dict.get("CTA_SIMPIPE", None))
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -34,35 +34,35 @@ def test_collect_dict_data(args_dict, io_handler, caplog) -> None:
         with open(test_yaml_file, "w") as output:
             yaml.dump(dict_for_yaml, output, sort_keys=False)
 
-    d1 = gen.collect_data_from_yaml_or_dict(None, in_dict)
+    d1 = gen.collect_data_from_file_or_dict(None, in_dict)
     assert "k2" in d1.keys()
     assert d1["k1"] == 2
 
-    d2 = gen.collect_data_from_yaml_or_dict(test_yaml_file, None)
+    d2 = gen.collect_data_from_file_or_dict(test_yaml_file, None)
     assert "k3" in d2.keys()
     assert d2["k4"] == ["bla", 2]
 
-    d3 = gen.collect_data_from_yaml_or_dict(test_yaml_file, in_dict)
+    d3 = gen.collect_data_from_file_or_dict(test_yaml_file, in_dict)
     assert d3 == d2
 
-    assert gen.collect_data_from_yaml_or_dict(None, None, allow_empty=True) is None
+    assert gen.collect_data_from_file_or_dict(None, None, allow_empty=True) is None
     assert "Input has not been provided (neither by yaml file, nor by dict)" in caplog.text
 
     with pytest.raises(InvalidConfigData):
-        gen.collect_data_from_yaml_or_dict(None, None, allow_empty=False)
+        gen.collect_data_from_file_or_dict(None, None, allow_empty=False)
         assert "Input has not been provided (neither by yaml file, nor by dict)" in caplog.text
 
 
 def test_collect_dict_from_url(io_handler) -> None:
     _file = "tests/resources/test_parameters.yml"
-    _reference_dict = gen.collect_data_from_yaml_or_dict(_file, None)
+    _reference_dict = gen.collect_data_from_file_or_dict(_file, None)
 
     _url = "https://raw.githubusercontent.com/gammasim/simtools/main/"
     _url_dict = gen.collect_data_from_http(_url + _file)
 
     assert _reference_dict == _url_dict
 
-    _dict = gen.collect_data_from_yaml_or_dict(_url + _file, None)
+    _dict = gen.collect_data_from_file_or_dict(_url + _file, None)
     assert isinstance(_dict, dict)
     assert len(_dict) > 0
 
@@ -71,32 +71,9 @@ def test_collect_dict_from_url(io_handler) -> None:
         gen.collect_data_from_http(_url + _file)
 
 
-def test_collect_dict_from_file() -> None:
-    # Test 1: file_path is a yaml file
-    file_path = "tests/resources/test_parameters.yml"
-    file_name = None
-    _dict = gen.collect_dict_from_file(file_path, file_name)
-    assert isinstance(_dict, dict)
-    assert len(_dict) == 7
-
-    # Test 2: file_path is a directory
-    file_path = "tests/resources/"
-    file_name = "test_parameters.yml"
-    _dict = gen.collect_dict_from_file(file_path, file_name)
-    assert isinstance(_dict, dict)
-    assert len(_dict) == 7
-
-    # Test 3: file_path is a directory, but file_name is not given
-    file_path = "tests/resources/"
-    file_name = None
-    _dict = gen.collect_dict_from_file(file_path, file_name)
-    assert isinstance(_dict, dict)
-    assert len(_dict) == 0
-
-
 def test_validate_config_data(args_dict, io_handler, caplog) -> None:
     parameter_file = io_handler.get_input_data_file(file_name="test_parameters.yml", test=True)
-    parameters = gen.collect_data_from_yaml_or_dict(parameter_file, None)
+    parameters = gen.collect_data_from_file_or_dict(parameter_file, None)
 
     validated_data = gen.validate_config_data(
         config_data=None,
@@ -545,7 +522,7 @@ def test_is_url():
 
 def test_collect_data_dict_from_json():
     file = "tests/resources/altitude.json"
-    data = gen.collect_data_from_yaml_or_dict(file, None)
+    data = gen.collect_data_from_file_or_dict(file, None)
     assert len(data) == 5
     assert data["units"] == "m"
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -531,8 +531,6 @@ def test_collect_data_from_http():
     file = "tests/resources/test_parameters.yml"
     url = "https://raw.githubusercontent.com/gammasim/simtools/main/"
 
-    # TEMPORARY - will be changed to 'main' before merging (this file is adding in this PR)
-    url = "https://raw.githubusercontent.com/gammasim/simtools/json-reader/"
     data = gen.collect_data_from_http(url + file)
     assert isinstance(data, dict)
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -46,11 +46,11 @@ def test_collect_dict_data(args_dict, io_handler, caplog) -> None:
     assert d3 == d2
 
     assert gen.collect_data_from_file_or_dict(None, None, allow_empty=True) is None
-    assert "Input has not been provided (neither by yaml file, nor by dict)" in caplog.text
+    assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
 
     with pytest.raises(InvalidConfigData):
         gen.collect_data_from_file_or_dict(None, None, allow_empty=False)
-        assert "Input has not been provided (neither by yaml file, nor by dict)" in caplog.text
+        assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
 
 
 def test_collect_dict_from_url(io_handler) -> None:


### PR DESCRIPTION
Follow suggestion from @VictorBarbosaMartins during the PR #763 discussion to rename `collect_data_from_yaml_or_dict` to `collect_data_from_file_or_dict`. This reflects better the added functionality of reading also json files.

Remove function `collect_dict_from_file` from general.py, as it provided almost the same functionality as `collect_data_from_yaml_or_dict`.

Removes also the temporary url forgotten in tests/unit_tests/utils/test_general.py (from PR 763).
