### PR TITLE
Housekeeping: pylint and location of schema files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,8 @@ disable = [
 ]
 # see https://github.com/pylint-dev/pylint/issues/2289
 generated-members = ["gist_heat_r"]
+# see https://stackoverflow.com/questions/49846940/incorrect-pylint-errors-on-astropy-in-vscode
+ignored-classes=["astropy.units"]
 
 # Maximum number of characters on a single line.
 max-line-length = 100

--- a/simtools/constants.py
+++ b/simtools/constants.py
@@ -5,6 +5,5 @@ METADATA_JSON_SCHEMA = "schemas/metadata.metaschema.yml"
 
 # URL to the schema repository
 SCHEMA_URL = (
-    "https://gitlab.cta-observatory.org/cta-science/"
-    "simulations/simulation-model/model_parameters/-/raw/main/schema/"
+    "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/"
 )

--- a/tests/integration_tests/config/validate_file_using_schema_json_validate_data.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_validate_data.yml
@@ -3,6 +3,6 @@ CTA_SIMPIPE:
   TEST_NAME: json_validate_data
   CONFIGURATION:
     SCHEMA: >
-      https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/reference_point_altitude.schema.yml
+      https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
     FILE_NAME: tests/resources/reference_point_altitude.json
     DATA_TYPE: data

--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -43,7 +43,7 @@ CTA:
       MODEL:
         NAME: simpipe-schema
         VERSION: 0.1.0
-        URL: "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/mirror_panel_2f_measurements.schema.yml"
+        URL: "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml"
   CONTEXT:
     ASSOCIATED_ELEMENTS:
       - SITE: South

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -26,7 +26,7 @@
                     "MODEL": {
                         "NAME": "reference_point_altitude",
                         "VERSION": "0.1.0",
-                        "URL": "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/reference_point_altitude.schema.yml"
+                        "URL": "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/reference_point_altitude.schema.yml"
                     }
                 },
                 "FORMAT": "json",

--- a/tests/resources/telescope_positions-North-ground.ecsv
+++ b/tests/resources/telescope_positions-North-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#           URL: 'https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/array_coordinates.schema.yml',
+#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/resources/telescope_positions-North-utm.ecsv
+++ b/tests/resources/telescope_positions-North-utm.ecsv
@@ -25,7 +25,7 @@
 #         CATEGORY: CAL
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates_utm,
-#           URL: 'https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/array_coordinates_UTM.schema.yml',
+#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions for the CTAO Northern site (UTM coordinate system). Consistent with document CTA-SPE-PSC-000000-0001

--- a/tests/resources/telescope_positions-North-utm.meta.yml
+++ b/tests/resources/telescope_positions-North-utm.meta.yml
@@ -43,7 +43,7 @@ CTA:
       MODEL:
         NAME: array_coordinates_utm
         VERSION: 0.1.0
-        URL: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/array_coordinates_UTM.schema.yml
+        URL: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
   CONTEXT:
     DOCUMENT:
       - TYPE: CTAO-DOC

--- a/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
+++ b/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#         URL: 'https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/array_coordinates.schema.yml',
+#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/resources/telescope_positions-South-ground.ecsv
+++ b/tests/resources/telescope_positions-South-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#         URL: 'https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/raw/main/schema/array_coordinates.schema.yml',
+#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 
 import astropy.units as u
 import jsonschema
@@ -97,11 +98,8 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
         assert "Successful validation of yaml/json file" in caplog.text
 
     # schema explicitly given
-    schema_file = (
-        "https://gitlab.cta-observatory.org/cta-science/simulations/"
-        "simulation-model/model_parameters/-/raw/main/"
-        "schema/reference_point_altitude.schema.yml"
-    )
+    schema_dir = Path(__file__).parent / "../../../simtools/schemas/model_parameters/"
+    schema_file = str(schema_dir) + "/reference_point_altitude.schema.yml"
     with caplog.at_level(logging.DEBUG):
         data_reader.read_value_from_file(
             "tests/resources/reference_point_altitude.json",

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -45,8 +45,8 @@ def test_get_data_model_schema_file_name():
     # from data model_name
     _collector.data_model_name = "array_coordinates"
     schema_file = _collector.get_data_model_schema_file_name()
-    url = "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/"
-    url += "model_parameters/-/raw/main/schema/array_coordinates.schema.yml"
+    url = "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/"
+    url += "model_parameters/array_coordinates.schema.yml"
     assert schema_file == url
 
     # from input metadata

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -3,6 +3,7 @@
 import logging
 import shutil
 import sys
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -498,12 +499,11 @@ def test_read_validation_schema(tmp_test_directory):
 # incomplete test
 def test_validate_data_dict():
 
+    schema_dir = Path(__file__).parent / "../../../simtools/schemas/model_parameters/"
+
     # parameter with unit
     data_validator = validate_data.DataValidator(
-        schema_file=(
-            "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/"
-            "model_parameters/-/raw/main/schema/reference_point_altitude.schema.yml"
-        )
+        schema_file=str(schema_dir) + "/reference_point_altitude.schema.yml"
     )
     data_validator.data_dict = {
         "name": "reference_point_altitude",
@@ -514,10 +514,7 @@ def test_validate_data_dict():
 
     # parameter without unit
     data_validator_2 = validate_data.DataValidator(
-        schema_file=(
-            "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/"
-            "model_parameters/-/raw/main/schema/num_gains.schema.yml"
-        )
+        schema_file=str(schema_dir) + "/num_gains.schema.yml"
     )
     data_validator_2.data_dict = {"name": "num_gains", "value": [2], "unit": [""]}
     data_validator_2._validate_data_dict()


### PR DESCRIPTION
This is a short PR with changes to fix issues with the CI pipelines:

- solved in issue of pylint with astropy units by adding ignored-classes=["astropy.units"] to pyproject.toml
- changed urls pointing to schemas on gitlab to github (as we moved them with pull request #894); this required changes in several places