### PR TITLE
Improvements to names.py - introduction of CTA array elements ID.

### DIFF
--- a/docs/source/coding_guidelines.rst
+++ b/docs/source/coding_guidelines.rst
@@ -129,7 +129,7 @@ Validating names
 
 Names that are recurrently used along the the package should be validated when given as input.
 Examples of names are: telescope, site, camera, model version. The functionalities to validate names
-are found in  :ref:`utils.names <utilsnames>`. The function validate_name receives the input string
+are found in  :ref:`utils.names <utilsnames>`. The function _validate_name receives the input string
 and a name dictionary,
 that is usually called all_something_names. This dictionary contain the possible names (as keys) and
 lists
@@ -139,7 +139,7 @@ is returned.
 
 The name dictionaries are also defined in util.names. One should also define specific functions
 named
-validate_something_names that call the validate_name with the proper name dictionary. This is only
+validate_something_names that call the _validate_name with the proper name dictionary. This is only
 meant to
 provide a clear interface.
 

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -13,7 +13,6 @@ from pymongo.errors import BulkWriteError
 
 import simtools.utils.general as gen
 from simtools.io_operations import io_handler
-from simtools.model.model_utils import get_telescope_class
 from simtools.utils import names
 
 __all__ = ["DatabaseHandler"]
@@ -287,7 +286,7 @@ class DatabaseHandler:
 
         """
 
-        _tel_class = get_telescope_class(telescope_model_name)
+        _tel_class = names.get_telescope_class(telescope_model_name)
         _tel_name_converted = names.convert_telescope_model_name_to_yaml(telescope_model_name)
 
         if _tel_class == "MST":
@@ -346,7 +345,7 @@ class DatabaseHandler:
 
         _site_validated = names.validate_site_name(site)
         _tel_name_db = self._get_telescope_model_name_for_db(_site_validated, telescope_model_name)
-        _tel_class = get_telescope_class(telescope_model_name)
+        _tel_class = names.get_telescope_class(telescope_model_name)
 
         self._logger.debug(f"Tel_name_db: {_tel_name_db}")
         self._logger.debug(f"Tel_class: {_tel_class}")

--- a/simtools/db_handler.py
+++ b/simtools/db_handler.py
@@ -287,7 +287,7 @@ class DatabaseHandler:
         """
 
         _tel_class = names.get_telescope_class(telescope_model_name)
-        _tel_name_converted = names.convert_telescope_model_name_to_yaml(telescope_model_name)
+        _tel_name_converted = names.convert_telescope_model_name_to_yaml_name(telescope_model_name)
 
         if _tel_class == "MST":
             # MST-FlashCam or MST-NectarCam

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -425,7 +425,7 @@ class ArrayLayout:
             )
         except ValueError:
             self._logger.warning(
-                "Missing definition of CORSIKA sphere center for telescope {tel_name}"
+                f"Missing definition of CORSIKA sphere center for telescope {tel_name}"
             )
 
         return 0.0 * u.m

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -156,7 +156,7 @@ class ArrayModel:
         _all_telescope_model_names = []  # List of telescope names without repetition
         _all_pars_to_change = {}
         for tel in self.layout:
