### PR TITLE
Simple changes to accelerate integration tests.

### DIFF
--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -371,7 +371,7 @@ def main():
             simtel_source_path=args_dict.get("simtel_path", None),
             use_random_focal_length=args_dict["use_random_flen"],
         )
-        ray.simulate(test=False, force=True)  # force has to be True, always
+        ray.simulate(test=args_dict["test"], force=True)  # force has to be True, always
         ray.analyze(force=True)
 
         return (

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -349,7 +349,7 @@ def main():
     tel = _define_telescope_model(label, args_dict, db_config)
 
     if args_dict["test"]:
-        args_dict["number_of_mirrors_to_test"] = 4
+        args_dict["number_of_mirrors_to_test"] = 2
 
     if args_dict["psf_measurement"]:
         _get_psf_containment(logger, args_dict)

--- a/simtools/applications/plot_array_layout.py
+++ b/simtools/applications/plot_array_layout.py
@@ -40,6 +40,7 @@
 import logging
 from pathlib import Path
 
+import matplotlib
 import matplotlib.pyplot as plt
 from astropy import units as u
 
@@ -152,6 +153,7 @@ def main():
 
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
+    matplotlib.use("Agg")
 
     if args_dict["telescope_list"] is not None:
         logger.info("Plotting array from telescope list file(s).")
@@ -195,6 +197,7 @@ def main():
                 rotate_angle=one_angle,
                 show_tel_label=args_dict["show_tel_label"],
             )
+
             output_dir = io_handler_instance.get_output_directory(
                 label, sub_dir="application-plots"
             )
@@ -218,6 +221,7 @@ def main():
                     logger.info(f"Saving figure to {plot_file}.{ext}.")
                     plt.savefig(f"{str(plot_file)}.{ext}", bbox_inches="tight", dpi=400)
                 fig_out.clf()
+            plt.close()
 
 
 if __name__ == "__main__":

--- a/simtools/applications/tune_psf.py
+++ b/simtools/applications/tune_psf.py
@@ -222,6 +222,8 @@ def main():
     # Range around the previous values are hardcoded
     # Number of runs is hardcoded
     n_runs = 50
+    if args_dict["test"]:
+        n_runs = 5
     for _ in range(n_runs):
         mrra_range = 0.004 if not args_dict["fixed"] else 0
         mrf_range = 0.1

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -90,7 +90,7 @@ class SimtelRunnerRayTracing(SimtelRunner):
         # RayTracing - default parameters
         self._rep_number = 0
         self.runs_per_set = 1 if self.config.single_mirror_mode else 20
-        self.photons_per_run = 100000 if not test else 10000
+        self.photons_per_run = 100000 if not test else 5000
 
         self._load_required_files(force_simulate)
 

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg.yml
@@ -10,6 +10,6 @@ CTA_SIMPIPE:
     ZENITH_ANGLE: 20
     START_RUN: 0
     RUN: 2
-    NSHOW: 10
+    NSHOW: 5
     DATA_DIRECTORY: simtools-output
     OUTPUT_PATH: simtools-output

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml
@@ -10,7 +10,7 @@ CTA_SIMPIPE:
     ZENITH_ANGLE: 20
     START_RUN: 0
     RUN: 2
-    NSHOW: 10
+    NSHOW: 5
     DATA_DIRECTORY: simtools-output
     OUTPUT_PATH: simtools-output
     PACK_FOR_GRID_REGISTER: true


### PR DESCRIPTION
Try to look and implement some easy changes to accelerate integration tests. Currently, the then slowest tests are:

```
173.56s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-derive-mirror-rnda_psf_mean]
52.05s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-production_array_only]
51.03s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-derive-mirror-rnda_psf_no_tuning]
50.67s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-derive-mirror-rnda_psf_random_flen]
50.30s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-derive-mirror-rnda_psf_measurement]
39.07s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-production_showers_only]
34.18s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-simulate-prod_gamma_20_deg_pack_for_grid]
33.08s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-simulate-prod_gamma_20_deg]
21.68s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-tune-psf_run]
19.07s call     tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-plot-array-layout_two_files_two_angles]
======================= 151 passed in 1081.43s (0:18:01) =======================
```

I did not  look at any test slower than 30 s.

The changes below reduces the time for integration locally by 40% (hard to see immediately on github, as we don't control what kind of machine we get for the integration tests).

## derive_mirror_rnda

Changes applied:

- reduce number of mirrors tested (from 4 to 2) and photons (from 10k to 5k) in integration tests
- use `args_dict['test']` when calling `raytracing.simulate` (I think this was a bug that this was always set to true)

## production.py

This runs corsika and sim_telarray and generates 5 proton and 5 gamma-ray shower each. Don't think we should reduce it and I leave it as it is.

## simulate_prod.py

Is running two runs with 10 showers each. Reduced this to 5 showers (should be enough)

### tune_psf.py

Reduce the number of runs for testing from 50 to 5 (there was no reduction for tests before)

### plot_array_layout.py

Locally a lot of interactive python windows are opened when plotting. Add the corresponding matplotlib setting to avoid this and close all windows.

