### PR TITLE
Add CONTEXT:NOTES to metadata

### DIFF
--- a/simtools/schemas/metadata.metaschema.yml
+++ b/simtools/schemas/metadata.metaschema.yml
@@ -462,6 +462,39 @@ definitions:
         type: object
         additionalProperties: false
         properties:
+          NOTES:
+            title: Context notes.
+            description: |-
+              Notes that provide additional context for this data product.
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                TITLE:
+                  description: |-
+                    Title of note.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                TEXT:
+                  description: |-
+                    Note text.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                CREATION_TIME:
+                  description: |-
+                    Creation time of document.
+                  anyOf:
+                    - type: string
+                      format: date-time
+                    - type: "null"
+                  default: null
+              required:
+                - TEXT
           DOCUMENT:
             title: Context documents.
             description: |-


### PR DESCRIPTION
Context fields are useful to add additional information for a data product. Adding here a CONTEXT:NOTES filed to add any associated comments / notes to the metadata.  As all CONTEXT field, this one is also optional.

In detail, this is a list:
```
CONTEXT:
   NOTES:
       - TITLE: "..."  (optional)
          TEXT: "..."  (required)
          CREATION_TIME: "date field"  (optional)
```    