-            tel_size = names.get_telescope_type(tel.name)
+            tel_size = names.get_telescope_class(tel.name)
 
             # Collecting telescope name and pars to change from array_config_data
             tel_model_name, pars_to_change = self._get_single_telescope_info_from_array_config(

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -11,7 +11,7 @@ from scipy.spatial import cKDTree as KDTree
 from scipy.spatial import distance
 
 import simtools.visualization.legend_handlers as leg_h
-from simtools.model.model_utils import get_camera_name, is_two_mirror_telescope
+from simtools.model.model_utils import is_two_mirror_telescope
 from simtools.utils import names
 from simtools.utils.geometry import rotate
 
@@ -48,7 +48,7 @@ class Camera:
         self._logger = logging.getLogger(__name__)
 
         self._telescope_model_name = telescope_model_name
-        self._camera_name = get_camera_name(self._telescope_model_name)
+        _, self._camera_name, _ = names.split_telescope_model_name(telescope_model_name)
         self._camera_config_file = camera_config_file
         self._focal_length = focal_length
         if self._focal_length <= 0:

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -11,11 +11,8 @@ from scipy.spatial import cKDTree as KDTree
 from scipy.spatial import distance
 
 import simtools.visualization.legend_handlers as leg_h
-from simtools.model.model_utils import (
-    get_camera_name,
-    get_telescope_class,
-    is_two_mirror_telescope,
-)
+from simtools.model.model_utils import get_camera_name, is_two_mirror_telescope
+from simtools.utils import names
 from simtools.utils.geometry import rotate
 
 __all__ = ["Camera"]
@@ -743,7 +740,7 @@ class Camera:
 
             if self._pixels["pix_id"][i_pix] < pixels_id_to_print + 1:
                 font_size = 4
-                if get_telescope_class(self._telescope_model_name) == "SCT":
+                if names.get_telescope_class(self._telescope_model_name) == "SCT":
                     font_size = 2
                 plt.text(
                     xy_pix_pos[0],

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -1,13 +1,11 @@
 #!/usr/bin/python3
 
-import logging
 import math
 
 from simtools.utils import names
 
 __all__ = [
     "compute_telescope_transmission",
-    "get_camera_name",
     "is_two_mirror_telescope",
     "split_simtel_parameter",
 ]
@@ -59,52 +57,6 @@ def compute_telescope_transmission(pars, off_axis):
 
     t = math.sin(off_axis * _deg_to_rad) / (pars[3] * _deg_to_rad)
     return pars[0] / (1.0 + pars[2] * t ** pars[4])
-
-
-def get_camera_name(telescope_model_name):
-    """
-    Get camera name from the telescope name.
-
-    Parameters
-    ----------
-    telescope_model_name: str
-        Telescope model name (e.g., LST-1).
-
-    Returns
-    -------
-    str
-        Camera name (validated by util.names).
-    """
-
-    _logger = logging.getLogger(__name__)
-    camera_name = ""
-    tel_class, tel_type, _ = names.split_telescope_model_name(telescope_model_name)
-    if tel_class == "LST":
-        camera_name = "LST"
-    elif tel_class == "MST":
-        if "FlashCam" in tel_type:
-            camera_name = "FlashCam"
-        elif "NectarCam" in tel_type:
-            camera_name = "NectarCam"
-        else:
-            _logger.error("Camera not found for MST class telescope")
-    elif tel_class == "SCT":
-        camera_name = "SCT"
-    elif tel_class == "SST":
-        if "ASTRI" in tel_type:
-            camera_name = "ASTRI"
-        elif "GCT" in tel_type:
-            camera_name = "GCT"
-        elif "1M" in tel_type:
-            camera_name = "1M"
-        else:
-            camera_name = "SST"
-    else:
-        _logger.error("Invalid telescope name - please validate it first")
-
-    camera_name = names.validate_sub_system_name(camera_name)
-    _logger.debug(f"Camera name - {camera_name}")
-    return camera_name
 
 
 def is_two_mirror_telescope(telescope_model_name):

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -103,7 +103,7 @@ def get_camera_name(telescope_model_name):
     else:
         _logger.error("Invalid telescope name - please validate it first")
 
-    camera_name = names.validate_camera_name(camera_name)
+    camera_name = names.validate_sub_system_name(camera_name)
     _logger.debug(f"Camera name - {camera_name}")
     return camera_name
 

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -7,7 +7,6 @@ from simtools.utils import names
 
 __all__ = [
     "compute_telescope_transmission",
-    "get_telescope_class",
     "get_camera_name",
     "is_two_mirror_telescope",
     "split_simtel_parameter",
@@ -79,7 +78,7 @@ def get_camera_name(telescope_model_name):
 
     _logger = logging.getLogger(__name__)
     camera_name = ""
-    tel_class, tel_type = names.split_telescope_model_name(telescope_model_name)
+    tel_class, tel_type, _ = names.split_telescope_model_name(telescope_model_name)
     if tel_class == "LST":
         camera_name = "LST"
     elif tel_class == "MST":
@@ -108,25 +107,6 @@ def get_camera_name(telescope_model_name):
     return camera_name
 
 
-def get_telescope_class(telescope_model_name):
-    """
-    Get telescope class from telescope name.
-
-    Parameters
-    ----------
-    telescope_model_name: str
-        Telescope model name (ex. LST-1).
-
-    Returns
-    -------
-    str
-        Telescope class (SST, MST, ...).
-    """
-
-    tel_class, _ = names.split_telescope_model_name(telescope_model_name)
-    return tel_class
-
-
 def is_two_mirror_telescope(telescope_model_name):
     """
     Check if the telescope is a two mirror design.
@@ -141,7 +121,7 @@ def is_two_mirror_telescope(telescope_model_name):
     bool
         True if the telescope is a two mirror one.
     """
-    tel_class, tel_type = names.split_telescope_model_name(telescope_model_name)
+    tel_class, tel_type, _ = names.split_telescope_model_name(telescope_model_name)
     if tel_class == "SST":
         # Only 1M is False
         return "1M" not in tel_type

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -4,6 +4,7 @@ import re
 _logger = logging.getLogger(__name__)
 
 __all__ = [
+    "array_element_id_from_telescope_model_name",
     "camera_efficiency_log_file_name",
     "camera_efficiency_results_file_name",
     "camera_efficiency_simtel_file_name",
@@ -15,10 +16,14 @@ __all__ = [
     "ray_tracing_file_name",
     "ray_tracing_plot_file_name",
     "ray_tracing_results_file_name",
+    "sanitize_name",
     "simtel_array_config_file_name",
+    "simtel_single_mirror_list_file_name",
     "simtel_telescope_config_file_name",
     "simtools_instrument_name",
     "split_telescope_model_name",
+    "telescope_model_name_from_array_element_id",
+    "translate_simtools_to_corsika",
     "validate_array_layout_name",
     "validate_model_version_name",
     "validate_name",

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -120,6 +120,7 @@ all_array_element_id_names = {
 # simulation_model parameter naming to DB parameter naming mapping
 # simtel: True if alternative "db_name" is used in simtools (e.g., ref_lat)
 #         and in the model database.
+# (this can be extended in future to include CORSIKA/sim_telarray and simtools names)
 site_parameters = {
     # Note inconsistency between old and new model
     # altitude was the corsika observation level in the old model
@@ -346,7 +347,7 @@ def validate_telescope_model_name(name):
         Validated name.
     """
 
-    # e.g, MSTN or MSN-01
+    # e.g, MSTN or MSTN-01
     try:
         return _validate_name(name, all_array_element_id_names)
     except ValueError:
@@ -429,12 +430,22 @@ def get_site_from_telescope_name(name):
     str
         Site name (South or North).
     """
+    # e.g, MSTN or MSTN-01
+    try:
+        _is_valid_name(name, all_array_element_id_names)
+        return validate_site_name(name[3])
+    except ValueError:
+        pass
+    # e.g., South-MST-FlashCam
     return validate_site_name(name.split("-")[0])
 
 
 def validate_telescope_name_db(name):
     """
     Validate a telescope DB name.
+    Examples are North-LST-1, North-MST-NectarCam-D, or South-SST-Structure-D.
+
+    TODO - inconsistent naming with def simtools_instrument_name
 
     Parameters
     ----------
@@ -576,6 +587,9 @@ def telescope_model_name_from_array_element_id(
 def simtools_instrument_name(site, telescope_class_name, sub_system_name, telescope_id_name):
     """
     Instrument name following simtools naming convention
+    Examples are North-LST-1, North-MST-NectarCam-D, or South-SST-Structure-D.
+
+    TODO - inconsistent naming with validate_telescope_name_db
 
     Parameters
     ----------

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -10,7 +10,7 @@ __all__ = [
     "camera_efficiency_simtel_file_name",
     "convert_telescope_model_name_to_yaml",
     "get_site_from_telescope_name",
-    "get_telescope_type",
+    "get_telescope_class",
     "layout_telescope_list_file_name",
     "ray_tracing_file_name",
     "ray_tracing_plot_file_name",
@@ -214,7 +214,7 @@ def validate_telescope_id_name(name):
         If name is not valid.
     """
 
-    if isinstance(name, int) or name.upper() == "D" or name.upper() == "D234" or name.isdigit():
+    if isinstance(name, int) or name.upper() in ("D", "D234", "TEST") or name.isdigit():
         return str(name).upper()
 
     msg = f"Invalid telescope ID name {name}"
@@ -921,9 +921,9 @@ def camera_efficiency_log_file_name(site, telescope_model_name, zenith_angle, az
     return name
 
 
-def get_telescope_type(telescope_name):
+def get_telescope_class(telescope_name):
     """
-    Guess telescope type from name, e.g. "LST", "MST", ...
+    Guess telescope class from name, e.g. "LST", "MST", ...
 
     Parameters
     ----------

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -158,7 +158,7 @@ def validate_telescope_id_name(name):
 
     Valid names e.g.,
     - D
-    - telescope ID (1, 5, 15)
+    - telescope ID (e.g., 1, 5, 15)
 
     Parameters
     ----------

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -8,7 +8,7 @@ __all__ = [
     "camera_efficiency_log_file_name",
     "camera_efficiency_results_file_name",
     "camera_efficiency_simtel_file_name",
-    "convert_telescope_model_name_to_yaml",
+    "convert_telescope_model_name_to_yaml_name",
     "get_site_from_telescope_name",
     "get_telescope_class",
     "layout_telescope_list_file_name",
@@ -421,7 +421,7 @@ def validate_telescope_name_db(name):
     return f"{validate_site_name(site)}-{validate_telescope_model_name(tel_model_name)}"
 
 
-def convert_telescope_model_name_to_yaml(name):
+def convert_telescope_model_name_to_yaml_name(name):
     """
     Get telescope name following the old convention (yaml files) from the current telescope name.
 

--- a/simtools/visualization/visualize.py
+++ b/simtools/visualization/visualize.py
@@ -563,7 +563,7 @@ def get_telescope_patch(name, x, y, radius):
         Instance of mpatches.Circle.
     """
     tel_obj = leg_h.TelescopeHandler()
-    valid_name = names.get_telescope_type(name)
+    valid_name = names.get_telescope_class(name)
     fill_flag = False
 
     x = x.to(u.m)
@@ -647,7 +647,7 @@ def plot_array(telescopes, rotate_angle=0, show_tel_label=False):
         for tel_type in tel_counters:
             if tel_type in tel_now["telescope_name"]:
                 tel_counters[tel_type] += 1
-        i_tel_name = names.get_telescope_type(telescopes[i_tel]["telescope_name"])
+        i_tel_name = names.get_telescope_class(telescopes[i_tel]["telescope_name"])
         patches.append(
             get_telescope_patch(
                 i_tel_name,

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -600,21 +600,13 @@ def test_try_set_coordinate(
     )
 
 
-def test_get_corsika_sphere_center(telescope_north_test_file, caplog):
+def test_get_corsika_sphere_center(telescope_north_test_file):
     layout = ArrayLayout(telescope_list_file=telescope_north_test_file)
 
     assert layout._get_corsika_sphere_center("LST") == 16.0 * u.m
 
-    with caplog.at_level(logging.WARNING):
-        assert layout._get_corsika_sphere_center("not_a_telescope") == 0.0 * u.m
-    assert (
-        "Missing definition of CORSIKA sphere center for telescope not_a_telescope of type"
-        in caplog.text
-    )
-
-    with caplog.at_level(logging.WARNING):
-        assert layout._get_corsika_sphere_center("") == 0.0 * u.m
-    assert "Missing definition of CORSIKA sphere center for telescope  of type " in caplog.text
+    assert layout._get_corsika_sphere_center("not_a_telescope") == 0.0 * u.m
+    assert layout._get_corsika_sphere_center("") == 0.0 * u.m
 
 
 def test_len(telescope_north_test_file):

--- a/tests/unit_tests/test_db_handler.py
+++ b/tests/unit_tests/test_db_handler.py
@@ -255,7 +255,7 @@ def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name_db="North-LST-Test",
+        telescope_model_name_db="North-LST-TEST",
         model_version="test",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
@@ -281,7 +281,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
         db_name=db.DB_CTA_SIMULATION_MODEL,
         tel_to_copy="North-LST-1",
         version_to_copy="Released",
-        new_tel_name="North-LST-Test",
+        new_tel_name="North-LST-TEST",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
         collection_to_copy_to="telescopes_" + random_id,
@@ -295,7 +295,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     )
     db.update_parameter_field(
         db_name=f"sandbox_{random_id}",
-        telescope="North-LST-Test",
+        telescope="North-LST-TEST",
         version="Released",
         parameter="camera_pixels",
         field="Applicable",
@@ -304,7 +304,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name_db="North-LST-Test",
+        telescope_model_name_db="North-LST-TEST",
         model_version="Released",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -137,12 +137,8 @@ def test_validate_telescope_name():
         logging.getLogger().info(f"New name {new_name}")
         assert value == new_name
 
-        _class, _type, _id = names.split_telescope_model_name(value)
+        _class, _, _id = names.split_telescope_model_name(value)
         assert names._is_valid_name(_class, names.all_telescope_class_names)
-        # TODO not sure about _type
-        # LST-1 returns "1"
-        # MST-FlashCam-D returns "FlashCam-D"
-        # "sst-1m" return "1M"
         if len(_id) > 0:
             assert names.validate_telescope_id_name(_id)
 
@@ -155,6 +151,7 @@ def test_get_site_from_telescope_name():
     assert "South" == names.get_site_from_telescope_name("South-MST-FlashCam-D")
     with pytest.raises(ValueError):
         names.get_site_from_telescope_name("NorthWest-LST-1")
+    assert "North" == names.get_site_from_telescope_name("MSTN")
     assert "North" == names.get_site_from_telescope_name("MSTN-05")
     assert "South" == names.get_site_from_telescope_name("MSTS-05")
 
@@ -173,7 +170,7 @@ def test_validate_name(caplog):
         names._validate_name("Aar", all_site_names)
 
 
-def test__is_valid_name():
+def test_is_valid_name():
     all_site_names = {
         "South": ["paranal", "south", "cta-south", "ctao-south", "s"],
         "North": ["lapalma", "north", "cta-north", "ctao-north", "n"],
@@ -194,7 +191,6 @@ def test_validate_telescope_name_db():
         "north-mst-nectarcam-d": "North-MST-NectarCam-D",
         "north-lst-1": "North-LST-1",
     }
-
     for key, value in telescopes.items():
         logging.getLogger().info(f"Validating {key}")
         new_name = names.validate_telescope_name_db(key)
@@ -207,7 +203,6 @@ def test_validate_telescope_name_db():
         "no-rth-mst-nectarcam-d": "No-rth-MST-NectarCam-D",
         "north-ls-1": "North-LS-1",
     }
-
     for key, value in telescopes.items():
         logging.getLogger().info(f"Validating {key}")
         with pytest.raises(ValueError):
@@ -232,14 +227,12 @@ def test_validate_model_version_name():
         names.validate_model_version_name("p0")
 
 
-def test_simtools_instrument_name():
-    assert names.simtools_instrument_name("South", "MST", "FlashCam", "D") == "South-MST-FlashCam-D"
-    assert (
-        names.simtools_instrument_name("North", "MST", "NectarCam", "7") == "North-MST-NectarCam-7"
-    )
+def test_get_telescope_name_db():
+    assert names.get_telescope_name_db("South", "MST", "FlashCam", "D") == "South-MST-FlashCam-D"
+    assert names.get_telescope_name_db("North", "MST", "NectarCam", "7") == "North-MST-NectarCam-7"
 
     with pytest.raises(ValueError):
-        names.simtools_instrument_name("West", "MST", "FlashCam", "D")
+        names.get_telescope_name_db("West", "MST", "FlashCam", "D")
 
 
 # TODO - this will go with the new naming convention
@@ -480,7 +473,6 @@ def test_simtel_single_mirror_list_file_name():
 
 
 def test_layout_telescope_list_file_name():
-    # TODO - discuss if usage of "-" and "_" is consistent
     assert (
         names.layout_telescope_list_file_name(
             name="Alpha",

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -209,13 +209,15 @@ def test_validate_telescope_name_db():
             names.validate_telescope_name_db(key)
 
 
-def test_convert_telescope_model_name_to_yaml():
-    assert names.convert_telescope_model_name_to_yaml("LST-1") == "LST"
-    assert names.convert_telescope_model_name_to_yaml("LST-D234") == "LST"
-    assert names.convert_telescope_model_name_to_yaml("MST-FlashCam-D") == "MST-FlashCam"
-    assert names.convert_telescope_model_name_to_yaml("SCT-D") == "SCT"
+def test_convert_telescope_model_name_to_yaml_name():
+    assert names.convert_telescope_model_name_to_yaml_name("LST-1") == "LST"
+    assert names.convert_telescope_model_name_to_yaml_name("LST-D234") == "LST"
+    assert names.convert_telescope_model_name_to_yaml_name("MST-FlashCam-D") == "MST-FlashCam"
+    assert names.convert_telescope_model_name_to_yaml_name("SCT-D") == "SCT"
     with pytest.raises(ValueError):
-        names.convert_telescope_model_name_to_yaml("South-SCT-D")
+        names.convert_telescope_model_name_to_yaml_name("South-SCT-D")
+    with pytest.raises(ValueError):
+        names.convert_telescope_model_name_to_yaml_name("LST-NectarCam-D")
 
 
 def test_validate_model_version_name():

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -155,6 +155,8 @@ def test_get_site_from_telescope_name():
     assert "South" == names.get_site_from_telescope_name("South-MST-FlashCam-D")
     with pytest.raises(ValueError):
         names.get_site_from_telescope_name("NorthWest-LST-1")
+    assert "North" == names.get_site_from_telescope_name("MSTN-05")
+    assert "South" == names.get_site_from_telescope_name("MSTS-05")
 
 
 def test_validate_name(caplog):

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -9,15 +9,126 @@ from simtools.utils import names
 logging.getLogger().setLevel(logging.DEBUG)
 
 
+all_telescope_names = [
+    "North-LST-1",
+    "North-LST-D234",
+    "North-MST-FlashCam-D",
+    "North-MST-NectarCam-D",
+    "North-MST-Structure-D",
+    "South-LST-D",
+    "South-MST-FlashCam-D",
+    "South-MST-Structure-D",
+    "South-SCT-D",
+    "South-SST-1M-D",
+    "South-SST-ASTRI-D",
+    "South-SST-Camera-D",
+    "South-SST-GCT-D",
+    "South-SST-Structure-D",
+]
+
+
+def test_validate_sub_system_name():
+    for key, value in names.all_subsystem_names.items():
+        for test_name in value:
+            assert key == names.validate_sub_system_name(test_name)
+    with pytest.raises(ValueError):
+        names.validate_sub_system_name("Not a camera")
+
+
+def test_validate_telescope_id_name(caplog):
+    for _id in [1, "1", "01", "D", "D234"]:
+        assert names.validate_telescope_id_name(_id) == str(_id)
+
+    for _id in ["no_id", "D2345"]:
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(ValueError):
+                names.validate_telescope_id_name(_id)
+            assert f"Invalid telescope ID name {_id}" in caplog.text
+
+
+def test_validate_site_name():
+    for key, value in names.all_site_names.items():
+        for test_name in value:
+            assert key == names.validate_site_name(test_name)
+    with pytest.raises(ValueError):
+        names.validate_site_name("Not a site")
+
+
+def test_validate_array_layout_name():
+    for key, value in names.all_array_layout_names.items():
+        for test_name in value:
+            assert key == names.validate_array_layout_name(test_name)
+    with pytest.raises(ValueError):
+        names.validate_array_layout_name("Not a layout")
+
+
 def test_validate_telescope_name():
-    telescopes = {"sst-d": "SST-D", "mst-flashcam-d": "MST-FlashCam-D", "sct-d": "SCT-D"}
+    telescopes = {
+        "lst-1": "LST-1",
+        "lst-D234": "LST-D234",
+        "mst-flashcam-d": "MST-FlashCam-D",
+        "mst-nectarcam-d": "MST-NectarCam-D",
+        "mst-NectarCam-5": "MST-NectarCam-5",
+        "MST-Structure-1": "MST-Structure-1",
+        "sct-d": "SCT-D",
+        "sst-1m": "SST-1M",
+        "sst-astri-d": "SST-ASTRI-D",
+        "SST-GCT-d": "SST-GCT-D",
+        "sst-gct-d": "SST-GCT-D",
+        "sst-d": "SST-D",
+    }
 
     for key, value in telescopes.items():
         logging.getLogger().info(f"Validating {key}")
         new_name = names.validate_telescope_model_name(key)
         logging.getLogger().info(f"New name {new_name}")
-
         assert value == new_name
+
+        _class, _type = names.split_telescope_model_name(value)
+        assert names.is_valid_name(_class, names.all_telescope_class_names)
+        # TODO not sure about _type
+        # LST-1 returns "1"
+        # MST-FlashCam-D returns "FlashCam-D"
+        # "sst-1m" return "1M"
+
+    _class, _type = names.split_telescope_model_name("North-MST-FlashCam-D")
+    print("AAA", _class, _type)
+
+
+def test_get_site_from_telescope_name():
+    assert "North" == names.get_site_from_telescope_name("North-LST-1")
+    assert "South" == names.get_site_from_telescope_name("South-MST-FlashCam-D")
+    with pytest.raises(ValueError):
+        names.get_site_from_telescope_name("NorthWest-LST-1")
+
+
+def test_validate_name(caplog):
+    all_site_names = {
+        "South": ["paranal", "south", "cta-south", "ctao-south", "s"],
+        "North": ["lapalma", "north", "cta-north", "ctao-north", "n"],
+    }
+
+    for key, value in all_site_names.items():
+        for _site in value:
+            assert key == names.validate_name(_site, all_site_names)
+
+    with pytest.raises(ValueError, match=r"Invalid name Aar"):
+        names.validate_name("Aar", all_site_names)
+
+
+def test_is_valid_name():
+    all_site_names = {
+        "South": ["paranal", "south", "cta-south", "ctao-south", "s"],
+        "North": ["lapalma", "north", "cta-north", "ctao-north", "n"],
+    }
+
+    for _, value in all_site_names.items():
+        for _site in value:
+            assert names.is_valid_name(_site, all_site_names)
+
+    assert not names.is_valid_name("Aar", all_site_names)
+    assert not names.is_valid_name("Aar", {})
+    assert not names.is_valid_name(5, all_site_names)
 
 
 def test_validate_telescope_name_db():
@@ -46,11 +157,20 @@ def test_validate_telescope_name_db():
             names.validate_telescope_name_db(key)
 
 
-def test_validate_other_names():
+def test_convert_telescope_model_name_to_yaml():
+    assert names.convert_telescope_model_name_to_yaml("LST-1") == "LST"
+    assert names.convert_telescope_model_name_to_yaml("LST-D234") == "LST"
+    with pytest.raises(ValueError):
+        names.convert_telescope_model_name_to_yaml("South-SCT-D")
+
+
+def test_validate_model_version_name():
     model_version = names.validate_model_version_name("p4")
-    logging.getLogger().info(model_version)
 
     assert model_version == "prod4"
+
+    with pytest.raises(ValueError):
+        names.validate_model_version_name("p0")
 
 
 def test_simtools_instrument_name():
@@ -63,13 +183,7 @@ def test_simtools_instrument_name():
         names.simtools_instrument_name("West", "MST", "FlashCam", "D")
 
 
-def test_translate_corsika_to_simtools():
-    corsika_pars = ["OBSLEV", "corsika_sphere_radius", "corsika_sphere_center"]
-    simtools_pars = ["corsika_obs_level", "corsika_sphere_radius", "corsika_sphere_center"]
-    for step, corsika_par in enumerate(corsika_pars):
-        assert names.translate_corsika_to_simtools(corsika_par) == simtools_pars[step]
-
-
+# TODO - this will go with the new naming convention
 def test_translate_simtools_to_corsika():
     corsika_pars = ["OBSLEV", "corsika_sphere_radius", "corsika_sphere_center"]
     simtools_pars = ["corsika_obs_level", "corsika_sphere_radius", "corsika_sphere_center"]
@@ -82,6 +196,10 @@ def test_sanitize_name():
     assert names.sanitize_name("Y_EDGES UNIT") == "y_edges_unit"
     assert names.sanitize_name("123name") == "_123name"
     assert names.sanitize_name("na!@#$%^&*()me") == "na__________me"
+    assert names.sanitize_name("!validName") == "_validname"
+
+    with pytest.raises(ValueError):
+        names.sanitize_name("")
 
 
 def test_get_telescope_type():
@@ -173,4 +291,307 @@ def test_camera_efficiency_names():
             site, telescope_model_name, zenith_angle, azimuth_angle, label
         )
         == "camera-efficiency-table-South-LST-1-za020deg_azm180deg.ecsv"
+    )
+
+
+def test_telescope_model_name_from_array_element_id(caplog):
+    tests_naming = {
+        "LSTN-01": {"sub_system": "structure", "tel": "LST-1"},
+        "LSTN-02": {"sub_system": "structure", "tel": "LST-D234"},
+        "LSTN-03": {"sub_system": "structure", "tel": "LST-D234"},
+        "LSTN-04": {"sub_system": "structure", "tel": "LST-D234"},
+        "MSTN-04": {"sub_system": "camera", "tel": "MST-NectarCam-D"},
+        "MSTN-03": {"sub_system": "structure", "tel": "MST-Structure-D"},
+        "LSTS-01": {"sub_system": "structure", "tel": "LST-D"},
+        "LSTS-04": {"sub_system": "structure", "tel": "LST-D"},
+        "LSTS-03": {"sub_system": "camera", "tel": "LST-D"},
+        "MSTS-25": {"sub_system": "camera", "tel": "MST-FlashCam-D"},
+        "MSTS-03": {"sub_system": "structure", "tel": "MST-Structure-D"},
+        "SCTS-02": {"sub_system": "structure", "tel": "SCT-D"},
+        "SCTS-01": {"sub_system": "camera", "tel": "SCT-D"},
+        "SSTS-32": {"sub_system": "structure", "tel": "SST-Structure-D"},
+        "SSTS-34": {"sub_system": "camera", "tel": "SST-Camera-D"},
+        "LSTS": {"sub_system": "camera", "tel": "LST-D"},
+        "MSTS": {"sub_system": "structure", "tel": "MST-Structure-D"},
+        "MSTN": {"sub_system": "camera", "tel": "MST-NectarCam-D"},
+    }
+
+    for key, value in tests_naming.items():
+        assert (
+            names.telescope_model_name_from_array_element_id(
+                array_element_id=key,
+                sub_system_name=value["sub_system"],
+                available_telescopes=all_telescope_names,
+            )
+            == value["tel"]
+        )
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(IndexError):
+            names.telescope_model_name_from_array_element_id(
+                array_element_id="LS",
+                sub_system_name="camera",
+                available_telescopes=all_telescope_names,
+            )
+        assert "Invalid array element ID LS" in caplog.text
+
+
+def test_array_element_id_from_telescope_model_name():
+    available_telescopes_north = {
+        "LST-1": "LSTN-01",
+        "LST-D234": "LSTN",
+        "MST-NectarCam-D": "MSTN",
+        "MST-NectarCam-14": "MSTN-14",
+        "MST-Structure-D": "MSTN",
+        "MST-Structure-3": "MSTN-03",
+    }
+    for key, value in available_telescopes_north.items():
+        assert (
+            names.array_element_id_from_telescope_model_name(site="North", telescope_model_name=key)
+            == value
+        )
+
+    available_telescopes_south = {
+        "LST-D": "LSTS",
+        "LST-3": "LSTS-03",
+        "MST-FlashCam-D": "MSTS",
+        "MST-FlashCam-12": "MSTS-12",
+        "MST-Structure-D": "MSTS",
+        "MST-Structure-9": "MSTS-09",
+        "SCT-D": "SCTS",
+        "SCT-11": "SCTS-11",
+        "SST-Camera-D": "SSTS",
+        "SST-Camera-04": "SSTS-04",
+        "SST-Camera-72": "SSTS-72",
+        "SST-Structure-D": "SSTS",
+        "SST-Structure-12": "SSTS-12",
+    }
+    for key, value in available_telescopes_south.items():
+        assert (
+            names.array_element_id_from_telescope_model_name(site="South", telescope_model_name=key)
+            == value
+        )
+
+
+def test_simtel_telescope_config_file_name():
+    assert (
+        names.simtel_telescope_config_file_name(
+            "South", "LST-1", "prod5", label=None, extra_label=None
+        )
+        == "CTA-South-LST-1-prod5.cfg"
+    )
+    assert (
+        names.simtel_telescope_config_file_name(
+            "South", "LST-1", "prod5", label="A", extra_label=None
+        )
+        == "CTA-South-LST-1-prod5_A.cfg"
+    )
+    assert (
+        names.simtel_telescope_config_file_name(
+            "South", "LST-1", "prod5", label="A", extra_label="B"
+        )
+        == "CTA-South-LST-1-prod5_A_B.cfg"
+    )
+
+
+def test_simtel_array_config_file_name():
+    assert (
+        names.simtel_array_config_file_name(
+            array_name="4LSTs", site="South", model_version="prod5", label=None
+        )
+        == "CTA-4LSTs-South-prod5.cfg"
+    )
+    assert (
+        names.simtel_array_config_file_name(
+            array_name="4LSTs", site="South", model_version="prod5", label="A"
+        )
+        == "CTA-4LSTs-South-prod5_A.cfg"
+    )
+
+
+def test_simtel_single_mirror_list_file_name():
+    assert (
+        names.simtel_single_mirror_list_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            model_version="prod5",
+            mirror_number=5,
+            label=None,
+        )
+        == "CTA-single-mirror-list-South-LST-1-prod5-mirror5.dat"
+    )
+    assert (
+        names.simtel_single_mirror_list_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            model_version="prod5",
+            mirror_number=5,
+            label="A",
+        )
+        == "CTA-single-mirror-list-South-LST-1-prod5-mirror5_A.dat"
+    )
+
+
+def test_layout_telescope_list_file_name():
+    # TODO - discuss if usage of "-" and "_" is consistent
+    assert (
+        names.layout_telescope_list_file_name(
+            name="Alpha",
+            label=None,
+        )
+        == "telescope_positions-Alpha.ecsv"
+    )
+    assert (
+        names.layout_telescope_list_file_name(
+            name="Alpha",
+            label="sub_MST",
+        )
+        == "telescope_positions-Alpha_sub_MST.ecsv"
+    )
+
+
+def test_ray_tracing_file_name():
+    assert (
+        names.ray_tracing_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            off_axis_angle=2.5,
+            mirror_number=3,
+            label="instance1",
+            base="Photons",
+        )
+        == "Photons-South-LST-1-d10.5-za45.0-off2.500_mirror3_instance1.lis"
+    )
+
+    assert (
+        names.ray_tracing_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            off_axis_angle=2.5,
+            mirror_number=None,
+            label=None,
+            base="log",
+        )
+        == "log-South-LST-1-d10.5-za45.0-off2.500.log"
+    )
+
+
+def test_ray_tracing_results_file_name():
+    assert (
+        names.ray_tracing_results_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            label="instance1",
+        )
+        == "ray-tracing-South-LST-1-d10.5-za45.0_instance1.ecsv"
+    )
+    assert (
+        names.ray_tracing_results_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            label=None,
+        )
+        == "ray-tracing-South-LST-1-d10.5-za45.0.ecsv"
+    )
+
+
+def test_ray_tracing_plot_file_name():
+    assert (
+        names.ray_tracing_plot_file_name(
+            key="d80_cm",
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            label="instance1",
+        )
+        == "ray-tracing-South-LST-1-d80_cm-d10.5-za45.0_instance1.pdf"
+    )
+    assert (
+        names.ray_tracing_plot_file_name(
+            key="d80_cm",
+            site="South",
+            telescope_model_name="LST-1",
+            source_distance=10.5,
+            zenith_angle=45.0,
+            label=None,
+        )
+        == "ray-tracing-South-LST-1-d80_cm-d10.5-za45.0.pdf"
+    )
+
+
+def test_camera_efficiency_results_file_name():
+    assert (
+        names.camera_efficiency_results_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label="test",
+        )
+        == "camera-efficiency-table-South-LST-1-za020deg_azm180deg_test.ecsv"
+    )
+    assert (
+        names.camera_efficiency_results_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label=None,
+        )
+        == "camera-efficiency-table-South-LST-1-za020deg_azm180deg.ecsv"
+    )
+
+
+def test_camera_efficiency_simtel_file_name():
+    assert (
+        names.camera_efficiency_simtel_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label="test",
+        )
+        == "camera-efficiency-South-LST-1-za020deg_azm180deg_test.dat"
+    )
+    assert (
+        names.camera_efficiency_simtel_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label=None,
+        )
+        == "camera-efficiency-South-LST-1-za020deg_azm180deg.dat"
+    )
+
+
+def test_camera_efficiency_log_file_name():
+    assert (
+        names.camera_efficiency_log_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label="test",
+        )
+        == "camera-efficiency-South-LST-1-za020deg_azm180deg_test.log"
+    )
+    assert (
+        names.camera_efficiency_log_file_name(
+            site="South",
+            telescope_model_name="LST-1",
+            zenith_angle=20,
+            azimuth_angle=180,
+            label=None,
+        )
+        == "camera-efficiency-South-LST-1-za020deg_azm180deg.log"
     )

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -259,18 +259,18 @@ def test_sanitize_name():
         names.sanitize_name("")
 
 
