### PR TITLE
Generate docker files for different corsika/sim_telarray versions

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -22,23 +22,26 @@ env:
 
 jobs:
 
-  corsika-simtelarray-container:
+  download:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        type: ['prod6-sc']
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: download corsikasimtelpackage
         run: |
           wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240318 }}/download
           mv download corsika7.7_simtelarray.tar.gz
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: corsika-package
+          path: corsika7.7_simtelarray.tar.gz
+
+  prepare:
+    runs-on: ubuntu-latest
+    needs: download
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -52,6 +55,19 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+
+  build-corsika-simtelarray:
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        type: ['prod6-sc']
+
+    steps:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: download corsikasimtelpackage
         run: |
-          secret_name="CLOUD_SIMTEL_${{ matrix.version }}"
-          secret_value=${{ secrets[format('CLOUD_SIMTEL_{0}', matrix.version)] }}
+          echo "CLOUD_SIMTEL_${{ matrix.version }}"
           wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets[format('CLOUD_SIMTEL_{0}', matrix.version)] }}/download
           mv download corsika7.7_simtelarray.tar.gz
 

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -30,19 +30,22 @@ jobs:
     strategy:
       matrix:
         type: ['prod6-sc']
+        version: ['240318']
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: download corsikasimtelpackage
         run: |
           wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240318 }}/download
           mv download corsika7.7_simtelarray.tar.gz
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -50,9 +53,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -68,6 +65,9 @@ jobs:
         type: ['prod6-sc']
 
     steps:
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -29,7 +29,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        type: ['prod6-sc']
+        type: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
         version: ['240318']
 
     steps:
@@ -63,7 +63,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.type }}
+          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.type }}-${{ matrix.version }}
           flavor: latest=true
 
       - name: Build and push Docker image
@@ -76,4 +76,4 @@ jobs:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-simtelarray
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.type }}
+          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.type }}-${{ matrix.version }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -29,7 +29,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        type: ['corsika_sim_telarray']
+        type: ['prod6-sc']
 
     steps:
       - name: Checkout repository
@@ -62,7 +62,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-          images: ${{ env.REGISTRY }}/gammasim/simtools-${{ matrix.type }}
+          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.type }}
           flavor: latest=true
 
       - name: Build and push Docker image
@@ -70,8 +70,9 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
+          build-args: '{"BUILD_OPT": ${{ matrix.type }}, "HADRONIC_MODEL": "qgs2"}'
           push:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-simtelarray
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}-${{ matrix.type }}
+          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.type }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -22,24 +22,22 @@ env:
 
 jobs:
 
-  download:
+  build-corsika-simtelarray:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        type: ['prod6-sc']
+
     steps:
+
       - name: download corsikasimtelpackage
         run: |
           wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240318 }}/download
           mv download corsika7.7_simtelarray.tar.gz
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: corsika-package
-          path: corsika7.7_simtelarray.tar.gz
-
-  prepare:
-    runs-on: ubuntu-latest
-    needs: download
-    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -52,19 +50,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-
-  build-corsika-simtelarray:
-    runs-on: ubuntu-latest
-    needs: prepare
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        type: ['prod6-sc']
-
-    steps:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -6,11 +6,6 @@ on:
   pull_request:
     paths:
       - './docker/Dockerfile-simtelarray'
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
   release:
     types: [published]
   schedule:
@@ -29,7 +24,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        type: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
+        production: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
         version: ['240318']
         hadronic_model: ['qgs2']
 
@@ -65,7 +60,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.type }}-${{ matrix.version }}
+          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.production }}-${{ matrix.version }}
           flavor: latest=true
 
       - name: Build and push Docker image
@@ -73,9 +68,9 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64/v8
-          build-args: '{"BUILD_OPT": ${{ matrix.type }}, "HADRONIC_MODEL": "qgs2"}'
+          build-args: '{"BUILD_OPT": ${{ matrix.production }}, "HADRONIC_MODEL": "qgs2"}'
           push:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-simtelarray
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.type }}-${{ matrix.version }}
+          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.production }}-${{ matrix.version }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         type: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
         version: ['240318']
+        hadronic_model: ['qgs2']
 
     steps:
       - name: Checkout repository
@@ -38,7 +39,9 @@ jobs:
 
       - name: download corsikasimtelpackage
         run: |
-          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets.CLOUD_SIMTEL_240318 }}/download
+          secret_name="CLOUD_SIMTEL_${{ matrix.version }}"
+          secret_value=${{ secrets[format('CLOUD_SIMTEL_{0}', matrix.version)] }}
+          wget --no-verbose https://syncandshare.desy.de/index.php/s/${{ secrets[format('CLOUD_SIMTEL_{0}', matrix.version)] }}/download
           mv download corsika7.7_simtelarray.tar.gz
 
       - name: Set up QEMU
@@ -63,7 +66,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.type }}-${{ matrix.version }}
+          images: ${{ env.REGISTRY }}/gammasim/simtools-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.type }}-${{ matrix.version }}
           flavor: latest=true
 
       - name: Build and push Docker image
