### PR TITLE
Move model parameter schemas from gitlab into simtools

### DIFF
--- a/simtools/schemas/model_parameters/adjust_gain.schema.yml
+++ b/simtools/schemas/model_parameters/adjust_gain.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for adjust_gain model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: adjust_gain
+description: |-
+  Multiplicative adjustment for FADC and discriminator/comparator amplitude
+  and PMT gain.
+short_description: |-
+  Gain adjustment for amplitudes and PMT gain.
+data:
+  - type: double
+    unit: dimensionless
+    default: 1.0
+    allowed_range:
+      min: 0.1
+      max: 10.
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/altitude.schema.yml
+++ b/simtools/schemas/model_parameters/altitude.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for altitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: altitude
+description: |-
+  Altitude above sea level of site centre.
+  Telescope z-positions are defined relative to this level
+  (taking `telescope_axes_height` into account).
+short_description: Altitude above sea level of site centre.
+data:
+  - type: double
+    unit: m
+    default: 1800.
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/array_coordinates.schema.yml
+++ b/simtools/schemas/model_parameters/array_coordinates.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for array_coordinates model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: array_coordinates
+description: |-
+  Array element positions (e.g., telescope positions) in ground coordinates.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+++ b/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
@@ -1,0 +1,77 @@
+%YAML 1.2
+---
+title: Schema for array_coordinates_utm input data
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: array_coordinates_utm
+description: |-
+  Array element positions (e.g., telescope positions) in UTM coordinates.
+developer_note: |-
+  Use NaN for missing values.
+data:
+  - type: data_table
+    table_columns:
+      - name: asset_code
+        description: |-
+          Asset code of the array element.
+        type: string
+        required: true
+        unit: dimensionless
+      - name: sequence_number
+        description: |-
+          Sequence number of the array element.
+        type: string
+        required: true
+        unit: dimensionless
+      - name: utm_east
+        description: |-
+          UTM East coordinate of the array element.
+        type: double
+        required: true
+        unit: m
+        input_processing:
+          - allow_nan
+      - name: utm_north
+        description: |-
+          UTM North coordinate of the array element.
+        type: double
+        required: true
+        unit: m
+        input_processing:
+          - allow_nan
+      - name: altitude
+        description: |-
+          Altitude of the array element.
+        required: true
+        type: double
+        unit: m
+        allowed_range:
+          min: 0.
+        input_processing:
+          - allow_nan
+      - name: geo_code
+        description: |-
+          Geographic code of the array element.
+        type: string
+        required: false
+        unit: dimensionless
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/array_triggers.schema.yml
+++ b/simtools/schemas/model_parameters/array_triggers.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for array_triggers model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: array_triggers
+description: |-
+  Stereo (array) trigger definition. Can also include specific coincidence gate
+  widths and different telescope multi- plicities for each line
+short_description: |-
+  Stereo (array) trigger definition.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/asum_clipping.schema.yml
+++ b/simtools/schemas/model_parameters/asum_clipping.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for asum_clipping model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: asum_clipping
+description: |-
+  The amplitude level at which the signal from each pixel
+  (after optional shaping) is clipped for its contribution
+  to the analog sum trigger.
+data:
+  - type: double
+    default: 0.0
+    unit: mV
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/asum_offset.schema.yml
+++ b/simtools/schemas/model_parameters/asum_offset.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for asum_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: asum_offset
+description: Offset in time where shaping convolution is done.
+data:
+  - type: double
+    default: 0.0
+    unit: ns
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/asum_shaping.schema.yml
+++ b/simtools/schemas/model_parameters/asum_shaping.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for asum_shaping model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: asum_shaping
+description: |-
+  Shaping (convolution) parameters for an input photo detector signal to the
+  resulting signal from which an analog-sum trigger decision may be derived.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: asum_shaping_file

--- a/simtools/schemas/model_parameters/asum_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/asum_threshold.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for asum_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: asum_threshold
+description: |-
+  The amplitude level above which an analog sum leads to a telescope
+  trigger.
+data:
+  - type: double
+    default: 0.0
+    unit: mV
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==AnalogSum
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
+++ b/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for atmospheric_profile model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: atmospheric_profile
+description: Density, thickness, and index of refraction as function of altitude.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: corsika
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
+++ b/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for atmospheric_transmission model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: atmospheric_transmission
+description: |-
+  Optical thickness as a function of photon emission altitude
+  and wavelength.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'atm_trans_2147_1_10_2_0_2147.dat'
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: corsika
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/axes_offsets.schema.yml
+++ b/simtools/schemas/model_parameters/axes_offsets.schema.yml
@@ -1,0 +1,53 @@
+%YAML 1.2
+---
+title: Schema for axes_offsets model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: axes_offsets
+description: |-
+  Geometric offsets to be used in case that the azimuth, altitude, and
+  optical axes do not intersect at the reference point (the center of
+  the fiducial sphere in CORSIKA simulations). If both
+  values are non-zero but equal, the optical axis coincides with the
+  azimuth axis for vertical pointing.
+short_description: |-
+  Geometric offsets to be used in case that the azimuth, altitude,
+  and optical axes do not intersect at the reference point.
+data:
+  - type: double
+    unit: cm
+    default: 0.
+    description: |-
+      Horizontal offset between the (vertical) azimuth axis and the
+      (horizontal) altitude rotation axis. A positive value corresponds
+      to an altitude axis towards the reflector. Altitude axis is on
+      the optical axis, if the second parameter is zero.
+  - type: double
+    unit: cm
+    default: 0.
+    description: |-
+      Displacement perpendicular to the optical axis and the altitude
+      axis of the altitude rotation axis w.r.t to the reflector.
+      If the altitude axis is on the optical axis, the second parameter
+      is zero.
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for camera_body_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_body_diameter
+description: |-
+  Diameter of camera body (used to account for effects of shadowing).
+  Flat-to-flat for square and hexagonal shapes.
+data:
+  - type: double
+    unit: cm
+    default: 160.0
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_body_shape.schema.yml
+++ b/simtools/schemas/model_parameters/camera_body_shape.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for camera_body_shape model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_body_shape
+description: |-
+  Code for the shape of the camera,
+  \begin{itemize}
+  \item[$\circ$] 0 -- circular (default);
+  \item[$\circ$] 1 or 3 -- hexagonal;
+  \item[$\circ$] 2 -- square.
+  \end{itemize}
+  This shape is used only for the estimation of the shadowing.
+short_description: Camera body shape parameter (used to account for effects of shadowing).
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+      max: 3
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_config_file.schema.yml
+++ b/simtools/schemas/model_parameters/camera_config_file.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for camera_config_file model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: camera_config_file
+description: |-
+  Definition of pixel types, positions, status (on/off), relative gain
+  (w.r.t the provided gain) and quantum/photodetector efficiency
+  scaling (scale the provided quantum/photodetector efficiency distribution,
+  ignoring wavelength dependence).
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateCameraGeometry
+    - ValidatePixelStatus
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Initial instrument setup
+  - Calibration
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
+++ b/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for camera_config_rotate model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_config_rotate
+developer_note: Part of sim_telarray camera_config_file (parameter Rotate).
+description: |-
+  Camera rotation angle, rotating the whole camera with all the pixels by
+  the given angle.
+short_description: Camera rotation angle.
+data:
+  - type: double
+    unit: deg
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
+++ b/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for camera_degraded_efficiency model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_degraded_efficiency
+description: |-
+  Camera efficiency degradation factor (wavelength independent).
+  What matters typically is the overall product of the efficiencies.
+  Breaking it down into mirror(s) and/or camera degradation
+  only matters where BYPASS_OPTICS becomes involved. Then this parameter
+  is still applied to the camera efficiency.
+short_description: |-
+  Camera efficiency degradation factor (wavelength independent).
+data:
+  - type: double
+    unit: dimensionless
+    default: 1.
+    allowed_range:
+      min: 0.
+      max: 1.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
+++ b/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for camera_degraded_map model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: |-
+  To be replaced by a data table. Accepted range is 0 to 1
+name: camera_degraded_map
+description: |-
+  Position-dependent map of degradation factors for the camera efficiency.
+  The degradation gets applied on top of camera_degraded_efficiency and
+  is not accounted for in the NSB pixel p.e. rate calculations
+  (and in particular not for a localized NSB reduction).
+  Tables with equidistant spacing in both x and y are highly recommended.
+short_description: |-
+  Position-dependent map of degradation factors for the camera efficiency.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_depth.schema.yml
+++ b/simtools/schemas/model_parameters/camera_depth.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for camera_depth model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_depth
+description: |-
+  Depth of a camera body, used for shadowing.
+  If non-zero, shadowing is checked both at the height of the camera front
+  and the camera depth.
+short_description: Depth of the camera body (used to account for effects of shadowing).
+data:
+  - type: double
+    unit: cm
+    default: 0.
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_filter.schema.yml
+++ b/simtools/schemas/model_parameters/camera_filter.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for camera_filter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: camera_filter
+description: |-
+  Wavelength dependence of the camera filter transmission, independent
+  of the pixel type.  The transmission may be given for the average or
+  various incident angles.  In the latter case, the transmission is
+  applied for each photon as a function of both its wavelength and its
+  incident angle.  The efficiency factors will be applied on top of the
+  global par:camera-transmission factor, and on top of any pixel-type
+  dependent efficiency (both angular and by wavelength), according to
+  the what is listed in par:camera_config_pixel_type.
+short_description: |-
+  Wavelength dependence of the camera transmission, possibly as a function
+  of incidence angle.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
+++ b/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for camera_filter_incidence_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: camera_filter_incidence_angle
+description: |-
+  Distribution of incidence angle on the camera filter.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_file.dat'
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_pixels.schema.yml
+++ b/simtools/schemas/model_parameters/camera_pixels.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for camera_pixels model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_pixels
+description: Number of pixels in the camera.
+developer_note: |-
+  Max limit depend on sim_telarray pre-compiler settings
+data:
+  - type: uint
+    default: 1
+    allowed_range:
+      min: 1
+      max: 11328
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/camera_transmission.schema.yml
+++ b/simtools/schemas/model_parameters/camera_transmission.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for camera_transmission model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: camera_transmission
+description: |-
+  Global wavelength-independent transmission factor of the camera,
+  including any plexiglas window (note that transmission might be
+  included in the par:camera-filter file).
+short_description: |-
+  Global wavelength-independent transmission factor of the camera,
+  including any plexiglass window.
+data:
+  - type: double
+    default: 1.0
+    allowed_range:
+      min: 0.01
+      max: 1.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for channels_per_chip model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: channels_per_chip
+description: |-
+  Number of channels per readout chip.
+  Potentially useful for crosstalk calculations.
+short_description: Number of channels per readout chip.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 4
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for corsika_observation_level model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_observation_level
+description: |-
+  Observation altitude above see level assumed in the air-shower code.
+  This should be lower than the lowest altitude of any telescope.
+short_description: Observation altitude above see level assumed in the air-shower code.
+data:
+  - type: double
+    unit: m
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika
+    internal_parameter_name: OBSLEV
+  - name: sim_telarray
+    internal_parameter_name: altitude

