### PR TITLE
Add CONTEXT:NOTES to test file for metadata; rename test file altitude.json

### DIFF
--- a/simtools/constants.py
+++ b/simtools/constants.py
@@ -6,4 +6,4 @@ METADATA_JSON_SCHEMA = "schemas/metadata.metaschema.yml"
 DATA_JSON_SCHEMA = "schemas/data.metaschema.yml"
 
 # URL to the schema repository
-SCHEMA_URL = "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/"
+SCHEMA_URL = "https://raw.githubusercontent.com/gammasim/workflows/main/schemas/"

--- a/simtools/constants.py
+++ b/simtools/constants.py
@@ -6,4 +6,4 @@ METADATA_JSON_SCHEMA = "schemas/metadata.metaschema.yml"
 DATA_JSON_SCHEMA = "schemas/data.metaschema.yml"
 
 # URL to the schema repository
-SCHEMA_URL = "https://raw.githubusercontent.com/gammasim/workflows/main/schemas/"
+SCHEMA_URL = "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/"

--- a/tests/integration_tests/config/validate_file_using_schema_json_input.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input.yml
@@ -4,4 +4,4 @@ CTA_SIMPIPE:
   CONFIGURATION:
     SCHEMA: >
       https://raw.githubusercontent.com/gammasim/workflows/main/schemas/altitude.schema.yml
-    FILE_NAME: tests/resources/altitude.json
+    FILE_NAME: tests/resources/reference_point_altitude.json

--- a/tests/integration_tests/config/validate_file_using_schema_json_input.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input.yml
@@ -3,5 +3,5 @@ CTA_SIMPIPE:
   TEST_NAME: json_input
   CONFIGURATION:
     SCHEMA: >
-      https://raw.githubusercontent.com/gammasim/workflows/main/schemas/altitude.schema.yml
+      https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/reference_point_altitude.schema.yml
     FILE_NAME: tests/resources/reference_point_altitude.json

--- a/tests/integration_tests/config/validate_file_using_schema_json_input_no_schema.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input_no_schema.yml
@@ -2,4 +2,4 @@ CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
   TEST_NAME: json_input_no_schema
   CONFIGURATION:
-    FILE_NAME: tests/resources/altitude.json
+    FILE_NAME: tests/resources/reference_point_altitude.json

--- a/tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_input_test_meta.yml
@@ -2,5 +2,5 @@ CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
   TEST_NAME: json_input_test_meta
   CONFIGURATION:
