### PR TITLE
Add CI for daily backups of the simulation model DB

### DIFF
--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -5,8 +5,6 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Run every night at 2 am
   workflow_dispatch:     # Manual trigger
-  pull_request:
-    types: [opened, synchronize]
 
 jobs:
   backup:

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -1,0 +1,62 @@
+name: Simulation model DB Backup
+env:
+  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
+  SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
+  SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
+  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
+  SIMTOOLS_DB_BACKUP_TOKEN: ${{ secrets.DB_BACKUP_TOKEN }}
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Run every night at 2 am
+  workflow_dispatch:     # Manual trigger
+
+jobs:
+  backup:
+    name: Backup Simulation Model DB
+    runs-on: ubuntu-latest
+    container:
+      image: mongo:latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        db: 
+          - CTA-Reference-Data
+          - CTA-Simulation-Model
+          - CTA-Simulation-Model-Derived-Values
+          - CTA-Simulation-Model-Descriptions
+          - Staging-CTA-Reference-Data
+          - Staging-CTA-Simulation-Model
+          - Staging-CTA-Simulation-Model-Derived-Values
+
+    steps:
+      - name: Dump MongoDB databases
+        run: | 
+          mongodump \
+           --uri="mongodb://${SIMTOOLS_DB_SERVER}:${SIMTOOLS_DB_API_PORT}"\
+           --ssl --tlsInsecure \
+           --username=$SIMTOOLS_DB_USER \
+           --password='KqK6cLku5U7S5SQT' \
+           --authenticationDatabase=$SIMTOOLS_DB_API_AUTHENTICATION_DATABASE \
+           --db=${{ matrix.db }} \
+           --gzip \
+           --archive="mongodump-${{ matrix.db }}"
+
+      - name: Checksums
+        run: |
+          md5sum mongodump-${{ matrix.db }} > mongodump-${{ matrix.db }}.md5
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date -u +'%Y%m%dT%H%MZ')"
+
+      - name: Upload backup to Sync & Share
+        run: |
+          apt-get update
+          apt-get install -y curl
+          curl -T mongodump-${{ matrix.db }} \
+           -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
+           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ steps.date.outputs.date }}"
+          curl -T mongodump-${{ matrix.db }}.md5 \
+           -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
+           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ steps.date.outputs.date }}.md5sum"

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -21,12 +21,12 @@ jobs:
       matrix:
         db:
           - CTA-Reference-Data
-#          - CTA-Simulation-Model
-#          - CTA-Simulation-Model-Derived-Values
-#          - CTA-Simulation-Model-Descriptions
-#          - Staging-CTA-Reference-Data
-#          - Staging-CTA-Simulation-Model
-#          - Staging-CTA-Simulation-Model-Derived-Values
+          - CTA-Simulation-Model
+          - CTA-Simulation-Model-Derived-Values
+          - CTA-Simulation-Model-Descriptions
+          - Staging-CTA-Reference-Data
+          - Staging-CTA-Simulation-Model
+          - Staging-CTA-Simulation-Model-Derived-Values
 
     steps:
 

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -1,12 +1,5 @@
 ---
 name: Simulation model DB Backup
-env:
-  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
-  SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
-  SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
-  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_API_AUTHENTICATION_DATABASE: ${{ secrets.DB_API_AUTHENTICATION_DATABASE }}
-  SIMTOOLS_DB_BACKUP_TOKEN: ${{ secrets.DB_BACKUP_TOKEN }}
 
 on:
   schedule:
@@ -22,26 +15,35 @@ jobs:
     container:
       image: mongo:latest
       options: --user 0
+      env:
+        SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
+        SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
+        SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
+        SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
+        SIMTOOLS_DB_API_AUTHENTICATION_DATABASE: ${{ secrets.DB_API_AUTHENTICATION_DATABASE }}
+        SIMTOOLS_DB_BACKUP_TOKEN: ${{ secrets.DB_BACKUP_TOKEN }}
+
     strategy:
       max-parallel: 1
       matrix:
         db:
           - CTA-Reference-Data