--- a/simtools/schemas/model_parameters/dark_events.schema.yml
+++ b/simtools/schemas/model_parameters/dark_events.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for dark_events model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dark_events
+description: |-
+  Pedestal events at start of run with camera lid closed (completely dark, no NSB).
+short_description: |-
+  Pedestal events at start of run closed lid.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/default_trigger.schema.yml
+++ b/simtools/schemas/model_parameters/default_trigger.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for default_trigger model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: default_trigger
+description: Trigger algorithm used.
+data:
+  - type: string
+    default: Majority
+    unit: dimensionless
+    allowed_values:
+      - Majority
+      - AnalogSum
+      - DigitalSum
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
+++ b/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for disc_ac_coupled model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: disc_ac_coupled
+description: Discriminators/comparator are AC coupled (if true).
+short_description: Control AC coupling of the discriminators.
+data:
+  - type: boolean
+    default: true
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/disc_bins.schema.yml
+++ b/simtools/schemas/model_parameters/disc_bins.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for disc_bins model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: disc_bins
+description: |-
+  Number of time bins used for the discriminator or comparator simulation.
+  This trigger simulation might cover a larger time window than the
+  FADC signals.
+short_description: Number of time bins used for the discriminator simulation.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 20
+    allowed_range:
+      min: 1
+      max: 160
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/disc_start.schema.yml
+++ b/simtools/schemas/model_parameters/disc_start.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for disc_start model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: disc_start
+description: |-
+  Number of time bins by which the discriminator or comparator simulation
+  is ahead of the FADC readout. That is mainly relevant if different time
+  windows are simulated for comparator inputs and digitized ADC values.
+short_description: |-
+  Number of time bins by which the discriminator simulation is ahead of
+  the FADC readout.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+      max: 159
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for discriminator_amplitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_amplitude
+developer_note: |-
+  TODO - Units of mV are always used for CTA. Expect that this will
+  continue to be the case in future.
+  Note - sim_telarray array allows definition with arbitrary units
+  (same definition of units required for discriminator_threshold).
+description: |-
+  Signal amplitude after amplifier per mean p.e. at the input of the
+  discriminators/comparators.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: mV
+    default: 1.0
+    condition: default_trigger==AnalogSum or default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_fall_time model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_fall_time
+description: |-
+  Fall time of discriminator/comparator output after the logical output
+  is reset to false.
+short_description: |-
+  Fall time of the discriminator output after the logical output is
+  reset to false.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: ns
+    default: 1.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_gate_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_gate_length
+description: |-
+  Effective discriminator gate length. To achieve a comparator-type
+  response this gate length must match the time over threshold below.
+  Use negative values for strict discriminator type, positive values
+  for comparator or updating discriminator type.
+short_description: Effective discriminator gate length.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: ns
+    default: 2.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: -100.0
+      max: 100.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for discriminator_hysteresis model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_hysteresis
+description: |-
+  The switching off of a comparator is normally with some hysteresis to
+  avoid oscillating behavior. As a consequence, the signal has to be
+  below the threshold minus the hysteresis before it switches off.
+short_description: Value of the discriminator hysteresis.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: mV
+    default: 0.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_output_amplitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_output_amplitude
+description: |-
+  The nominal output amplitude of a pixel discriminator or comparator as
+  seen at the sector (trigger group) coincidence unit.
+short_description: |-
+  The nominal output amplitude of a pixel discriminator as seen at the
+  trigger group coincidence unit.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: mV
+    default: 42.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_output_var_percent model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_output_var_percent
+description: |-
+  Channel-to-channel variation (Gaussian r.m.s.) of the output amplitude
+  of a pixel discriminator or comparator.
+short_description: |-
+  Channel-to-channel variation (Gaussian r.m.s.) of the output amplitude
+  of a pixel discriminator.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: double
+    unit: pct
+    default: 10.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 50.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for discriminator_pulse_shape model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: discriminator_pulse_shape
+description: Pulse shape at the discriminator/comparator of an individual pixel.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'unspecified_shape.dat'
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for discriminator_rise_time model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_rise_time
+description: |-
+  Rise time of the discriminator/comparator output. After the
+  discriminator/comparator logical output is set true, the output
+  signal linearly rises from 0 to 100\% within the given time period.
+short_description: |-
+  Rise time of the discriminator output. The output signal rises linearly
+  within time frame.
+data:
+  - type: double
+    unit: ns
+    default: 1.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for discriminator_scale_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_scale_threshold
+description: |-
+  Scale factor for discriminator or comparator threshold
+  and its variations.
+short_description: Discriminator/comparator threshold scale factor.
+data:
+  - type: double
+    default: 1.0
+    unit: dimensionless
+    allowed_range:
+      min: 0.5
+      max: 2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for discriminator_sigsum_over_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_sigsum_over_threshold
+developer_note: |-
+  Intended as mV * ns, but if unit of
+  discriminator_time_over_threshold is not mV,
+  it scales accordingly.
+description: |-
+  Integrated signal required over threshold. See also
+  discriminator_time_over_threshold above for combined effects. If
+  discriminator_time_over_threshold is not mV, it scales
+  accordingly.
+short_description: Integrated signal required over threshold.
+data:
+  - type: double
+    unit: mV * ns
+    condition: default_trigger==Majority
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for discriminator_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_threshold
+description: Discriminator/comparator threshold.
+data:
+  - type: double
+    unit: mV
+    default: 4.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==Majority
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for discriminator_time_over_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_time_over_threshold
+description: |-
+  Time over threshold required before logic response switches to true.
+  To achieve a comparator-type response this time must match the gate
+  length above.  Note that in addition a minimum signal integral
+  discriminator_sigsum_over_threshold may be set up. If so, both time over
+  threshold and signal integral conditions have to be met before a `true'
+  output signal starts. Normally, either of them being non-zero should be
+  sufficient.
+short_description: Time over threshold required before logic response switches to
+  true.
+data:
+  - type: double
+    unit: ns
+    default: 1.5
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_gate_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_var_gate_length
+description: |-
+  Variation of gate length (Gaussian r.m.s.). In comparator-type
+  response, this variable is not used but only
+  discriminator_var_time_over_threshold.
+short_description: Variation of gate length (Gaussian r.m.s).
+data:
+  - type: double
+    unit: ns
+    default: 0.1
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_sigsum_over_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_var_sigsum_over_threshold
+developer_note: |-
+  Intended as mV * ns, but if unit of
+  discriminator_time_over_threshold is not mV,
+  it scales accordingly.
+description: |-
+  Gaussian r.m.s. spread of discriminator_sigsum_over_threshold
+  (Pixel-to-pixel variation).
+data:
+  - type: double
+    unit: mV * ns
+    default: 0.0
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_var_threshold
+description: |-
+  Channel-to-channel variations (random Gaussian r.m.s.) of
+  discriminator/comparator threshold.
+short_description: Channel-to-channel variation of discriminator threshold.
+data:
+  - type: double
+    unit: mV
+    default: 0.2
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for discriminator_var_time_over_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: discriminator_var_time_over_threshold
+description: |-
+  Pixel-to-pixel variation of the time over threshold required before logic
+  response switches to true.
+data:
+  - type: double
+    unit: ns
+    default: 0.1
+    condition: default_trigger==Majority
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dish_shape_length.schema.yml
+++ b/simtools/schemas/model_parameters/dish_shape_length.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for dish_shape_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dish_shape_length
+description: |-
+  Dish curvature length, best equal to focal length. For a Davies-Cotton
+  dish, this is the radius of the sphere on which the mirror tiles are
+  positioned. For a parabolic dish, this is the focal length of the
+  paraboloid on which the mirrors are placed. This parameter is only
+  needed when variations to the standard shapes are tried out, e.g.
+  intermediate shapes between parabolic and Davies-Cotton.
+short_description: Dish curvature length, best equal to focal length.
+data:
+  - type: double
+    unit: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_clipping.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_clipping.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for dsum_clipping model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_clipping
+description: |-
+  The amplitude level (in ADC counts above pedestal) at which the digitized
+  signal from each pixel (after optional shaping) is clipped for its
+  contribution to the digital sum trigger.
+short_description: Amplitude level at which the digitized signal from each pixel is
+  clipped.
+data:
+  - type: int
+    default: 0
+    unit: count
+    allowed_range:
+      min: 0
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for dsum_ignore_below model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_ignore_below
+description: |-
+  FADC signals (pedestal subtracted and/or shaped) below this value,
+  i.e. in the noise, do not contribute to the digital signal sum and
+  are set to zero.  A value of zero means that no such lower threshold
+  gets applied.
+short_description: FADC signal minimum contribution to digital signal sum.
+data:
+  - type: uint
+    unit: count
+    default: 0
+    condition: default_trigger==DigitalSum
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_offset.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_offset.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for dsum_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_offset
+description: |-
+  Offset in time where digital pulse shaping is done. Time intervals at
+  the start and end of the simulated time window that are affected by
+  shaping of missing outside signals are not used for trigger evaluation.
+short_description: Time offset applied before signal processing.
+data:
+  - type: double
+    unit: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for dsum_pedsub model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_pedsub
+description: |-
+  Expected pedestal is first subtracted before any
+  shaping, scaling, clipping, etc. operations (if true).
+  Without pedestal subtraction, shaping kernels with non-zero
+  sum are not practical.
+data:
+  - type: boolean
+    default: true
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for dsum_pre_clipping model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_pre_clipping
+description: |-
+  The amplitude level (in ADC counts above pedestal)
+  at which the digitized signal from each pixel (before optional shaping) is
+  clipped for its contribution to the digital sum trigger.
+  A value of zero indicates no clipping is applied.
+  Any such clipping is usually not a good idea, with FADC maximum
+  value defined by fadc_max_signal anyway.
+data:
+  - type: uint
+    unit: count
+    default: 0
+    condition: default_trigger==DigitalSum
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_prescale.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_prescale.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for dsum_prescale model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_prescale
+developer_note: TODO - Remove comment on DDSUM_DOUBLE?
+description: |-
+  Shaped signals are scaled by first multiplying with the
+  first value (to integer unless sim\_telarray was compiled with
+  \texttt{DDSUM_DOUBLE}) and then divided by the second value
+  (discarding the remainder).
+  No such scaling is applied if first and second value are equal.
+short_description: Scaling of shaped signals.
+data:
+  - type: uint
+    description: multiplier
+    default: 0
+    unit: dimensionless
+    condition: default_trigger==DigitalSum
+  - type: uint
+    description: divider
+    default: 0
+    unit: dimensionless
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for dsum_presum_max model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_presum_max
+description: |-
+  After bit-shifting the pre-sum, the resulting value
+  (zero-clipped, typically) may have the given maximum
+  value to be represented in the available number of bits.
+  A value of zero implies no maximum to be applied.
+short_description: Maximum of pre-sum in available number of bits.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    condition: default_trigger==DigitalSum
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for dsum_presum_shift model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_presum_shift
+description: |-
+  After a patch-wise pre-summation, the resulting sum may be
+  right-shifted to reduce the significant number of bits.
+  The presence of patches is indicated for
+  par:trigger_decision_circuitry
+  for the DigitalSumTrigger by e.g.\\
+  \texttt{DigitalSumTrigger * of 1[2,3] 4[5,6]} \\
+  instead of using a plain list of pixel IDs like\\
+  \texttt{DigitalSumTrigger * of 1 2 3 4 5 6}.
+short_description: |-
+  After a patch-wise pre-summation, the resulting sum may be
+  right-shifted to reduce the significant number of bits.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+      max: 4
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_shaping.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_shaping.schema.yml
@@ -1,0 +1,44 @@
+%YAML 1.2
+---
+title: Schema for dsum_shaping model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: dsum_shaping
+description: |-
+  Shaping (convolution) parameters for a digitized detector signal
+  (time step of ADC time slices) to the resulting signal from which a
+  digital-sum trigger decision may be derived. The values are a digital
+  signal processing kernel.  For example, a file containing
+  $\left( \begin{smallmatrix} 0 & 1\\ 1&-1 \end{smallmatrix} \right)$
+  would be a simple differencing filter,
+  $b[n] = a[n] - a[n-1]$.
+  The first column is in ADC bins behind current interval, the second
+  value is the factor applied to the corresponding ADC value.
+short_description: |-
+  Shaping (convolution) parameters for a digitized detector signal
+  to the resulting signal from which a digital-sum trigger decision may be
+  derived.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: dsum_shaping_file

--- a/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for dsum_shaping_renormalize model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_shaping_renormalize
+description: |-
+  The positive part of the shaping kernel is auto-normalized
+  to a sum of 1.0 (if true). If false, the shaping kernel is used as-is.
+data:
+  - type: boolean
+    default: false
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -13,7 +13,7 @@ description: |-
   must exceed (\'>\') the threshold here before we declare the telescope
   triggered. The assigned threshold value would have to be one count lower
   than in a camera-internal trigger implementation (like MSTS) where
-  reaching (\’>=\’) the threshold is enough.
+  reaching (\'>=\') the threshold is enough.
 short_description: Amplitude level above which a digital sum leads to a telescope
   trigger.
 data:

--- a/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for dsum_threshold model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_threshold
+description: |-
+  The amplitude level above pedestal sum above which a
+  digital sum leads to a telescope trigger.
+  Note that, like for discriminator/comparator and analog sum, the signal
+  must exceed (\'>\') the threshold here before we declare the telescope
+  triggered. The assigned threshold value would have to be one count lower
+  than in a camera-internal trigger implementation (like MSTS) where
+  reaching (\’>=\’) the threshold is enough.
+short_description: Amplitude level above which a digital sum leads to a telescope
+  trigger.
+data:
+  - type: double
+    unit: count
+    default: 0.0
+    allowed_range:
+      min: 0.0
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTriggerThresholdsFromRateScan
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
+++ b/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for dsum_zero_clip model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: dsum_zero_clip
+description: |-
+  With a value of 1, any negative shaped signals are clipped at zero
+  (which a non-zero dsum_ignore_below does anyway).
+  With a value of $-1$, negative signals are not clipped immediately
+  but together with patch-wise pre-summation they are clipped at zero
+  after pre-summation.
+  A value of zero means that negative shaped signals are preserved
+  for the final digital sum.
+short_description: Clipping of negative shaped signals.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: -1
+      max: 1
+    condition: default_trigger==DigitalSum
+instrument:
+  class: Camera
+  type:
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -11,7 +11,7 @@ developer_note: |-
   Should be discussed further if this is the right place.
 description: |-
   Due to asymmetric image aberrations, in particular for single-reflector
-  telescope, segmented or not, the inverse image ‘plate scale’ or, more
+  telescope, segmented or not, the inverse image 'plate scale' or, more
   precisely, the ratio of off-center distance in the focal plane
   (projection for curved focal surface) to the tangent of the off-axis
   angle, does not match the nominal focal plane very well. This effective

--- a/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -1,0 +1,61 @@
+%YAML 1.2
+---
+title: Schema for effective_focal_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: effective_focal_length
+developer_note: |-
+  Not a simulation model parameter but used for the analysis only.
+  Should be discussed further if this is the right place.
+description: |-
+  Due to asymmetric image aberrations, in particular for single-reflector
+  telescope, segmented or not, the inverse image ‘plate scale’ or, more
+  precisely, the ratio of off-center distance in the focal plane
+  (projection for curved focal surface) to the tangent of the off-axis
+  angle, does not match the nominal focal plane very well. This effective
+  value here should be better suitable for shower reconstruction than the
+  nominal focal length and is supposed to be based on ray-tracing
+  simulations of point sources, at distances typical of showers and
+  imaged onto the actual focal surface at the level of the pixel entrances.
+  Non-zero values will be reported as-is in the output data and
+  may be used for the built-in reconstruction in sim_telarray. If no value is given,
+  sim_telarray may estimate a value, based on optics type and f/D ratio, for its
+  internal purpose but will not report such an estimate in the output data.
+  Due to subtle effects of image cleaning (and thus image intensity) on
+  cutting off parts of the asymmetric point-spread function, analysis
+  programs should use this value or, if not available, an estimate of it
+  only as a starting point and evaluate the actual analysis specific
+  and perhaps image intensity and NSB dependent real effective focal length
+  by itself.
+short_description: |-
+  Effective focal length.
+  Only to be used for image analysis, has no effect on the simulation.
+data:
+  - type: double
+    unit: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetEffectiveFocalLength
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraPlateScale
+source:
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/epsg_code.schema.yml
+++ b/simtools/schemas/model_parameters/epsg_code.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for epsg_code model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: epsg_code
+developer_note: |-
+  Obtained from https://epsg.io/32628 and
+  https://epsg.io/32719
+description: |-
+  EPSG code to describe geodetic datums, spatial reference
+  system, and Earth ellipsoids at the site.
+short_description: Site EPSG code
+data:
+  - type: int
+    unit: dimensionless
+    allowed_range:
+      min: 1024
+      max: 32767
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup

--- a/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for fadc_ac_coupled model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_ac_coupled
+description: |-
+  AC coupling of the FADCs.  If set to 1, then FADCs are AC coupled.
+  A change in night sky background rate will then only change the pedestal
+  noise but not the average pedestal.
+short_description: AC coupling of the FADCs.
+data:
+  - type: boolean
+    unit: dimensionless
+    default: 1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+title: Schema for fadc_amplitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_amplitude
+description: |-
+  Peak amplitude at ADC/FADC (for high-gain channel for dual-gain readout).
+  fadc_amplitude are ADC counts maximum amplitude above pedestal
+  (per time slice) for a photo-electron with average (not most probable)
+  signal.  This is after photo detector, preamplifier, cable, and shaper
+  at the input of the ADC or FADC.
+short_description: Peak amplitude above pedestal for a photo electron with average
+  signal.
+data:
+  - type: double
+    description: FADC amplitude (for high-gain channel in case of dual-readout chain).
+    unit: count
+    default: 14.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_bins.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_bins.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for fadc_bins model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_bins
+description: |-
+  Number of FADC bins to be simulated.
+  The median of all Cherenkov light photo-electrons will be near 40\% of
+  the interval length determined by fadc_bins, unless shifted by
+  photon_delay. If photon_delay is set to zero, this will be the number of
+  FADC bins read out.
+short_description: Number of FADC bins to be simulated.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 20
+    allowed_range:
+      min: 1
+      max: 160
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for fadc_compensate_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_compensate_pedestal
+description: |-
+  Emulate FADC pedestal compensation (as e.g., done in camera firmware using FPGAs)
+  to homogenise significant pixel-to-pixel variations of raw pedestals values
+  (for high-gain channel for dual-gain readout).
+  The resulting values are still unsigned integers and no rescaling takes place
+  (pure integer pedestal offset). No compensation takes place for the default value
+  of "-1".  Values greater or equal to zero indicate the compensated pedestal value,
+  rounded to the nearest integer. For DC-coupled sensors, the compensation includes
+  any NSB pedestal shift. For cameras with multiple interlaced FADCs per channel and,
+  therefore, multiple pedestal values, the same integer compensation gets applied to
+  all pedestals of a channel. While the normal pedestal reported in the data includes
+  the compensation, the individual compensations applied for each pixel are reported
+  separately. If individual FADC values would fall below zero through this compensation,
+  they are clipped at zero.
+short_description: Emulation of FADC pedestal compensation.
+data:
+  - type: int
+    unit: dimensionless
+    default: -1
+    allowed_range:
+      min: -1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for fadc_dev_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_dev_pedestal
+developer_note: |-
+  Not applicable for CTA telescopes.
+  TODO - decide if we should list parameters which are not relevant
+  for CTA (don't think we should).
+description: |-
+  Deviation of (F)ADCs pedestals in a single channel.
+  (for high-gain channel in case of dual-readout chain).
+data:
+  - type: double
+    description: |-
+      Deviation of (F)ADCs pedestals
+      (for high-gain channel in case of dual-readout chain).
+    unit: dimensionless
+    default: 0.
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_err_compensate_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_err_compensate_pedestal
+description: |-
+  R.M.S. error on the pedestal evaluation for the compensation step
+  (for high-gain channel for dual-gain readout). Accounts for the
+  inexact pedestal compensation (as camera firmware or server
+  evaluate the actual pedestal from a finite number of samples/events).
+  Used only when fadc_compensate_pedestal is activated.
+short_description: R.M.S. error on the pedestal evaluation for the compensation step.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.
+    allowed_range:
+      min: 0.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
@@ -1,0 +1,49 @@
+%YAML 1.2
+---
+title: Schema for fadc_err_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_err_pedestal
+developer_note: |-
+  TODO - check if this is relevant as this affects only the reported
+  pedestals (which are not used in the reconstruction).
+description: |-
+  Assumed error (Gaussian r.m.s.) in initial calibration of pedestal
+  (for high-gain channel for dual-gain readout).
+  The calibration is based on a limited number of events and therefore the
+  reported pedestal value is not exactly what is used in the simulation.
+  The parameter affects only the reported pedestal
+  (reported as monitoring data), not the true pedestals used in the
+  simulation.
+short_description: |-
+  Assumed error in initial calibration of pedestal
+  (affects only the reported pedestal).
+data:
+  - type: double
+    default: 0.08
+    description: |-
+      Error in pedestal calibration
+      (for high-gain channel in case of dual-readout chain).
+    unit: count
+    allowed_range:
+      min: 0.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_amplitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_amplitude
+description: |-
+  Peak amplitude at ADC/FADC (low-gain channels).
+  fadc_amplitude are ADC counts maximum amplitude above pedestal
+  (per time slice) for a photo-electron with average (not most probable)
+  signal.  This is after photo detector, preamplifier, cable, and shaper
+  at the input of the ADC or FADC.
+short_description: Peak amplitude above pedestal for a photo electron with average
+  signal (low-gain channels).
+data:
+  - type: double
+    description: FADC amplitude (for low-gain channel in case of dual-readout chain).
+    unit: count
+    condition: num_gains==2
+    default: 1.
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -1,0 +1,51 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_compensate_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_compensate_pedestal
+description: |-
+  Emulate FADC pedestal compensation (as e.g., done in camera firmware using FPGAs)
+  to homogenise significant pixel-to-pixel variations of raw pedestals values
+  (for low-gain channel for dual-gain readout).
+  The resulting values are still unsigned integers and no rescaling takes place
+  (pure integer pedestal offset). No compensation takes place for the default value
+  of "-1".  Values greater or equal to zero indicate the compensated pedestal value,
+  rounded to the nearest integer. For DC-coupled sensors, the compensation includes
+  any NSB pedestal shift. For cameras with multiple interlaced FADCs per channel and,
+  therefore, multiple pedestal values, the same integer compensation gets applied to
+  all pedestals of a channel. While the normal pedestal reported in the data includes
+  the compensation, the individual compensations applied for each pixel are reported
+  separately. If individual FADC values would fall below zero through this compensation,
+  they are clipped at zero.
+short_description: Emulation of FADC pedestal compensation.
+data:
+  - type: int
+    unit: dimensionless
+    default: -1
+    condition: num_gains==2
+    allowed_range:
+      min: -1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_dev_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_dev_pedestal
+developer_note: |-
+  Not applicable for CTA telescopes.
+  TODO - decide if we should list parameters which are not relevant
+  for CTA (don't think we should).
+description: |-
+  Deviation of (F)ADCs pedestals in a single channel (low-gain channels).
+data:
+  - type: double
+    description: |-
+      Deviation of (F)ADCs pedestals (for low-gain channels).
+    unit: dimensionless
+    default: -1.
+    condition: num_gains==2
+    allowed_range:
+      min: -2.0
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_err_compensate_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_err_compensate_pedestal
+description: |-
+  R.M.S. error on the pedestal evaluation for the compensation step
+  (for low-gain channel for dual-gain readout). Accounts for the
+  inexact pedestal compensation (as camera firmware or server
+  evaluate the actual pedestal from a finite number of samples/events).
+  Used only when fadc_compensate_pedestal is activated.
+short_description: R.M.S. error on the pedestal evaluation for the compensation step.
+data:
+  - type: double
+    unit: dimensionless
+    default: -1.
+    allowed_range:
+      min: -1.
+    condition: num_gains==2
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
@@ -1,0 +1,49 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_err_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_err_pedestal
+developer_note: |-
+  TODO - check if this is relevant as this affects only the reported
+  pedestals (which are not used in the reconstruction).
+description: |-
+  Assumed error (Gaussian r.m.s.) in initial calibration of pedestal (low-gain channels).
+  The calibration is based on a limited number of events and therefore the
+  reported pedestal value is not exactly what is used in the simulation.
+  The parameter affects only the reported pedestal
+  (reported as monitoring data), not the true pedestals used in the
+  simulation.
+short_description: |-
+  Assumed error in initial calibration of pedestal
+  (low-gain channels; affects only the reported pedestal).
+data:
+  - type: double
+    description: |-
+      Error in pedestal calibration
+      (for low-gain channel in case of dual-readout chain).
+    unit: count
+    default: -1.
+    condition: num_gains==2
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_max_signal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_max_signal
+description: |-
+  Maximum value of digitized signal per sample (low-gain channels).
+  For a typical 12-bit ADC this would be 4095.
+short_description: Maximum value of digitized signal per sample (low-gain channels).
+data:
+  - type: int
+    description: |-
+      Maximum FADC signal
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    unit: count
+    default: -1
+    allowed_range:
+      min: -2
+      max: 65535
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidateCameraLinearity
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_max_sum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_max_sum
+developer_note: Not applicable for CTA telescopes.
+description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples (low-gain channels).
+  Typical limitations are 15 or 16 bits, i.e. 32767 or 65535.
+short_description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples (low-gain channels).
+data:
+  - type: int
+    description: |-
+      Maximum value of a pulse sum
+      (for low-gain channel in case of dual-readout chain)
+    condition: num_gains==2
+    unit: count
+    default: -1
+    allowed_range:
+      min: -2
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - None
+  validation:
+    - None
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_noise model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_noise
+description: |-
+  Gaussian r.m.s. spread of white noise per time bin in digitisation
+  (for low-gain channel, if different gains are used).
+short_description: Gaussian r.m.s. spread of white noise per time bin in digitisation (low-gain channels).
+data:
+  - type: double
+    description: |-
+      Gaussian r.m.s. spread of white noise per time bin in digitisation
+      (for low-gain channel in case of dual-readout chain)
+    condition: num_gains==2
+    unit: count
+    default: 1.3
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_pedestal
+description: (F)ADC pedestal value per time slice (low-gain channels).
+data:
+  - type: double
+    description: |-
+      (F)ADC pedestal value per time slice
+      (for low-gain channel in case of dual-readout chain).
+    unit: count
+    condition: num_gains==2
+    default: -1.
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_sensitivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_sensitivity
+developer_note: |-
+  DISCUSS - suggest to fix this to 1. for CTA and enforce
+  that fadc_amplitude is given in the correct units.
+description: |-
+  FADC counts per mV voltage (or whatever unit is used for
+  par:fadc-amplitude; for low-gain channels).  The definition of '1.0' means that ADC
+  amplitudes have to be given directly in units of the average
+  amplitude of a single photo-electron.
+short_description: FADC counts per mV voltage (for low-gain channels).
+data:
+  - type: double
+    description: |-
+      FADC counts per mV voltage.
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    default: -1.
+    unit: count / mV
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_sysvar_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_sysvar_pedestal
+description: |-
+  Systematic common (e.g. due to temperature) variation of pedestals (ow-gain channels).
+  All reported monitoring data in the same run is offset by the same
+  (random) amount. Parameter determines the Gaussian r.m.s.
+short_description: Systematic common variations of pedestals (low-gain channels).
+data:
+  - type: double
+    description: |-
+      Systematic common variations of pedestals.
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    default: -1.
+    unit: count
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_var_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_var_pedestal
+description: |-
+  Channel-to-channel (or pixel-to-pixel) variation of the pedestal per FADC
+  time slice (low-gain channels). Value is the r.m.s. of the randomly chosen pedestal values
+  around the FADC pedestal.
+data:
+  - type: double
+    description: |-
+      Pedestal variations
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    unit: count
+    default: -1.
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_lg_var_sensitivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_lg_var_sensitivity
+description: Relative variations in sensitivity (even for FADCs of the same channel; low-gain channels).
+data:
+  - type: double
+    description: |-
+      Relative variations in sensitivity
+      (for low-gain channel in case of dual-readout chain).
+    condition: num_gains==2
+    unit: dimensionless
+    default: -1.
+    allowed_range:
+      min: -2.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_max_signal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_max_signal
+description: |-
+  Maximum value of digitized signal per sample
+  (for high-gain channel for dual-gain readout).
+  For a typical 12-bit ADC this would be 4095.
+short_description: Maximum value of digitized signal per sample.
+data:
+  - type: uint
+    description: |-
+      Maximum FADC signal
+      (for high-gain channel in case of dual-readout chain).
+    unit: count
+    default: 0
+    allowed_range:
+      min: 0
+      max: 65535
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidateCameraLinearity
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for fadc_max_sum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_max_sum
+developer_note: Not applicable for CTA telescopes.
+description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples
+  (for high-gain channel for dual-gain readout).
+  Typical limitations are 15 or 16 bits, i.e. 32767 or 65535.
+short_description: |-
+  The maximum value of a pulse sum produced by hardware pulse summation,
+  in sum mode rather than recording pulse samples.
+data:
+  - type: uint
+    description: |-
+      Maximum value of a pulse sum
+      (for high-gain channel in case of dual-readout chain)
+    unit: count
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - None
+activity:
+  setting:
+    - None
+  validation:
+    - None
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_mhz.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_mhz.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for fadc_mhz model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_mhz
+description: FADC sampling rate.
+data:
+  - type: double
+    default: 1000.
+    unit: MHz
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for fadc_noise model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_noise
+description: |-
+  Gaussian r.m.s. spread of white noise per time bin in digitisation
+  (for high-gain channel, if different gains are used).
+short_description: Gaussian r.m.s. spread of white noise per time bin in digitisation.
+data:
+  - type: double
+    description: |-
+      Gaussian r.m.s. spread of white noise per time bin in digitisation
+      (for high-gain channel in case of dual-readout chain)
+    unit: count
+    default: 4.0
+    allowed_range:
+      min: 0.0
+      max: 100.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for fadc_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_pedestal
+description: |-
+  (F)ADC pedestal value per time slice (for high-gain channel for dual-gain readout).
+data:
+  - type: double
+    description: |-
+      (F)ADC pedestal value per time slice
+      (for high-gain channel in case of dual-readout chain).
+    unit: count
+    default: 100.
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+    - ValidatePedestalEvents
+    - ValidateTelescopeSimulationModel
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for fadc_pulse_shape model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: fadc_pulse_shape
+description: |-
+  (F)ADC pulse shape (amplitude vs time) for low and high gain
+  readout chain.  The pulse amplitude scale is ignored and the pulses are
+  re-scaled to peak values of par:fadc-amplitude times par:fadc-sensitivity.
+short_description: (F)ADC pulse shape (amplitude vs time).
+data:
+  - type: file
+    unit: dimensionless
+    default: 'unspecified_shape.dat'
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetReadoutPulseShape
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for fadc_sensitivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_sensitivity
+developer_note: |-
+  DISCUSS - suggest to fix this to 1. for CTA and enforce
+  that fadc_amplitude is given in the correct units.
+description: |-
+  FADC counts per mV voltage (or whatever unit is used for
+  par:fadc-amplitude).  The definition of '1.0' means that ADC
+  amplitudes have to be given directly in units of the average
+  amplitude of a single photo-electron
+  (for high-gain channel for dual-gain readout).
+short_description: FADC counts per mV voltage.
+data:
+  - type: double
+    description: |-
+      FADC counts per mV voltage.
+      (for high-gain channel in case of dual-readout chain).
+    unit: count / mV
+    default: 1.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_sum_bins model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_sum_bins
+description: |-
+  Number of bins summed up in ADC sum data or read out in sampled data.
+  This number corresponds to the experimental length of the readout window.
+  The start of the readout window starts fadc_sum_offset bins
+  before the calculated time of the trigger, as long as the readout window
+  fits fully in the simulated window.  With peak sensing readout, the same
+  interval is used for searching the peak signal.
+short_description: |-
+  Number of bins read out in sampled data or summed up in ADC sum data.
+  Corresponds to the experimental length of the readout window.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for fadc_sum_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_sum_offset
+description: |-
+  Number of bins before telescope trigger where summing or reading of
+  sampled data starts (see also description of fadc_sum_bins).  With peak
+  sensing readout, the same offset is used for setting the interval for
+  the searching of the peak signal.  For negative values, the summing or
+  reading starts after the trigger.
+short_description: |-
+  Number of bins before telescope trigger where summing or reading of
+  sampled data starts.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: -160
+      max: 160
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_sysvar_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_sysvar_pedestal
+description: |-
+  Systematic common (e.g. due to temperature) variation of pedestals
+  (for high-gain channel for dual-gain readout).
+  All reported monitoring data in the same run is offset by the same
+  (random) amount. Parameter determines the Gaussian r.m.s.
+short_description: Systematic common variations of pedestals.
+data:
+  - type: double
+    description: |-
+      Systematic common variations of pedestals.
+      (for high-gain channel in case of dual-readout chain).
+    unit: count
+    default: 0.04
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for fadc_var_pedestal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_var_pedestal
+description: |-
+  Channel-to-channel (or pixel-to-pixel) variation of the pedestal per FADC
+  time slice. Value is the r.m.s. of the randomly chosen pedestal values
+  around the FADC pedestal
+  (for high-gain channel for dual-gain readout.
+data:
+  - type: double
+    description: |-
+      Pedestal variations
+      (for high-gain channel in case of dual-readout chain).
+    unit: count
+    default: 0.75
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
+++ b/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for fadc_var_sensitivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: fadc_var_sensitivity
+description: |-
+  Relative variations in sensitivity (even for FADCs of the same channel).
+data:
+  - type: double
+    description: |-
+      Relative variations in sensitivity
+      (for high-gain channel in case of dual-readout chain).
+    unit: dimensionless
+    default: 0.02
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateReadout
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/flatfielding.schema.yml
+++ b/simtools/schemas/model_parameters/flatfielding.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for flatfielding model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: flatfielding
+developer_note: |-
+  This is of integer type in sim_telarray with allowed values 0 and 1.
+  Assigned here as type boolean, discuss if this is correct.
+description: |-
+  If enabled, the gains in pixels are adjusted to achieve the same signal
+  from the same illumination. If disabled, the gains are adjusted to
+  have equal single-p.e. amplitudes.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+data:
+  - type: boolean
+    unit: dimensionless
+    default: 1
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/focal_length.schema.yml
+++ b/simtools/schemas/model_parameters/focal_length.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for focal_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: focal_length
+description: |-
+  Nominal overall focal length of the entire telescope. This defines the
+  image scale near the centre of the field of view. For segmented primary
+  focus telescopes this determines the alignment of the segments and the
+  separation from the reflector, at its centre to the camera. The
+  alignment focus is on the surface determined by the par:focus-offset
+  (see parameter description for details).  For secondary mirror
+  configurations this value is not actually used in the optics simulation
+  but only reported as a nominal value, typically close to the effective
+  focal length.
+short_description: Nominal overall focal length of the entire telescope.
+data:
+  - type: double
+    unit: cm
+    default: 1500.0
+    allowed_range:
+      min: 10.0
+      max: 10000.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
+++ b/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
@@ -1,0 +1,158 @@
+%YAML 1.2
+---
+title: Schema for focal_surface_parameters model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: focal_surface_parameters
+description: |-
+  Defines the position of the focal surface along the optical axis and
+  its off-axis shape.  The par:focus-offset still applies, but with a
+  curved focal surface only in the camera centre, such that star light
+  would be focused on the camera lid surface but light from the typical
+  distance of the shower maximum would be focused on the pixel entrance.
+  Note that this offset may be impractically small with secondary mirrors
+  reducing the plate scale.  The direction of the incoming rays is not
+  transformed into the normal plane of the focal surface, thus
+  corresponding to pixels shifted w.r.t.\ to a plane.
+short_description: |-
+  Defines the position of the focal surface along the optical axis and its
+  off-axis shape.
+data:
+  - name: p0
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p1
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p2
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p3
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p4
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p5
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p6
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p7
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p8
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p9
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p10
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p11
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p12
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p13
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p14
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p15
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p16
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p17
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p18
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+  - name: p19
+    type: double
+    description: coefficient describing focal surface
+    required: true
+    unit: cm
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
+++ b/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for focal_surface_ref_radius model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: focal_surface_ref_radius
+description: The length scale to which the focal_surface_parameters apply.
+data:
+  - type: double
+    condition: mirror_class==2
+    unit: cm
+    default: 1.0
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/focus_offset.schema.yml
+++ b/simtools/schemas/model_parameters/focus_offset.schema.yml
@@ -1,0 +1,66 @@
+%YAML 1.2
+---
+title: Schema for focus_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: focus_offset
+description: |-
+  Distance of the starlight focus from the camera pixels (light guides)
+  entry. In telescopes without dynamic focusing capability (either
+  through mirror alignment and camera positioning) this is best set
+  such that starlight gets focused onto the camera lid while showers
+  are focused onto the pixel entry.
+  Zenith angle dependence of the focus offset can be applied and includes
+  the constant value $\Delta_0$ and terms depending on cosine and sine
+  of the zenith angle. The total focus offset is
+  $\Delta = \Delta_0 + \Delta_c + \Delta_s$.
+  Set to zero for all 2M telescope types, as it is already included in
+  the first of the par:focal-surface-parameters values, assuming the
+  design value of that is for a light source at a typical shower maximum
+  distance.
+short_description: |-
+  Distance of the starlight focus from the camera pixels (light guides)
+  entry.
+data:
+  - type: double
+    name: focus_offset
+    description: Constant focus offset $\Delta_0$.
+    unit: cm
+    default: 2.8
+  - type: double
+    description: Zenith angle $\Delta_0$ at which minimum is reached.
+    unit: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\Delta_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    unit: dimensionless
+    default: 0.0
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\Delta_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    unit: dimensionless
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/gain_variation.schema.yml
+++ b/simtools/schemas/model_parameters/gain_variation.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for gain_variation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: gain_variation
+short_description: |-
+  Fractional gain variation between different photo detectors after
+  adjusting the voltage to have approximately the same gain in all channels.
+description: |-
+  Fractional gain variation between different photo detectors after
+  adjusting the voltage to have approximately the same gain in all channels.
+  The parameter sets the Gaussian r.m.s. spread of random fluctuations, used
+  as \texttt{amplitude *= RandGaus(1., gain_variation)}.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.02
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
+++ b/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for geomag_horizontal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: geomag_horizontal
+short_description: Horizontal component of geomagnetic field.
+description: |-
+   Horizontal component in direction of magnetic North of the geomagnetic
+   field at given site.
+data:
+  - type: double
+    unit: uT
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetGeomagneticField
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - External
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/geomag_rotation.schema.yml
+++ b/simtools/schemas/model_parameters/geomag_rotation.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for geomag_rotation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: geomag_rotation
+short_description: Rotation angle between geographic South and geomagnetic North.
+description: |-
+   Rotation angle between geographic South and geomagnetic North direction
+   (corresponds to CORSIKA ARRANG parameter).
+data:
+  - type: double
+    unit: deg
+    allowed_range:
+      min: -180.0
+      max: 180.0
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetGeomagneticField
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - External
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/geomag_vertical.schema.yml
+++ b/simtools/schemas/model_parameters/geomag_vertical.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for geomag_vertical model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: geomag_vertical
+short_description: Vertical component of geomagnetic field.
+description: |-
+   Vertical component in downwards direction of the geomagnetic
+   field at given site.
+data:
+  - type: double
+    unit: uT
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetGeomagneticField
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateAtmosphericModel
+    - ValidateTelescopeSimulationModel
+source:
+  - External
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
+++ b/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for hg_lg_variation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: hg_lg_variation
+description: |-
+  Relative pixel-to-pixel variation of the ratio of high-gain to
+  low-gain amplitudes.
+data:
+  - type: double
+    required: false
+    condition: num_gains==2
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 0.25
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateReadout
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
+++ b/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for iobuf_maximum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: iobuf_maximum
+description: |-
+  Buffer limits for input and output of eventio data
+data:
+  - type: int
+    unit: byte
+    default: 200000000
+    allowed_range:
+      min: 100000
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
+++ b/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for iobuf_output_maximum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: iobuf_output_maximum
+description: |-
+  The maximum size of the I/O buffer for output data, including raw data for all telescopes.
+data:
+  - type: int
+    unit: byte
+    default: 20000000
+    allowed_range:
+      min: 100000
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for laser_events model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_events
+description: |-
+  Laser (or LED or other pulsed light source) events at start of run, before the first shower event.\
+  The assumed light source would typically be in the center of the dish and is assumed to illuminate all pixels uniformly.\
+  The camera lid is assumed to be open, i.e. events will also be subject to NSB.\
+  A value of zero means that the data will not contain any such events.
+short_description: |-
+  Relative variation of laser shots from shot to shot.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
+++ b/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for laser_external_trigger model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_external_trigger
+description: |-
+  A laser/LED flatfielding unit would typically operate at a sufficient illumination \
+  that the camera can trigger by itself. If operated at low illumination \
+  (e.g. a single-p.e. calibration unit outside of the camera), then an external trigger is needed.
+short_description: |-
+  Use external trigger for calibration.
+data:
+  - type: int
+    default: 0
+    allowed_range:
+      min: 0
+      max: 1
+
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for laser_photons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_photons
+description: |-
+  Number of laser photons at each photodetector.
+short_description: |-
+  Number of laser photons at each photodetector.
+data:
+  - type: double
+    unit: dimensionless
+    default: 500
+    allowed_range:
+      min: 1
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
+++ b/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for laser_pulse_exptime model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_pulse_exptime
+description: |-
+  To be used (non-zero) if the pulse shape of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit follows an exponential, e.g. as used in early HESS calibration \
+  units with a UV laser illuminating a scintillator and exciting it to emit light with a decay time of 2.5 ns.
+short_description: |-
+  Exponentially decaying pulse shape time.
+data:
+  - type: double
+    unit: "ns"
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
+++ b/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for laser_pulse_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_pulse_offset
+description: |-
+  The flat-fielding and single-p.e. calibration units are assumed to operate with an external trigger.\
+  Thus the position of the signal in the read-out window can be shifted \
+  (negative number: earlier, positive numbers: later).
+short_description: |-
+  Shift position of the signal in the read-out window.
+data:
+  - type: double
+    unit: "ns"
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
+++ b/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for laser_pulse_sigtime model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_pulse_sigtime
+description: |-
+  To be used (non-zero) if the pulse shape of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit follows a Gaussian, with the given number standing for the sigma of the Gaussian.
+short_description: |-
+  Gaussian pulse time width.
+data:
+  - type: double
+    unit: "ns"
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
+++ b/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for laser_pulse_twidth model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_pulse_twidth
+description: |-
+  To be used (non-zero) if the pulse shape of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit follows a top-hat (Heavyside) function, with the given number standing for the full width.
+short_description: |-
+  Top-Hat pulse time full-width.
+data:
+  - type: double
+    unit: "ns"
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_var_photons.schema.yml
+++ b/simtools/schemas/model_parameters/laser_var_photons.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for laser_var_photons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_var_photons
+description: |-
+  Relative variation of laser shots from shot to shot, independent for each telescope.
+short_description: |-
+  Relative variation of laser shots from shot to shot.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.05
+    allowed_range:
+      min: 0
+      max: 1
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/laser_wavelength.schema.yml
+++ b/simtools/schemas/model_parameters/laser_wavelength.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for laser_wavelength model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: laser_wavelength
+description: |-
+  The wavelength of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit. Applies to both laser and LED type events.
+short_description: |-
+  Wavelength of light-source.
+data:
+  - type: double
+    unit: "nm"
+    default: 400
+    allowed_range:
+      min: 200
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/led_events.schema.yml
+++ b/simtools/schemas/model_parameters/led_events.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for led_events model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: led_events
+description: |-
+  If greater than zero than additional calibration-type events are simulated before \
+  the first shower events, assuming an independent LED in front of each pixel, \
+  taking this type of data with closed lid, i.e. without NSB.
+short_description: |-
+  Additional calibration-type events.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/led_photons.schema.yml
+++ b/simtools/schemas/model_parameters/led_photons.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for led_photons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: led_photons
+description: |-
+  The intensity of LEDs assumed to sit in the camera lid in front of each pixel \
+  (like originally HESS CT3) when simulating extra calibration-type events (with LED_EVENTS greater than zero).\
+  Typically this would be single-p.e. calibration events without NSB background.
+short_description: |-
+  LED intensity in the camera lid in front of each pixel.
+data:
+  - type: double
+    unit: dimensionless
+    default: 4.0
+    allowed_range:
+      min: 0.05
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
+++ b/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for led_pulse_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: led_pulse_offset
+description: |-
+  The flat-fielding and single-p.e. calibration units are assumed to operate with an external trigger.\
+  Thus the position of the signal in the read-out window can be shifted \
+  (negative number: earlier, positive numbers: later).
+short_description: |-
+  Shift position of the signal in the read-out window.
+data:
+  - type: double
+    unit: "ns"
+    default: 0.0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
+++ b/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for led_pulse_sigtime model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: led_pulse_sigtime
+description: |-
+  To be used (non-zero) if the pulse shape of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit follows a Gaussian, with the given number standing for the sigma of the Gaussian.
+short_description: |-
+  Gaussian sigma LED pulse width.
+data:
+  - type: double
+    unit: "ns"
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/led_var_photons.schema.yml
+++ b/simtools/schemas/model_parameters/led_var_photons.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for led_var_photons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: led_var_photons
+description: |-
+  Variation of the average amplitude of the LEDs in front of each pixel,\
+  from pixel to pixel (not including the statistical event-to-event fluctuation).
+short_description: |-
+  Average amplitude variation of LED in front of each pixel.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 1.0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/lightguide_efficiency_vs_incident_angle.schema.yml
+++ b/simtools/schemas/model_parameters/lightguide_efficiency_vs_incident_angle.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for lightguide_efficiency_vs_incident_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
+name: lightguide_efficiency_vs_incident_angle
+developer_note: |-
+  Part of sim_telarray camera_config_file (parameter PixType).
+  To be replaced by a data table.
+description: |-
+  Lightguide efficiency as a function of incidence angle.
+  The wavelength dependence is averaged over, weighting by the
+  Cherenkov spectrum on the ground.
+short_description: Lightguide efficiency as a function of incidence angle.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetLightGuideEfficiency
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for lightguide_efficiency_vs_wavelength model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_version: 0.1.0
+name: lightguide_efficiency_vs_wavelength
+developer_note: |-
+  The extra funnel efficiency table is interpreted such that
+  efficiency factors are not double-counted on top of that in
+  the angle-dependence table (normalized to yield no extra
+  correction for 400 nm wavelength at the expected average
+  incidence angle).
+  This is not interchangeable with the window filter transmission.
+  Part of sim_telarray camera_config_file (parameter PixType).
+  To be replaced by a data table.
+description: Lightguide efficiency for on-axis photons vs wavelength.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetLightGuideEfficiency
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
+++ b/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for min_photoelectrons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: min_photoelectrons
+short_description: |-
+  Minimum number of detected photoelectrons required before running electronics simulation.
+description: |-
+  Minimum number of detected photoelectrons required in a camera before running the
+  more CPU-intense electronics simulation.
+data:
+  - type: int
+    unit: dimensionless
+    default: -1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/min_photons.schema.yml
+++ b/simtools/schemas/model_parameters/min_photons.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for min_photons model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: min_photons
+description: |-
+  Minimum number of photons required before doing simulation.
+data:
+  - type: double
+    unit: dimensionless
+    default: -1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_distance model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_align_random_distance
+description: |-
+  Gaussian r.m.s. spread of random fluctuations in the aligned mirror
+  distance from the focus.
+data:
+  - type: double
+    unit: cm
+    default: 2.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
@@ -1,0 +1,64 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_horizontal model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_align_random_horizontal
+description: |-
+  Fluctuations of the mirror alignment angle with respect to nominal
+  alignment in the horizontal component (in azimuth or y direction in
+  dish coordinates). The three terms are added up as independent
+  (i.e., by squares; therefore he square of the horizontal mirror
+  alignment error is $\sigma^2 = \sigma_0^2 + \sigma_c^2 + \sigma_s^2$).
+  The values here are usually derived from fits to the measured point
+  spread functions, with the single mirror point-spread function adapted
+  beforehand. Note that, since this affects the angles of the mirrors,
+  the impact on the combined spot size is twice as large.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of the mirror alignment
+  angle with respect to nominal alignment in the horizontal component.
+data:
+  - type: double
+    description: Constant value $\sigma_0$.
+    unit: deg
+    default: 0.0035
+  - type: double
+    description: Zenith angle $\theta_0$ at which minimum is reached.
+    unit: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    unit: dimensionless
+    default: 0.023
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    unit: dimensionless
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
@@ -1,0 +1,64 @@
+%YAML 1.2
+---
+title: Schema for mirror_align_random_vertical model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_align_random_vertical
+description: |-
+  Fluctuations of the mirror alignment angle with respect to nominal
+  alignment in the vertical component (in altitude or $x$ direction in
+  dish coordinates). The three terms are added up as independent
+  (i.e., by squares; therefore he square of the vertical mirror
+  alignment error is $\sigma^2 = \sigma_0^2 + \sigma_c^2 + \sigma_s^2$).
+  The values here are usually derived from fits to the measured point
+  spread functions, with the single mirror point-spread function adapted
+  beforehand. Note that, since this affects the angles of the mirrors,
+  the impact on the combined spot size is twice as large.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of the mirror alignment
+  angle with respect to nominal alignment in the vertical component.
+data:
+  - type: double
+    description: Constant value $\sigma_0$.
+    unit: deg
+    default: 0.0034
+  - type: double
+    description: Zenith angle $\theta_0$ at which minimum is reached.
+    unit: deg
+    default: 28.0
+  - type: double
+    description: |-
+      Scaling term $k_c$ in
+      $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
+    unit: dimensionless
+    default: 0.01
+  - type: double
+    description: |-
+      Scaling term $k_s$ in
+      $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.
+    unit: dimensionless
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetMirrorPanelAlignment
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for mirror_class model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_class
+description: |-
+  Parameter to control the type of mirror used.
+  Includes segmented primary mirror optics with spherical mirror tiles (0),
+  parabolic primary made of a single piece (1), and a a secondary mirror
+  optics (2), with primary and secondary each made of a single piece.
+  Class 3 represents a simple Fresnel lens implementation.
+short_description: Parameter to control the type of mirror used (DC, parabolic or
+  SC).
+data:
+  - type: uint
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+      max: 3
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
@@ -1,0 +1,51 @@
+%YAML 1.2
+---
+title: Schema for mirror_degraded_reflection model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_degraded_reflection
+description: |-
+  Mirror degradation factor (wavelength independent).
+  Applied to the mirror reflectivity of the primary mirror
+  (note also the primary, secondary, and camera efficiency
+  degradation factors).
+  What matters typically is the overall product of the efficiencies.
+  Breaking it down into mirror(s) and/or camera degradation
+  only matters where BYPASS_OPTICS becomes involved. Then this parameter
+  is actually interpreted as being for reflection on the primary mirror
+  (would not be relevant for a flat-fielding light source directly illuminating
+  the camera or illuminating it via reflection on the secondary mirror).
+  The nightsky background in each pixel is also scaled by the same factor
+  (even if the actual simulation bypasses optical ray-tracing).
+  For wavelength-dependent degradation, the tables for reflectivity,
+  window transmission, or light-cone efficiency need to be adapted.
+short_description: |-
+  Mirror degradation factor (wavelength independent).
+data:
+  - type: double
+    unit: dimensionless
+    default: 1.
+    allowed_range:
+      min: 0.
+      max: 1.
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for mirror_focal_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_focal_length
+description: |-
+  Standard focal length of mirror tiles. This parameter is only used if
+  the focal lengths of the mirror tiles in the par:mirror_list
+  are zero. For a parabolic dish any non-zero value will then force
+  all mirror tiles to have the same focal lengths (which should then match
+  the average distance of the parabolic dish from the focus, not exactly
+  the overall focal length).
+short_description: Standard focal length of mirror tiles.
+data:
+  - type: double
+    unit: cm
+    default: 0.0
+    allowed_range:
+      min: 0.
+      max: 10000.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_list.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_list.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for mirror_list model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: mirror_list
+description: List of mirror positions, diameters, focal lengths, and shape codes.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_offset.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_offset.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for mirror_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_offset
+description: |-
+  Offset of mirror back plane from fixed point of telescope mount
+  (if axes intersect) or from the altitude rotation axis, along
+  the direction of the optical axis.  Positive if fixed point
+  (or altitude axis) is between the mirror back plane and the focus or,
+  in other words, the center of the primary mirror is behind/below
+  the altitude rotation axis.
+short_description: |-
+  Offset of mirror back plane from fixed point of telescope mount or
+  from the altitude rotation axis, along the direction of the optical axis.
+data:
+  - type: double
+    unit: cm
+    default: 130.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for mirror panel 2F measurements
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_panel_2f_measurement
+description: |-
+  Mirror panel 2F measurements determining
+  panel radius and panel PSF.
+data:
+  - type: data_table
+    table_columns:
+      - name: mirror_panel_id
+        description: |-
+          Mirror panel ID.
+        required: true
+        unit: dimensionless
+        type: string
+      - name: mirror_panel_radius
+        description: |-
+          Mirror panel radius.
+        required: true
+        unit: cm
+        type: double
+      - name: psf
+        description: |-
+          Spot size of mirror panel PSF at nominal distance.
+        required: true
+        unit: cm
+        type: double
+      - name: psf_opt
+        description: |-
+          Spot size of mirror panel PSF
+          (best value, not at nominal distance).
+        required: false
+        unit: cm
+        type: double

--- a/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
@@ -1,0 +1,61 @@
+%YAML 1.2
+---
+title: Schema for mirror_reflection_random_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: mirror_reflection_random_angle
+description: |-
+  Gaussian random fluctuations of reflection angles, due to
+  small-scale surface deviations, with one or two components.
+  For two components, the random reflection angle is applied
+  separately to each projection, in the coordinate system of the mirror
+  surface, with the same r.m.s. in both projections.
+short_description: |-
+  Gaussian r.m.s. spread of random fluctuations of microscopic reflection
+  angles due to small-scale surface deviations.
+data:
+  - type: double
+    description: Projected Gaussian r.m.s. of the first component.
+    unit: deg
+    default: 0.0066
+    allowed_range:
+      min: 0.0
+      max: 2.0
+  - type: double
+    description: Fractional amplitude of second component.
+    unit: dimensionless
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 1.0
+  - type: double
+    description: Projected Gaussian r.m.s. of the second component.
+    unit: deg
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 2.0
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetMirrorPanelRandomReflection
+    - SetParameterFromExternal
+  validation:
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
+++ b/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for mirror_reflectivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: mirror_reflectivity
+description: |-
+  Mirror reflectivity measured directly on the facet as function of
+  wavelength. For dual mirror telescopes without explicit reflectivity
+  table given for the secondary, this reflectivity given here is
+  applied twice.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_reflectivity.dat'
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeEfficiency
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
+++ b/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
@@ -1,0 +1,46 @@
+%YAML 1.2
+---
+title: Schema for multiplicity_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: multiplicity_offset
+description: |-
+  This number tells where the actual threshold of the telescope trigger
+  is adjusted relative to the nominal number of required pixels.
+  A value of -0.5 means that with par:trigger-pixels of 4, the sum of
+  pixel discriminator/comparator outputs must exceed 3.5 times the
+  average output amplitude for the given minimum time and by the
+  given minimum signal integral in order to accept any `sector'
+  trigger (and therefore a telescope trigger) with the majority
+  trigger logic.
+short_description: |-
+  Actual threshold of the telescope trigger, adjusted relative to the
+  number of required pixels.
+data:
+  - type: double
+    unit: dimensionless
+    default: -0.5
+    allowed_range:
+      min: -0.5
+      max: 0.5
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
@@ -1,0 +1,51 @@
+%YAML 1.2
+---
+title: Schema for nsb_autoscale_airmass model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_autoscale_airmass
+description: |-
+  NSB scaling as function of airmass (zenith angle).
+  This only takes effect if nsb_scaling_factor is exactly 1.0
+short_description: NSB scaling as function of airmass (zenith angle).
+data:
+  - type: double
+    description: |-
+      Zenith-level fraction of NSB resulting from airglow.
+      Value should be on the order of 0.7.
+    unit: dimensionless
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 1.0
+  - type: double
+    description: |-
+      Effective extinction coefficient applicable for NSB light
+      (due to scattering it should be smaller than extinction
+      coefficient for line-of-sight propagation).
+      Value should be on the order of 0.15.
+    unit: dimensionless
+    default: 0.15
+    allowed_range:
+      min: 0.0
+      max: 1.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for nsb_gain_drop_scale model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_gain_drop_scale
+description: |-
+  This parameter, if non-zero, indicates the pixel p.e. rate at which the
+  gain drops to half the nominal value due to bias resistance and
+  cell capacitance (applicable as such for SiPM cameras). \\
+  \textbf{Example:} 1./(2.4 [kOhm] $\times$ 85 [fF])/1e9 [ns] = 4.90 [GHz].
+short_description: |-
+  Pixel p.e. rate at which the gain drops to half the nominal value due to
+  bias resistance and cell capacitance (SiPM cameras).
+data:
+  - type: double
+    unit: GHz
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
@@ -1,0 +1,79 @@
+%YAML 1.2
+---
+title: Schema for nsb_offaxis model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_offaxis
+description: |-
+  Fall-off of NSB with off-axis angle due to change of effective optical
+  area across the field of view (partly covered by
+  par:telescope-transmission).  The first parameter is the function
+  number. Function zero is a constant (all following parameters ignored),
+  function one is $f = 1/(1 + p_1 * (r/p_2)^{p_3})$ if $p_4=0$ or missing
+  and $f = 1/(1 + p_1 * (r/p_2)^{p_3})^{p_4}$ if $p_4\ne0$ where
+  $r$ is the ($x$/$y$ projected) pixel off-axis radius and $p_1$ to
+  $p_4$ are the second to fifth parameter, with $p_2$ understood as a
+  camera reference radius for the purpose of this function.
+short_description: |-
+  Fall-off of NSB with off-axis angle due to off-axis angle-dependent
+  effective optical area.
+data:
+  - name: nsb_offaxis_function
+    required: false
+    type: double
+    description: |
+      Function identifier.
+    default: 0
+    allowed_range:
+      min: 0
+      max: 1
+    unit: dimensionless
+  - name: nsb_offaxis_p1
+    description: |
+      NSB off-axis factor $p_1$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+  - name: reference_radius_p2
+    description: |
+      Camera reference radius $p_2$.
+    required: false
+    type: double
+    default: 0.0
+    unit: cm
+  - name: nsb_offaxis_p3
+    description: |
+      NSB off-axis factor $p_3$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+  - name: nsb_offaxis_p4
+    description: |
+      NSB off-axis factor $p_4$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetNightSkyBackgroundRate
+    - SetParameterFromExternal
+  validation:
+    - ValidatePedestalEvents
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
@@ -1,0 +1,47 @@
+%YAML 1.2
+---
+title: Schema for nightsky_background model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_pixel_rate
+description: |-
+  'Number of photo-electrons per nanosecond per pixel due to night-sky
+  background. Note that the number here takes into account all
+  photo-electrons, including those not properly amplified or lost at the
+  first dynode.  A range of pixels can be given with
+  nightsky_background = (0-1236): 0.2, (1237-1854): 0.15.
+  Alternatively, all pixels can be set with nightsky_background = all: 0.2.'
+short_description: |-
+  Number of photo-electrons per nanosecond per pixel due to nightsky
+  background.
+data:
+  - type: double
+    unit: GHz
+    default: 0.218
+    allowed_range:
+      min: 0.
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetNightSkyBackgroundRate
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidatePedestalEvents
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: nightsky_background

