### PR TITLE
add illuminator to instrument

### DIFF
--- a/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -261,6 +261,8 @@ definitions:
     description: "specific type of instrument"
     enum:
       - Atmosphere
+      - ILLN
+      - ILLS
       - LSTN
       - LSTS
       - MSTN


### PR DESCRIPTION
Fixes pipeline in `model_parameters` failing due to missing illuminator entries.