### PR TITLE
Improve configuration of make_regular_arrays

### DIFF
--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -13,7 +13,7 @@
     Command line arguments
     ----------------------
     site (str, required)
-        North or South.
+        observatory site (e.g., North or South).
     model_version (str, optional)
         Model version to use. If not provided, the latest version is used.
     verbosity (str, optional)

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -27,15 +27,6 @@
 
         simtools-make-regular-arrays --site=North
 
-    The output is saved in simtools-output/make_regular_arrays.
-
-    Expected final print-out message:
-
-    .. code-block:: console
-
-        INFO::array_layout(l608)::export_telescope_list::Exporting telescope list to /workdir/exter\
-        nal/simtools/simtools-output/make_regular_arrays/layout/telescope_positions-North-4LS\
-        T-corsika.ecsv
 """
 
 import logging

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -15,7 +15,7 @@
     site (str, required)
         observatory site (e.g., North or South).
     model_version (str, optional)
-        Model version to use. If not provided, the latest version is used.
+        Model version to use (e.g., prod6). If not provided, the latest version is used.
     verbosity (str, optional)
         Log level to print.
 

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -12,6 +12,10 @@
 
     Command line arguments
     ----------------------
+    site (str, required)
+        North or South.
+    model_version (str, optional)
+        Model version to use. If not provided, the latest version is used.
     verbosity (str, optional)
         Log level to print.
 
@@ -21,7 +25,7 @@
 
     .. code-block:: console
 
-        simtools-make-regular-arrays
+        simtools-make-regular-arrays --site=North
 
     The output is saved in simtools-output/make_regular_arrays.
 
@@ -36,6 +40,7 @@
 
 import logging
 from pathlib import Path
+import os
 
 import astropy.units as u
 
@@ -57,7 +62,7 @@ def main():
             "The array layout files created should be available at the data/layout directory."
         ),
     )
-    args_dict, db_config = config.initialize(db_config=True, output=True)
+    args_dict, db_config = config.initialize(db_config=True, site_model=True, output=True)
 
     label = "make_regular_arrays"
 
@@ -72,101 +77,101 @@ def main():
 
     # Reading site parameters from DB
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
+    site_pars_db = db.get_site_parameters(
+        site=args_dict["site"], model_version=args_dict["model_version"])
 
-    site_pars_db = {}
     layout_center_data = {}
+    layout_center_data["center_lat"] = (
+        float(site_pars_db["ref_lat"]["Value"]) * u.deg
+    )
+    layout_center_data["center_lon"] = (
+        float(site_pars_db["ref_long"]["Value"]) * u.deg
+    )
+    layout_center_data["center_alt"] = (
+        float(site_pars_db["altitude"]["Value"]) * u.m
+    )
+    layout_center_data["EPSG"] = site_pars_db["EPSG"]["Value"]
     corsika_telescope_data = {}
-    for site in ["North", "South"]:
-        site_pars_db[site] = db.get_site_parameters(site=site, model_version="prod5")
-
-        layout_center_data[site] = {}
-        layout_center_data[site]["center_lat"] = (
-            float(site_pars_db[site]["ref_lat"]["Value"]) * u.deg
-        )
-        layout_center_data[site]["center_lon"] = (
-            float(site_pars_db[site]["ref_long"]["Value"]) * u.deg
-        )
-        layout_center_data[site]["center_alt"] = (
-            float(site_pars_db[site]["altitude"]["Value"]) * u.m
-        )
-        layout_center_data[site]["EPSG"] = site_pars_db[site]["EPSG"]["Value"]
-        corsika_telescope_data[site] = {}
-        corsika_telescope_data[site]["corsika_obs_level"] = layout_center_data[site]["center_alt"]
-        corsika_telescope_data[site]["corsika_sphere_center"] = corsika_pars[
-            "corsika_sphere_center"
-        ]
-        corsika_telescope_data[site]["corsika_sphere_radius"] = corsika_pars[
-            "corsika_sphere_radius"
-        ]
+    corsika_telescope_data["corsika_obs_level"] = layout_center_data["center_alt"]
+    corsika_telescope_data["corsika_sphere_center"] = corsika_pars[
+        "corsika_sphere_center"
+    ]
+    corsika_telescope_data["corsika_sphere_radius"] = corsika_pars[
+        "corsika_sphere_radius"
+    ]
 
     # Telescope distances for 4 tel square arrays
     # !HARDCODED
     telescope_distance = {"LST": 57.5 * u.m, "MST": 70 * u.m, "SST": 80 * u.m}
 
-    for site in ["South", "North"]:
-        for array_name in ["1SST", "4SST", "1MST", "4MST", "1LST", "4LST"]:
-            logger.info(f"Processing array {array_name}")
-            layout = ArrayLayout(
-                site=site,
-                mongo_db_config=db_config,
-                label=label,
-                name=f"{site}-{array_name}",
-                layout_center_data=layout_center_data[site],
-                corsika_telescope_data=corsika_telescope_data[site],
+    for array_name in ["1SST", "4SST", "1MST", "4MST", "1LST", "4LST"]:
+        logger.info(f"Processing array {array_name}")
+        layout = ArrayLayout(
+            site=args_dict["site"],
+            mongo_db_config=db_config,
+            label=label,
+            name=f"{args_dict['site']}-{array_name}",
+            layout_center_data=layout_center_data,
+            corsika_telescope_data=corsika_telescope_data,
+        )
+
+        tel_size = array_name[1:4]
+
+        # Single telescope at the center
+        if array_name[0] == "1":
+            layout.add_telescope(
+                telescope_name=tel_size + "-01",
+                crs_name="ground",
+                xx=0 * u.m,
+                yy=0 * u.m,
+                tel_corsika_z=0 * u.m,
+            )
+        # 4 telescopes in a regular square grid
+        else:
+            layout.add_telescope(
+                telescope_name=tel_size + "-01",
+                crs_name="ground",
+                xx=telescope_distance[tel_size],
+                yy=telescope_distance[tel_size],
+                tel_corsika_z=0 * u.m,
+            )
+            layout.add_telescope(
+                telescope_name=tel_size + "-02",
+                crs_name="ground",
+                xx=-telescope_distance[tel_size],
+                yy=telescope_distance[tel_size],
+                tel_corsika_z=0 * u.m,
+            )
+            layout.add_telescope(
+                telescope_name=tel_size + "-03",
+                crs_name="ground",
+                xx=telescope_distance[tel_size],
+                yy=-telescope_distance[tel_size],
+                tel_corsika_z=0 * u.m,
+            )
+            layout.add_telescope(
+                telescope_name=tel_size + "-04",
+                crs_name="ground",
+                xx=-telescope_distance[tel_size],
+                yy=-telescope_distance[tel_size],
+                tel_corsika_z=0 * u.m,
             )
 
-            tel_size = array_name[1:4]
-
-            # Single telescope at the center
-            if array_name[0] == "1":
-                layout.add_telescope(
-                    telescope_name=tel_size + "-01",
-                    crs_name="ground",
-                    xx=0 * u.m,
-                    yy=0 * u.m,
-                    tel_corsika_z=0 * u.m,
-                )
-            # 4 telescopes in a regular square grid
-            else:
-                layout.add_telescope(
-                    telescope_name=tel_size + "-01",
-                    crs_name="ground",
-                    xx=telescope_distance[tel_size],
-                    yy=telescope_distance[tel_size],
-                    tel_corsika_z=0 * u.m,
-                )
-                layout.add_telescope(
-                    telescope_name=tel_size + "-02",
-                    crs_name="ground",
-                    xx=-telescope_distance[tel_size],
-                    yy=telescope_distance[tel_size],
-                    tel_corsika_z=0 * u.m,
-                )
-                layout.add_telescope(
-                    telescope_name=tel_size + "-03",
-                    crs_name="ground",
-                    xx=telescope_distance[tel_size],
-                    yy=-telescope_distance[tel_size],
-                    tel_corsika_z=0 * u.m,
-                )
-                layout.add_telescope(
-                    telescope_name=tel_size + "-04",
-                    crs_name="ground",
-                    xx=-telescope_distance[tel_size],
-                    yy=-telescope_distance[tel_size],
-                    tel_corsika_z=0 * u.m,
-                )
-
-            layout.convert_coordinates()
-            layout.print_telescope_list()
-            writer.ModelDataWriter.dump(
-                args_dict=args_dict,
-                metadata=None,
-                product_data=layout.export_telescope_list_table(
-                    crs_name="ground",
-                    corsika_z=False,
-                ),
-            )
+        layout.convert_coordinates()
+        layout.print_telescope_list()
+        output_file = str(args_dict.get("output_file", None))
+        if output_file is not None:
+            base_name, file_extension = os.path.splitext(output_file)
+            output_file = f"{base_name}-{args_dict['site']}-{array_name}{file_extension}"
+        writer.ModelDataWriter.dump(
+            args_dict=args_dict,
+            output_file=output_file,
+            metadata=None,
+            product_data=layout.export_telescope_list_table(
+                crs_name="ground",
+                corsika_z=False,
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -30,8 +30,8 @@
 """
 
 import logging
