### PR TITLE
Fix workflow to generate packages after release

### DIFF
--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -9,7 +9,8 @@ RUN microdnf update -y && microdnf install -y \
     python3.11-devel && \
     microdnf clean all
 
-RUN git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1
+RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \
+    git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1
 RUN cd /workdir/ && \
     python3.11 -m venv env && \
     source env/bin/activate && \

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,4 +1,4 @@
-From almalinux as build_image
+FROM almalinux as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -26,7 +26,7 @@ RUN rm -f sim_telarray/corsika-run && \
    mv sim_telarray/corsika-77*/run sim_telarray/corsika-run && \
    rm -rf sim_telarray/corsika-77*
 
-From almalinux/9-minimal
+FROM almalinux/9-minimal
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/


### PR DESCRIPTION
Workflows to generate packages don't run through for releases, see e.g., [here](https://github.com/gammasim/simtools/actions/runs/7712878687/job/21021437303#step:8:335)

Reason is that we are using

`git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git`

to clone a certain package. This works for pull requests with $BUILD_BRANCH is the actual branch name.

For releases, $BUILD_BRANCH is set e.g., to `refs/tags/v0.6.0`, which does not work with `git clone`. Added a sed command to remove `refs/tags/` so that in the example we do `git clone -b v0.6.0 ...`

I think the final test can only be done with a release. So after review and approval, I will release v0.6.1.