-    FILE_NAME: tests/resources/altitude.json
+    FILE_NAME: tests/resources/reference_point_altitude.json
     VALIDATE_METADATA: true

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -1,5 +1,5 @@
 {
-    "value": 2162.0,
+    "Value": 2162.0,
     "units": "m",
     "type": "numpy.float64",
     "file": false,

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -1,9 +1,9 @@
 {
-    "Value": 2157.0,
+    "value": 2162.0,
     "units": "m",
-    "Type": "numpy.float64",
-    "File": false,
-    "Metadata": {
+    "type": "numpy.float64",
+    "file": false,
+    "metadata": {
         "CTA": {
             "REFERENCE": {
                 "VERSION": "1.0.0"
@@ -14,43 +14,42 @@
                 "EMAIL": null
             },
             "PRODUCT": {
-                "DESCRIPTION": "Altitude above sea level of site centre.",
-                "CREATION_TIME": null,
+                "DESCRIPTION": "Reference point altitude as used in prod6",
+                "CREATION_TIME": "2024-01-11T08:16:11",
                 "ID": null,
                 "DATA": {
-                    "CATEGORY": "CAL",
-                    "ASSOCIATION": "Subarray",
+                    "CATEGORY": null,
+                    "ASSOCIATION": "Site",
                     "LEVEL": "R1",
                     "TYPE": "Service",
                     "MODEL": {
-                        "NAME": "altitude",
+                        "NAME": "reference_point_altitude",
                         "VERSION": "0.1.0",
-                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/altitude.schema.yml"
+                        "URL": "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/reference_point_altitude.schema.yml"
                     }
                 },
                 "FORMAT": "json",
                 "VALID": {
                     "START": null,
                     "END": null
-                },
-                "FILENAME": null
+                }
             },
             "INSTRUMENT": {
-                "SITE": "CTAO-South",
-                "CLASS": null,
-                "TYPE": null,
+                "SITE": "CTA-South",
+                "CLASS": "Site",
+                "TYPE": "Observatory",
                 "SUBTYPE": null,
                 "ID": null,
                 "DESCRIPTION": null
             },
             "PROCESS": {
-                "TYPE": null,
-                "SUBTYPE": null,
+                "TYPE": "simulation",
+                "SUBTYPE": "simulation model parameter",
                 "ID": null
             },
             "ACTIVITY": {
-                "NAME": null,
-                "TYPE": null,
+                "NAME": "manual entry",
+                "TYPE": "user",
                 "ID": null,
                 "SOFTWARE": {
                     "NAME": null,

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -59,6 +59,11 @@
                 "END": null
             },
             "CONTEXT": {
+                "NOTES": [
+                    {
+                       "TEXT": "(this is just a test that notes are read out)"
+                    }
+                ],
                 "DOCUMENT": [
                     {
                         "TYPE": "CTAO-DOC",

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -47,7 +47,8 @@ def test_read_table_from_file_and_validate(telescope_north_test_file):
 
 def test_read_value_from_file(tmp_test_directory):
     assert isinstance(
-        data_reader.read_value_from_file("tests/resources/altitude.json"), u.quantity.Quantity
+        data_reader.read_value_from_file("tests/resources/reference_point_altitude.json"),
+        u.quantity.Quantity,
     )
 
     with pytest.raises(FileNotFoundError):
@@ -90,7 +91,9 @@ def test_read_value_from_file(tmp_test_directory):
 def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     # schema file from metadata in file
     with caplog.at_level(logging.DEBUG):
-        data_reader.read_value_from_file("tests/resources/altitude.json", validate=True)
+        data_reader.read_value_from_file(
+            "tests/resources/reference_point_altitude.json", validate=True
+        )
         assert "Successful validation of yaml/json file" in caplog.text
 
     # schema explicitly given
@@ -100,7 +103,7 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     )
     with caplog.at_level(logging.DEBUG):
         data_reader.read_value_from_file(
-            "tests/resources/altitude.json",
+            "tests/resources/reference_point_altitude.json",
             schema_file=schema_file,
             validate=True,
         )

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -99,7 +99,7 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     # schema explicitly given
     schema_file = (
         "https://raw.githubusercontent.com/gammasim/simulation_model/"
-        "main/schema/altitude.schema.yml"
+        "main/schema/reference_point_altitude.schema.yml"
     )
     with caplog.at_level(logging.DEBUG):
         data_reader.read_value_from_file(

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -117,7 +117,7 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
     metadata_1.args_dict["input_meta"] = "tests/resources/MLTdata-preproduction.meta.yml"
     assert len(metadata_1._read_input_metadata_from_file()) > 0
 
-    metadata_1.args_dict["input_meta"] = "tests/resources/altitude.json"
+    metadata_1.args_dict["input_meta"] = "tests/resources/reference_point_altitude.json"
     assert len(metadata_1._read_input_metadata_from_file()) > 0
 
     test_dict = {

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -45,7 +45,7 @@ def test_get_data_model_schema_file_name():
     # from data model_name
     _collector.data_model_name = "array_coordinates"
     schema_file = _collector.get_data_model_schema_file_name()
-    url = "https://raw.githubusercontent.com/gammasim/workflows/main/schemas/"
+    url = "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/"
     url += "array_coordinates.schema.yml"
     assert schema_file == url
 

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -45,7 +45,7 @@ def test_get_data_model_schema_file_name():
     # from data model_name
     _collector.data_model_name = "array_coordinates"
     schema_file = _collector.get_data_model_schema_file_name()
-    url = "https://raw.githubusercontent.com/gammasim/simulation_model/main/schema/"
+    url = "https://raw.githubusercontent.com/gammasim/workflows/main/schemas/"
     url += "array_coordinates.schema.yml"
     assert schema_file == url
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -521,7 +521,7 @@ def test_is_url():
 
 
 def test_collect_data_dict_from_json():
-    file = "tests/resources/altitude.json"
+    file = "tests/resources/reference_point_altitude.json"
     data = gen.collect_data_from_file_or_dict(file, None)
     assert len(data) == 5
     assert data["units"] == "m"
@@ -534,7 +534,7 @@ def test_collect_data_from_http():
     data = gen.collect_data_from_http(url + file)
     assert isinstance(data, dict)
 
-    file = "tests/resources/altitude.json"
+    file = "tests/resources/reference_point_altitude.json"
     data = gen.collect_data_from_http(url + file)
     assert isinstance(data, dict)
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -529,7 +529,7 @@ def test_collect_data_dict_from_json():
 
 def test_collect_data_from_http():
     file = "tests/resources/test_parameters.yml"
-    url = "https://raw.githubusercontent.com/gammasim/simtools/reference-point-altitude/"
+    url = "https://raw.githubusercontent.com/gammasim/simtools/main/"
 
     data = gen.collect_data_from_http(url + file)
     assert isinstance(data, dict)

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -529,7 +529,7 @@ def test_collect_data_dict_from_json():
 
 def test_collect_data_from_http():
     file = "tests/resources/test_parameters.yml"
-    url = "https://raw.githubusercontent.com/gammasim/simtools/main/"
+    url = "https://raw.githubusercontent.com/gammasim/simtools/reference-point-altitude/"
 
     data = gen.collect_data_from_http(url + file)
     assert isinstance(data, dict)


### PR DESCRIPTION
This pull requests serves two purposes:

- add CONTEXT:NOTES to test file (see PR #787)
- rename the test file `altitude.json` to sync with the naming in the simulation model repository `reference_point_altitude.json` - there is no need to review this file, this is done in https://github.com/gammasim/simulation_model/pull/4 - here we have a copy of this file.

Following tests cannot run successfully due to the renaming:

- tests/unit_tests/utils/test_general.py::test_collect_data_from_http (it looks for the new file reference_point_altitude.json in the simtools main branch, which will be there after merging of this PR; see [the successful test when given this branch name temporarily](https://github.com/gammasim/simtools/actions/runs/7640908598)

Related to #789 (but it doesn't close that issue)