### PR TITLE
Name of simulation model database as configuration entry

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -6,6 +6,7 @@ SIMTOOLS_DB_SERVER='cta-simpipe-protodb.zeuthen.desy.de' # MongoDB server
 SIMTOOLS_DB_API_USER=YOUR_USERNAME # username for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model'
 # SIMTOOLS_DB_SIMULATION_MODEL_URL=''
 SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
 

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -7,6 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
+  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model"
   SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -7,6 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
+  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model"
 
 on:
   pull_request:

--- a/simtools/applications/add_file_to_db.py
+++ b/simtools/applications/add_file_to_db.py
@@ -81,12 +81,6 @@ def main():
     config.parser.add_argument(
         "--db",
         type=str,
-        default=_db_tmp.DB_TABULATED_DATA,
-        choices=[
-            _db_tmp.DB_TABULATED_DATA,
-            _db_tmp.DB_DERIVED_VALUES,
-            "sandbox",
-        ],
         help=("The database to insert the files to."),
     )
     args_dict, db_config = config.initialize(paths=False, db_config=True)

--- a/simtools/applications/add_value_from_json_to_db.py
+++ b/simtools/applications/add_value_from_json_to_db.py
@@ -38,7 +38,6 @@ from simtools.db import db_handler
 
 
 def main():
-    _db_tmp = db_handler.DatabaseHandler(mongo_db_config=None)
     config = configurator.Configurator(description="Add a new parameter to the DB.")
     group = config.parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--file_name", help="file to be added", type=str)
@@ -52,14 +51,6 @@ def main():
     )
     config.parser.add_argument(
         "--db",
-        type=str,
-        default=_db_tmp.DB_TABULATED_DATA,
-        choices=[
-            _db_tmp.DB_TABULATED_DATA,
-            _db_tmp.DB_DERIVED_VALUES,
-            "sandbox",
-        ],
-        help=("The database to insert the new values to."),
     )
     args_dict, db_config = config.initialize(db_config=True)
 

