### PR TITLE
Remove `str` in make_regular array on output_file

### DIFF
--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -141,7 +141,7 @@ def main():
 
         layout.convert_coordinates()
         layout.print_telescope_list()
-        output_file = str(args_dict.get("output_file", None))
+        output_file = args_dict.get("output_file", None)
         if output_file is not None:
             base_name, file_extension = os.path.splitext(output_file)
             output_file = f"{base_name}-{args_dict['site']}-{array_name}{file_extension}"


### PR DESCRIPTION
This has been remarked [https://github.com/gammasim/simtools/pull/777#pullrequestreview-1815993322](https://github.com/gammasim/simtools/pull/777#pullrequestreview-1815993322) and after looking into it I realized that `args_dict["output_file"]` is always a string. So the `str` is not needed.