### PR TITLE
Bug fix in mercator coordinator transformation

### DIFF
--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -162,7 +162,7 @@ def main():
     layout = array_layout.ArrayLayout(
         telescope_list_file=args_dict["input"],
         telescope_list_metadata_file=args_dict["input_meta"],
-        validate=True,
+        validate=False,
     )
     layout.select_assets(args_dict["select_assets"])
     layout.convert_coordinates()

--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -162,7 +162,7 @@ def main():
     layout = array_layout.ArrayLayout(
         telescope_list_file=args_dict["input"],
         telescope_list_metadata_file=args_dict["input_meta"],
-        validate=False,
+        validate=True,
     )
     layout.select_assets(args_dict["select_assets"])
     layout.convert_coordinates()

--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -145,6 +145,13 @@ def _parse(label=None, description=None):
         default=None,
         nargs="+",
     )
+    config.parser.add_argument(
+        "--skip_input_validation",
+        help="skip input data validation against schema",
+        default=False,
+        required=False,
+        action="store_true",
+    )
     return config.initialize(output=True, require_command_line=True)
 
 
@@ -162,7 +169,7 @@ def main():
     layout = array_layout.ArrayLayout(
         telescope_list_file=args_dict["input"],
         telescope_list_metadata_file=args_dict["input_meta"],
-        validate=True,
+        validate=not args_dict["skip_input_validation"],
     )
     layout.select_assets(args_dict["select_assets"])
     layout.convert_coordinates()

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -566,7 +566,6 @@ class ArrayLayout:
             data table with array element coordinates
 
         """
-        print(table)
         for row in table:
             tel = self._load_telescope_names(row)
             self._try_set_coordinate(row, tel, table, "ground", "position_x", "position_y")

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -566,11 +566,12 @@ class ArrayLayout:
             data table with array element coordinates
 
         """
+        print(table)
         for row in table:
             tel = self._load_telescope_names(row)
             self._try_set_coordinate(row, tel, table, "ground", "position_x", "position_y")
             self._try_set_coordinate(row, tel, table, "utm", "utm_east", "utm_north")
-            self._try_set_coordinate(row, tel, table, "mercator", "mercator", "lon")
+            self._try_set_coordinate(row, tel, table, "mercator", "latitude", "longitude")
             self._try_set_altitude(row, tel, table)
 
             self._telescope_list.append(tel)

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -552,7 +552,7 @@ class ArrayLayout:
         except KeyError:
             pass
         try:
