### PR TITLE
Add validation of parameter name to be consistent with file name for for model_parameter files

### DIFF
--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -130,7 +130,7 @@ def validate_data_file(args_dict, logger):
         data_file=args_dict["file_name"],
         check_exact_data_type=args_dict["require_exact_data_type"],
     )
-    data_validator.validate_and_transform()
+    data_validator.validate_and_transform(is_model_parameter=True)
     if args_dict["data_type"].lower() == "model_parameter":
         data_validator.validate_parameter_and_file_name()
 

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -63,7 +63,7 @@ def _parse(label, description):
     config.parser.add_argument(
         "--data_type",
         help="type of input data",
-        choices=["metadata", "schema", "data"],
+        choices=["metadata", "schema", "data", "model_parameter"],
         default="data",
     )
     config.parser.add_argument(
@@ -131,6 +131,9 @@ def validate_data_file(args_dict, logger):
         check_exact_data_type=args_dict["require_exact_data_type"],
     )
     data_validator.validate_and_transform()
+    if args_dict["data_type"].lower() == "model_parameter":
+        data_validator.validate_parameter_and_file_name()
+
     logger.info(f"Successful validation of data file {args_dict['file_name']}")
 
 

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -57,9 +57,14 @@ class DataValidator:
         self.data_table = data_table
         self.check_exact_data_type = check_exact_data_type
 
-    def validate_and_transform(self):
+    def validate_and_transform(self, is_model_parameter=False):
         """
         Data and data file validation.
+
+        Parameters
+        ----------
+        is_model_parameter: bool
+            This is a model parameter (add some data preparation)
 
         Returns
         -------
@@ -76,6 +81,8 @@ class DataValidator:
         if self.data_file_name:
             self.validate_data_file()
         if isinstance(self.data_dict, dict):
+            if is_model_parameter:
+                self._prepare_model_parameter()
             self._validate_data_dict()
             return self.data_dict
         if isinstance(self.data_table, Table):
@@ -665,3 +672,13 @@ class DataValidator:
                 f"Data column '{column_name}' not found in reference column definition"
             )
             raise
+
+    def _prepare_model_parameter(self):
+        """
+        Apply data preparation for model parameters.
+
+        """
+        if isinstance(self.data_dict["value"], str):
+            self.data_dict["value"] = gen.convert_string_to_list(self.data_dict["value"])
+        if isinstance(self.data_dict["unit"], str):
+            self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -102,6 +102,19 @@ class DataValidator:
         except (AttributeError, TypeError):
             pass
 
+    def validate_parameter_and_file_name(self):
+        """
+        Validate that file name and key 'parameter_name' in data dict are the same.
+
+        """
+
+        if not self.data_dict.get("parameter") == Path(self.data_file_name).stem:
+            self._logger.error(
+                f"Parameter name in data dict {self.data_dict.get('parameter')} and "
+                f"file name {Path(self.data_file_name).stem} do not match."
+            )
+            raise ValueError
+
     def _validate_data_dict(self):
         """
         Validate values in a dictionary. Handles different types of naming in data dicts

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -1068,8 +1068,8 @@ def convert_list_to_string(data, comma_separated=False):
 
 def convert_string_to_list(data_string, is_float=True):
     """
-    Convert string (as used e.g. in sim_telarray) to list of floats
-    or integers.  Allow coma or space separated strings.
+    Convert string (as used e.g. in sim_telarray) to list.
+    Allow coma or space separated strings.
 
     Parameters
     ----------
@@ -1090,4 +1090,9 @@ def convert_string_to_list(data_string, is_float=True):
         return [int(v) for v in data_string.split()]
     except ValueError:
         pass
+    if "," in data_string:
+        result = data_string.split(",")
+        return [item.strip() for item in result]
+    if " " in data_string:
+        return data_string.split()
     return data_string

--- a/tests/integration_tests/config/validate_file_using_schema_json_validate_model_parameter.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_validate_model_parameter.yml
@@ -1,0 +1,8 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-validate-file-using-schema
+  TEST_NAME: json_validate_model_parameter
+  CONFIGURATION:
+    SCHEMA: >
+      https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/reference_point_altitude.schema.yml
+    FILE_NAME: tests/resources/reference_point_altitude.json
+    DATA_TYPE: model_parameter

--- a/tests/integration_tests/config/validate_file_using_schema_json_validate_model_parameter.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_validate_model_parameter.yml
@@ -2,7 +2,6 @@ CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
   TEST_NAME: json_validate_model_parameter
   CONFIGURATION:
-    SCHEMA: >
-      https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/reference_point_altitude.schema.yml
-    FILE_NAME: tests/resources/reference_point_altitude.json
+    SCHEMA: tests/resources/num_gains.schema.yml
+    FILE_NAME: tests/resources/num_gains.json
     DATA_TYPE: model_parameter

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -56,6 +56,18 @@ def test_validate_data_file(caplog):
     assert "Validating data from:" in caplog.text
 
 
+def test_validate_parameter_and_file_name():
+
+    data_validator = validate_data.DataValidator()
+    data_validator.data_file_name = "tests/resources/num_gains.json"
+    data_validator.schema_file_name = "tests/resources/num_gains.schema.yml"
+    data_validator.validate_and_transform()
+
+    data_validator.data_dict["parameter"] = "incorrect_name"
+    with pytest.raises(ValueError):
+        data_validator.validate_parameter_and_file_name()
+
+
 def test_validate_data_columns(tmp_test_directory, caplog):
     data_validator = validate_data.DataValidator()
     with pytest.raises(TypeError):

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -537,6 +537,34 @@ def test_validate_data_dict():
     data_validator_2._validate_data_dict()
 
 
+def test_prepare_model_parameter():
+    data_validator = validate_data.DataValidator()
+    data_validator.data_dict = {
+        "name": "reference_point_altitude",
+        "value": 1000.0,
+        "unit": "km",
+    }
+    data_validator._prepare_model_parameter()
+    assert pytest.approx(data_validator.data_dict["value"]) == 1000.0
+    assert data_validator.data_dict["unit"] == "km"
+
+    data_validator.data_dict["value"] = "1000. 2000. 3000."
+    data_validator._prepare_model_parameter()
+    assert pytest.approx(data_validator.data_dict["value"][0]) == 1000.0
+    assert pytest.approx(data_validator.data_dict["value"][2]) == 3000.0
+    assert data_validator.data_dict["unit"] == "km"
+
+    data_validator.data_dict["unit"] = "km, kg, s"
+    data_validator._prepare_model_parameter()
+    assert data_validator.data_dict["unit"][0] == "km"
+    assert data_validator.data_dict["unit"][1] == "kg"
+    assert data_validator.data_dict["unit"][2] == "s"
+
+    data_validator.data_dict["unit"] = ", , "
+    data_validator._prepare_model_parameter()
+    assert all(item == "" for item in data_validator.data_dict["unit"])
+
+
 def get_reference_columns_name_colx():
     """
     return a test reference data column definition

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -61,10 +61,10 @@ def test_get_parameter_value(telescope_model_lst):
     assert len(t_2) == 2
     assert pytest.approx(t_2[0]) == 0.8
     assert pytest.approx(t_2[1]) == 0.9
