### PR TITLE
Simplify application to add values to DB from json file; move to main application directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
 "repository" = "https://github.com/gammasim/simtools"
 [project.scripts]
 simtools-add-file-to-db = "simtools.applications.add_file_to_db:main"
+simtools-add-value-from-json-to-db = "simtools.applications.add_value_from_json_to_db:main"
 simtools-compare-cumulative-psf = "simtools.applications.compare_cumulative_psf:main"
 simtools-convert-all-model-parameters-from-simtel = "simtools.applications.convert_all_model_parameters_from_simtel:main"
 simtools-convert-model-parameter-from-simtel = "simtools.applications.convert_model_parameter_from_simtel:main"

--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -50,25 +50,6 @@ from simtools.configuration import configurator
 from simtools.db import db_handler
 
 
-def _user_confirm():
-    """
-    Ask the user to enter y or n (case-insensitive).
-
-    Returns
-    -------
-    bool: True if the answer is Y/y.
-    """
-
-    answer = ""
-    while answer not in ["y", "n"]:
-        try:
-            answer = input("Is this OK? [y/n]").lower()
-            return answer == "y"
-        except EOFError:
-            return False
-    return False
-
-
 def main():
     _db_tmp = db_handler.DatabaseHandler(mongo_db_config=None)
 
@@ -142,7 +123,7 @@ def main():
     print(f"Should the following file{plural} be inserted to the {args_dict['db']} DB?:\n")
     print(*files_to_insert, sep="\n")
     print()
-    if _user_confirm():
+    if gen.user_confirm():
         for file_to_insert_now in files_to_insert:
             db.insert_file_to_db(file_to_insert_now, args_dict["db"])
             logger.info(f"File {file_to_insert_now} inserted to {args_dict['db']} DB")

--- a/simtools/applications/add_value_from_json_to_db.py
+++ b/simtools/applications/add_value_from_json_to_db.py
@@ -3,11 +3,26 @@
 """
     Summary
     -------
-    This application is used to add a new parameter to a collection in the DB
-    using a json file as input.
+    This application adds a new parameter / value to a collection in the DB using a json
+    file as input.
 
-    This application should not be used by anyone but expert users and not often.
-    Therefore, no additional documentation about this applications will be given.
+    Command line arguments
+    ----------------------
+    file_name (str, required)
+        Name of the file to upload including the full path.
+    db_collection (str, required)
+        The DB collection to which to add the file.
+
+    Example
+    -------
+
+    Upload a file to sites collection:
+
+    .. code-block:: console
+
+        simtools-add-value-from-json-to-db \
+            --file_name new_value.json --db_collection sites
+
 
 """
 
@@ -33,28 +48,29 @@ def main():
 
     par_dict = gen.collect_data_from_file_or_dict(file_name=args_dict["file_name"], in_dict=None)
 
-    logger.info(f"Adding the following parameters to the DB: {par_dict['parameter']}")
+    logger.info(f"Adding the following parameter to the DB: {par_dict['parameter']}")
 
-    value_and_version = {
-        "prod6": par_dict["value"],
-        "default": 0,
-    }
-
-    for version, value in value_and_version.items():
+    print(f"Should {par_dict} be inserted to the {args_dict['db_collection']} collection?:\n")
+    if gen.user_confirm():
         db.add_new_parameter(
             db_name=db.DB_CTA_SIMULATION_MODEL,
             telescope=par_dict["instrument"],
             parameter=par_dict["parameter"],
-            version=version,
-            value=value,
+            version=par_dict["version"],
+            value=par_dict["value"],
             site=par_dict["site"],
             type=par_dict["type"],
             collection_name=args_dict["db_collection"],
             applicable=par_dict["applicable"],
             file=par_dict["file"],
-            unit=par_dict["unit"] if "unit" in par_dict and par_dict["unit"] is not None else None,
+            unit=par_dict.get("unit", None),
             file_prefix="./",
         )
+        logger.info(
+            f"Value for {par_dict['parameter']} added to {args_dict['db_collection']} collection"
+        )
+    else:
+        logger.info("Aborted, no change applied to the database")
 
 
 if __name__ == "__main__":

