### PR TITLE
Add yaml to extensions

### DIFF
--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -46,7 +46,7 @@ class DatabaseHandler:
     DB_REFERENCE_DATA = "CTA-Reference-Data"
     DB_DERIVED_VALUES = "CTA-Simulation-Model-Derived-Values"
 
-    ALLOWED_FILE_EXTENSIONS = [".dat", ".txt", ".lis", ".cfg", ".yml", ".ecsv"]
+    ALLOWED_FILE_EXTENSIONS = [".dat", ".txt", ".lis", ".cfg", ".yml", ".yaml", ".ecsv"]
 
     db_client = None
 


### PR DESCRIPTION
Decided to support both `yml` and `yaml` extensions. See #768.