-from pathlib import Path
 import os
+from pathlib import Path
 
 import astropy.units as u
 
@@ -69,27 +69,18 @@ def main():
     # Reading site parameters from DB
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
     site_pars_db = db.get_site_parameters(
-        site=args_dict["site"], model_version=args_dict["model_version"])
+        site=args_dict["site"], model_version=args_dict["model_version"]
+    )
 
     layout_center_data = {}
-    layout_center_data["center_lat"] = (
-        float(site_pars_db["ref_lat"]["Value"]) * u.deg
-    )
-    layout_center_data["center_lon"] = (
-        float(site_pars_db["ref_long"]["Value"]) * u.deg
-    )
-    layout_center_data["center_alt"] = (
-        float(site_pars_db["altitude"]["Value"]) * u.m
-    )
+    layout_center_data["center_lat"] = float(site_pars_db["ref_lat"]["Value"]) * u.deg
+    layout_center_data["center_lon"] = float(site_pars_db["ref_long"]["Value"]) * u.deg
+    layout_center_data["center_alt"] = float(site_pars_db["altitude"]["Value"]) * u.m
     layout_center_data["EPSG"] = site_pars_db["EPSG"]["Value"]
     corsika_telescope_data = {}
     corsika_telescope_data["corsika_obs_level"] = layout_center_data["center_alt"]
