### PR TITLE
Add simulation_software:parameter_name to schema

### DIFF
--- a/simtools/schemas/data.metaschema.yml
+++ b/simtools/schemas/data.metaschema.yml
@@ -283,6 +283,10 @@ definitions:
         type: string
         description: |-
           "version of simulation software this parameter is used"
+      parameter_name:
+        type: string
+        description: |-
+          "name of simulation model parameter as used by this software"
     required:
       - name
     title: SimulationSoftware


### PR DESCRIPTION
Allow to specify the name of the parameter in the specific simulation software.

Example:

- `corsika_observation_level` is the name of the parameter used in simtools
- `OBSLEVEL` is the name of the same parameter used in CORSIKA

(don't plan at this point that this is used in the schema files except for documentation purposed).