### PR TITLE
Allow to push packages for manual workflow

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -47,6 +47,7 @@ jobs:
           else
             echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
           fi
+          echo "BUILD BRANCH ${{ env.BUILD_BRANCH }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -107,6 +107,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          build-args: BUILD_BRANCH=${{ env.BUILD_BRANCH }}
           platforms: linux/amd64,linux/arm64/v8
           push:
             ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Set build arguments (correct branch)
         run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]] || [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
+          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
             echo "BUILD_BRANCH=${GITHUB_HEAD_REF}" >> "$GITHUB_ENV"
           else
             echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -40,13 +40,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set build arguments
+      - name: Set build arguments (correct branch)
         run: |
-          if [[ "${{ github.event_name }}" == 'pull_request' ]]; then
+          if [[ "${{ github.event_name }}" == 'pull_request' ]] || [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             echo "BUILD_BRANCH=${GITHUB_HEAD_REF}" >> "$GITHUB_ENV"
           else
             echo "BUILD_BRANCH=${GITHUB_REF#refs/heads/}" >> "$GITHUB_ENV"
           fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -107,7 +108,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64/v8
           push:
-            ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' }}
+            ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-${{ matrix.type }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}


### PR DESCRIPTION
`.github/workflows/build-docker-images.yml` builds the images `simtools-dev` and `simtools-prod`, but pushes them to the package registry only for the events 'merge to main' and 'release'. 

This PR allows to push an image to the package registry using the manual workflow `workflow dispatch`.

Fixes also a bug that all images have been generated for main only (which was not an issue really before, but would be now).

Tests:

- this workflow was triggered manually: https://github.com/gammasim/simtools/actions/runs/8362792450
- this package was uploaded by the workflow: https://github.com/gammasim/simtools/pkgs/container/simtools-prod/193601007?tag=20240320-163811