--- a/simtools/applications/add_value_from_json_to_db.py
+++ b/simtools/applications/add_value_from_json_to_db.py
@@ -92,7 +92,7 @@ def main():
             )
             logger.info(f"Adding the following parameter to the DB: {par_dict['parameter']}")
             db.add_new_parameter(
-                db_name=db.DB_CTA_SIMULATION_MODEL,
+                db_name=db_config["db_simulation_model"],
                 telescope=par_dict["instrument"],
                 parameter=par_dict["parameter"],
                 version=par_dict["version"],

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -51,6 +51,7 @@ def main():
             )
             for version_now in all_versions:
                 db.add_new_parameter(
+                    db_name=db_config["db_simulation_model"],
                     telescope=telescope_now,
                     parameter=par_now,
                     version=version_now,
@@ -61,6 +62,7 @@ def main():
                     file_prefix="./",
                 )
                 pars = db.read_mongo_db(
+                    db_name=db_config["db_simulation_model"],
                     telescope_model_name=telescope_now,
                     model_version=version_now,
                     run_location="./",

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -44,7 +44,6 @@ def main():
     for telescope_now in telescopes:
         for par_now, par_value in parameter.items():
             all_versions = db.get_all_versions(
-                db_name=db.DB_CTA_SIMULATION_MODEL,
                 telescope_model_name="-".join(telescope_now.split("-")[1:]),
                 site=names.get_site_from_telescope_name(telescope_now),
                 parameter="camera_config_file",  # Just a random parameter to get the versions
@@ -52,7 +51,6 @@ def main():
             )
             for version_now in all_versions:
                 db.add_new_parameter(
-                    db_name=db.DB_CTA_SIMULATION_MODEL,
                     telescope=telescope_now,
                     parameter=par_now,
                     version=version_now,
@@ -63,7 +61,6 @@ def main():
                     file_prefix="./",
                 )
                 pars = db.read_mongo_db(
-                    db_name=db.DB_CTA_SIMULATION_MODEL,
                     telescope_model_name=telescope_now,
                     model_version=version_now,
                     run_location="./",

--- a/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
+++ b/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
@@ -35,14 +35,13 @@ def main():
     for site in ["North", "South"]:
         for par_now, unit_now in zip(pars_to_update, units):
             all_versions = db.get_all_versions(
-                db_name=db.DB_CTA_SIMULATION_MODEL,
                 site=site,
                 parameter=par_now,
                 collection_name="sites",
             )
             for version_now in all_versions:
                 db.update_parameter_field(
-                    db_name=db.DB_CTA_SIMULATION_MODEL,
+                    db_name=None,
                     site=site,
                     version=version_now,
                     parameter=par_now,

--- a/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
+++ b/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
@@ -78,7 +78,7 @@ def main():
         for site in ["North", "South"]:
             for par_now in non_optic_parameters:
                 db.update_parameter_field(
-                    db_name=db.DB_CTA_SIMULATION_MODEL,
+                    db_name=db_config["db_simulation_model"],
                     telescope=f"{site}-MST-Structure-D",
                     version=version_now,
                     parameter=par_now,
@@ -86,7 +86,7 @@ def main():
                     new_value=False,
                 )
             pars = db.read_mongo_db(
-                db_name=db.DB_CTA_SIMULATION_MODEL,
+                db_name=db_config["db_simulation_model"],
                 telescope_model_name=f"{site}-MST-Structure-D",
                 model_version=version_now,
                 run_location="",

--- a/simtools/applications/get_file_from_db.py
+++ b/simtools/applications/get_file_from_db.py
@@ -65,8 +65,7 @@ def main():
 
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
     available_dbs = [
-        db.DB_TABULATED_DATA,
-        db.DB_CTA_SIMULATION_MODEL,
+        db_config["db_simulation_model"],
         db.DB_CTA_SIMULATION_MODEL_DESCRIPTIONS,
         db.DB_DERIVED_VALUES,
         "sandbox",

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -201,6 +201,13 @@ class CommandLineParser(argparse.ArgumentParser):
             default="admin",
         )
         _job_group.add_argument(
+            "--db_simulation_model",
+            help="name of simulation model database",
+            type=str,
+            required=False,
+            default="Staging-CTA-Simulation-Model",
+        )
+        _job_group.add_argument(
             "--db_simulation_model_url",
             help="simulation model repository URL",
             type=str,

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -473,6 +473,7 @@ class Configurator:
             "db_api_pw",
             "db_api_port",
             "db_server",
+            "db_simulation_model",
             "db_simulation_model_url",
         )
         try:

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -35,14 +35,11 @@ class DatabaseHandler:
         "db_api_user" - API username
         "db_api_pw" - Password for the API user
         "db_api_authentication_database" - DB with user info (optional, default is "admin")
+        "db_simulation_model" - Name of simulation model database
     """
 
     DB_CTA_SIMULATION_MODEL_DESCRIPTIONS = "CTA-Simulation-Model-Descriptions"
-    #    DB_TABULATED_DATA = "CTA-Simulation-Model"
-    #    DB_CTA_SIMULATION_MODEL = "CTA-Simulation-Model"
     # DB collection with updates field names
-    DB_TABULATED_DATA = "Staging-CTA-Simulation-Model"
-    DB_CTA_SIMULATION_MODEL = "Staging-CTA-Simulation-Model"
     DB_DERIVED_VALUES = "Staging-CTA-Simulation-Model-Derived-Values"
 
     ALLOWED_FILE_EXTENSIONS = [".dat", ".txt", ".lis", ".cfg", ".yml", ".yaml", ".ecsv"]
@@ -147,7 +144,7 @@ class DatabaseHandler:
             pass
 
         _pars = self._get_model_parameters_mongo_db(
-            DatabaseHandler.DB_CTA_SIMULATION_MODEL,
+            self.mongo_db_config.get("db_simulation_model", None),
             _telescope_model_name,
             _model_version,
             only_applicable,
@@ -191,6 +188,7 @@ class DatabaseHandler:
             If the desired file is not found.
 
         """
+        db_name = self._get_db_name(db_name)
 
         self._logger.debug(f"Getting {file_name} from {db_name} and writing it to {dest}")
         file_path_instance = self._get_file_mongo_db(db_name, file_name)
@@ -223,12 +221,8 @@ class DatabaseHandler:
                 if Path(dest).joinpath(info["value"]).exists():
                     self._logger.debug(f"File {info['value']} already exists in {dest}")
                     continue
-                file = self._get_file_mongo_db(
-                    DatabaseHandler.DB_CTA_SIMULATION_MODEL, info["value"]
-                )
-                self._write_file_from_mongo_to_disk(
-                    DatabaseHandler.DB_CTA_SIMULATION_MODEL, dest, file
-                )
+                file = self._get_file_mongo_db(self._get_db_name(), info["value"])
+                self._write_file_from_mongo_to_disk(self._get_db_name(), dest, file)
         if self.mongo_db_config.get("db_simulation_model_url", None) is not None:
             self._logger.warning(
                 "Exporting model files from simulation model repository not yet implemented"
@@ -331,13 +325,9 @@ class DatabaseHandler:
         collection = DatabaseHandler.db_client[db_name][collection_name]
         _parameters = {}
 
-        _model_version = self._convert_version_to_tagged(
-            model_version, DatabaseHandler.DB_CTA_SIMULATION_MODEL
-        )
-
         query = {
             "instrument": telescope_model_name,
-            "version": _model_version,
+            "version": self._convert_version_to_tagged(model_version),
         }
 
         self._logger.debug(f"Trying the following query: {query} to {db_name} {collection_name}")
@@ -385,8 +375,9 @@ class DatabaseHandler:
 
         """
         _site, _, _model_version = self._validate_model_input(site, None, model_version)
+        _db_name = self._get_db_name()
         self._logger.debug(
-            f"Getting {site} parameters from MongoDB {DatabaseHandler.DB_CTA_SIMULATION_MODEL}"
+            f"Getting {site} parameters from MongoDB {_db_name}"
             f" {model_version} {only_applicable}"
         )
         _site_cache_key = self._parameter_cache_key(site, None, model_version)
@@ -396,7 +387,7 @@ class DatabaseHandler:
             pass
 
         _pars = self._get_site_parameters_mongo_db(
-            DatabaseHandler.DB_CTA_SIMULATION_MODEL,
+            _db_name,
             _site,
             _model_version,
             only_applicable,
@@ -506,7 +497,7 @@ class DatabaseHandler:
         )
         try:
             return self.read_mongo_db(
-                DatabaseHandler.DB_CTA_SIMULATION_MODEL,
+                self._get_db_name(),
                 _telescope_model_name,
                 _model_version,
                 run_location=None,
@@ -515,7 +506,7 @@ class DatabaseHandler:
             )
         except ValueError:
             return self.read_mongo_db(
-                DatabaseHandler.DB_CTA_SIMULATION_MODEL,
+                self._get_db_name(),
                 names.get_telescope_type_from_telescope_name(_telescope_model_name) + "-design",
                 _model_version,
                 run_location=None,
@@ -539,11 +530,7 @@ class DatabaseHandler:
         return (
             names.validate_site_name(site),
             names.validate_telescope_name(telescope_model_name) if telescope_model_name else None,
-            names.validate_model_version_name(
-                self._convert_version_to_tagged(
-                    model_version, DatabaseHandler.DB_CTA_SIMULATION_MODEL
-                )
-            ),
+            names.validate_model_version_name(self._convert_version_to_tagged(model_version)),
         )
 
     @staticmethod
@@ -635,6 +622,7 @@ class DatabaseHandler:
 
         """
 
+        db_name = self._get_db_name(db_name)
         if db_to_copy_to is None:
             db_to_copy_to = db_name
 
@@ -649,9 +637,7 @@ class DatabaseHandler:
         collection = DatabaseHandler.db_client[db_name][collection_name]
         db_entries = []
 
-        _version_to_copy = self._convert_version_to_tagged(
-            version_to_copy, DatabaseHandler.DB_CTA_SIMULATION_MODEL
-        )
+        _version_to_copy = self._convert_version_to_tagged(version_to_copy)
 
         query = {
             "instrument": tel_to_copy,
@@ -700,6 +686,7 @@ class DatabaseHandler:
         BulkWriteError
 
         """
+        db_name = self._get_db_name(db_name)
 
         _collection = DatabaseHandler.db_client[db_name][collection]
         if collection_to_copy_to is None:
@@ -747,9 +734,7 @@ class DatabaseHandler:
         _collection = DatabaseHandler.db_client[db_name][collection]
 
         if "version" in query:
-            query["version"] = self._convert_version_to_tagged(
-                query["version"], DatabaseHandler.DB_CTA_SIMULATION_MODEL
-            )
+            query["version"] = self._convert_version_to_tagged(query["version"])
 
         self._logger.info(f"Deleting {_collection.count_documents(query)} entries from {db_name}")
 
@@ -801,15 +786,13 @@ class DatabaseHandler:
 
         """
 
+        db_name = self._get_db_name(db_name)
         allowed_fields = ["applicable", "unit", "type", "items", "minimum", "maximum"]
         if field not in allowed_fields:
             raise ValueError(f"The field {field} must be one of {', '.join(allowed_fields)}")
 
         collection = DatabaseHandler.db_client[db_name][collection_name]
-
-        _model_version = self._convert_version_to_tagged(
-            version, DatabaseHandler.DB_CTA_SIMULATION_MODEL
-        )
+        _model_version = self._convert_version_to_tagged(version)
 
         query = {
             "version": _model_version,
@@ -905,6 +888,7 @@ class DatabaseHandler:
 
         """
 
+        db_name = self._get_db_name(db_name)
         collection = DatabaseHandler.db_client[db_name][collection_name]
 
         db_entry = {}
@@ -957,23 +941,26 @@ class DatabaseHandler:
 
         self._reset_parameter_cache(site, telescope, version)
 
-    def _convert_version_to_tagged(self, model_version, db_name):
+    def _convert_version_to_tagged(self, model_version):
         """Convert to tagged version, if needed."""
         if model_version in ["Released", "Latest"]:
-            return self._get_tagged_version(db_name, model_version)
+            return self._get_tagged_version(model_version)
 
         return model_version
 
     def add_tagged_version(
-        self, db_name, released_version, released_label, latest_version, latest_label
+        self,
+        released_version,
+        released_label,
+        latest_version,
+        latest_label,
+        db_name=None,
     ):
         """
         Set the tag of the "Released" or "Latest" version of the MC Model.
 
         Parameters
         ----------
-        db_name: str
-            the name of the DB
         released_version: str
             The version name to set as "Released"
         released_label: str
@@ -982,8 +969,11 @@ class DatabaseHandler:
             The version name to set as "Latest"
         latest_label: str
             The latest version name as label.
+        db_name: str
+            Database name
 
         """
+        db_name = self._get_db_name(db_name)
 
         collection = DatabaseHandler.db_client[db_name]["metadata"]
         db_entry = {}
@@ -994,8 +984,23 @@ class DatabaseHandler:
         }
         collection.insert_one(db_entry)
 
-    @staticmethod
-    def _get_tagged_version(db_name, version="Released"):
+    def _get_db_name(self, db_name=None):
+        """
+        Return database name. If not provided, return the default database name.
+
+        Parameters
+        ----------
+        db_name: str
+            Database name
+
+        Returns
+        -------
+        str
+            Database name
+        """
+        return self.mongo_db_config["db_simulation_model"] if db_name is None else db_name
+
+    def _get_tagged_version(self, version="Released", db_name=None):
         """
         Get the tag of the "Released" or "Latest" version of the MC Model.
         The "Released" is the latest stable MC Model,
@@ -1003,10 +1008,10 @@ class DatabaseHandler:
 
         Parameters
         ----------
-        db_name: str
-            the name of the DB
         version: str
             Can be "Released" or "Latest" (default: "Released").
+        db_name: str
+            Database name
 
         Returns
         -------
@@ -1023,14 +1028,14 @@ class DatabaseHandler:
         if version not in ["Released", "Latest"]:
             raise ValueError('The only default versions are "Released" or "Latest"')
 
-        collection = DatabaseHandler.db_client[db_name].metadata
+        collection = DatabaseHandler.db_client[self._get_db_name(db_name)].metadata
         query = {"Entry": "Simulation-Model-Tags"}
 
         tags = collection.find(query).sort("_id", pymongo.DESCENDING)[0]
 
         return tags["Tags"][version]["Value"]
 
-    def insert_file_to_db(self, file_name, db_name=DB_CTA_SIMULATION_MODEL, **kwargs):
+    def insert_file_to_db(self, file_name, db_name=None, **kwargs):
         """
         Insert a file to the DB.
 
@@ -1052,6 +1057,7 @@ class DatabaseHandler:
             "newly created DB GridOut._id.
 
         """
+        db_name = self._get_db_name(db_name)
 
         db = DatabaseHandler.db_client[db_name]
         file_system = gridfs.GridFS(db)
@@ -1074,7 +1080,6 @@ class DatabaseHandler:
 
     def get_all_versions(
         self,
-        db_name,
         parameter,
         telescope_model_name=None,
         site=None,
@@ -1085,8 +1090,6 @@ class DatabaseHandler:
 
         Parameters
         ----------
-        db_name: str
-            the name of the DB
         parameter: str
             Which parameter to get the versions of
         telescope_model_name: str
@@ -1110,7 +1113,7 @@ class DatabaseHandler:
 
         """
 
-        collection = DatabaseHandler.db_client[db_name][collection_name]
+        collection = DatabaseHandler.db_client[self._get_db_name()][collection_name]
 
         query = {
             "parameter": parameter,
@@ -1132,11 +1135,7 @@ class DatabaseHandler:
 
         return _all_versions
 
-    def get_all_available_telescopes(
-        self,
-        model_version,
-        db_name=DB_CTA_SIMULATION_MODEL,
-    ):
+    def get_all_available_telescopes(self, model_version, db_name=None):
         """
         Get all available telescope names in the collection "telescopes" in the DB.
 
@@ -1153,16 +1152,13 @@ class DatabaseHandler:
             List of all telescope names found
 
         """
-
+        db_name = self._get_db_name(db_name)
         collection = DatabaseHandler.db_client[db_name]["telescopes"]
 
-        _model_version = self._convert_version_to_tagged(
-            names.validate_model_version_name(model_version),
-            DatabaseHandler.DB_CTA_SIMULATION_MODEL,
-        )
-
         query = {
-            "version": _model_version,
+            "version": self._convert_version_to_tagged(
+                names.validate_model_version_name(model_version)
+            ),
         }
 
         _all_available_telescopes = collection.find(query).distinct("instrument")
@@ -1214,9 +1210,8 @@ class DatabaseHandler:
         Create a cache key for the parameter cache dictionaries.
 
         """
-        _model_version = self._convert_version_to_tagged(
-            model_version, DatabaseHandler.DB_CTA_SIMULATION_MODEL
-        )
+        _model_version = self._convert_version_to_tagged(model_version)
+
         if telescope is None:
             return f"{site}-{_model_version}"
         return f"{site}-{telescope}-{_model_version}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,7 @@ def mock_settings_env_vars(tmp_test_directory):
             "SIMTOOLS_DB_API_PW": "12345",
             "SIMTOOLS_DB_API_PORT": "42",
             "SIMTOOLS_DB_SERVER": "abc@def.de",
+            "SIMTOOLS_DB_SIMULATION_MODEL": "sim_model",
             "SIMTOOLS_DB_SIMULATION_MODEL_URL": _url,
         },
         clear=True,
@@ -145,7 +146,14 @@ def db_config():
         key.lower().replace("simtools_", ""): value
         for key, value in dict(dotenv_values(".env")).items()
     }
-    _db_para = ("db_api_user", "db_api_pw", "db_api_port", "db_server", "db_simulation_model_url")
+    _db_para = (
+        "db_api_user",
+        "db_api_pw",
+        "db_api_port",
+        "db_server",
+        "db_simulation_model",
+        "db_simulation_model_url",
+    )
     for _para in _db_para:
         if _para not in mongo_db_config:
             mongo_db_config[_para] = os.environ.get(f"SIMTOOLS_{_para.upper()}")

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -209,6 +209,7 @@ def test_get_db_parameters_from_env(configurator, args_dict):
     args_dict["db_api_port"] = 42
     args_dict["db_server"] = "abc@def.de"
     args_dict["db_api_authentication_database"] = "admin"
+    args_dict["db_simulation_model"] = "Staging-CTA-Simulation-Model"
     args_dict["db_simulation_model_url"] = (
         "https://gitlab.cta-observatory.org/cta-science/simulations/"
         "simulation-model/model_parameters/-/raw/main"
@@ -319,6 +320,7 @@ def test_get_db_parameters():
         "db_api_pw": None,
         "db_api_user": None,
         "db_server": None,
+        "db_simulation_model": "Staging-CTA-Simulation-Model",  # only parameter with default value
         "db_simulation_model_url": None,
     }
 
@@ -329,6 +331,7 @@ def test_get_db_parameters():
         "db_api_user": "user",
         "db_api_pw": "password",
         "db_api_port": 1234,
+        "db_simulation_model": "Staging-CTA-Simulation-Model",
         "db_server": "localhost",
     }
 
@@ -338,6 +341,7 @@ def test_get_db_parameters():
         "db_api_pw": "password",
         "db_api_port": 1234,
         "db_server": "localhost",
+        "db_simulation_model": "Staging-CTA-Simulation-Model",
     }
 
     # empty config

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -111,7 +111,7 @@ def test_get_sim_telarray_configuration_parameters(db, model_version):
 def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version):
     logger.info("----Testing copying a whole telescope-----")
     db.copy_telescope(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         tel_to_copy="LSTN-01",
         version_to_copy=model_version,
         new_tel_name="LSTN-test",
@@ -120,7 +120,7 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version)
         collection_to_copy_to="telescopes_" + random_id,
     )
     db.copy_documents(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         collection="metadata",
         query={"Entry": "Simulation-Model-Tags"},
         db_to_copy_to=f"sandbox_{random_id}",
@@ -165,15 +165,17 @@ def test_add_tagged_version(db, random_id, db_cleanup, io_handler, model_version
         latest_label="Prod26",
     )
 
-    assert db._get_tagged_version(f"sandbox_{random_id}", "Released") == "2020-06-28"
-    assert db._get_tagged_version(f"sandbox_{random_id}", "Latest") == "2024-02-01"
+    assert (
+        db._get_tagged_version(db_name=f"sandbox_{random_id}", version="Released") == "2020-06-28"
+    )
+    assert db._get_tagged_version(db_name=f"sandbox_{random_id}", version="Latest") == "2024-02-01"
     db.db_client[f"sandbox_{random_id}"]["metadata"].drop()
 
 
 def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler, model_version):
     logger.info("----Testing adding a new parameter-----")
     db.copy_telescope(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         tel_to_copy="LSTN-01",
         version_to_copy=model_version,
         new_tel_name="LSTN-test",
@@ -311,7 +313,7 @@ def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler, model_ve
 def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
     logger.info("----Testing modifying a field of a parameter-----")
     db.copy_telescope(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         tel_to_copy="LSTN-01",
         version_to_copy="Released",
         new_tel_name="LSTN-test",
@@ -320,7 +322,7 @@ def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
         collection_to_copy_to="telescopes_" + random_id,
     )
     db.copy_documents(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         collection="metadata",
         query={"Entry": "Simulation-Model-Tags"},
         db_to_copy_to=f"sandbox_{random_id}",
@@ -402,7 +404,7 @@ def test_export_file_db(db, io_handler):
     output_dir = io_handler.get_output_directory(sub_dir="model", dir_type="test")
     file_name = "mirror_CTA-S-LST_v2020-04-07.dat"
     file_to_export = output_dir / file_name
-    db.export_file_db(db.DB_CTA_SIMULATION_MODEL, output_dir, file_name)
+    db.export_file_db(None, output_dir, file_name)
     assert file_to_export.exists()
 
 
@@ -434,7 +436,6 @@ def test_insert_files_db(db, io_handler, db_cleanup_file_sandbox, random_id, cap
 
 def test_get_all_versions(db):
     all_versions = db.get_all_versions(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
         telescope_model_name="LSTN-01",
         site="North",
         parameter="camera_config_file",
@@ -445,7 +446,6 @@ def test_get_all_versions(db):
     assert all(_v in all_versions for _v in ["2020-06-28", "2024-02-01"])
 
     all_versions = db.get_all_versions(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
         site="North",
         parameter="corsika_observation_level",
         collection_name="sites",
@@ -494,7 +494,7 @@ def test_parameter_cache_key(db):
 def test_get_tagged_version(db):
 
     with pytest.raises(ValueError):
-        db._get_tagged_version(db.DB_CTA_SIMULATION_MODEL, version="NotReleased")
+        db._get_tagged_version(version="NotReleased")
 
-    assert db._get_tagged_version(db.DB_CTA_SIMULATION_MODEL, version="Released") == "2020-06-28"
-    assert db._get_tagged_version(db.DB_CTA_SIMULATION_MODEL, version="Latest") == "2020-06-28"
+    assert db._get_tagged_version(version="Released") == "2020-06-28"
+    assert db._get_tagged_version(version="Latest") == "2020-06-28"

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -139,7 +139,7 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version)
     logger.info("Testing deleting a query (a whole telescope in this case and metadata)")
     query = {"instrument": "LSTN-test"}
     db.delete_query(f"sandbox_{random_id}", "telescopes_" + random_id, query)
-    query = {"Entry": "Simulation-Model-Tags"}
+    query = {"Entry": "Simulation-Model-Tags", "version": model_version}
     db.delete_query(f"sandbox_{random_id}", "metadata_" + random_id, query)
 
     # After deleting the copied telescope

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -27,7 +27,7 @@ def test_plot_1d(db, io_handler):
 
     test_file_name = "ref_LST1_2022_04_01.dat"
     db.export_file_db(
-        db_name=db.DB_CTA_SIMULATION_MODEL,
+        db_name=None,
         dest=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         file_name=test_file_name,
     )


### PR DESCRIPTION
This PR adds functionality to configure the name of the simulation model using the environmental variables or the command line. This is especially useful now in the period of substantial updates and modifications to the model databases.

Before this PR: name of the simulation model DB is hardwired as class variable in the db_handler class.

This PR removes also the database DB_TABULATED_DATA, which is not used anymore.

Note that a surprisingly large number of changes are necessary, as this class variable has been accessed quite frequently.

There are two database names still hardwired in the db_handler class:

- db.DB_CTA_SIMULATION_MODEL_DESCRIPTIONS - can be removed as soon as we have integrated the model schema files into simtools
- db.DB_DERIVED_VALUES will be replaced in future by a to-be-discussed functionality (but I am pretty sure that we won't keep it this way)