### PR TITLE
Add unix find to development docker

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -3,6 +3,7 @@ WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN microdnf update -y && microdnf install -y \
+    findutils \
     git \
     python3.11-pip \
     python3.11-devel \


### PR DESCRIPTION
This PR adds the standard unix 'find' utility to the development container.

This is needed for debugging and finding e.g., a certain generated configuration file in the simtools output directories. 