### PR TITLE
Re-enable docker images for arm64 architectures 

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -108,9 +108,7 @@ jobs:
         with:
           context: .
           build-args: BUILD_BRANCH=${{ env.BUILD_BRANCH }}
-          # TODO disable arm64/v8 until issues with boost histograms are solved
-          # platforms: linux/amd64,linux/arm64/v8
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64/v8
           push:
             ${{ github.event_name == 'release' || github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
           file: ./docker/Dockerfile-${{ matrix.type }}

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN microdnf update -y && microdnf install -y \
     findutils \
+    gcc-c++ \
     git \
     python3.11-pip \
     python3.11-devel \

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_BRANCH=main
 
 RUN microdnf update -y && microdnf install -y \
+    gcc-c++ \
     git \
     python3.11-pip \
     python3.11-devel && \


### PR DESCRIPTION
I am opening this pull request to test in certain intervals if this has been fixed on the boost-histogram side.

We definitely need those images ready for arm64.