-    corsika_telescope_data["corsika_sphere_center"] = corsika_pars[
-        "corsika_sphere_center"
-    ]
-    corsika_telescope_data["corsika_sphere_radius"] = corsika_pars[
-        "corsika_sphere_radius"
-    ]
+    corsika_telescope_data["corsika_sphere_center"] = corsika_pars["corsika_sphere_center"]
+    corsika_telescope_data["corsika_sphere_radius"] = corsika_pars["corsika_sphere_radius"]
 
     # Telescope distances for 4 tel square arrays
     # !HARDCODED

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -32,6 +32,7 @@ class CommandLineParser(argparse.ArgumentParser):
         paths=True,
         output=False,
         telescope_model=False,
+        site_model=False,
         db_config=False,
         job_submission=False,
     ):
@@ -46,6 +47,8 @@ class CommandLineParser(argparse.ArgumentParser):
             Add output file configuration to list of args.
         telescope_model: bool
             Add telescope model configuration to list of args.
+        site_model: bool
+            Add site model configuration to list of args (not required of telescope_model is True).
         db_config: bool
             Add database configuration parameters to list of args.
         job_submission: bool
@@ -54,6 +57,8 @@ class CommandLineParser(argparse.ArgumentParser):
 
         if telescope_model:
             self.initialize_telescope_model_arguments()
+        elif site_model:
+            self.initialize_telescope_model_arguments(add_telescope=False)
         if job_submission:
             self.initialize_job_submission_arguments()
         if db_config:

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -242,7 +242,10 @@ class CommandLineParser(argparse.ArgumentParser):
             Set to allow a telescope name argument.
         """
 
-        _job_group = self.add_argument_group("telescope model")
+        if add_telescope:
+            _job_group = self.add_argument_group("telescope model")
+        else:
+            _job_group = self.add_argument_group("site model")
         _job_group.add_argument(
             "--site", help="CTAO site (e.g., North, South)", type=self.site, required=False
         )
@@ -282,10 +285,8 @@ class CommandLineParser(argparse.ArgumentParser):
 
         """
 
-        fsite = str(value)
-        if not names.validate_site_name(fsite):
-            raise argparse.ArgumentTypeError(f"{fsite} is an invalid site")
-        return fsite
+        names.validate_site_name(str(value))
+        return str(value)
 
     @staticmethod
     def telescope(value):
