### PR TITLE
Simplify usage of simtools-validate-file-using-schema

### DIFF
--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -61,7 +61,9 @@ def _parse(label, description):
 
 def _validate_yaml_or_json_file(args_dict, logger):
     """
-    Validate a yaml or json file
+    Validate a yaml or json file.
+    Schema is either given as command line argument, read from the meta_schema_url entry
+    in the data, or read from the metadata.
 
     """
 
@@ -71,8 +73,15 @@ def _validate_yaml_or_json_file(args_dict, logger):
         logger.error(f"Input file {args_dict['file_name']} not found")
         raise
 
-    _collector = metadata_collector.MetadataCollector(args_dict)
-    print("FFF", _collector.get_data_model_schema_file_name())
+    if args_dict.get("schema", None) is None and "meta_schema_url" in data:
+        args_dict["schema"] = data["meta_schema_url"]
+        logger.debug(f'Using schema from meta_schema_url: {args_dict["schema"]}')
+    if args_dict.get("schema", None) is None:
+        _collector = metadata_collector.MetadataCollector(
+            None, metadata_file_name=args_dict["file_name"]
+        )
+        args_dict["schema"] = _collector.get_data_model_schema_file_name()
+        logger.debug(f'Using schema from meta_data_url: {args_dict["schema"]}')
 
     metadata_model.validate_schema(data, args_dict.get("schema", None))
 

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import simtools.utils.general as gen
 from simtools.configuration import configurator
-from simtools.data_model import metadata_model, validate_data
+from simtools.data_model import metadata_collector, metadata_model, validate_data
 
 
 def _parse(label, description):
@@ -55,7 +55,7 @@ def _parse(label, description):
 
     config = configurator.Configurator(label=label, description=description)
     config.parser.add_argument("--file_name", help="file to be validated", required=True)
-    config.parser.add_argument("--schema", help="json schema file", required=True)
+    config.parser.add_argument("--schema", help="json schema file", required=False)
     return config.initialize(paths=False)
 
 
@@ -71,7 +71,10 @@ def _validate_yaml_or_json_file(args_dict, logger):
         logger.error(f"Input file {args_dict['file_name']} not found")
         raise
 
-    metadata_model.validate_schema(data, args_dict["schema"])
+    _collector = metadata_collector.MetadataCollector(args_dict)
+    print("FFF", _collector.get_data_model_schema_file_name())
+
+    metadata_model.validate_schema(data, args_dict.get("schema", None))
 
 
 def _validate_ecsv_file(args_dict):

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import simtools.utils.general as gen
 from simtools.configuration import configurator
-from simtools.data_model import metadata_collector, metadata_model, validate_data
+from simtools.data_model import data_reader, metadata_collector, validate_data
 
 
 def _parse(label, description):
@@ -73,24 +73,12 @@ def _validate_yaml_or_json_file(args_dict, logger):
 
     """
 
-    try:
-        data = gen.collect_data_from_file_or_dict(file_name=args_dict["file_name"], in_dict=None)
-    except FileNotFoundError:
-        logger.error(f"Input file {args_dict['file_name']} not found")
-        raise
-
-    if args_dict.get("schema", None) is None and "meta_schema_url" in data:
-        args_dict["schema"] = data["meta_schema_url"]
-        logger.debug(f'Using schema from meta_schema_url: {args_dict["schema"]}')
-    if args_dict.get("schema", None) is None:
-        _collector = metadata_collector.MetadataCollector(
-            None, metadata_file_name=args_dict["file_name"]
-        )
-        args_dict["schema"] = _collector.get_data_model_schema_file_name()
-        logger.debug(f'Using schema from meta_data_url: {args_dict["schema"]}')
-
-    metadata_model.validate_schema(data, args_dict.get("schema", None))
-    logger.debug("Successful validation of yaml/json file")
+    data_reader.read_value_from_file(
+        file_name=args_dict["file_name"],
+        schema_file=args_dict["schema"],
+        validate=True,
+    )
+    logger.debug("Successful validation of json/yaml file")
 
 
 def _validate_ecsv_file(args_dict, logger):

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -62,8 +62,8 @@ def _parse(label, description):
 def _validate_yaml_or_json_file(args_dict, logger):
     """
     Validate a yaml or json file.
-    Schema is either given as command line argument, read from the meta_schema_url entry
-    in the data, or read from the metadata.
+    Schema is either given as command line argument, read from the meta_schema_url or from
+    the metadata section of the data dictionary.
 
     """
 

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -38,12 +38,6 @@ def validate_schema(data, schema_file):
 
     """
 
