### PR TITLE
Add 2024, Feb 5 simtel version

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: download corsikasimtelpackage
         run: |
-          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL }}/download
+          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240205 }}/download
           mv download corsika7.7_simtelarray.tar.gz
 
       - name: Set up QEMU

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -16,7 +16,7 @@ RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
     tar -xvf corsika7.7_simtelarray.tar.gz && \
-    ./build_all prod5 qgs2 gsl
+    ./build_all prod6-sc qgs2 gsl
 
 RUN find sim_telarray/ -name "*.tar.gz" -exec rm -f {} \;
 


### PR DESCRIPTION
Use an updated sim_telarray / CORSIKA package (downloaded 2024, Feb5) pulled from a new sync&share link. 

- changed compiled options to `prod6-sc` (from `prod5`)
- new github secret `CLOUD_SIMTEL_240205`

This will be the new base image for the simtools-prod and simtools-dev containers.