@@ -309,10 +310,8 @@ class CommandLineParser(argparse.ArgumentParser):
 
         """
 
-        ftelescope = str(value)
-        if not names.validate_telescope_model_name(ftelescope):
-            raise argparse.ArgumentTypeError(f"{ftelescope} is an invalid telescope name")
-        return ftelescope
+        names.validate_telescope_model_name(str(value))
+        return str(value)
 
     @staticmethod
     def efficiency_interval(value):

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -101,6 +101,7 @@ class Configurator:
         paths=True,
         output=False,
         telescope_model=False,
+        site_model=False,
         db_config=False,
         job_submission=False,
     ):
@@ -125,6 +126,8 @@ class Configurator:
             Add output file configuration to list of args.
         telescope_model: bool
             Add telescope model configuration to list of args.
+        site_model: bool
+            Add site model configuration to list of args (not required if telescope_model is set)
         db_config: bool
             Add database configuration parameters to list of args.
         job_submission: bool
@@ -148,6 +151,7 @@ class Configurator:
             paths=paths,
             output=output,
             telescope_model=telescope_model,
+            site_model=site_model,
             db_config=db_config,
             job_submission=job_submission,
         )

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -46,7 +46,9 @@ class ModelDataWriter:
         self.product_data_format = self._astropy_data_format(product_data_format)
 
     @staticmethod
-    def dump(args_dict, output_file=None, metadata=None, product_data=None, validate_schema_file=None):
+    def dump(
+        args_dict, output_file=None, metadata=None, product_data=None, validate_schema_file=None
+    ):
         """
         Write model data and metadata (as static method).
 
@@ -67,8 +69,8 @@ class ModelDataWriter:
 
         writer = ModelDataWriter(
             product_data_file=(
-                args_dict.get("output_file", None) if output_file is None else output_file)
-            ,
+                args_dict.get("output_file", None) if output_file is None else output_file
+            ),
             product_data_format=args_dict.get("output_file_format", "ascii.ecsv"),
             args_dict=args_dict,
         )

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -46,7 +46,7 @@ class ModelDataWriter:
         self.product_data_format = self._astropy_data_format(product_data_format)
 
     @staticmethod
-    def dump(args_dict, metadata=None, product_data=None, validate_schema_file=None):
+    def dump(args_dict, output_file=None, metadata=None, product_data=None, validate_schema_file=None):
         """
         Write model data and metadata (as static method).
 
@@ -54,6 +54,8 @@ class ModelDataWriter:
         ----------
         args_dict: dict
             Dictionary with configuration parameters (including output file name and path).
+        output_file: string or Path
+            Name of output file (args["output_file"] is used if this parameter is not set).
         metadata: dict
             Metadata to be written.
         product_data: astropy Table
@@ -64,7 +66,9 @@ class ModelDataWriter:
         """
 
         writer = ModelDataWriter(
-            product_data_file=args_dict.get("output_file", None),
+            product_data_file=(
+                args_dict.get("output_file", None) if output_file is None else output_file)
+            ,
             product_data_format=args_dict.get("output_file_format", "ascii.ecsv"),
             args_dict=args_dict,
         )

--- a/tests/integration_tests/config/make_regular_arrays_run_north.yml
+++ b/tests/integration_tests/config/make_regular_arrays_run_north.yml
@@ -3,3 +3,4 @@ CTA_SIMPIPE:
   TEST_NAME: run
   CONFIGURATION:
     OUTPUT_PATH: simtools-tests
+    SITE: North

--- a/tests/integration_tests/config/make_regular_arrays_run_south.yml
+++ b/tests/integration_tests/config/make_regular_arrays_run_south.yml
@@ -1,0 +1,6 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-make-regular-arrays
+  TEST_NAME: run
+  CONFIGURATION:
+    OUTPUT_PATH: simtools-tests
+    SITE: South

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -109,6 +109,7 @@ def test_initialize_default_arguments():
     for group in job_groups:
         assert str(group.title) in [
             "positional arguments",
+            "optinal arguments",
             "options",
             "paths",
             "configuration",

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -101,7 +101,6 @@ def test_azimuth_angle(caplog):
 
 
 def test_initialize_default_arguments():
-
     _parser_1 = parser.CommandLineParser()
 
     # default arguments
@@ -109,30 +108,34 @@ def test_initialize_default_arguments():
     job_groups = _parser_1._action_groups
     for group in job_groups:
         assert str(group.title) in [
-            'positional arguments', 'options', 'paths', 'configuration', 'execution'
-            ]
+            "positional arguments",
+            "options",
+            "paths",
+            "configuration",
+            "execution",
+        ]
 
     _parser_2 = parser.CommandLineParser()
     _parser_2.initialize_default_arguments(output=True)
     job_groups = _parser_2._action_groups
-    assert 'output' in [str(group.title) for group in job_groups]
+    assert "output" in [str(group.title) for group in job_groups]
 
     _parser_3 = parser.CommandLineParser()
     _parser_3.initialize_default_arguments(telescope_model=True)
     job_groups = _parser_3._action_groups
