### PR TITLE
Unify array elements in names.py and json schema

### DIFF
--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -15,6 +15,7 @@ import jsonschema
 
 import simtools.constants
 import simtools.utils.general as gen
+from simtools.utils import names
 
 _logger = logging.getLogger(__name__)
 
@@ -109,8 +110,47 @@ def _load_schema(schema_file=None):
         schema_file = files("simtools").joinpath("schemas") / schema_file
         schema = gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)
     _logger.debug(f"Loading schema from {schema_file}")
+    _add_array_elements("InstrumentTypeElement", schema)
 
     return schema, schema_file
+
+
+def _add_array_elements(key, schema):
+    """
+    Add list of array elements to schema.
+    This assumes an element [key]['enum'] is a list of elements.
+
+    Parameters
+    ----------
+    key: str
+        Key in schema dictionary
+    schema: dict
+        Schema dictionary
+
+    Returns
+    -------
+    dict
+        Schema dictionary with added array elements.
+
+    """
+
+    _list_of_array_elements = sorted(list(names.array_elements().keys()))
+
+    def recursive_search(sub_schema, key):
+        if key in sub_schema:
+            if "enum" in sub_schema[key] and isinstance(sub_schema[key]["enum"], list):
+                sub_schema[key]["enum"] = list(
+                    set(sub_schema[key]["enum"] + _list_of_array_elements)
+                )
+            else:
+                sub_schema[key]["enum"] = _list_of_array_elements
+        else:
+            for _, v in sub_schema.items():
+                if isinstance(v, dict):
+                    recursive_search(v, key)
+
+    recursive_search(schema, key)
+    return schema
 
 
 def _resolve_references(yaml_data, observatory="CTA"):

--- a/simtools/schemas/array_elements.yml
+++ b/simtools/schemas/array_elements.yml
@@ -1,0 +1,137 @@
+%YAML 1.2
+---
+title: List of allowed array elements
+version: 0.1.0
+description: |
+  List of array elements known to simtools and its
+  corresponding database collections.
+  Also used as part of the schema validation process.
+data:
+  LSTN:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "North"
+  MSTN:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "North"
+  LSTS:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "South"
+  MSTS:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "South"
+  SSTS:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "South"
+    description: "Small-sized telescope"
+  SCTS:
+    collection: "telescopes"
+    observatory: "CTAO"
+    site: "South"
+    description: "Mid-sized Schwarzschild-Couder telescope"
+  ILLN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Illuminator"
+  RLDN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Raman lidar"
+  STPN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Wide-field stellar photometer"
+  MSPN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Moon/sun photometer"
+  CEIN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Ceilometer"
+  WSTN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Weather station"
+  ASCN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "All-sky camera"
+  DUSN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Dust sensor"
+  LISN:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "North"
+    description: "Lightning sensor"
+  ILLS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Illuminator"
+  RLDS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Raman lidar"
+  STPS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Wide-field stellar photometer"
+  MSPS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Moon/sun photometer"
+  CEIS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Ceilometer"
+  WSTS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Weather station"
+  ASCS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "All-sky camera"
+  DUSS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Dust sensor"
+  LISS:
+    collection: "calibration_devices"
+    observatory: "CTAO"
+    site: "South"
+    description: "Lightning sensor"
+  HESS:
+    collection: "telescopes"
+    site: "South"
+    observatory: "HESS"
+  MAGIC:
+    collection: "telescopes"
+    site: "North"
+    observatory: "MAGIC"
+  VERITAS:
+    collection: "telescopes"
+    site: "North"
+    observatory: "VERITAS"

--- a/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -262,14 +262,6 @@ definitions:
     description: "specific type of instrument"
     enum:
       - Atmosphere
-      - ILLN
-      - ILLS
-      - LSTN
-      - LSTS
-      - MSTN
-      - MSTS
-      - SSTS
-      - SCTS
       - Observatory
       - None
     title: InstrumentTypeElement

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from functools import lru_cache
+from pathlib import Path
 
 import yaml
 
