### PR TITLE
Fix push to package registry for merge to main

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -71,7 +71,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'schedule'}}
+            ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-simtelarray
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -102,7 +102,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'release' || github.event.pull_request.merged == true }}
+            ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
sim-prod images are not pushed to the registry after merge to main.

This can also be seen in the last lines of the step "Push Docker images" in https://github.com/gammasim/simtools/actions/runs/7410884476/job/20164135774:

```
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

Changed this with the pull request.

Obviously this can only be tested after a merge to main....although I have changed it in the same way in another project and it successfully worked there, see https://github.com/GernotMaier/VTS-SimPipe/actions/runs/7422132746/job/20196828380 with:
```
 #23 exporting to image
#23 pushing layers 3.8s done
#23 pushing manifest for ghcr.io/gernotmaier/vtsimpipe-corsika:20240105-130218@sha256:89ac03fbb32252f87bbd7a4affe00718d5dbdd420dbd923e01b423238f00cbe2
#23 pushing manifest for ghcr.io/gernotmaier/vtsimpipe-corsika:20240105-130218@sha256:89ac03fbb32252f87bbd7a4affe00718d5dbdd420dbd923e01b423238f00cbe2 2.4s done
#23 pushing layers 0.3s done
#23 pushing manifest for ghcr.io/gernotmaier/vtsimpipe-corsika:latest@sha256:89ac03fbb32252f87bbd7a4affe00718d5dbdd420dbd923e01b423238f00cbe2
#23 pushing manifest for ghcr.io/gernotmaier/vtsimpipe-corsika:latest@sha256:89ac03fbb32252f87bbd7a4affe00718d5dbdd420dbd923e01b423238f00cbe2 1.1s done
```

Final check will be after this PR is merge to main, to check in the package repository that a new package is generated.