-    # mixed strings should stay string
+    # mixed strings should become list of strings
     _tmp_dict["value"] = "0.8 abc"
     t_2 = tel_model.get_parameter_value("t_2", _tmp_dict)
-    assert t_2 == "0.8 abc"
+    assert t_2 == ["0.8", "abc"]
 
 
 def test_get_parameter_value_with_unit(telescope_model_lst):

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -837,3 +837,8 @@ def test_convert_string_to_list():
     assert pytest.approx(t_3[0]) == 0.1
 
     assert gen.convert_string_to_list("bla_bla") == "bla_bla"
+    assert gen.convert_string_to_list("bla bla") == ["bla", "bla"]
+    assert gen.convert_string_to_list("bla,bla") == ["bla", "bla"]
+    # import for list of dimensionless entries in database
+    assert gen.convert_string_to_list(",") == ["", ""]
+    assert gen.convert_string_to_list(" , , ") == ["", "", ""]


### PR DESCRIPTION
A typical model_parameter files requires the file name to be the same as the `parameter` entry in the file.

e.g., num_gains.json looks like:

```
{
    "parameter": "num_gains",
    "instrument": "LSTN-01",
    "site": "North",
    "version": "2024-03-06",
    "value": 2,
    "unit": null,
    "type": "int64",
    "applicable": true,
    "file": false
}
```

Introduce in the application `validate_file_using_schema.py` a new `data_type` option called `model_parameter` which triggers the validation of file name and `parameter` entry.

After merging, this should be changed in the gitlab CI file in [model_parameters](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/blob/main/.gitlab-ci.yml?ref_type=heads#L52) (from `data` to `model_parameter`).