-    if schema_file is None and "meta_schema_url" in data:
-        schema_file = data["meta_schema_url"]
-        _logger.debug(f"Using schema from meta_schema_url: {schema_file}")
-    if schema_file is None:
-        print("FFFFF", data)
-
     schema, schema_file = _load_schema(schema_file)
 
     try:

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -21,8 +21,6 @@ _logger = logging.getLogger(__name__)
 def validate_schema(data, schema_file):
     """
     Validate dictionary against schema.
-    If no schema is given (schema_file=None), the metadata section of the data dictionary
-    is evaluated (if present) to find the schema to be used for validation.
 
     Parameters
     ----------

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -21,6 +21,8 @@ _logger = logging.getLogger(__name__)
 def validate_schema(data, schema_file):
     """
     Validate dictionary against schema.
+    If no schema is given (schema_file=None), the metadata section of the data dictionary
+    is evaluated (if present) to find the schema to be used for validation.
 
     Parameters
     ----------
@@ -35,6 +37,12 @@ def validate_schema(data, schema_file):
         if validation fails
 
     """
+
+    if schema_file is None and "meta_schema_url" in data:
+        schema_file = data["meta_schema_url"]
+        _logger.debug(f"Using schema from meta_schema_url: {schema_file}")
+    if schema_file is None:
+        print("FFFFF", data)
 
     schema, schema_file = _load_schema(schema_file)
 

--- a/tests/integration_tests/config/validate_file_using_schema_ecsv_input_test_meta.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_ecsv_input_test_meta.yml
@@ -1,0 +1,6 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-validate-file-using-schema
+  TEST_NAME: ecsv_input_test_meta
+  CONFIGURATION:
+    FILE_NAME: tests/resources/telescope_positions-North-utm.ecsv
+    VALIDATE_METADATA: true

--- a/tests/integration_tests/config/validate_file_using_schema_json_input.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input.yml
@@ -1,6 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
-  TEST_NAME: yml_input
+  TEST_NAME: json_input
   CONFIGURATION:
     SCHEMA: >
       https://raw.githubusercontent.com/gammasim/workflows/main/schemas/altitude.schema.yml

--- a/tests/integration_tests/config/validate_file_using_schema_json_input_no_schema.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input_no_schema.yml
@@ -1,0 +1,5 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-validate-file-using-schema
+  TEST_NAME: yml_input_no_schema
+  CONFIGURATION:
+    FILE_NAME: tests/resources/altitude.json

--- a/tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml
@@ -1,5 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
-  TEST_NAME: json_input_no_schema
+  TEST_NAME: json_input_test_meta
   CONFIGURATION:
     FILE_NAME: tests/resources/altitude.json
+    VALIDATE_METADATA: true

--- a/tests/integration_tests/config/validate_file_using_schema_yml_input_no_schema.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_yml_input_no_schema.yml
@@ -1,0 +1,5 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-validate-file-using-schema
+  TEST_NAME: yml_input_no_schema
+  CONFIGURATION:
+    FILE_NAME: tests/resources/MST_mirror_2f_measurements.schema.yml

--- a/tests/resources/altitude.json
+++ b/tests/resources/altitude.json
@@ -25,7 +25,6 @@
                     "MODEL": {
                         "NAME": "altitude",
                         "VERSION": "0.1.0",
-                        "__comment": "TODO - temporary set to file in site-parameter branch (until merge)",
                         "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/site-parameters/schema/altitude.schema.yml"
                     }
                 },

--- a/tests/resources/altitude.json
+++ b/tests/resources/altitude.json
@@ -25,7 +25,8 @@
                     "MODEL": {
                         "NAME": "altitude",
                         "VERSION": "0.1.0",
-                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/altitude.schema.yml"
+                        "__comment": "TODO - temporary set to file in site-parameter branch (until merge)",
+                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/site-parameters/schema/altitude.schema.yml"
                     }
                 },
                 "FORMAT": "json",

--- a/tests/resources/reference_position_mercator.schema.yml
+++ b/tests/resources/reference_position_mercator.schema.yml
@@ -2,9 +2,9 @@
 ---
 title: Schema for reference_position_mercator parameter
 version: 0.1.0
-base_schema: simpipe-schema
-base_schema_url: https://github.com/gammasim/workflows/schema/jsonschema.yml
-base_schema_version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
 name: reference_position_mercator
 description: |-
   Latitude and longitude of site reference position

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -1,10 +1,18 @@
 #!/usr/bin/python3
 
+import json
+import logging
+
+import astropy.units as u
+import jsonschema
 import pytest
 from astropy.io.registry.base import IORegistryError
 from astropy.table import Table
 
+import simtools.utils.general as gen
 from simtools.data_model import data_reader
+
+logger = logging.getLogger()
 
 
 def test_read_table_from_file(telescope_north_test_file):
@@ -35,3 +43,81 @@ def test_read_table_from_file_and_validate(telescope_north_test_file):
         ),
         Table,
     )
+
+
+def test_read_value_from_file(tmp_test_directory):
+    assert isinstance(
+        data_reader.read_value_from_file("tests/resources/altitude.json"), u.quantity.Quantity
+    )
+
+    with pytest.raises(FileNotFoundError):
+        data_reader.read_value_from_file("this_file_does_not_exist.json", validate=True)
+
+    with pytest.raises(gen.InvalidConfigData):
+        data_reader.read_value_from_file(None, validate=False)
+
+    test_dict_1 = {"Value": 5.0}
+    with open(tmp_test_directory / "test_read_value_from_file_1.json", "w", encoding="utf-8") as f:
+        json.dump(test_dict_1, f)
+    assert isinstance(
+        data_reader.read_value_from_file(
+            tmp_test_directory / "test_read_value_from_file_1.json", validate=False
+        ),
+        float,
+    )
+
+    test_dict_2 = {"Value": "string_test"}
+    with open(tmp_test_directory / "test_read_value_from_file_2.json", "w", encoding="utf-8") as f:
+        json.dump(test_dict_2, f)
+    assert (
+        data_reader.read_value_from_file(
+            tmp_test_directory / "test_read_value_from_file_2.json", validate=False
+        )
+        == "string_test"
+    )
+
+    test_dict_3 = {"No_Value": "no_value"}
+    with open(tmp_test_directory / "test_read_value_from_file_3.json", "w", encoding="utf-8") as f:
+        json.dump(test_dict_3, f)
+    assert (
+        data_reader.read_value_from_file(
+            tmp_test_directory / "test_read_value_from_file_3.json", validate=False
+        )
+        is None
+    )
+
+
+def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
+    # schema file from metadata in file
+    with caplog.at_level(logging.DEBUG):
+        data_reader.read_value_from_file("tests/resources/altitude.json", validate=True)
+        assert "Successful validation of yaml/json file" in caplog.text
+
+    # schema explicitly given
+    schema_file = (
+        "https://raw.githubusercontent.com/gammasim/simulation_model/"
+        "site-parameters/schema/altitude.schema.yml"
+    )
+    with caplog.at_level(logging.DEBUG):
+        data_reader.read_value_from_file(
+            "tests/resources/altitude.json",
+            schema_file=schema_file,
+            validate=True,
+        )
+        assert "Successful validation of yaml/json file" in caplog.text
+
+    # no schema given
+    test_dict_1 = {"Value": 5.0}
+    with open(tmp_test_directory / "test_read_value_from_file_1.json", "w", encoding="utf-8") as f:
+        json.dump(test_dict_1, f)
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        data_reader.read_value_from_file(
+            tmp_test_directory / "test_read_value_from_file_1.json", validate=True
+        ),
+
+    # schema_file in meta_schema_url
+    with caplog.at_level(logging.DEBUG):
+        data_reader.read_value_from_file(
+            "tests/resources/MST_mirror_2f_measurements.schema.yml", validate=True
+        )
+        assert "Successful validation of yaml/json file" in caplog.text


### PR DESCRIPTION
Simplify the usage of the application `simtools-validate-file-using-schema`: read `schema` file from metadata if this parameter is not given on the command line. This could be either the usual CTA metadata convention, or from a `meta_schema` field for validation of schema using meta_schema.

Add functionality to test the metadata header of data files. Use the flag `validate_metadata` for this (see integration tests [tests/integration_tests/config/validate_file_using_schema_ecsv_input_test_meta.yml](tests/integration_tests/config/validate_file_using_schema_ecsv_input_test_meta.yml) and [tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml](tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml)).

Other changes:

- corrected `base_schema` to `meta_schema` in `tests/resources/reference_position_mercator.schema.yml` (this was forgotten earlier)

Important to note that there is a preliminary entry in [tests/resources/altitude.json](tests/resources/altitude.json) (required [this one](https://github.com/gammasim/simulation_model/pull/3) to be merged).