@@ -76,4 +79,4 @@ jobs:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-simtelarray
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.type }}-${{ matrix.version }}
+          labels: ${{ steps.meta.outputs.labels }}-corsika-sim-telarray-${{ matrix.hadronic_model }}-${{ matrix.type }}-${{ matrix.version }}

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,4 +1,7 @@
-FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
+ARG BUILD_OPT="prod6-sc"
+ARG HADRONIC_MODEL="qgs2"
+ARG VERSION="240318"
+FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${HADRONIC_MODEL}-${BUILD_OPT}-${VERSION}
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -1,4 +1,7 @@
-FROM ghcr.io/gammasim/simtools-corsika_sim_telarray
+ARG BUILD_OPT="prod6-sc"
+ARG HADRONIC_MODEL="qgs2"
+ARG VERSION="240318"
+FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${HADRONIC_MODEL}-${BUILD_OPT}-${VERSION}
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_BRANCH=main

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,6 +1,8 @@
 FROM almalinux as build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
+ARG BUILD_OPT="prod6-sc"
+ARG HADRONIC_MODEL="qgs2"
 
 RUN yum update -y && yum install -y \
     csh \
@@ -16,7 +18,7 @@ RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
     tar -xvf corsika7.7_simtelarray.tar.gz && \
-    ./build_all prod6-sc qgs2 gsl
+    ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
 RUN find sim_telarray/ -name "*.tar.gz" -exec rm -f {} \;
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,8 @@ Types of dockerfiles and containers available:
 
 - [simtools users](#container-for-simtools-users): a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
 - [simtools developers](#container-for-simtools-developers): a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
-- [CORSIKA/sim_telarray](#container-for-corsika-and-simtelarray): provides containers with the CORSIKA and sim\_telarray installed (for different sim\_telarray version, hadronic interaction models, CTAO MC productions). This provides base images for the previously listed containers. See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for different available containers.
+- [CORSIKA and sim_telarray](#container-for-corsika-and-simtelarray): provides containers with the CORSIKA and sim\_telarray installed (for different sim\_telarray version, hadronic interaction models, CTAO MC productions).
+This provides base images for the previously listed containers. See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for different available containers.
 
 ## Container for simtools users
 
@@ -95,7 +96,7 @@ docker build -f Dockerfile-dev -t simtools-dev .
 
 Use the docker container in the same way as above, replacing `ghcr.io/gammasim/simtools-dev:latest` by `simtools-dev`.
 
-## Container for CORSIKA and sim\_telarray
+## Container for CORSIKA and simtelarray
 
 Provide a container including the following the CORSIKA and sim\_telarray simulation software packages.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,9 +8,9 @@ Types of dockerfiles and containers available:
 
 - [simtools users](#container-for-simtools-users): a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
 - [simtools developers](#container-for-simtools-developers): a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
-- [sim_telarray](#container-for-corsika-and-simtelarray): provides a container with the CORSIKA and sim\_telarray installed. This provides the base image for the previously listed containers. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-simtelarray:latest`
+- [CORSIKA/sim_telarray](#container-for-corsika-and-simtelarray): provides containers with the CORSIKA and sim\_telarray installed (for different sim\_telarray version, hadronic interaction models, CTAO MC productions). This provides base images for the previously listed containers. See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for different available containers.
 
-## Container for simtools Users
+## Container for simtools users
 
 Provide a container for simtools users, which includes:
 
@@ -55,7 +55,7 @@ docker build -f Dockerfile-prod  -t simtools-prod .
 
 Building will take a while and the image is large (~1.4 GB). For using images build on your own, replace in all examples `ghcr.io/gammasim/simtools-prod:latest` by the local image name `simtools-prod`.
 
-## Container for simtools Developers
+## Container for simtools developers
 
 Provide a container for testing and development of simtools, including:
 
@@ -101,12 +101,12 @@ Provide a container including the following the CORSIKA and sim\_telarray simula
 
 ### Download from simtools container repository
 
-Packages are available from the [simtools container repository](https://github.com/gammasim/containers/pkgs/container/simtools-simtel).
+Packages are available from the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for different options (e.g., sim\_telarray versions, hadronic interaction models, CTA MC productions).
 
-To download and run a prepared container in bash:
+To download and run a prepared container in bash using e.g., a container for prod6:
 
 ```bash
-docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/simtools-simtelarray:latest bash
+docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/simtools-corsika-sim-telarray-qgs2-prod6-baseline-240318:latest bash
 ```
 
 ## Build a new container locally

--- a/docker/README.md
+++ b/docker/README.md
@@ -96,6 +96,14 @@ docker build -f Dockerfile-dev -t simtools-dev .
 
 Use the docker container in the same way as above, replacing `ghcr.io/gammasim/simtools-dev:latest` by `simtools-dev`.
 
+Containers can be built using different build arguments, e.g.,
+
+```bash
+docker build -f Dockerfile-simtelarray --build-arg="BUILD_OPT=prod5" -t simtel-docker-dev .
+```
+
+See the docker files for all available build arguments.
+
 ## Container for CORSIKA and simtelarray
 
 Provide a container including the following the CORSIKA and sim\_telarray simulation software packages.


### PR DESCRIPTION
The container [simtools-corsika_sim_telarray](https://github.com/gammasim/simtools/pkgs/container/simtools-corsika_sim_telarray) is the base for all simtools containers. As sim_telarray compilation depends on the production, this PR adds matrix jobs to generate containers for the most important production options.

- add build option as a matrix type (added also hadronic interaction model to docker build options; not used the the moment)
- add version of sim_telarray package into matrix (currently: run only over newest package, 240318)
- corsika / sim_telarray containers are build not for every simtools PR (as nothing changes with regards to those)

For now, this generates only different versions of the corsika/sim-telarray package and uses for the prod and dev containers the newest version of those (hardwired as defaults in the docker files).

In future, we might want to publish prod and dev containers for many versions (issue #421)

**Important**: nothing changes at this point for `simtools-prod` and `simtools-dev` containers.
