### PR TITLE
Remove python 3.9 and add 3.12 from CI workflow

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -34,6 +34,10 @@ jobs:
             python-version: "3.11"
             install-method: pip
 
+          - os: ubuntu-latest
+            python-version: "3.12"
+            install-method: mamba
+
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -21,12 +21,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
-            python-version: "3.9"
-            install-method: mamba
-
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.11"
             install-method: mamba
 
           - os: ubuntu-latest


### PR DESCRIPTION
see #858 

3.12 is definitely more important than 3.9.