-          - CTA-Simulation-Model
-          - CTA-Simulation-Model-Derived-Values
-          - CTA-Simulation-Model-Descriptions
-          - Staging-CTA-Reference-Data
-          - Staging-CTA-Simulation-Model
-          - Staging-CTA-Simulation-Model-Derived-Values
+#          - CTA-Simulation-Model
+#          - CTA-Simulation-Model-Derived-Values
+#          - CTA-Simulation-Model-Descriptions
+#          - Staging-CTA-Reference-Data
+#          - Staging-CTA-Simulation-Model
+#          - Staging-CTA-Simulation-Model-Derived-Values
 
     steps:
+
       - name: Dump MongoDB databases
         shell: bash -l {0}
         run: |
           mongodump \
            --uri="mongodb://${{ env.SIMTOOLS_DB_SERVER }}:${{ env.SIMTOOLS_DB_API_PORT }}"\
            --ssl --tlsInsecure \
-           --username=${{ env.SIMTOOLS_DB_USER }} \
+           --username=${{ env.SIMTOOLS_DB_API_USER }} \
            --password=${{ env.SIMTOOLS_DB_API_PW }} \
            --authenticationDatabase=${{ env.SIMTOOLS_DB_API_AUTHENTICATION_DATABASE }}\
            --db=${{ matrix.db }} \

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Run every night at 2 am
   workflow_dispatch:     # Manual trigger
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   backup:

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -4,6 +4,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
+  SIMTOOLS_DB_API_AUTHENTICATION_DATABASE: ${{ secrets.DB_API_AUTHENTICATION_DATABASE }}
   SIMTOOLS_DB_BACKUP_TOKEN: ${{ secrets.DB_BACKUP_TOKEN }}
 
 on:
@@ -38,11 +39,11 @@ jobs:
         shell: bash -l {0}
         run: |
           mongodump \
-           --uri="mongodb://${SIMTOOLS_DB_SERVER}:${SIMTOOLS_DB_API_PORT}"\
+           --uri="mongodb://${{ env.SIMTOOLS_DB_SERVER }}:${{ env.SIMTOOLS_DB_API_PORT }}"\
            --ssl --tlsInsecure \
-           --username=$SIMTOOLS_DB_USER \
-           --password='KqK6cLku5U7S5SQT' \
-           --authenticationDatabase=$SIMTOOLS_DB_API_AUTHENTICATION_DATABASE \
+           --username=${{ env.SIMTOOLS_DB_USER }} \
+           --password=${{ env.SIMTOOLS_DB_API_PW }} \
+           --authenticationDatabase=${{ env.SIMTOOLS_DB_API_AUTHENTICATION_DATABASE }}\
            --db=${{ matrix.db }} \
            --gzip \
            --archive="mongodump-${{ matrix.db }}"

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mongo:latest
+      ports:
+        - 27017:27017
     strategy:
       max-parallel: 1
       matrix:
@@ -33,6 +35,7 @@ jobs:
 
     steps:
       - name: Dump MongoDB databases
+        shell: bash -l {0}
         run: |
           mongodump \
            --uri="mongodb://${SIMTOOLS_DB_SERVER}:${SIMTOOLS_DB_API_PORT}"\
@@ -45,20 +48,23 @@ jobs:
            --archive="mongodump-${{ matrix.db }}"
 
       - name: Checksums
+        shell: bash -l {0}
         run: |
           md5sum mongodump-${{ matrix.db }} > mongodump-${{ matrix.db }}.md5
 
       - name: Get current date
+        shell: bash -l {0}
         id: date
-        run: echo "::set-output name=date::$(date -u +'%Y%m%dT%H%MZ')"
+        run: echo "date=$(date -u +'%Y%m%dT%H%MZ')" >> $GITHUB_ENV
 
       - name: Upload backup to Sync & Share
+        shell: bash -l {0}
         run: |
           apt-get update
           apt-get install -y curl
           curl -T mongodump-${{ matrix.db }} \
            -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