-            tel.set_altitude(self._assign_unit_to_quantity(row["alt"], table["alt"].unit))
+            tel.set_altitude(self._assign_unit_to_quantity(row["altitude"], table["altitude"].unit))
         except KeyError:
             pass
 

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -47,7 +47,7 @@ class TelescopePosition:
         telstr = self.name
         if self.has_coordinates("ground"):
             telstr += (
-                f"\t CORSIKA x(->North): {self.crs['ground']['xx']['value']:0.2f} "
+                f"\t Ground x(->North): {self.crs['ground']['xx']['value']:0.2f} "
                 f"y(->West): {self.crs['ground']['yy']['value']:0.2f}"
             )
         if self.has_coordinates("utm"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,6 +279,11 @@ def telescope_north_utm_test_file():
 
 
 @pytest.fixture
+def telescope_north_mercator_test_file():
+    return "tests/resources/telescope_positions-North-mercator.ecsv"
+
+
+@pytest.fixture
 def telescope_south_test_file():
     return "tests/resources/telescope_positions-South-ground.ecsv"
 

--- a/tests/integration_tests/config/print_array_elements_mercator_to_utm_meta_in_table.yml
+++ b/tests/integration_tests/config/print_array_elements_mercator_to_utm_meta_in_table.yml
@@ -1,0 +1,16 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-print-array-elements
+  TEST_NAME: mercator_to_utm_meta_in_table
+  CONFIGURATION:
+    INPUT: tests/resources/telescope_positions-North-mercator.ecsv
+    EXPORT: utm
+    OUTPUT_PATH: simtools-tests
+    OUTPUT_FILE: test.ecsv
+    SELECT_ASSETS: ['LST', 'MST']
+    SKIP_INPUT_VALIDATION: True
+    SKIP_OUTPUT_VALIDATION: True
+    LOG_LEVEL: DEBUG
+  INTEGRATION_TESTS:
+    - REFERENCE_OUTPUT_FILE: |
+        ./tests/resources/telescope_positions-North-utm.ecsv
+      TOLERANCE: 1.e-2

--- a/tests/integration_tests/config/print_array_elements_utm_to_mercator_meta_in_table.yml
+++ b/tests/integration_tests/config/print_array_elements_utm_to_mercator_meta_in_table.yml
@@ -1,0 +1,15 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-print-array-elements
+  TEST_NAME: utm_to_mercator_meta_in_table
+  CONFIGURATION:
+    INPUT: tests/resources/telescope_positions-North-utm.ecsv
+    EXPORT: mercator
+    OUTPUT_PATH: simtools-tests
+    OUTPUT_FILE: test.ecsv
+    SELECT_ASSETS: ['LST', 'MST']
+    SKIP_OUTPUT_VALIDATION: True
+    LOG_LEVEL: DEBUG
+  INTEGRATION_TESTS:
+    - REFERENCE_OUTPUT_FILE: |
+        ./tests/resources/telescope_positions-North-mercator.ecsv
+      TOLERANCE: 1.e-2

--- a/tests/resources/telescope_positions-North-mercator.ecsv
+++ b/tests/resources/telescope_positions-North-mercator.ecsv
@@ -7,8 +7,17 @@
 # - {name: latitude, unit: deg, datatype: float64}
 # - {name: longitude, unit: deg, datatype: float64}
 # - {name: altitude, unit: m, datatype: float64}
-# meta:
-#   CTA:
+# meta: !!omap
+# - {data_type: position_file}
+# - {description: CTAO Northern Array Element Coordinates}
+# - {center_northing: 3185067.275 m}
+# - {center_easting: 217608.975 m}
+# - {center_alt: 2177.0 m}
+# - {corsika_obs_level: 2156 m}
+# - corsika_sphere_radius: {LST: 12.5 m, MST: 9.15 m, SST: 3 m}
+# - corsika_sphere_center: {LST: 16 m, MST: 9 m, SST: 3.25 m}
+# - {EPSG: 32628}
+# - CTA:
 #     ACTIVITY:
 #       END: '2024-01-17T08:18:14'
 #       ID: 2f5a2ee4-32c9-4302-bc71-9ea418f9e385
@@ -52,36 +61,6 @@
 #       ID: 2f5a2ee4-32c9-4302-bc71-9ea418f9e385
 #       VALID: {END: null, START: null}
 #     REFERENCE: {VERSION: 1.0.0}
-#   EPSG: 32628
-#   __serialized_columns__:
-#     altitude:
-#       __class__: astropy.units.quantity.Quantity
-#       unit: &id002 !astropy.units.Unit {unit: m}
-#       value: !astropy.table.SerializedColumn {name: altitude}
-#     latitude:
-#       __class__: astropy.units.quantity.Quantity
-#       unit: &id001 !astropy.units.Unit {unit: deg}
-#       value: !astropy.table.SerializedColumn {name: latitude}
-#     longitude:
-#       __class__: astropy.units.quantity.Quantity
-#       unit: *id001
-#       value: !astropy.table.SerializedColumn {name: longitude}
-#   array_name: null
-#   center_alt: !astropy.units.Quantity
-#     unit: *id002
-#     value: 2177.0
-#   center_easting: !astropy.units.Quantity
-#     unit: *id002
-#     value: 217608.975
-#   center_lat: !astropy.units.Quantity
-#     unit: *id001
-#     value: 28.762166014809267
-#   center_lon: !astropy.units.Quantity
-#     unit: *id001
-#     value: -17.892032777402406
-#   center_northing: !astropy.units.Quantity
-#     unit: *id002
-#     value: 3185067.275
 # schema: astropy-2.0
 asset_code sequence_number geo_code latitude longitude altitude
 LST 01 2B5 28.76152646788508 -17.891496913272913 2185.0

--- a/tests/resources/telescope_positions-North-mercator.ecsv
+++ b/tests/resources/telescope_positions-North-mercator.ecsv
@@ -1,0 +1,99 @@
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: asset_code, datatype: string}
+# - {name: sequence_number, datatype: string}
+# - {name: geo_code, datatype: string}
+# - {name: latitude, unit: deg, datatype: float64}
+# - {name: longitude, unit: deg, datatype: float64}
+# - {name: altitude, unit: m, datatype: float64}
+# meta:
+#   CTA:
+#     ACTIVITY:
+#       END: '2024-01-17T08:18:14'
+#       ID: 2f5a2ee4-32c9-4302-bc71-9ea418f9e385
+#       NAME: print_array_elements
+#       SOFTWARE: {NAME: simtools, VERSION: 0.5.2.dev1253+g8e35ba20}
+#       START: '2024-01-17T08:18:14'
+#       TYPE: software
+#     CONTACT: {EMAIL: null, NAME: maierg, ORGANIZATION: CTAO}
+#     CONTEXT:
+#       ASSOCIATED_DATA:
+#       - CREATION_TIME: null
+#         DATA:
+#           ASSOCIATION: null
+#           CATEGORY: null
+#           LEVEL: null
+#           MODEL: {NAME: null, TYPE: null, URL: null, VERSION: null}
+#           TYPE: null
+#         DESCRIPTION: null
+#         FILENAME: null
+#         FORMAT: null
+#         ID: null
+#         VALID: {END: null, START: null}
+#       ASSOCIATED_ELEMENTS:
+#       - {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
+#       DOCUMENT:
+#       - {CREATION_TIME: null, ID: null, TITLE: null, TYPE: null, URL: null}
+#     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
+#     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
+#     PRODUCT:
+#       CREATION_TIME: '2024-01-17T08:18:14'
+#       DATA:
+#         ASSOCIATION: Site
+#         CATEGORY: SIM
+#         LEVEL: R1
+#         MODEL: {NAME: null, TYPE: simpipe-schema, URL: null,
+#           VERSION: 0.1.0}
+#         TYPE: Service
+#       DESCRIPTION: Telescope positions.
+#       FILENAME: test.ecsv
+#       FORMAT: ecsv
+#       ID: 2f5a2ee4-32c9-4302-bc71-9ea418f9e385
+#       VALID: {END: null, START: null}
+#     REFERENCE: {VERSION: 1.0.0}
+#   EPSG: 32628
+#   __serialized_columns__:
+#     altitude:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: &id002 !astropy.units.Unit {unit: m}
+#       value: !astropy.table.SerializedColumn {name: altitude}
+#     latitude:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: &id001 !astropy.units.Unit {unit: deg}
+#       value: !astropy.table.SerializedColumn {name: latitude}
+#     longitude:
+#       __class__: astropy.units.quantity.Quantity
+#       unit: *id001
+#       value: !astropy.table.SerializedColumn {name: longitude}
+#   array_name: null
+#   center_alt: !astropy.units.Quantity
+#     unit: *id002
+#     value: 2177.0
+#   center_easting: !astropy.units.Quantity
+#     unit: *id002
+#     value: 217608.975
+#   center_lat: !astropy.units.Quantity
+#     unit: *id001
+#     value: 28.762166014809267
+#   center_lon: !astropy.units.Quantity
+#     unit: *id001
+#     value: -17.892032777402406
+#   center_northing: !astropy.units.Quantity
+#     unit: *id002
+#     value: 3185067.275
+# schema: astropy-2.0
+asset_code sequence_number geo_code latitude longitude altitude
+LST 01 2B5 28.76152646788508 -17.891496913272913 2185.0
+LST 02 2B4 28.761847808998038 -17.892707541577614 2172.5
+LST 03 1B0 28.762845266359122 -17.892546711522133 2168.2
+LST 04 1B1 28.762444510414237 -17.891379946029033 2172.8
+MST 01 4B3 28.760257303921474 -17.892088374279254 2195.5
+MST 02 4B1 28.760783413417712 -17.893761183064754 2175.7
+MST 03 2B2 28.76240824076097 -17.894167382973972 2158.4
+MST 04 3B0 28.763750425914342 -17.892778468677292 2156.5
+MST 05 3B5 28.763353592279586 -17.89003842616224 2178.0
+MST 06 2B6 28.761408892893755 -17.89003702137571 2192.0
+MST 07 4B6 28.760219477039175 -17.890316442755925 2212.0
+MST 10 1B4 28.76234818896549 -17.88842097029393 2209.0
+MST 15 0A1 28.762207888794336 -17.89202548742537 2176.5

