### PR TITLE
allow to add to calibration_devices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.4.0
     hooks:
       - id: black
         args: ["--line-length=100"]
@@ -18,7 +18,7 @@ repos:
         args: ["--max-line-length=100"]
   # https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -37,13 +37,13 @@ repos:
           ]
   # https://github.com/HunterMcGushion/docstr_coverage
   - repo: https://github.com/HunterMcGushion/docstr_coverage
-    rev: v2.3.0  # most recent docstr-coverage release or commit sha
+    rev: v2.3.1  # most recent docstr-coverage release or commit sha
     hooks:
       - id: docstr-coverage
         args: ["--verbose", "2", "--fail-under", "70.", "simtools"]
   # gitup action
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.26
+    rev: v1.6.27
     hooks:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1039,8 +1039,14 @@ class DatabaseHandler:
             db_entry["instrument"] = names.validate_telescope_name(telescope)
         elif "sites" in collection_name:
             db_entry["instrument"] = names.validate_site_name(site)
+        # TODO: generalize later
+        elif "calibration_devices" in collection_name:
+            db_entry["calibration_devices"] = names.validate_telescope_name(site)
         else:
-            raise ValueError("Can only add new parameters to the sites or telescopes collections")
+            raise ValueError(
+                "Can only add new parameters to the sites, \
+                telescopes or calibration_devices collections"
+            )
 
         db_entry["version"] = version
         db_entry["parameter"] = parameter

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1041,7 +1041,7 @@ class DatabaseHandler:
             db_entry["instrument"] = names.validate_site_name(site)
         # TODO: generalize later
         elif "calibration_devices" in collection_name:
-            db_entry["calibration_devices"] = names.validate_telescope_name(site)
+            db_entry["calibration_devices"] = names.validate_telescope_name(telescope)
         else:
             raise ValueError(
                 "Can only add new parameters to the sites, \

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1039,9 +1039,8 @@ class DatabaseHandler:
             db_entry["instrument"] = names.validate_telescope_name(telescope)
         elif "sites" in collection_name:
             db_entry["instrument"] = names.validate_site_name(site)
-        # TODO: generalize later
         elif "calibration_devices" in collection_name:
-            db_entry["calibration_devices"] = names.validate_telescope_name(telescope)
+            db_entry["instrument"] = names.validate_telescope_name(telescope)
         else:
             raise ValueError(
                 "Can only add new parameters to the sites, \

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -314,6 +314,26 @@ def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler):
     assert pars["corsika_observation_level"]["value"] == pytest.approx(1800.0)
     assert pars["corsika_observation_level"]["unit"] == "m"
 
+    # calibration_devices parameters
+    db.add_new_parameter(
+        db_name=f"sandbox_{random_id}",
+        telescope="ILLN-design",
+        version="test",
+        parameter="led_pulse_offset",
+        value="0 ns",
+        collection_name="calibration_devices_" + random_id,
+    )
+    pars = db.read_mongo_db(
+        db_name=f"sandbox_{random_id}",
+        telescope_model_name="ILLN-design",
+        model_version="test",
+        run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
+        collection_name="calibration_devices_" + random_id,
+        write_files=False,
+    )
+    assert pars["led_pulse_offset"]["value"] == 0
+    assert pars["led_pulse_offset"]["unit"] == "ns"
+
     # wrong collection
     with pytest.raises(ValueError):
         db.add_new_parameter(


### PR DESCRIPTION
This PR allows to add json schemas to the collection of calibration_devices. I have added a TODO to modify the code later to be more general and to remove the naming of telescope and adjust the validation methods.