-           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ steps.date.outputs.date }}"
+           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ env.date }}"
           curl -T mongodump-${{ matrix.db }}.md5 \
            -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
-           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ steps.date.outputs.date }}.md5sum"
+           "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ env.date }}.md5sum"

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mongo:latest
-      ports:
-        - 27017:27017
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        db: 
+        db:
           - CTA-Reference-Data
           - CTA-Simulation-Model
           - CTA-Simulation-Model-Derived-Values
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Dump MongoDB databases
-        run: | 
+        run: |
           mongodump \
            --uri="mongodb://${SIMTOOLS_DB_SERVER}:${SIMTOOLS_DB_API_PORT}"\
            --ssl --tlsInsecure \

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -1,3 +1,4 @@
+---
 name: Simulation model DB Backup
 env:
   SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
@@ -20,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mongo:latest
+      options: --user 0
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/DB-Backup.yml
+++ b/.github/workflows/DB-Backup.yml
@@ -15,13 +15,6 @@ jobs:
     container:
       image: mongo:latest
       options: --user 0
-      env:
-        SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
-        SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
-        SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
-        SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-        SIMTOOLS_DB_API_AUTHENTICATION_DATABASE: ${{ secrets.DB_API_AUTHENTICATION_DATABASE }}
-        SIMTOOLS_DB_BACKUP_TOKEN: ${{ secrets.DB_BACKUP_TOKEN }}
 
     strategy:
       max-parallel: 1
@@ -41,11 +34,11 @@ jobs:
         shell: bash -l {0}
         run: |
           mongodump \
-           --uri="mongodb://${{ env.SIMTOOLS_DB_SERVER }}:${{ env.SIMTOOLS_DB_API_PORT }}"\
+           --uri="mongodb://${{ secrets.DB_SERVER }}:${{ secrets.DB_API_PORT }}"\
            --ssl --tlsInsecure \
-           --username=${{ env.SIMTOOLS_DB_API_USER }} \
-           --password=${{ env.SIMTOOLS_DB_API_PW }} \
-           --authenticationDatabase=${{ env.SIMTOOLS_DB_API_AUTHENTICATION_DATABASE }}\
+           --username=${{ secrets.DB_API_USER }} \
+           --password=${{ secrets.DB_API_PW }} \
+           --authenticationDatabase=${{ secrets.DB_API_AUTHENTICATION_DATABASE }}\
            --db=${{ matrix.db }} \
            --gzip \
            --archive="mongodump-${{ matrix.db }}"
@@ -66,8 +59,8 @@ jobs:
           apt-get update
           apt-get install -y curl
           curl -T mongodump-${{ matrix.db }} \
-           -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
+           -u ${{ secrets.DB_BACKUP_TOKEN }}::"" -H "X-Requested-With: XMLHttpRequest" \
            "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ env.date }}"
           curl -T mongodump-${{ matrix.db }}.md5 \
-           -u "$SIMTOOLS_DB_BACKUP_TOKEN":"" -H "X-Requested-With: XMLHttpRequest" \
+           -u ${{ secrets.DB_BACKUP_TOKEN }}:"" -H "X-Requested-With: XMLHttpRequest" \
            "https://syncandshare.desy.de/public.php/webdav/mongodump-${{ matrix.db }}-${{ env.date }}.md5sum"


### PR DESCRIPTION
Add a CI for daily backups of the simulation model DB:

- runs every night at 2 am
- backup to sync and share folder at DESY (in GM area)
- runs md5sum over all files and moves the checksums also to sync and share
- all 7 databases are backed up (not that the matrix workflow is forced to run non-sequential by setting `max-parallel: 1` (no need to query the DB in parallel)
- mongodump uses the gzip option (important to note for restoring)

Uses the official mongo container. There is one inefficiency in the script: curl is installed for each matrix job, I simply could find out how to do this out of the loop. This takes 20s, and I don't think we are performance limited.

Quite important: I backup is only verified when it has been used to restore the data. This is what we haven't done and I am not sure if we should add this with a sandbox as part of this CI.