@@ -24,7 +25,8 @@ __all__ = [
 
 @lru_cache(maxsize=None)
 def load_array_elements():
-    with open("simtools/schemas/array_elements.yml", "r", encoding="utf-8") as file:
+    base_path = Path(__file__).parent
+    with open(base_path / "../schemas/array_elements.yml", "r", encoding="utf-8") as file:
         return yaml.safe_load(file)["data"]
 
 

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -24,7 +24,7 @@ __all__ = [
 
 
 @lru_cache(maxsize=None)
-def load_array_elements():
+def array_elements():
     """
     Load array elements from reference files and keep in cache.
 
@@ -36,18 +36,6 @@ def load_array_elements():
     base_path = Path(__file__).parent
     with open(base_path / "../schemas/array_elements.yml", "r", encoding="utf-8") as file:
         return yaml.safe_load(file)["data"]
-
-
-def array_elements():
-    """
-    Access to array elements table
-
-    Returns
-    -------
-    dict
-        Array elements.
-    """
-    return load_array_elements()
 
 
 site_names = {

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -25,12 +25,28 @@ __all__ = [
 
 @lru_cache(maxsize=None)
 def load_array_elements():
+    """
+    Load array elements from reference files and keep in cache.
+
+    Returns
+    -------
+    dict
+        Array elements.
+    """
     base_path = Path(__file__).parent
     with open(base_path / "../schemas/array_elements.yml", "r", encoding="utf-8") as file:
         return yaml.safe_load(file)["data"]
 
 
 def array_elements():
+    """
+    Access to array elements table
+
+    Returns
+    -------
+    dict
+        Array elements.
+    """
     return load_array_elements()
 
 

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -1,5 +1,8 @@
 import logging
 import re
+from functools import lru_cache
+
+import yaml
 
 _logger = logging.getLogger(__name__)
 
@@ -18,39 +21,16 @@ __all__ = [
     "validate_telescope_name",
 ]
 
-# Telescopes and other array elements
-array_element_names = {
-    # CTAO telescopes
-    "LSTN": {"site": "North", "observatory": "CTAO", "collection": "telescopes"},
-    "MSTN": {"site": "North", "observatory": "CTAO", "collection": "telescopes"},
-    "LSTS": {"site": "South", "observatory": "CTAO", "collection": "telescopes"},
-    "MSTS": {"site": "South", "observatory": "CTAO", "collection": "telescopes"},
-    "SSTS": {"site": "South", "observatory": "CTAO", "collection": "telescopes"},
-    "SCTS": {"site": "South", "observatory": "CTAO", "collection": "telescopes"},
-    # calibration devices
-    "ILLN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "RLDN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "STPN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "MSPN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "CEIN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "WSTN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "ASCN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "DUSN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "LISN": {"site": "North", "observatory": "CTAO", "collection": "calibration_devices"},
-    "ILLS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "RLDS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "STPS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "MSPS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "CEIS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "WSTS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "ASCS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "DUSS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    "LISS": {"site": "South", "observatory": "CTAO", "collection": "calibration_devices"},
-    # other telescopes
-    "MAGIC": {"site": "North", "observatory": "MAGIC", "collection": "telescopes"},
-    "VERITAS": {"site": "North", "observatory": "VERITAS", "collection": "telescopes"},
-    "HESS": {"site": "South", "observatory": "HESS", "collection": "telescopes"},
-}
+
+@lru_cache(maxsize=None)
+def load_array_elements():
+    with open("simtools/schemas/array_elements.yml", "r", encoding="utf-8") as file:
+        return yaml.safe_load(file)["data"]
+
+
+def array_elements():
+    return load_array_elements()
+
 
 site_names = {
     "South": ["paranal", "south", "cta-south", "ctao-south", "s"],
@@ -314,9 +294,7 @@ def validate_telescope_name(name):
     except ValueError as exc:
         msg = f"Invalid name {name}"
         raise ValueError(msg) from exc
-    return (
-        _validate_name(_tel_type, array_element_names) + "-" + validate_telescope_id_name(_tel_id)
-    )
+    return _validate_name(_tel_type, array_elements()) + "-" + validate_telescope_id_name(_tel_id)
 
 
 def get_telescope_name_from_type_site_id(telescope_type, site, telescope_id):
@@ -356,7 +334,7 @@ def get_telescope_type_from_telescope_name(name):
     str
         Telescope type.
     """
-    return _validate_name(name.split("-")[0], array_element_names)
+    return _validate_name(name.split("-")[0], array_elements())
 
 
 def get_list_of_telescope_types(array_element_class="telescopes", site=None, observatory="CTAO"):
@@ -377,7 +355,7 @@ def get_list_of_telescope_types(array_element_class="telescopes", site=None, obs
     """
     return [
         key
-        for key, value in array_element_names.items()
+        for key, value in array_elements().items()
         if value["collection"] == array_element_class
         and (site is None or value["site"] == site)
         and (observatory is None or value["observatory"] == observatory)
@@ -398,7 +376,7 @@ def get_site_from_telescope_name(name):
     str
         Site name (South or North).
     """
-    return array_element_names[get_telescope_type_from_telescope_name(name)]["site"]
+    return array_elements()[get_telescope_type_from_telescope_name(name)]["site"]
 
 
 def get_collection_name_from_array_element_name(name):
@@ -416,7 +394,7 @@ def get_collection_name_from_array_element_name(name):
         Collection name .
     """
 
-    return array_element_names[get_telescope_type_from_telescope_name(name)]["collection"]
+    return array_elements()[get_telescope_type_from_telescope_name(name)]["collection"]
 
 
 def get_simtel_name_from_parameter_name(

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -120,6 +120,16 @@ def test_resolve_references():
     assert metadata_model._resolve_references(yaml_data) == expected_result
 
 
+def test_add_array_elements():
+
+    test_dict_1 = {"data": {"InstrumentTypeElement": {"enum": ["LSTN", "MSTN"]}}}
+    test_dict_added = metadata_model._add_array_elements("InstrumentTypeElement", test_dict_1)
+    assert len(test_dict_added["data"]["InstrumentTypeElement"]["enum"]) > 2
+    test_dict_2 = {"data": {"InstrumentTypeElement": {"not_the_right_enum": ["LSTN", "MSTN"]}}}
+    test_dict_added_2 = metadata_model._add_array_elements("InstrumentTypeElement", test_dict_2)
+    assert len(test_dict_added_2["data"]["InstrumentTypeElement"]["enum"]) > 2
+
+
 def test_fill_defaults(caplog):
     schema = {
         "CTA": {


### PR DESCRIPTION
This PR removes the duplicated listing of all allowed array elements (e.g., names of telescopes or calibration devices). Introduces a yaml file with the list of all allowed array elements and necessary properties.

This list is:

- ready in names.py using the new `load_array_elements` function. The dictionary read in is cached, so reading of the yaml file is happening only once.
- this dict is now returned instead of `names.array_element_names`
- this is added to the enum field of allowed array elements in the json schema field `InstrumentTypeElement` in `simtools/schemas/model_parameter_and_data_schema.metaschema.yml`