--- a/tests/resources/telescope_positions-North-utm-without-cta-meta.ecsv
+++ b/tests/resources/telescope_positions-North-utm-without-cta-meta.ecsv
@@ -5,7 +5,7 @@
 # - {name: sequence_number, datatype: string, description: sequence number}
 # - {name: utm_east, unit: m, datatype: float64}
 # - {name: utm_north, unit: m, datatype: float64}
-# - {name: alt, unit: m, datatype: float64, description: telescope position upwards relative to NNN}
+# - {name: altitude, unit: m, datatype: float64, description: telescope position upwards relative to NNN}
 # - {name: geo_code, datatype: string, description: Geographical Position Code}
 # meta: !!omap
 # - data_type: position_file
@@ -26,7 +26,7 @@
 #       in CTA-SPE-PSC-000000-0001 1c)
 #       Never change positions here. This should always be
 #       synchronized with the reference repository
-asset_code sequence_number utm_east utm_north alt geo_code
+asset_code sequence_number utm_east utm_north altitude geo_code
 LST 01 217659.6 3184995.1 2185.0 2B5
 LST 02 217542.2 3185033.6 2172.5 2B4
 LST 03 217560.6 3185143.8 2168.2 1B0

--- a/tests/resources/telescope_positions-North-utm.ecsv
+++ b/tests/resources/telescope_positions-North-utm.ecsv
@@ -5,7 +5,7 @@
 # - {name: sequence_number, datatype: string, description: sequence number}
 # - {name: utm_east, unit: m, datatype: float64}
 # - {name: utm_north, unit: m, datatype: float64}
