### PR TITLE
drop sandboxes

### DIFF
--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -23,6 +23,7 @@ def db_cleanup(db, random_id):
     # Cleanup
     logger.info(f"dropping the telescopes_{random_id} and metadata_{random_id} collections")
     db.db_client[f"sandbox_{random_id}"]["telescopes_" + random_id].drop()
+    db.db_client[f"sandbox_{random_id}"]["calibration_devices_" + random_id].drop()
     db.db_client[f"sandbox_{random_id}"]["metadata_" + random_id].drop()
     db.db_client[f"sandbox_{random_id}"]["sites_" + random_id].drop()
 


### PR DESCRIPTION
Removes the sandboxes generated by the unittests for the calibration_devices.