### PR TITLE
Failing linters

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -102,7 +102,7 @@ jobs:
           YAML_CONFIG_FILE: yaml_config.yaml
           YAML_ERROR_ON_WARNING: false
           # isort
-          VALIDATE_PYTHON_ISORT: false
+          VALIDATE_PYTHON_ISORT: true
           PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           # flake8
           VALIDATE_PYTHON_FLAKE8: true

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -102,8 +102,8 @@ jobs:
           YAML_CONFIG_FILE: yaml_config.yaml
           YAML_ERROR_ON_WARNING: false
           # isort
-          # VALIDATE_PYTHON_ISORT: false
-          # PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+          VALIDATE_PYTHON_ISORT: false
+          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           # flake8
           VALIDATE_PYTHON_FLAKE8: true
           # black
@@ -113,8 +113,6 @@ jobs:
           VALIDATE_MARKDOWN: true
           # docker
           VALIDATE_DOCKERFILE_HADOLINT: true
-          # copy and paste
-          VALIDATE_JSCPD_ALL_CODEBASE: true
           # .env file
           VALIDATE_ENV: true
           # language
@@ -128,13 +126,3 @@ jobs:
           LOG_FILE: superlinter.log
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # Upload super-linter log file
-      # and keep it for 5 days
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: super-linter reports
-          path: |
-             superlinter.log
-             retention-days: 5

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -88,7 +88,7 @@ jobs:
 
 
       - name: Lint Code Base
-        uses: super-linter/super-linter@v5
+        uses: super-linter/super-linter@v6
         env:
           VALIDATE_ALL_CODEBASE: false
           # github actions

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -98,8 +98,8 @@ jobs:
           YAML_CONFIG_FILE: yaml_config.yaml
           YAML_ERROR_ON_WARNING: false
           # isort
-          VALIDATE_PYTHON_ISORT: true
-          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
+          VALIDATE_PYTHON_ISORT: false
+          # PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           # flake8
           VALIDATE_PYTHON_FLAKE8: true
           # black

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -98,7 +98,7 @@ jobs:
           YAML_CONFIG_FILE: yaml_config.yaml
           YAML_ERROR_ON_WARNING: false
           # isort
-          VALIDATE_PYTHON_ISORT: false
+          # VALIDATE_PYTHON_ISORT: false
           # PYTHON_ISORT_CONFIG_FILE: pyproject.toml
           # flake8
           VALIDATE_PYTHON_FLAKE8: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.2.0
     hooks:
       - id: black
         args: ["--line-length=100"]
   # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ["--max-line-length=100"]
@@ -48,6 +48,6 @@ repos:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.0.0"
+    rev: "1.7.0"
     hooks:
       - id: pyproject-fmt


### PR DESCRIPTION
This is to fix the failing superlinter runs in:

- https://github.com/gammasim/simtools/actions/runs/7970736433/job/21773599831
- https://github.com/gammasim/simtools/actions/runs/7962515062/job/21773848354

Fixed by:

- adding `fetch-depth 0` (new to super linter; see example in [manual](https://github.com/marketplace/actions/super-linter))
- remove depreciated `VALIDATE_JSCPD_ALL_CODEBASE`
- remove upload of log files as artifact (not sure why this fails, but we never used it!)

Also updates the tools in pre-commit using `pre-commit autoupdate`.

Merging this should also close #808 