### PR TITLE
No need of test-data DB, as files are now in tests/resources

### DIFF
--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -86,7 +86,6 @@ def main():
             _db_tmp.DB_TABULATED_DATA,
             _db_tmp.DB_DERIVED_VALUES,
             "sandbox",
-            "test-data",
         ],
         help=("The database to insert the files to."),
     )

--- a/simtools/applications/add_value_from_json_to_db.py
+++ b/simtools/applications/add_value_from_json_to_db.py
@@ -51,7 +51,6 @@ def main():
             _db_tmp.DB_TABULATED_DATA,
             _db_tmp.DB_DERIVED_VALUES,
             "sandbox",
-            "test-data",
         ],
         help=("The database to insert the new values to."),
     )

--- a/simtools/applications/get_file_from_db.py
+++ b/simtools/applications/get_file_from_db.py
@@ -70,7 +70,6 @@ def main():
         db.DB_CTA_SIMULATION_MODEL_DESCRIPTIONS,
         db.DB_DERIVED_VALUES,
         "sandbox",
-        "test-data",
     ]
     file_id = None
     for db_name in available_dbs:

--- a/tests/integration_tests/config/get_file_from_db_test-data.yml
+++ b/tests/integration_tests/config/get_file_from_db_test-data.yml
@@ -1,6 +1,0 @@
-CTA_SIMPIPE:
-  APPLICATION: simtools-get-file-from-db
-  TEST_NAME: test-data
-  CONFIGURATION:
-    FILE_NAME: PSFcurve_data_v2.txt
-    OUTPUT_PATH: simtools-output


### PR DESCRIPTION
The test-data DB is not used anymore, as we have moved all files to tests/resources.

This PR does some minor maintenance:

- remove an integration test still using the test-data (the functionality of getting files from a DB is tested with two other tests, so no loss in testing)
- removal of `-test-data` from list of DBs.

Also dropped the test-data mongo DB.