-def test_get_telescope_type():
-    assert names.get_telescope_type("LSTN-01") == "LST"
-    assert names.get_telescope_type("MSTN-02") == "MST"
-    assert names.get_telescope_type("SSTS-27") == "SST"
-    assert names.get_telescope_type("SCTS-27") == "SCT"
-    assert names.get_telescope_type("MAGIC-2") == "MAGIC"
-    assert names.get_telescope_type("VERITAS-4") == "VERITAS"
-    assert names.get_telescope_type("LST-") == "LST"
-    assert names.get_telescope_type("MST-1") == "MST"
+def test_get_telescope_class():
+    assert names.get_telescope_class("LSTN-01") == "LST"
+    assert names.get_telescope_class("MSTN-02") == "MST"
+    assert names.get_telescope_class("SSTS-27") == "SST"
+    assert names.get_telescope_class("SCTS-27") == "SCT"
+    assert names.get_telescope_class("MAGIC-2") == "MAGIC"
+    assert names.get_telescope_class("VERITAS-4") == "VERITAS"
+    assert names.get_telescope_class("LST-") == "LST"
+    assert names.get_telescope_class("MST-1") == "MST"
     for _name in ["", "01", "Not_a_telescope"]:
         with pytest.raises(ValueError):
-            names.get_telescope_type(_name)
+            names.get_telescope_class(_name)
 
 
 def test_camera_efficiency_names():


