### PR TITLE
Add `-n auto` options to pytest CI

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -42,4 +42,4 @@ jobs:
           source /workdir/env/bin/activate
           pip install '.[tests,dev,doc]'
           export PYTHONPATH=$PYTHONPATH:.
-          pytest --color=yes --durations=10 --no-cov tests/integration_tests/
+          pytest --color=yes --durations=10 -n auto --dist loadscope --no-cov tests/integration_tests/

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Unit tests
         shell: bash -l {0}
         run: |
-          pytest --durations=10 --color=yes
+          pytest --durations=10 --color=yes -n auto --dist loadscope
 
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v4

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -69,14 +69,6 @@ def array_layout_south_four_LST_instance(
     return layout
 
 
-def test_array_layout_empty(db_config):
-    layout = ArrayLayout(mongo_db_config=db_config, site="South")
-    assert layout.get_number_of_telescopes() == 0
-
-    with pytest.raises(ValueError):
-        ArrayLayout(mongo_db_config=None, site=None)
-
-
 def test_from_array_layout_name(io_handler, db_config):
     layout = ArrayLayout.from_array_layout_name(
         mongo_db_config=db_config, array_layout_name="South-4LST"

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -74,7 +74,7 @@ def test_array_layout_empty(db_config):
     assert layout.get_number_of_telescopes() == 0
 
     with pytest.raises(ValueError):
-        ArrayLayout(mongo_db_config=None, site="South")
+        ArrayLayout(mongo_db_config=None, site=None)
 
 
 def test_from_array_layout_name(io_handler, db_config):

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -69,9 +69,12 @@ def array_layout_south_four_LST_instance(
     return layout
 
 
-def test_array_layout_empty():
-    layout = ArrayLayout()
+def test_array_layout_empty(db_config):
+    layout = ArrayLayout(mongo_db_config=db_config, site="South")
     assert layout.get_number_of_telescopes() == 0
+
+    with pytest.raises(ValueError):
+        ArrayLayout(mongo_db_config=None, site="South")
 
 
 def test_from_array_layout_name(io_handler, db_config):


### PR DESCRIPTION
Add `-n auto` for parallel execution of pytests in CI (after seeing it in the ctapipe workflows).

Unit test time is reduced typically by a factor of 2 using this (typically we get 2 workers per workflow).

This revealed in a issue with the unit test `tests/unit_tests/layout/test_array_layout.py::test_array_layout_empty()` - success / failure seems to depend on other tests. I've spend an hour on trying to solve this (see also PR #833) but without success. I have now looked how we use the `ArrayLayout` class and I think there is no need to test the case of an constructor without arguments. I therefore removed the test.