--- a/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for nsb_reference_value model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_reference_value
+description: |-
+  Reference value for night-sky background flux in the wavelength range
+  from 300-650 nm (corresponding approximately to the extragalactic
+  night sky background level during astronomical darkness)
+short_description: Reference value for night-sky background flux.
+data:
+  - type: double
+    unit: 1/(sr*ns*cm**2)
+    default: 0.24
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for nsb_scaling_factor model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_scaling_factor
+description: |-
+  Common scaling of the NSB in all pixels of all telescopes against
+  reference setting.
+short_description: Global NSB scaling factor.
+data:
+  - type: double
+    unit: dimensionless
+    default: 1.0
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_skymap.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_skymap.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for nsb_sky_map model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: nsb_sky_map
+description: |-
+  An optional sky map (Az/Alt) of NSB enhancement factors, counted on top
+  of the configured pixel NSB p.e. rates and other scaling factors
+  mentioned in this section, but not any starlight which might get
+  added additionally. Recommend is to provide a regular grid in
+  azimuth and altitude. This map will be evaluated for each pixel
+  center pointed back into the sky, using the effective focal length
+  (no explicit ray-tracing), thus is only suitable for changes in
+  sky brightness exceeding the pixel sizes.
+short_description: Sky map (Az/Alt) of NSB enhancement factors.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
+++ b/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
@@ -1,0 +1,50 @@
+%YAML 1.2
+---
+title: Schema for night_sky_background_spectrum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: nsb_background_spectrum
+developer_note: |
+  TODO - check that wavelength range is sufficient
+  TODO - add possible zenith / azimuth dependence
+  (see Granada talk by C. Righi)
+description: Intensity of night-sky background light as function of wavelength.
+instrument:
+  class: Site
+  type:
+    - Atmosphere
+  site:
+    - North
+    - South
+data:
+  - type: data_table
+    table_columns:
+      - name: wavelength
+        description: Wavelength
+        required: true
+        unit: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+        input_processing:
+          - remove_duplicates
+          - sort
+      - name: intensity
+        description: Intensity of the night-sky background
+        required: true
+        unit: photons / arcsec**2 m**2 s** micron
+        type: double
+        required_range:
+          min: 0.0
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/num_gains.schema.yml
+++ b/simtools/schemas/model_parameters/num_gains.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for num_gains model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: num_gains
+description: Number of different gains the input signal gets digitized.
+data:
+  - type: int
+    unit: dimensionless
+    default: 2
+    allowed_range:
+      min: 1
+      max: 2
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
+++ b/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for only_triggered_telescopes model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: only_triggered_telescopes
+description: |-
+  Triggered telescopes are read out only (if true), otherwise
+  non-triggered telescopes are also read out.
+short_description: Switch to read out non-triggered telescopes.
+data:
+  - type: boolean
+    default: true
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/optics_properties.schema.yml
+++ b/simtools/schemas/model_parameters/optics_properties.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for optics_properties model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: optics_properties
+description: |-
+  Derived properties of the telescope optics.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_file.dat'
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - SimPipe Derived

