### PR TITLE
Add push of docker images on manual run

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -87,17 +87,12 @@ jobs:
       - name: Test Docker image
         if: matrix.type == 'prod'
         run: >
-          # Clone simulation model repo for faster file access
-          git clone https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git
-          # run docker
           docker run --rm
           -e "SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'"
           -e "SIMTOOLS_DB_API_PORT=${{ env.SIMTOOLS_DB_API_PORT }}"
           -e "SIMTOOLS_DB_API_USER=${{ env.SIMTOOLS_DB_API_USER }}"
           -e "SIMTOOLS_DB_API_PW=${{ env.SIMTOOLS_DB_API_PW }}"
-          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}"
-          -e "SIMTOOLS_DB_SIMULATION_MODEL_URL='./model_parameters'"
-          -v "$(pwd):/workdir/external" ${{ env.TEST_TAG }}
+          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}" -v "$(pwd):/workdir/external" ${{ env.TEST_TAG }}
           bash -c "cd /workdir/external && simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml"
         shell: /usr/bin/bash -e {0}
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -87,12 +87,17 @@ jobs:
       - name: Test Docker image
         if: matrix.type == 'prod'
         run: >
+          # Clone simulation model repo for faster file access
+          git clone https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git
+          # run docker
           docker run --rm
           -e "SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'"
           -e "SIMTOOLS_DB_API_PORT=${{ env.SIMTOOLS_DB_API_PORT }}"
           -e "SIMTOOLS_DB_API_USER=${{ env.SIMTOOLS_DB_API_USER }}"
           -e "SIMTOOLS_DB_API_PW=${{ env.SIMTOOLS_DB_API_PW }}"
-          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}" -v "$(pwd):/workdir/external" ${{ env.TEST_TAG }}
+          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}"
+          -e "SIMTOOLS_DB_SIMULATION_MODEL_URL='./model_parameters'"
+          -v "$(pwd):/workdir/external" ${{ env.TEST_TAG }}
           bash -c "cd /workdir/external && simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml"
         shell: /usr/bin/bash -e {0}
 
@@ -102,7 +107,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
+            ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
Allow to push the generated image also for manual workflow (trigger `workflow_dispatch`).

This is required during the development, where the simtools-prod and simtools-dev images generated from branches are needed.