### PR TITLE
Update of to simtel / corsika package with date 240318

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: download corsikasimtelpackage
         run: |
-          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240205 }}/download
+          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240318 }}/download
           mv download corsika7.7_simtelarray.tar.gz
 
       - name: Set up QEMU


### PR DESCRIPTION
Update of to simtel / corsika package with date 240318

This includes the most recent prod6 configuration for South.

The build is working fine, see [here](https://github.com/gammasim/simtools/actions/runs/8519039179/job/23332288210).

The corsika/simtel package is as always pulled from a DESY cloud directory and a new secret has been introduced for the cloud path.

Note that we need to introduce a mechanism to deal with different simulation software versions (see also #421).