--- a/simtools/schemas/model_parameters/parabolic_dish.schema.yml
+++ b/simtools/schemas/model_parameters/parabolic_dish.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for parabolic_dish model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: parabolic_dish
+description: |-
+  Parabolic dish.
+  Mirror tiles still have spherical shape (similar to the Davies-Cotton
+  optics), but their focal lengths are adapted to the distance from the
+  focus (since the geometric mean of minimum and maximum radius of
+  curvature of the paraboloid is very close to that distance).
+short_description: Parabolic dish shape is used.
+data:
+  - type: boolean
+    default: false
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for pedestal_events model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pedestal_events
+description: |-
+  Number of pedestal events at start of run with camera lid open (same NSB as for normal events).
+short_description: |-
+  Number of pedestal events at start of run with camera lid open (same NSB as for normal events).
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/photon_delay.schema.yml
+++ b/simtools/schemas/model_parameters/photon_delay.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for photon_delay model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: photon_delay
+developer_note: |-
+  Type corrected with respect to the sim_telarray manual
+  (double, not int)
+description: |-
+  Additional delay added to the arrival times
+  of all photons at the photo sensors.
+data:
+  - type: double
+    unit: ns
+    default: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetPhotonDelay
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/photons_per_run.schema.yml
+++ b/simtools/schemas/model_parameters/photons_per_run.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for photons_per_run model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: photons_per_run
+description: |-
+  Number of total emitted photons by the calibration light source per run.
+short_description: |-
+  Number of photons per run.
+data:
+  - type: double
+    unit: dimensionless
+    default: 1e10
+    allowed_range:
+      min: 1
+instrument:
+  class: Calibration
+  type:
+    - ILLN
+    - ILLS
+
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pixel_cells.schema.yml
+++ b/simtools/schemas/model_parameters/pixel_cells.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for pixel_cells model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pixel_cells
+description: |-
+  Modeling of pixel saturation. Value corresponds to the
+  limited number of cells in a pixel (of SiPM type) which each can only
+  fire once during the typical arrival time spread of Cherenkov photons.
+  The presence of a non-zero value does not imply any microscopic model
+  of the pixel structure.
+data:
+  - type: int
+    unit: dimensionless
+    default: 0
+    allowed_range:
+      min: 0
+instrument:
+  class: Camera
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pixels_parallel.schema.yml
+++ b/simtools/schemas/model_parameters/pixels_parallel.schema.yml
@@ -1,0 +1,54 @@
+%YAML 1.2
+---
+title: Schema for pixels_parallel model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pixels_parallel
+description: |-
+  Parameter controlling the orientation of the pixels, setting it to be
+  aligned with the optical axis or the focal surface normal.
+  A value of 0 indicates that the pixel is oriented such that the surface
+  is aligned with the focal surface (pixel axis parallel to focal surface
+  normal).
+  A value of 1 indicates, that pixels are only shifted parallel to the
+  optical axis. Pixel surfaces remain perpendicular to the optical axis.
+  A value of 2 places all pixels belonging to the same module
+  (as configured in the ``Pixels'' lines in the par:camera-config-file)
+  on a common plane, with its orientation along the normal to the focal
+  surface in the module center (c.o.g. of pixels) and with zero mean
+  displacements of pixels along the $z$ axis.
+  A value of 3 (=2+1) has all pixels in a common plane per module and
+  all of the modules (and thus all of the pixels) looking parallel to
+  the optical axis. The ‘height’ (in z) of the module is again the
+  average of where individually placed pixels would be (zero mean
+  displacement in module).
+  An extension to the camera definition file even allows for pixels to be
+  configured individually and not exactly following the focal surface
+  (in both height and orientation).
+short_description: |-
+  Parameter controlling the orientation of the pixels, setting it to be
+  aligned with the optical axis or the focal surface normal.
+data:
+  - type: uint
+    default: 1
+    allowed_range:
+      min: 0
+      max: 3
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraGeometry
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pixels_parallel.schema.yml
+++ b/simtools/schemas/model_parameters/pixels_parallel.schema.yml
@@ -21,7 +21,7 @@ description: |-
   displacements of pixels along the $z$ axis.
   A value of 3 (=2+1) has all pixels in a common plane per module and
   all of the modules (and thus all of the pixels) looking parallel to
