### PR TITLE
Bug fix: drop metadata collection after tests

### DIFF
--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -167,6 +167,7 @@ def test_add_tagged_version(db, random_id, db_cleanup, io_handler, model_version
 
     assert db._get_tagged_version(f"sandbox_{random_id}", "Released") == "2020-06-28"
     assert db._get_tagged_version(f"sandbox_{random_id}", "Latest") == "2024-02-01"
+    db.db_client[f"sandbox_{random_id}"]["metadata"].drop()
 
 
 def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler, model_version):


### PR DESCRIPTION
The db_handler unit tests are generating sandbox databases and remove them after the tests. One of them is not removed; this PR adds the explicit removal.

(note that the metadata collection is generated in a slightly different way then the other ones; this is why the fixture to remove all of them was not working).