-    assert 'telescope model' in [str(group.title) for group in job_groups]
+    assert "telescope model" in [str(group.title) for group in job_groups]
 
     _parser_4 = parser.CommandLineParser()
     _parser_4.initialize_default_arguments(telescope_model=False, site_model=True)
     job_groups = _parser_4._action_groups
-    assert 'site model' in [str(group.title) for group in job_groups]
+    assert "site model" in [str(group.title) for group in job_groups]
 
     _parser_5 = parser.CommandLineParser()
     _parser_5.initialize_default_arguments(job_submission=True)
     job_groups = _parser_5._action_groups
-    assert 'job submission' in [str(group.title) for group in job_groups]
+    assert "job submission" in [str(group.title) for group in job_groups]
 
     _parser_6 = parser.CommandLineParser()
     _parser_6.initialize_default_arguments(db_config=True)
     job_groups = _parser_6._action_groups
-    assert 'MongoDB configuration' in [str(group.title) for group in job_groups]
+    assert "MongoDB configuration" in [str(group.title) for group in job_groups]

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -98,3 +98,41 @@ def test_azimuth_angle(caplog):
     with pytest.raises(TypeError):
         parser.CommandLineParser.azimuth_angle([0, 10])
         assert "is not a valid number nor one of (north, south, east, west)" in caplog.text
+
+
+def test_initialize_default_arguments():
+
+    _parser_1 = parser.CommandLineParser()
+
+    # default arguments
+    _parser_1.initialize_default_arguments()
+    job_groups = _parser_1._action_groups
+    for group in job_groups:
+        assert str(group.title) in [
+            'positional arguments', 'options', 'paths', 'configuration', 'execution'
+            ]
+
+    _parser_2 = parser.CommandLineParser()
+    _parser_2.initialize_default_arguments(output=True)
+    job_groups = _parser_2._action_groups
+    assert 'output' in [str(group.title) for group in job_groups]
+
+    _parser_3 = parser.CommandLineParser()
+    _parser_3.initialize_default_arguments(telescope_model=True)
+    job_groups = _parser_3._action_groups
+    assert 'telescope model' in [str(group.title) for group in job_groups]
+
+    _parser_4 = parser.CommandLineParser()
+    _parser_4.initialize_default_arguments(telescope_model=False, site_model=True)
+    job_groups = _parser_4._action_groups
+    assert 'site model' in [str(group.title) for group in job_groups]
+
+    _parser_5 = parser.CommandLineParser()
+    _parser_5.initialize_default_arguments(job_submission=True)
+    job_groups = _parser_5._action_groups
+    assert 'job submission' in [str(group.title) for group in job_groups]
+
+    _parser_6 = parser.CommandLineParser()
+    _parser_6.initialize_default_arguments(db_config=True)
+    job_groups = _parser_6._action_groups
+    assert 'MongoDB configuration' in [str(group.title) for group in job_groups]

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -109,7 +109,7 @@ def test_initialize_default_arguments():
     for group in job_groups:
         assert str(group.title) in [
             "positional arguments",
-            "optinal arguments",
+            "optional arguments",
             "options",
             "paths",
             "configuration",

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -72,6 +72,16 @@ def test_dump(args_dict, tmp_test_directory):
             validate_schema_file="tests/resources/MST_mirror_2f_measurements.schema.yml",
         )
 
+    # explicitly set output_file
+    writer.ModelDataWriter().dump(
+        args_dict=args_dict,
+        output_file="test_file_2.ecsv",
+        metadata=_metadata,
+        product_data=empty_table,
+        validate_schema_file=None,
+    )
+    assert Path(args_dict["output_path"]).joinpath("test_file_2.ecsv").exists()
+
 
 def test_validate_and_transform(tmp_test_directory):
     w_1 = writer.ModelDataWriter()


### PR DESCRIPTION
Some improvements and changes to`make_regular_arrays`:

- allow to configure simulation model version on the command line (before: prod5 was hardwired)
- do not generate for North and Site sites the arrays, but allow to configure the site on the command line (`--site` as usual) and generate regular arrays for one site only
      - required to introduce a `site_model` flag in the configurator class
- fix a bug introduced when changing the output file writing using `writer.ModelDataWriter.dump`. This used always `args_dict[out_file]`, meaning that all subarray telescope lists are overwritten during the process of writing
   - required to add a `output_file` parameter to  `writer.ModelDataWriter.dump` to handle this case






 