--- a/simtools/applications/add_value_from_json_to_db.py
+++ b/simtools/applications/add_value_from_json_to_db.py
@@ -12,6 +12,9 @@
         Name of the file to upload including the full path.
     db_collection (str, required)
         The DB collection to which to add the file.
+    db (str)
+        The DB to insert the files to. \
+        The choices are either the default CTA simulation DB or a sandbox for testing.
 
     Example
     -------
@@ -34,10 +37,24 @@ from simtools.db import db_handler
 
 
 def main():
+    _db_tmp = db_handler.DatabaseHandler(mongo_db_config=None)
     config = configurator.Configurator(description="Add a new parameter to the DB.")
     config.parser.add_argument("--file_name", help="file to be added", required=True)
     config.parser.add_argument(
-        "--db_collection", help="DB collection to which to add the file ", required=True
+        "--db_collection", help="DB collection to which to add new values.", required=True
+    )
+    config.parser.add_argument(
+        "--db",
+        type=str,
+        default=_db_tmp.DB_TABULATED_DATA,
+        choices=[
+            _db_tmp.DB_TABULATED_DATA,
+            _db_tmp.DB_DERIVED_VALUES,
+            _db_tmp.DB_REFERENCE_DATA,
+            "sandbox",
+            "test-data",
+        ],
+        help=("The database to insert the new values to."),
     )
     args_dict, db_config = config.initialize(db_config=True)
 

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -974,5 +974,5 @@ def user_confirm():
             answer = input("Is this OK? [y/n]").lower()
             return answer == "y"
         except EOFError:
-            return False
+            break
     return False

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -956,3 +956,23 @@ def get_value_as_quantity(value, unit):
             _logger.error(f"Cannot convert {value.unit} to {unit}.")
             raise
     return value * unit
+
+
+def user_confirm():
+    """
+    Ask the user to enter y or n (case-insensitive) on the command line.
+
+    Returns
+    -------
+    bool:
+        True if the answer is Y/y.
+
+    """
+    answer = ""
+    while answer not in ["y", "n"]:
+        try:
+            answer = input("Is this OK? [y/n]").lower()
+            return answer == "y"
+        except EOFError:
+            return False
+    return False

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -975,4 +975,3 @@ def user_confirm():
             return answer == "y"
         except EOFError:
             break
-    return False

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -968,10 +968,10 @@ def user_confirm():
         True if the answer is Y/y.
 
     """
-    answer = ""
-    while answer not in ["y", "n"]:
+    while True:
         try:
             answer = input("Is this OK? [y/n]").lower()
             return answer == "y"
         except EOFError:
             break
+    return False

--- a/tests/integration_tests/config/add_value_from_json_to_db_run.yml
+++ b/tests/integration_tests/config/add_value_from_json_to_db_run.yml
@@ -1,0 +1,7 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-add-value-from-json-to-db
+  TEST_NAME: run
+  CONFIGURATION:
+    FILE_NAME: ./tests/resources/num_gains.json
+    DB_COLLECTION: telescopes
+    DB: sandbox

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -6,6 +6,7 @@ import os
 import time
 from copy import copy
 from pathlib import Path
+from unittest.mock import patch
 
 import astropy.units as u
 import numpy as np
@@ -745,3 +746,13 @@ def test_assign_unit_to_quantity():
 
     with pytest.raises(u.UnitConversionError):
         gen.get_value_as_quantity(1000 * u.TeV, u.m)
+
+
+@patch("builtins.input", side_effect=["Y", "y"])
+def test_user_confirm_yes(mock_input):
+    assert gen.user_confirm()
+
+
+@patch("builtins.input", side_effect=["N", "n", EOFError, "not_Y_or_N"])
+def test_user_confirm_no(mock_input):
+    assert not gen.user_confirm()


### PR DESCRIPTION
This PR simplifies to application used to add values to the DB using json files:

- consider it a more frequently used application and move it to the main simtools/application folder (as e.g., add_file_to_db.py already is)
- upload explicitly the content of the json file to the DB and remove the temporarily introduced hardwired prod6 and default versions
- move `user_confirm()` function (asking for y/n on the command line) to simtools.general

code_cov keeps complaining about an untested line in general.py - but I don't find a way on how to make pylint and code_cov happy.
