### PR TITLE
Address conda warning about pip

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - matplotlib-base
   - numpy
   - numpydoc
+  - pip
   - pre-commit
   - pylint
   - pymongo


### PR DESCRIPTION
Conda / mamba warns:

```
Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.
```

Added a one liner to add pip explicitly to the environment.