### PR TITLE
Schema is now available in main branch

### DIFF
--- a/tests/resources/altitude.json
+++ b/tests/resources/altitude.json
@@ -25,7 +25,7 @@
                     "MODEL": {
                         "NAME": "altitude",
                         "VERSION": "0.1.0",
-                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/site-parameters/schema/altitude.schema.yml"
+                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/altitude.schema.yml"
                     }
                 },
                 "FORMAT": "json",

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -96,7 +96,7 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     # schema explicitly given
     schema_file = (
         "https://raw.githubusercontent.com/gammasim/simulation_model/"
-        "site-parameters/schema/altitude.schema.yml"
+        "main/schema/altitude.schema.yml"
     )
     with caplog.at_level(logging.DEBUG):
         data_reader.read_value_from_file(


### PR DESCRIPTION
Schema for altitude.json is now in the main branch of the [simulation_model](https://github.com/gammasim/simulation_model) repository. Fix the url accordingly.

Closes #773


Related to https://github.com/gammasim/simulation_model/pull/6