### PR TITLE
Units with spaces

### DIFF
--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -679,5 +679,15 @@ class DataValidator:
 
         """
         if isinstance(self.data_dict["value"], str):
-            self.data_dict["value"] = gen.convert_string_to_list(self.data_dict["value"])
-            self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])
+            try:
+                _is_float = self.data_dict.get("type").startswith("float")
+            except AttributeError:
+                _is_float = True
+            self.data_dict["value"] = gen.convert_string_to_list(
+                self.data_dict["value"], is_float=_is_float
+            )
+            self.data_dict["unit"] = (
+                None
+                if self.data_dict["unit"] is None
+                else gen.convert_string_to_list(self.data_dict["unit"])
+            )

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -680,5 +680,4 @@ class DataValidator:
         """
         if isinstance(self.data_dict["value"], str):
             self.data_dict["value"] = gen.convert_string_to_list(self.data_dict["value"])
-        if isinstance(self.data_dict["unit"], str):
             self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -680,7 +680,9 @@ class DataValidator:
         """
         if isinstance(self.data_dict["value"], str):
             try:
-                _is_float = self.data_dict.get("type").startswith("float")
+                _is_float = self.data_dict.get("type").startswith("float") | self.data_dict.get(
+                    "type"
+                ).startswith("double")
             except AttributeError:
                 _is_float = True
             self.data_dict["value"] = gen.convert_string_to_list(

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -566,6 +566,13 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert all(item == "" for item in data_validator.data_dict["unit"])
 
+    data_validator.data_dict["value"] = "1000. 2000. 3000."
+    data_validator.data_dict["unit"] = "ct mV, m/s, N /m**2"
+    data_validator._prepare_model_parameter()
+    assert data_validator.data_dict["unit"][0] == "ct mV"
+    assert data_validator.data_dict["unit"][1] == "m/s"
+    assert data_validator.data_dict["unit"][2] == "N /m**2"
+
     data_validator.data_dict["value"] = "1000 2000 3000"
     data_validator.data_dict["unit"] = "ct"
     data_validator.data_dict["type"] = "int64"

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -566,6 +566,12 @@ def test_prepare_model_parameter():
     data_validator._prepare_model_parameter()
     assert all(item == "" for item in data_validator.data_dict["unit"])
 
+    data_validator.data_dict["value"] = "1000 2000 3000"
+    data_validator.data_dict["unit"] = "ct"
+    data_validator.data_dict["type"] = "int64"
+    data_validator._prepare_model_parameter()
+    assert isinstance(data_validator.data_dict["value"][0], int)
+
 
 def get_reference_columns_name_colx():
     """

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -554,12 +554,14 @@ def test_prepare_model_parameter():
     assert pytest.approx(data_validator.data_dict["value"][2]) == 3000.0
     assert data_validator.data_dict["unit"] == "km"
 
+    data_validator.data_dict["value"] = "1000. 2000. 3000."
     data_validator.data_dict["unit"] = "km, kg, s"
     data_validator._prepare_model_parameter()
     assert data_validator.data_dict["unit"][0] == "km"
     assert data_validator.data_dict["unit"][1] == "kg"
     assert data_validator.data_dict["unit"][2] == "s"
 
+    data_validator.data_dict["value"] = "1000. 2000. 3000."
     data_validator.data_dict["unit"] = ", , "
     data_validator._prepare_model_parameter()
     assert all(item == "" for item in data_validator.data_dict["unit"])


### PR DESCRIPTION
#865 introduces an issue for combined units including spaces: e.g., `m s` is resolved to `['m','s']`. 

This is solved by applying this only when `value` is also of list type. Note that this is still not perfect, but works for the current model parameters.

Solves also the missing correct treatment of `int` type for the string-to-list step (where the `type` field is now used to identify float entries).