### PR TITLE
Use astropy units in jsonschema validation

### DIFF
--- a/simtools/applications/generate_corsika_histograms.py
+++ b/simtools/applications/generate_corsika_histograms.py
@@ -65,7 +65,7 @@
                 bins: 100
                 scale: linear
                 start: !astropy.units.Quantity
-                    unit: &id001 !astropy.units.Unit {unit: m}
+                    unit: &id001 m
                     value: -1000.0
                 stop: &id002 !astropy.units.Quantity
                     unit: *id001
@@ -81,7 +81,7 @@
                 bins: 80
                 scale: linear
                 start: !astropy.units.Quantity
-                    unit: &id003 !astropy.units.Unit {unit: nm}
+                    unit: nm
                     value: 200.0
                 stop: !astropy.units.Quantity
                     unit: *id003
@@ -91,7 +91,7 @@
                 bins: 100
                 scale: linear
                 start: !astropy.units.Quantity
-                    unit: &id004 !astropy.units.Unit {unit: ns}
+                    unit: ns
                     value: -2000.0
                 stop: !astropy.units.Quantity
                     unit: *id004
@@ -100,7 +100,7 @@
                 bins: 100
                 scale: linear
                 start: !astropy.units.Quantity
-                    unit: &id005 !astropy.units.Unit {unit: km}
+                    unit: km
                     value: 120.0
                 stop: !astropy.units.Quantity
                     unit: *id005

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -10,12 +10,21 @@ Follows CTAO top-level data model definition.
 import logging
 from importlib.resources import files
 
+import astropy.units as u
 import jsonschema
 
 import simtools.constants
 import simtools.utils.general as gen
 
 _logger = logging.getLogger(__name__)
+
+
+@jsonschema.Draft7Validator.FORMAT_CHECKER.checks("astropy_unit", ValueError)
+def check_astropy_unit(unit_string):
+    if unit_string == "dimensionless":
+        return True
+    u.Unit(unit_string)
+    return True
 
 
 def validate_schema(data, schema_file):
@@ -39,7 +48,9 @@ def validate_schema(data, schema_file):
     schema, schema_file = _load_schema(schema_file)
 
     try:
-        jsonschema.validate(data, schema=schema)
+        jsonschema.validate(
+            data, schema=schema, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER
+        )
     except jsonschema.exceptions.ValidationError:
         _logger.error(f"Failed using {schema}")
         raise

--- a/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -360,30 +360,8 @@ definitions:
   Unit:
     type: string
     description: |-
-      "Unit correspond to astropy unit names
-      (wherever possible)"
-    enum:
-      - byte
-      - cm
-      - count
-      - count / mV
-      - count/mV
-      - deg
-      - dimensionless
-      - GHz
-      - m
-      - MHz
-      - mV
-      - mV * ns
-      - mV*ns
-      - nm
-      - ns
-      - 1/(sr*ns*cm**2)
-      - 1 / (sr * ns * cm**2)
-      - pct
-      - uA
-      - uT
-      - V
+      "Unit correspond to astropy unit names"
+    format: astropy_unit
     title: Unit
   SimulationSoftwareName:
     type: string

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -50,7 +50,7 @@ def test_validate_schema(tmp_test_directory):
         metadata_model.validate_schema(invalid_data, schema_file)
 
 
-def test_validate_schema_astro_py_units(caplog):
+def test_validate_schema_astropy_units(caplog):
     _schema = "simtools/schemas/model_parameter_and_data_schema.metaschema.yml"
 
     _dict_1 = gen.collect_data_from_file_or_dict(


### PR DESCRIPTION
Units for the schema and data file validation were hardwired until now in the schema files requiring explicit listing of all units.

This PR introduces a `format_checker` to allow testing that a given unit is a valid astropy unit (or `dimensionless`).