-# - {name: alt, unit: m, datatype: float64, description: telescope position upwards relative to NNN}
+# - {name: altitude, unit: m, datatype: float64, description: telescope position upwards relative to NNN}
 # - {name: geo_code, datatype: string, description: Geographical Position Code}
 # meta: !!omap
 # - {data_type: position_file}
@@ -59,7 +59,7 @@
 #       VALID: {START: '2022-05-30 12:00:00'}
 #     REFERENCE: {VERSION: 1.0.0}
 # schema: astropy-2.0
-asset_code sequence_number utm_east utm_north alt geo_code
+asset_code sequence_number utm_east utm_north altitude geo_code
 LST 01 217659.6 3184995.1 2185.0 2B5
 LST 02 217542.2 3185033.6 2172.5 2B4
 LST 03 217560.6 3185143.8 2168.2 1B0
@@ -73,15 +73,3 @@ MST 06 217801.9 3184978.6 2192.0  2B6
 MST 07 217771.4 3184847.4 2212.0 4B6
 MST 10 217962.3 3185078.9 2209.0 1B4
 MST 15 217609.8 3185071.9 2176.5  0A1
-RLD 01 217381.0 3185155.0 2158.5 2B1
-STP 01 217703.0 3184911.0 2194.7 4B5
-MSP 01 217463.1 3185305.0 2143.4 Nan
-ILL 01 nan nan nan Nan
-ILL 02 nan nan nan Nan
-CEI 01 217463.1 3185305.0 2143.4 Nan
-WST 01 217471.0 3185112.0 2160.0 2B3
-WST 02 217770.0 3185094.0 2181.0 1B2
-WST 03 217718.0 3184875.0 2215.0 4B4
-ASC 01 217463.1 3185305.0 2143.4 Nan
-DUS 01 217463.1 3185305.0 2143.4 Nan
-LIS 01 217463.1 3185305.0 2143.4 Nan

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -253,7 +253,7 @@ def test_build_layout(
         # test that certain keywords appear in printout
         layout.print_telescope_list()
         captured_printout, _ = capfd.readouterr()
-        substrings_to_check = ["LST", "CORSIKA", "UTM", "Longitude"]
+        substrings_to_check = ["LST", "Ground", "UTM", "Longitude"]
         assert all(substring in captured_printout for substring in substrings_to_check)
 
         layout.print_telescope_list("ground", corsika_z=True)
@@ -629,10 +629,14 @@ def test_getitem(telescope_north_test_file):
 
 
 def test_load_telescope_list(
-    telescope_north_test_file, telescope_north_utm_test_file, telescope_north_mercator_test_file
+    telescope_north_test_file,
+    telescope_north_utm_test_file,
+    telescope_north_mercator_test_file,
+    db_config,
+    io_handler,
 ):
     _ground_table = QTable.read(telescope_north_test_file, format="ascii.ecsv")
-    _ground_layout = ArrayLayout()
+    _ground_layout = ArrayLayout(mongo_db_config=db_config, site="North")
     _ground_layout._load_telescope_list(_ground_table)
     assert len(_ground_layout._telescope_list) == 13
     assert _ground_layout._telescope_list[0].crs["ground"]["xx"]["value"] == pytest.approx(
@@ -643,7 +647,7 @@ def test_load_telescope_list(
     )
 
     _utm_table = QTable.read(telescope_north_utm_test_file, format="ascii.ecsv")
-    _utm_layout = ArrayLayout()
+    _utm_layout = ArrayLayout(mongo_db_config=db_config, site="North")
     _utm_layout._load_telescope_list(_utm_table)
     # utm list includes additional calibration devices
     assert len(_utm_layout._telescope_list) == 25
@@ -655,7 +659,7 @@ def test_load_telescope_list(
     )
 
     _mercator_table = QTable.read(telescope_north_mercator_test_file, format="ascii.ecsv")
-    _mercator_layout = ArrayLayout()
+    _mercator_layout = ArrayLayout(mongo_db_config=db_config, site="North")
     _mercator_layout._load_telescope_list(_mercator_table)
     assert len(_mercator_layout._telescope_list) == 13
     assert _mercator_layout._telescope_list[0].crs["mercator"]["xx"]["value"] == pytest.approx(

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -649,8 +649,7 @@ def test_load_telescope_list(
     _utm_table = QTable.read(telescope_north_utm_test_file, format="ascii.ecsv")
     _utm_layout = ArrayLayout(mongo_db_config=db_config, site="North")
     _utm_layout._load_telescope_list(_utm_table)
-    # utm list includes additional calibration devices
-    assert len(_utm_layout._telescope_list) == 25
+    assert len(_utm_layout._telescope_list) == 13
     assert _utm_layout._telescope_list[0].crs["utm"]["xx"]["value"] == pytest.approx(
         _utm_table["utm_east"][0].value
     )

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -628,29 +628,42 @@ def test_getitem(telescope_north_test_file):
     assert layout[0].name == "LST-01"
 
 
-def test_load_telescope_list(telescope_north_test_file, telescope_north_utm_test_file, telescope_north_mercator_test_file):
-
-    _ground_table = QTable.read(telescope_north_test_file, format='ascii.ecsv')
+def test_load_telescope_list(
+    telescope_north_test_file, telescope_north_utm_test_file, telescope_north_mercator_test_file
+):
+    _ground_table = QTable.read(telescope_north_test_file, format="ascii.ecsv")
     _ground_layout = ArrayLayout()
     _ground_layout._load_telescope_list(_ground_table)
     assert len(_ground_layout._telescope_list) == 13
-    assert _ground_layout._telescope_list[0].crs['ground']['xx']['value'] == pytest.approx(_ground_table['position_x'][0].value)
-    assert _ground_layout._telescope_list[0].crs['ground']['yy']['value'] == pytest.approx(_ground_table['position_y'][0].value)
+    assert _ground_layout._telescope_list[0].crs["ground"]["xx"]["value"] == pytest.approx(
+        _ground_table["position_x"][0].value
+    )
+    assert _ground_layout._telescope_list[0].crs["ground"]["yy"]["value"] == pytest.approx(
+        _ground_table["position_y"][0].value
+    )
 
-    _utm_table = QTable.read(telescope_north_utm_test_file, format='ascii.ecsv')
+    _utm_table = QTable.read(telescope_north_utm_test_file, format="ascii.ecsv")
     _utm_layout = ArrayLayout()
     _utm_layout._load_telescope_list(_utm_table)
     # utm list includes additional calibration devices
     assert len(_utm_layout._telescope_list) == 25
-    assert _utm_layout._telescope_list[0].crs['utm']['xx']['value'] == pytest.approx(_utm_table['utm_east'][0].value)
-    assert _utm_layout._telescope_list[0].crs['utm']['yy']['value'] == pytest.approx(_utm_table['utm_north'][0].value)
+    assert _utm_layout._telescope_list[0].crs["utm"]["xx"]["value"] == pytest.approx(
+        _utm_table["utm_east"][0].value
+    )
+    assert _utm_layout._telescope_list[0].crs["utm"]["yy"]["value"] == pytest.approx(
+        _utm_table["utm_north"][0].value
+    )
 
-    _mercator_table = QTable.read(telescope_north_mercator_test_file, format='ascii.ecsv')
+    _mercator_table = QTable.read(telescope_north_mercator_test_file, format="ascii.ecsv")
     _mercator_layout = ArrayLayout()
     _mercator_layout._load_telescope_list(_mercator_table)
     assert len(_mercator_layout._telescope_list) == 13
-    assert _mercator_layout._telescope_list[0].crs['mercator']['xx']['value'] == pytest.approx(_mercator_table['latitude'][0].value)
-    assert _mercator_layout._telescope_list[0].crs['mercator']['yy']['value'] == pytest.approx(_mercator_table['longitude'][0].value)
+    assert _mercator_layout._telescope_list[0].crs["mercator"]["xx"]["value"] == pytest.approx(
+        _mercator_table["latitude"][0].value
+    )
+    assert _mercator_layout._telescope_list[0].crs["mercator"]["yy"]["value"] == pytest.approx(
+        _mercator_table["longitude"][0].value
+    )
 
 
 def test_export_telescope_list_table(telescope_north_test_file, telescope_north_utm_test_file):

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -628,6 +628,31 @@ def test_getitem(telescope_north_test_file):
     assert layout[0].name == "LST-01"
 
 
+def test_load_telescope_list(telescope_north_test_file, telescope_north_utm_test_file, telescope_north_mercator_test_file):
+
+    _ground_table = QTable.read(telescope_north_test_file, format='ascii.ecsv')
+    _ground_layout = ArrayLayout()
+    _ground_layout._load_telescope_list(_ground_table)
+    assert len(_ground_layout._telescope_list) == 13
+    assert _ground_layout._telescope_list[0].crs['ground']['xx']['value'] == pytest.approx(_ground_table['position_x'][0].value)
+    assert _ground_layout._telescope_list[0].crs['ground']['yy']['value'] == pytest.approx(_ground_table['position_y'][0].value)
+
+    _utm_table = QTable.read(telescope_north_utm_test_file, format='ascii.ecsv')
+    _utm_layout = ArrayLayout()
+    _utm_layout._load_telescope_list(_utm_table)
+    # utm list includes additional calibration devices
+    assert len(_utm_layout._telescope_list) == 25
+    assert _utm_layout._telescope_list[0].crs['utm']['xx']['value'] == pytest.approx(_utm_table['utm_east'][0].value)
+    assert _utm_layout._telescope_list[0].crs['utm']['yy']['value'] == pytest.approx(_utm_table['utm_north'][0].value)
+
+    _mercator_table = QTable.read(telescope_north_mercator_test_file, format='ascii.ecsv')
+    _mercator_layout = ArrayLayout()
+    _mercator_layout._load_telescope_list(_mercator_table)
+    assert len(_mercator_layout._telescope_list) == 13
+    assert _mercator_layout._telescope_list[0].crs['mercator']['xx']['value'] == pytest.approx(_mercator_table['latitude'][0].value)
+    assert _mercator_layout._telescope_list[0].crs['mercator']['yy']['value'] == pytest.approx(_mercator_table['longitude'][0].value)
+
+
 def test_export_telescope_list_table(telescope_north_test_file, telescope_north_utm_test_file):
     layout = ArrayLayout(telescope_list_file=telescope_north_test_file)
     table = layout.export_telescope_list_table(crs_name="ground", corsika_z=False)

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -55,7 +55,7 @@ def test_str(crs_wgs84, crs_local, crs_utm):
 
     tel.set_coordinates("ground", 50, -25.0, 2158.0 * u.m)
     _tcors = tel.__str__()
-    _test_string = "LST-01\t CORSIKA x(->North): 50.00 y(->West): -25.00"
+    _test_string = "LST-01\t Ground x(->North): 50.00 y(->West): -25.00"
     assert _tcors == (_test_string + "\t Alt: 2158.00")
     tel.convert_all(crs_local=crs_local, crs_wgs84=crs_wgs84)
     _tcors = tel.__str__()
@@ -63,7 +63,7 @@ def test_str(crs_wgs84, crs_local, crs_utm):
     assert _tcors == (_test_string + "\t Alt: 2158.00")
     tel.convert_all(crs_local=crs_local, crs_wgs84=crs_wgs84, crs_utm=crs_utm)
     _tcors = tel.__str__()
-    _test_string = "LST-01\t CORSIKA x(->North): 50.00 y(->West): -25.00"
+    _test_string = "LST-01\t Ground x(->North): 50.00 y(->West): -25.00"
     _test_string += "\t UTM East: 217635.45 UTM North: 3185116.68"
     _test_string += "\t Longitude: 28.76262 Latitude: -17.89177"
     assert _tcors == (_test_string + "\t Alt: 2158.00")


### PR DESCRIPTION
Fixed call to set coordinates of a telescopes when input is in Mercator in [simtools/layout/array_layout.py](simtools/layout/array_layout.py).

Includes also 

- improvements in both units and integration tests in this context. 
- renaming of `alt` to `altitude` in some remaining places (these had been missed before)
- renaming of 'CORSIKA' to 'Ground' in some remaining places (had also been missed before)

Note that we hardly use the longitude/latitude system (essentially only to get the coordinates of the reference positions, and we will not use them for telescope coordinates. Still, for testing we are doing the conversion - to allow this to work I introduced a flag `skip_input_validation`, as we don't want to introduce a schema for mercator just for testing.