-  the optical axis. The ‘height’ (in z) of the module is again the
+  the optical axis. The 'height' (in z) of the module is again the
   average of where individually placed pixels would be (zero mean
   displacement in module).
   An extension to the camera definition file even allows for pixels to be

--- a/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
+++ b/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for pixeltrg_time_step model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pixeltrg_time_step
+description: |-
+  If non-zero, the time between the telescope trigger and the time
+  when the pixel discriminator/comparator fired is recorded under
+  the telescope event in the given time steps (negative for
+  pixels fired before the telescope trigger; possible delays involved
+  in a real instrument are not accounted for).
+short_description: Time difference between telescope and pixel trigger recording.
+data:
+  - type: double
+    unit: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_average_gain.schema.yml
+++ b/simtools/schemas/model_parameters/pm_average_gain.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for pm_average_gain model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pm_average_gain
+description: |-
+  Photo detector average gain. Used to determine the DC currents
+  from night-sky background (NSB) pixel rates.
+data:
+  - type: double
+    default: 40000.0
+    allowed_range:
+      min: 10000.0
+      max: 30000000.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateNightSkyBackgroundMeasurement
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
+++ b/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for pm_collection_efficiency model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pm_collection_efficiency
+developer_note: Always set to 1. for CTA cameras.
+short_description: |-
+  Photoelectron collection efficiency at the first stage of the photo
+  detector.
+description: |-
+  Photoelectron collection efficiency at the first stage of the photo
+  detector. The default value is 1.0 since in most cases the non-amplified
+  photo-electrons are included in the amplitude distribution of the
+  single-p.e. spectrum.
+data:
+  - type: double
+    unit: dimensionless
+    allowed_range:
+      min: 0.01
+      max: 1.0
+    default: 1.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_gain_index.schema.yml
+++ b/simtools/schemas/model_parameters/pm_gain_index.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for pm_gain_index model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pm_gain_index
+description: |-
+  PMT gain g and voltage U are assumed to be related by
+  the PMT gain index p through $g \propto U^{p}$.
+  Used only for PMT timing.
+data:
+  - type: double
+    unit: dimensionless
+    default: 4.0
+    allowed_range:
+      min: 0.0
+      max: 15.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
+++ b/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for pm_photoelectron_spectrum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: pm_photoelectron_spectrum
+description: |-
+  Single photoelectron (p.e.) response distribution
+  (takes into account afterpulsing and the photoelectron collection
+  efficiency for PMT cameras).
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_pe_spectrum.dat'
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetSinglePhotoElectronResponse
+  validation:
+    - ValidateParameterByExpert
+    - ValidateSinglePhotoElectronResponse
+    - ValidateCameraChargeResponse
+    - ValidateCameraLinearity
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -1,0 +1,63 @@
+%YAML 1.2
+---
+title: Schema for pm_transit_time model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pm_transit_time
+description: Total transit time of the photodetector at the average voltage.
+data:
+  - name: pm_transit_time_at_average_voltage
+    type: double
+    description: Total transit time of the PMT at the average voltage.
+    unit: ns
+    default: 20.
+    allowed_range:
+      min: 0.0
+  - name: pm_transit_time_to_first_dynode
+    type: double
+    description: |-
+      Fixed transit time between cathode and first dynode, in case of
+      the first dynode being stabilized. Use zero for a passive divider.
+    unit: ns
+    default: 9.7
+    allowed_range:
+      min: 0.0
+  - name: fixed_voltage_first_dynode
+    type: double
+    description: |-
+      The fixed voltage (or fraction of total nominal voltage) applied to
+      a stabilized first dynode. Use zero for a passive divider.
+    unit: V
+    default: 300.
+    allowed_range:
+      min: 0.0
+    developer_note: "This parameter can describe in sim_telarray the fraction of total\n\
+      nominal voltage in case total nominal voltage is set to zero."
+  - name: total_nominal_voltage
+    type: double
+    default: 1100.
+    description: Total nominal voltage.
+    unit: V
+    allowed_range:
+      min: 0.0
+    developer_note: "If zero (or one), the third value of the fixed voltage is assumed\
+      \ to\nrepresent the fraction of the total nominal voltage in sim_telarray."
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTS
+    - MSTN
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
+++ b/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
@@ -1,0 +1,39 @@
+%YAML 1.2
+---
+title: Schema for pm_voltage_variation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: pm_voltage_variation
+short_description: |-
+  Fractional high voltage variation, used to adjust the transit time
+  variations ($\propto 1/\sqrt(V)$).
+description: |-
+  Fractional high voltage variation, used to adjust the transit time
+  variations ($\propto 1/\sqrt(V)$).  The parameter sets the Gaussian
+  r.m.s. spread of random voltage fluctuations,
+  \texttt{V = RandGaus(1., pm_voltage_variation)}.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.03
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_degraded_map model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: |-
+  To be replaced by a data table. Accepted range is 0 to 1
+name: primary_mirror_degraded_map
+description: |-
+  Position-dependent map of degradation factors for the primary mirror.
+  This degradation gets applied on top of mirror_degraded_reflection.
+  Note that the impact of it on the nightsky background is not automatically
+  accounted for and must be evaluated separately and included in the
+  configured NSB pixel p.e. rates. It is recommended to use a map with an
+  average efficiency of 1.0 and use mirror_degraded_reflection
+  for the overall degradation.  Tables with equidistant spacing in both x and
+  y are highly recommended because the interpolation is faster.
+short_description: |-
+  Position-dependent map of degradation factors for the primary mirror.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: primary_degraded_map

