### PR TITLE
Allow `model_version` command line configuration of integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,10 @@ def db_no_config_file():
     return db
 
 
+def pytest_addoption(parser):
+    parser.addoption("--model_version", action="store", default=None)
+
+
 @pytest.fixture
 def model_version():
     """

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -316,7 +316,7 @@ def prepare_configuration(config, output_path, model_version=None):
     get_list_of_test_configurations(),
     ids=get_list_of_test_configurations(get_test_names=True),
 )
-def test_applications_from_config(tmp_test_directory, config, monkeypatch, request):
+def test_applications_from_config(tmp_test_directory, config, monkeypatch, request, model_version):
     """
     Test all applications from config files found in the config directory.
 
@@ -367,6 +367,6 @@ def test_applications_from_config(tmp_test_directory, config, monkeypatch, reque
 
     # output validation for tests with default values
     # (no change of config from command line)
-    if request.config.getoption("--model_version") is None:
+    if request.config.getoption("--model_version") == model_version:
         output_status = validate_application_output(config)
         assert output_status == 0


### PR DESCRIPTION
This PR adds an option to allow to run the integration tests for different model versions and adds a `--model_version` to the integration tests.

Example:

```
pytest --no-cov --model_version="prod5" \
    "tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-print-array-elements_utm_to_ground_meta_in_yml]"
```

Adds also a matrix job to the integration test CI to run over prod6 (default, labeled as 2024-02-01) and prod5.

Note that the additional tests (e.g., file content comparison) are disabled for the non-default version (which is given in conftest.py through the `model_version` fixture. Reason for that is that we otherwise would have to keep track and add comparison tables in test/resources for all model versions.