### PR DESCRIPTION
This is an improvement of names.py, related to PR #761 . Decided to separate this from PR #761, otherwise development and review would be very hard.

We have a difficult naming convention with some history. This makes names.py a bit more complicated then necessary, but I think it should be ok. We should make an effort that anything related to naming is in names.py.

This pull requests includes:

- improve unit test coverage
- removal of duplicated functions between names.py and model_utils.py
- improvement in handling of telescope names in names.py
- integration of CTAO array element IDs into names.py (e.g., MSTN-01)
- improve naming in names.py (e.g., get_telescope_type returned the telescope class; version and model_version was used)
- correct of names.split_telescope_model_name - it returns now consistently telescope class, subsystem, id

## Examples for naming:

- telescope_DB_name
	- North-LST-1
	- North-MST-NectarCam-D
	- South-SST-Structure-D
- telescope_model_name
	- LST-1, LSTN-01
	- MST-NectarCam-D, MSTN-01
	- SST-Structure-D, MSTS-01
- site
	- North, S
	- South, S
- telescope class
	- LST
	- MST
- subsystem name
	- LST
	- FlashCam
	- Structure
```

## New array elements and backwards compatibility

New array element names provide some backwards compatibility. This is also includes in the unit test.

- get_site_from_telescope_name("MSTN") == "North"
- get_telescope_type("MSTN") == "MST"
- split_telescope_model_name("MSTN") == "MST", "NectarCam", ""
	- this does not work for "SSTS", as we do not know if structure or camera. In this case "SST" is returned for the subsystem.
- validate_sub_system_name("LSTN") == "LST"
- validate_sub_system_name("MSTN") == "NectarCam"
- validate_sub_system_name("MSTS") == "FlashCam"