--- a/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: primary_mirror_diameter
+description: |-
+  The outer diameter of the primary reflector.
+  Used only in case mirror_list is not defined (i.e., mirror_list=none).
+data:
+  - name: primary_mirror_diameter
+    type: double
+    unit: cm
+    condition: mirror_list==None&&mirror_class==2
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: primary_diameter

--- a/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_hole_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: primary_mirror_hole_diameter
+description: |-
+  The diameter of any non-reflective part of the primary mirror.
+data:
+  - name: primary_hole_diameter
+    description: Diameter of central hole in primary mirror.
+    type: double
+    default: 0.
+    unit: cm
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: primary_hole_diameter

--- a/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_incidence_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: primary_mirror_incidence_angle
+description: |-
+  Distribution of incidence angle on the SST primary mirror.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_file.dat'
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
@@ -1,0 +1,168 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_parameters model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: primary_mirror_parameters
+developer_note: |-
+  Note the application of dual_mirror_ref_radius (primary_ref_radius,
+  secondary_ref_radius) this this parameters.
+description: |-
+  Defines the position of the primary mirror along the optical
+  axis and its shape. The first parameter ($p_0$) is the offset of the
+  mirror with respect to the common reference point defined by
+  par:mirror-offset, with positive values indicating that the centre
+  of the primary (assuming it has no central hole) is above the reference
+  point. The secondary mirror looks the other way, i.e. $p_0$ will usually
+  be negative since in the coordinate frame of the secondary, it is
+  below the common reference point.  Apart from that, a parameter $p_i$
+  adds a term $p_i r^{2i}$ to the height of the mirror at
+  radial offset $r$.  A parabolic mirror will have the second parameter
+  ($p_1$) at a positive value and all further parameters at 0.
+  A concave secondary, reducing the focal length if placed between the
+  primary and its focus, will have $p_1 > 0.$.
+  A convex mirror (e.g.~for Cassegrain or Ritchey-Chr\'etien optics),
+  enlarging the focal length, will have $p_1 < 0$.
+short_description: |-
+  Parameters for a polynomial defining the position of the primary mirror
+  along the optical axis and its shape.
+data:
+  - name: p0
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p1
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p2
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p3
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p4
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p5
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p6
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p7
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p8
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p9
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p10
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p11
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p12
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p13
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p14
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p15
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p16
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p17
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p18
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p19
+    type: double
+    description: coefficient describing primary mirror
+    required: true
+    unit: cm
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateOpticalPSF
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_ref_radius model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: primary_mirror_ref_radius
+description: |-
+  The length scale to which the primary_mirror_parameters apply.
+  Typical values could be 1.0 or the focal length of the
+  primary/secondary.
+short_description: The length scale to which the primary_mirror_parameters apply.
+data:
+  - name: primary_ref_radius
+    description: The length scale to which the primary_mirror_parameters apply.
+    type: double
+    unit: cm
+    default: 1.0
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: primary_ref_radius

--- a/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
+++ b/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for primary_mirror_segmentation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: primary_mirror_segmentation
+description: |-
+  Definition of segments or segment groups of the primary reflector.
+short_description: |-
+  Definition of segments or segment groups of the primary reflector.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: primary_segmentation

--- a/simtools/schemas/model_parameters/qe_variation.schema.yml
+++ b/simtools/schemas/model_parameters/qe_variation.schema.yml
@@ -1,0 +1,43 @@
+%YAML 1.2
+---
+title: Schema for qe_variation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: qe_variation
+developer_note: |-
+  DISCUSS - rename to make clear this parameter is used for all
+  photodetectors (not PMTs only).
+description: |-
+  Variation of quantum or photon detection efficiency
+  (Gaussian r.m.s. spread of random fluctuations) between
+  photo detectors in a given camera. Given in fraction of
+  the average quantum or photon detection efficiency; the variation
+  is applied independent of the wavelength.
+data:
+  - type: double
+    unit: dimensionless
+    default: 0.035
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
+++ b/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for quantum_efficiency model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: quantum_efficiency
+description: |-
+  Quantum or photon detection efficiency
+  averaged over all pixels per camera.
+  Random pixel-to-pixel variations are calculated using
+  the qe_variation parameter. Pixel-to-pixel differences
+  in detection efficiency using scaling factors can be
+  specified in the camera_config_file.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_qe.dat'
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraChargeResponse
+    - ValidateCameraGainsAndEfficiency
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for random_focal_length model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: random_focal_length
+developer_note: Note - Description changed significantly in the sim_telarray manual
+  - Note
+description: |-
+  The spread of random fluctuations in mirror panel focal lengths.
+  These parameters get only applied if the focal lengths in the mirror list
+  file (par:mirror_list) are zero (automatic) or negative (individual with
+  error). For positive focal lengths in that list (definite values) the
+  random focal length value does not get applied.
+short_description: The spread of random fluctuations in mirror focal lengths.
+data:
+  - type: double
+    description: Width (r.m.s.) of Gaussian distribution for random focal lengths.
+    unit: cm
+    default: 7.4
+    condition: mirror_class==1
+  - type: double
+    description: Width of top-hat distribution for random focal lengths.
+    unit: cm
+    default: 0.0
+    condition: mirror_class==1
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateMirrorPanelParameters
+    - ValidateOpticalPSF
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/random_generator.schema.yml
+++ b/simtools/schemas/model_parameters/random_generator.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for random_generator model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: random_generator
+short_description: Random generator used.
+description: |-
+  Random generator used. Unless compiled with -DWITH_GSL_RNG the only valid
+  and known generator is "Ranlux". When using the GNU Scientific Library for
+  random number generators, this can be "Ranlux", "mt19937", "taus", "Ranlxd2",
+  or "GSL:" plus the name of any other GSL-based generator, or "GSL_RNG_TYPE"
+  to obtain the generator from the environment variable of that name.
+data:
+  - type: string
+    default: "Ranlux"
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
+++ b/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for reference_point_altitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: reference_point_altitude
+description: |-
+  Altitude above sea level of site reference point.
+  This location is typically identical or close to the site center.
+short_description: Altitude above sea level of site reference point.
+data:
+  - type: double
+    unit: m
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
+++ b/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for reference_point_latitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: reference_point_latitude
+description: |-
+  Latitude coincident with site reference point.
+  Not to be used for coordinate transformations (use UTM coordinates for this).
+short_description: Latitude of site reference point.
+data:
+  - type: double
+    unit: deg
+    allowed_range:
+      min: -90.0
+      max: 90.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
+++ b/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for ref_longitude model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: ref_longitude
+description: |-
+  Longitude coincident with site reference point.
+  Not to be used for coordinate transformations (use UTM coordinates for this).
+short_description: Longitude of site reference point.
+data:
+  - type: double
+    unit: deg
+    allowed_range:
+      min: -180.0
+      max: 180.0
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
+++ b/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for reference_point_utm_east model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: reference_point_utm_east
+description: |-
+  UTM east of site reference point.
+  Telescope x,y positions are calculated relative to this
+  position.
+short_description: UTM east of site reference point.
+data:
+  - type: double
+    unit: m
+    allowed_range:
+      min: 0.
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup

--- a/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
+++ b/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for reference_point_utm_north model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: reference_point_utm_north
+description: |-
+  UTM north of site reference point.
+  Telescope x,y positions are calculated relative to this
+  position.
+short_description: UTM north of site reference point.
+data:
+  - type: double
+    unit: m
+    allowed_range:
+      min: 0.
+instrument:
+  class: Site
+  type:
+    - Observatory
+  site:
+    - North
+    - South
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetArrayElementCoordinates
+  validation:
+    - ValidateParameterByExpert
+    - ValidateArrayElementCoordinates
+source:
+  - Initial instrument setup

--- a/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
@@ -1,0 +1,79 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_baffle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_baffle
+description: |-
+  Defines a baffle around the secondary mirror to keep NSB light from
+  falling directly onto the camera. Shadowing by the baffle is applied
+  both to incoming photons and to photons reflected from the primary
+  to the secondary mirror. Absence of a baffle is indicated by $r_1=0$.
+short_description: |-
+  Defines a baffle around the secondary mirror to keep NSB light from
+  falling directly onto the camera.
+data:
+  - name: baffle_z1
+    description: |-
+      Beginning of the baffle along the optical axis, counted from the
+      primary center, which means a z value of par:secondary_ref_radius
+      times the first par:secondary_mirror_parameters value is at the
+      height of the center of the secondary.
+    type: double
+    unit: cm
+    required: true
+    condition: mirror_class==2
+    default: 0.
+  - name: baffle_z2
+    description: |-
+      End of the baffle along the optical axis, counted from the
+      primary center, which means a z value of par:secondary_ref_radius
+      times the first par:secondary_mirror_parameters value is at the
+      height of the center of the secondary.
+    type: double
+    unit: cm
+    required: true
+    condition: mirror_class==2
+    default: 0.
+  - name: radius_r1
+    description: Radius of open cylinder shape or cone shape at baffle_z1.
+    type: double
+    unit: cm
+    required: true
+    condition: mirror_class==2
+    default: 0.
+  - name: thickness_d1
+    description: |-
+      Wall thickness of the baffle. The radius radius_r1 and radius_r2
+      are the inner radii in case of finite wall thickness.
+    type: double
+    unit: cm
+    required: false
+    condition: mirror_class==2
+    default: 0.
+  - name: radius_r2
+    description: Radius of open cylinder shape or cone shape at baffle_z2.
+    type: double
+    unit: cm
+    required: false
+    condition: mirror_class==2
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_baffle

--- a/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
@@ -1,0 +1,42 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_degraded_map model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: |-
+  To be replaced by a data table. Accepted range is 0 to 1
+name: secondary_mirror_degraded_map
+description: |-
+  Position-dependent map of degradation factors for the secondary mirror.
+  This degradation gets applied on top of secondary_mirror_degraded_reflection.
+  Note that the impact of it on the nightsky background is not automatically
+  accounted for and must be evaluated separately and included in the
+  configured NSB pixel p.e. rates. It is recommended to use a map with an
+  average efficiency of 1.0 and use secondary_mirror_degraded_reflection
+  for the overall degradation.  Tables with equidistant spacing in both x and
+  y are highly recommended because the interpolation is faster.
+short_description: |-
+  Position-dependent map of degradation factors for the secondary mirror.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_degraded_map

--- a/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_degraded_reflection model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_degraded_reflection
+description: |-
+  Mirror degradation factor for the secondary mirror (wavelength independent).
+  Strictly interpreted as being for reflection on the secondary mirror of a
+  dual-mirror telescope, and still gets applied in simulations where only
+  the reflection on the primary mirror is bypassd (for example a
+  flat-fielding light source illuminating the camera via reflection on the
+  secondary).
+short_description: |-
+  Mirror degradation factor for the secondary mirror (wavelength independent).
+data:
+  - type: double
+    unit: dimensionless
+    default: 1.
+    allowed_range:
+      min: 0.
+      max: 1.
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: mirror2_degraded_reflection

--- a/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_diameter
+description: |-
+  The outer diameter of the secondary reflector.
+  Used only in case mirror_list is not defined (i.e., mirror_list=none).
+data:
+  - name: secondary_mirror_diameter
+    type: double
+    unit: cm
+    condition: mirror_list==None&&mirror_class==2
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_diameter

--- a/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_hole_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_hole_diameter
+description: |-
+  The diameter of any non-reflective part of the secondary mirror.
+  For the secondary, this should not be a hole.
+  With a segments defined, it effectively clips the inner edge of
+  the segments
+data:
+  - name: secondary_hole_diameter
+    description: Diameter of any non-reflective part of the secondary mirror.
+    type: double
+    default: 0.
+    unit: cm
+    condition: mirror_class==2
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_hole_diameter

--- a/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_incidence_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: secondary_mirror_incidence_angle
+description: |-
+  Distribution of incidence angle on the SST secondary mirror.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_file.dat'
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - SimPipe Derived
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
@@ -1,0 +1,168 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_parameters model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_parameters
+developer_note: |-
+  Note the application of dual_mirror_ref_radius (primary_ref_radius,
+  secondary_ref_radius) this this parameters.
+description: |-
+  Defines the position of the secondary mirror along the optical
+  axis and its shape. The first parameter ($p_0$) is the offset of the
+  mirror with respect to the common reference point defined by
+  par:mirror-offset, with positive values indicating that the centre
+  of the primary (assuming it has no central hole) is above the reference
+  point. The secondary mirror looks the other way, i.e. $p_0$ will usually
+  be negative since in the coordinate frame of the secondary, it is
+  below the common reference point.  Apart from that, a parameter $p_i$
+  adds a term $p_i r^{2i}$ to the height of the mirror at
+  radial offset $r$.  A parabolic mirror will have the second parameter
+  ($p_1$) at a positive value and all further parameters at 0.
+  A concave secondary, reducing the focal length if placed between the
+  primary and its focus, will have $p_1 > 0.$.
+  A convex mirror (e.g.~for Cassegrain or Ritchey-Chr\'etien optics),
+  enlarging the focal length, will have $p_1 < 0$.
+short_description: |-
+  Parameters for a polynomial defining the position of the secondary mirror
+  along the optical axis and its shape.
+data:
+  - name: p0
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p1
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p2
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p3
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p4
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p5
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p6
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p7
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p8
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p9
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p10
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p11
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p12
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p13
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p14
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p15
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p16
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p17
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p18
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+  - name: p19
+    type: double
+    description: coefficient describing secondary mirror
+    required: true
+    unit: cm
+    default: 0.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateOpticalPSF
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_ref_radius model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_ref_radius
+description: |-
+  The length scale to which the secondary_mirror_parameters apply.
+  Typical values could be 1.0 or the focal length of the
+  secondary/secondary.
+short_description: The length scale to which the secondary_mirror_parameters apply.
+data:
+  - name: secondary_ref_radius
+    description: The length scale to which the secondary_mirror_parameters apply.
+    type: double
+    unit: cm
+    condition: mirror_class==2
+    default: 1.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_ref_radius

--- a/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_reflectivity model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: secondary_mirror_reflectivity
+description: |-
+  Secondary mirror reflectivity measured directly on the facet as function of
+  wavelength.
+data:
+  - type: file
+    unit: dimensionless
+    default: 'no_such_reflectivity.dat'
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeEfficiency
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: mirror_secondary_reflectivity

--- a/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_segmentation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: secondary_mirror_segmentation
+description: |-
+  Definition of segments or segment groups of the secondary reflector.
+  If not active (value "none") then the secondary is assumed
+  to be of one circular piece, with an optional central hole. The inner
+  and outer diameters still apply, even in case of segmentation.
+short_description: |-
+  Definition of segments or segment groups of the secondary reflector.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_segmentation

--- a/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_shadow_diameter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_shadow_diameter
+description: |-
+  The diameter of any non-reflective but not transparent (black)
+  central part of the secondary mirror in a dual-mirror telescope.
+  A value of $-1$ indicates that the same value as for the
+  reflective diameter of the secondary (par:secondary-diameter) is
+  to be used.
+short_description: |-
+  The diameter of any non-reflective but not transparent (black)
+  central part of the secondary mirror in a dual-mirror telescope.
+data:
+  - type: double
+    unit: cm
+    condition: mirror_class==2
+    default: -1.
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_shadow_diameter

--- a/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
+++ b/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for secondary_mirror_shadow_offset model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: secondary_mirror_shadow_offset
+description: |-
+  The secondary mirror shadowing element is normally assumed at the level
+  of the edge of the secondary.  If this parameter is non-zero, it can be
+  set at any position above the center of the primary mirror.
+  Even if placed in front of the secondary, it will not be used for
+  photons reflected from the secondary.
+short_description: |-
+  The offset of the shadowing element from the level of the edge of the
+  secondary mirror.
+data:
+  - type: double
+    unit: cm
+    condition: mirror_class==2
+    default: 0.0
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeStructure
+    - ValidateTelescopeShadowing
+    - ValidateTelescopeEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_shadow_offset

--- a/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
+++ b/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
@@ -1,0 +1,31 @@
+%YAML 1.2
+---
+title: Schema for telescope_axis_height model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: telescope_axis_height
+description: Height of telescope elevation axis above ground level.
+data:
+  - type: double
+    unit: m
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidationWorkflowMissing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
+++ b/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+title: Schema for telescope_random_angle model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: telescope_random_angle
+description: |-
+  Random (known) misalignment of the telescope in each axis
+  (Gaussian r.m.s.). The resulting telescope pointing including
+  this misalignment are saved as telescope azimuth and altitude
+  pointing directions.
+data:
+  - type: double
+    unit: deg
+    default: 0.001
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidationWorkflowMissing
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/telescope_random_error.schema.yml
+++ b/simtools/schemas/model_parameters/telescope_random_error.schema.yml
@@ -1,0 +1,34 @@
+%YAML 1.2
+---
+title: Schema for telescope_random_error model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: telescope_random_error
+description: |-
+  Random (unknown) alignment error of the telescope in each axis
+  (Gaussian r.m.s.). The resulting telescope pointing including
+  this misalignment is not saved to the simulation output.
+data:
+  - type: double
+    unit: deg
+    default: 0.001
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidationWorkflowMissing
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
+++ b/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for telescope_sphere_radius model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: telescope_sphere_radius
+developer_note: |-
+  Note the axes_offset in the calculation of the sphere radius.
+description: |-
+  Radius of fiducial sphere within which all telescope optical elements
+  are fully contained.
+short_description: Telescope fiducial sphere radius.
+data:
+  - type: double
+    unit: m
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeFiducialSphere
+  validation:
+    - ValidateParameterByExpert
+    - ValidationWorkflowMissing
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/telescope_transmission.schema.yml
+++ b/simtools/schemas/model_parameters/telescope_transmission.schema.yml
@@ -1,0 +1,113 @@
+%YAML 1.2
+---
+title: Schema for telescope_transmission model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: telescope_transmission
+developer_note: |-
+  Note 1 - If compiled with the \texttt{RAYTRACING_INTERSECT_RODS} pre-processor
+  definition, the default value is 1.00, as the absorption is
+  calculated explicitly.
+  Note 2 - p0 should be uint
+description: |-
+  Off-axis angle-dependent transmission, accounting for absorption and
+  shadowing by masts.  Two types of functions are available, a constant
+  and a variable one ($T(\theta)$), where the former is selected
+  if transmission_function = 0 and the latter if transmission_function = 1.
+  Two options are available for the variable function, it is defined as
+  \[
+  T(\theta)=p_0/(1.+p_2 ((\sin\theta)/r_3)^{p_4}),
+  \]
+  if $p_5=0$, and as
+  \[
+  T(\theta)=p_0/(1.+p_2 ((\sin\theta)/r_3)^{p_4})^{p_5},
+  \]
+  if $p_5\ne0$.
+  The parameter $r_3$ is defined as $r_3=p_3 \pi/180$ and
+  $p_0$, $p_2$, $p_3$, $p_4$ and $p_5$
+  are the first, third, fourth, fifth and sixth parameters.
+  Default values are $p_4=2$, $p_3=0.5 d/f$ when these are missing/zero.
+  The $p_5$ parameter may not be available/supported and is effectively
+  zero/unused if not.
+  A value of $p_0 = 0.89$ means that 11\% of all light is assumed to be
+  absorbed by masts.
+  Shadowing by camera body is accounted for later
+  (see parameter par:camera-body-diameter and par:camera-depth).
+short_description: |-
+  Off-axis angle-dependent transmission, accounting for absorption and
+  shadowing by masts.
+data:
+  - name: constant_p0
+    type: double
+    description: |
+      Constant transmission factor $p_0$.
+    required: true
+    unit: dimensionless
+    default: 0.89
+    allowed_range:
+      min: 0.0
+      max: 1.0
+  - name: transmission_function
+    required: false
+    type: double
+    description: |
+      Transmission function identifier.
+    default: 0
+    allowed_range:
+      min: 0
+      max: 1
+    unit: dimensionless
+  - name: transmission_p2
+    description: |
+      Transmission factor $p_2$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+  - name: transmission_p3
+    description: |
+      Transmission factor $p_3$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+  - name: transmission_p4
+    description: |
+      Transmission factor $p_4$.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+  - name: transmission_p5
+    description: |
+      Transmission factor $p_5.
+    required: false
+    type: double
+    default: 0.0
+    unit: dimensionless
+instrument:
+  class: Structure
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+    - SetTelescopeShadowingParameters
+    - SetTelescopeEfficiency
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTelescopeEfficiency
+    - ValidateTelescopeShadowing
+    - ValidateTriggerPerformance
+    - ValidateTelescopeSimulationModel
+source:
+  - Calibration
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
+++ b/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
@@ -1,0 +1,41 @@
+%YAML 1.2
+---
+title: Schema for teltrig_min_sigsum model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: teltrig_min_sigsum
+description: |-
+  Minimum signal sum at sector trigger over threshold.
+  Note that both the minimum time over threshold and the minimum signal
+  sum have to be satisfied before a trigger is obtained. Normally, either
+  of these values being non-zero should be sufficient.
+short_description: Minimum signal sum at sector trigger over threshold.
+data:
+  - type: double
+    unit: mV * ns
+    default: 7.8
+    allowed_range:
+      min: 0.0
+      max: 1000.0
+    condition: default_trigger==Majority
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
+++ b/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for teltrig_min_time model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: teltrig_min_time
+description: Minimum time of sector trigger over threshold.
+data:
+  - type: double
+    unit: ns
+    default: 1.5
+    allowed_range:
+      min: 0.0
+      max: 10.0
+    condition: default_trigger==Majority
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
+++ b/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for transit_time_calib_error model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: transit_time_calib_error
+description: |-
+  Accuracy with which the actual signal delay due to transit
+  time variation and corresponding compensation can be determined.
+data:
+  - type: double
+    unit: ns
+    default: 0.
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
+++ b/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
@@ -1,0 +1,37 @@
+%YAML 1.2
+---
+title: Schema for transit_time_compensate_error model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: transit_time_compensate_error
+description: |-
+  Additional error (r.m.s.) in how well the number of steps for
+  transit time compensation can be determined before the
+  compensation is applied.
+data:
+  - type: double
+    unit: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
+++ b/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for transit_time_compensate_step model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: transit_time_compensate_step
+description: |-
+  If signal delays can be compensated independent of the sampling,
+  this is the time step in which this compensation can be done.
+  A value of zero means no compensation is applied.
+  The same compensation is applied to all channels.
+data:
+  - type: double
+    unit: ns
+    default: 0.0
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/transit_time_error.schema.yml
+++ b/simtools/schemas/model_parameters/transit_time_error.schema.yml
@@ -1,0 +1,45 @@
+%YAML 1.2
+---
+title: Schema for transit_time_error model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: transit_time_error
+short_description: Errors (r.m.s.) in transit time, not related to high voltage.
+description: |-
+  Errors (r.m.s.) in transit time, additionally to and not related to
+  those depending on applied high voltage.
+  If this parameter is set to $-1$, the readout interval is assumed to be
+  adjusted, pixel by pixel, such that resulting transit time differences
+  are within one readout time slice. For correcting transit times by
+  electronic means with time steps independent of the sampling frequency the
+  par:transit-time-compensate-step and par:transit-time-compensate-error
+  can be used.  The resulting transit time difference, after application of
+  compensation if used, is reported in the calibration data block, but only
+  up to a random accuracy defined by par:transit-time-calib-error.
+data:
+  - type: double
+    unit: ns
+    default: 0.
+    allowed_range:
+      min: -1.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
+++ b/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
@@ -1,0 +1,36 @@
+%YAML 1.2
+---
+title: Schema for transit_time_jitter model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: transit_time_jitter
+description: |-
+  Time jitter (Gaussian r.m.s. spread of random fluctuations) of individual
+  photo-electrons.
+data:
+  - type: double
+    unit: ns
+    default: 0.75
+    allowed_range:
+      min: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraTimeResponse
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
+++ b/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
@@ -1,0 +1,32 @@
+%YAML 1.2
+---
+title: Schema for trigger_current_limit model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: trigger_current_limit
+description: Pixels above this limit are excluded from the trigger.
+data:
+  - type: double
+    unit: uA
+    default: 20.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
+++ b/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
@@ -1,0 +1,53 @@
+%YAML 1.2
+---
+title: Schema for trigger_delay_compensation model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: trigger_delay_compensation
+developer_note: Always zero for all cameras. Not clear what parameter 4 is.
+description: |-
+  The majority trigger, analog sum trigger, and digital sum trigger
+  decisions result in different times of the trigger decision. To
+  compensate for this, a delay is applied for array-level coincidences
+  of triggers from telescopes with different trigger types.
+short_description: |-
+  The delay applied to the trigger output to compensate for the different
+  execution times of each trigger algorithm.
+data:
+  - type: double
+    description: Delay applied for majority trigger.
+    unit: ns
+    default: 0.0
+  - type: double
+    description: Delay applied for analog sum trigger.
+    unit: ns
+    default: 0.0
+  - type: double
+    description: Delay applied for digital sum trigger.
+    unit: ns
+    default: 0.0
+  - type: double
+    description: Delay (TODO this value is unclear)
+    unit: ns
+    default: 0.0
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray

--- a/simtools/schemas/model_parameters/trigger_pixels.schema.yml
+++ b/simtools/schemas/model_parameters/trigger_pixels.schema.yml
@@ -1,0 +1,40 @@
+%YAML 1.2
+---
+title: Schema for trigger_pixels model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: trigger_pixels
+description: |-
+  Number of pixels required for single telescope trigger.
+  With flexible camera definitions, this is the default number for the
+  multiplicity required per trigger group. Any definition of trigger groups
+  (e.g., parameter DigitalSumTrigger) overwrites the setting of
+  trigger_pixels.
+short_description: Number of pixels required for single telescope trigger.
+data:
+  - type: uint
+    unit: dimensionless
+    default: 4
+    allowed_range:
+      min: 1
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateTriggerPerformance
+source:
+  - Observation execution
+simulation_software:
+  - name: sim_telarray


### PR DESCRIPTION
This PR adds the model parameter schemas from the [model parameter gitlab](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters) into simtools (see issue #852).

This will allow to get rid of some of the not-so-nice entries in names.py and also to consistently treat the model parameters with all information in simtools.

There is **no** review (no!) of the contents of the files necessary. As a reviewer, you can disagree with moving all files into simtools, which means we have to discuss again the approach. None of the files has been changed and they have been reviewed before in the gitlab instance (any changes, CI updates, updates to names.py will come in follow up PRs).