### PR TITLE
Add pytest repeat  to find dependencies between unit tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-profiling
+  - pytest-repeat
   - pytest-xdist
   - python-dotenv
   - pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dynamic = [
@@ -65,6 +66,7 @@ dependencies = [
   "pytest-cov",
   "pytest-profiling",
   "pytest-random-order",
+  "pytest-repeat",
   "pytest-xdist",
 ]
 [project.urls]


### PR DESCRIPTION
Unit tests should be independent from each other - but occasionally this needs to be debugged and this is very hard.

Using the pytest random and repeat plugins are extremely helpful and this pull requests adds [pytest-repeat](https://pypi.org/project/pytest-repeat/).

Example usage:

```
pytest -n auto --count 10 --random-order --no-cov tests/unit_tests/layout/test_array_layout.py
```

This runs the unit tests in this file 10 times in random order. 