### PR TITLE
Fix failing raytracing unit test 

### DIFF
--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -408,16 +408,17 @@ class RayTracing:
         KeyError
             If key is not among the valid options.
         """
-        if key not in self.YLABEL:
-            msg = "Invalid key to plot"
-            self._logger.error(msg)
-            raise KeyError(msg)
 
         self._logger.info(f"Plotting {key} vs off-axis angle")
 
-        plot = visualize.plot_table(
-            self._results["Off-axis angle", key], self.YLABEL[key], no_legend=True, **kwargs
-        )
+        try:
+            plot = visualize.plot_table(
+                self._results["Off-axis angle", key], self.YLABEL[key], no_legend=True, **kwargs
+            )
+        except KeyError as exc:
+            msg = "Invalid key to plot"
+            self._logger.error(msg)
+            raise exc
 
         if save:
             plot_file_name = names.ray_tracing_plot_file_name(

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -325,8 +325,6 @@ def test_check_data_type(caplog):
         )
     assert "Data column 'wavelength' has correct data type" in caplog.text
 
-    print("AAA", caplog.text)
-
     with caplog.at_level(logging.ERROR):
         with pytest.raises(TypeError):
             assert data_validator._check_data_type(

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -178,6 +178,7 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog):
         assert "Invalid key" in caplog.text
 
     # Now test a valid key
+    caplog.set_level(logging.INFO)
     ray_tracing_lst.plot(key="d80_cm", save=True)
     assert "Saving fig in" in caplog.text
     plot_file_name = names.ray_tracing_plot_file_name(

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -178,9 +178,9 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog):
         assert "Invalid key" in caplog.text
 
     # Now test a valid key
-    caplog.set_level(logging.INFO)
-    ray_tracing_lst.plot(key="d80_cm", save=True)
-    assert "Saving fig in" in caplog.text
+    with caplog.at_level(logging.INFO):
+        ray_tracing_lst.plot(key="d80_cm", save=True)
+        assert "Saving fig in" in caplog.text
     plot_file_name = names.ray_tracing_plot_file_name(
         "d80_cm",
         ray_tracing_lst._telescope_model.site,


### PR DESCRIPTION
Unclear why this worked before - setting `caplog.at_level(logging.INFO)` uses the correct logging level.

Further minor changes:

- remove a spurious debug print out in a test
- slightly rearrange the check for KeyError in raytraing:plot (asking for forgiveness..)