### PR TITLE
Documentation maintenance updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,8 @@ Useful links:
 
 simtools provides:
 
-* libraries for simulation model management and model database interface
+* libraries for simulation model definition and management
+* model database interface
 * tools for the preparation and configuration of simulation productions
 * applications for simulation model parameter derivation and validation
 * standardized interfaces and data products independent of the underlying simulation software (e.g., `CORSIKA <https://www.iap.kit.edu/corsika/>`_, `sim_telarray <https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/>`_)
@@ -51,20 +52,12 @@ simtools is one part of the CTAO Simulation Pipeline, which consist of the follo
 
 - `CORSIKA <https://www.iap.kit.edu/corsika/>`_ air shower simulation code and the `sim_telarray <https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/>`_ telescope simulation code
 - `workflows <https://github.com/gammasim/workflows>`_ for setting, derivation and validation of simulation model parameters
-- `simulation model parameter and input data schema <https://github.com/gammasim/workflows/tree/main/schemas>`_
+- `simulation model parameter <https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters>`_
 - `databases <https://gammasim.github.io/simtools/databases.html>`_, especially the model parameter database
 
-simtools is under rapid development with continuous changes and additions planned.
-Please contact the developers before using it: simtools-developer@desy.de
-
 .. note::
-   simtools is currently under heavy development with continuous changes.
-   We are applying significant updates to the handling of model parameters
-   and to the model parameter database. Because of this, you need to have a
-   local copy of the `model_parameters <https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters>`_
-   repository in order to use simtools. Clone this and add to your .env file
-   the following entry: ``SIMTOOLS_DB_SIMULATION_MODEL_URL="../model_parameters/"``
-   (replace with the relative/absolute path for the location of the model_parameters repository).
+   simtools is currently under heavy development with continuous changes and additions planned.
+   Please contact the developers before using it: simtools-developer@desy.de
 
 
 Quick start
@@ -110,4 +103,4 @@ Please cite this software if it use used for a publication, see the `Zenodo reco
 Acknowledgements
 ================
 
-This project is supported by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) - project number 460248186 (PUNCH4NFDI).
+This project is supported by the Deutsche Forschungsgemeinschaft (DFG, German Research Foundation) - project number 460248186 (`PUNCH4NFDI <https://www.punch4nfdi.de/>`).

--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -1,12 +1,12 @@
 .. _applications:
 
 
-Applications
-************
+simtools Applications
+*********************
 
 Applications are python scripts built on the :ref:`Library` that execute a well defined task.
-Applications are the building blocks of `Simulation System Workflows <https://github.com/gammasim/workflows>`_.
 Application scripts can be found in ``simtools/applications``.
+They are the the building blocks of `Simulation System Workflows <https://github.com/gammasim/workflows>`_.
 
 Important: depending on the installation type, applications are named differently:
 
@@ -20,13 +20,19 @@ Some applications require one or multiple file names as input in the command lin
 first search on main simtools directory for these files, and in case it is not found, it will
 search into the directories given by the config parameter *model_path*.
 
-Output files of applications are written to $output_path/$label, where
+Output files of applications are written to `$output_path/$label`, where
 *output_path* is a config parameter and *label* is the name of the application. The plots
 produced directly by the application are stored in the sub-directory *application-plots*.
 High-level data produced intermediately (e.g PSF tables) can be found in the sub-directories relative to
 the specific type of application (e.g *ray-tracing* for optics related applications,
 *camera-efficiency* for camera efficiency applications etc). All files related to the simulation model (e.g,
 sim_telarray config files) are stored in the sub-directory *model*.
+
+Applications found in the *simtools/application/db_development_tools* directory are not intended for
+end-users, but for developers working on the database schema.
+
+List of applications
+********************
 
 
 add_file_to_db
@@ -36,12 +42,32 @@ add_file_to_db
    :members:
 
 
+add_value_from_json_to_db
+==========================
+
+.. automodule:: add_value_from_json_to_db
+   :members:
+
+
 compare_cumulative_psf
 ======================
 
 .. automodule:: compare_cumulative_psf
    :members:
 
+
+convert_all_model_parameters_from_simtel
+=========================================
+
+.. automodule:: convert_all_model_parameters_from_simtel
+   :members:
+
+
+convert_model_parameter_from_simtel
+====================================
+
+.. automodule:: convert_model_parameter_from_simtel
+   :members:
 
 derive_mirror_rnda
 ==================
@@ -153,14 +179,15 @@ validate_camera_fov
    :members:
 
 
-validate_optics
-===============
-
-.. automodule:: validate_optics
-   :members:
-
 validate_file_using_schema
 ==========================
 
 .. automodule:: validate_file_using_schema
+   :members:
+
+
+validate_optics
+===============
+
+.. automodule:: validate_optics
    :members:

--- a/docs/source/auxiliary_files.rst
+++ b/docs/source/auxiliary_files.rst
@@ -3,9 +3,12 @@
 Auxiliary Files
 ***************
 
-Auxiliary parameter files can found in the `data <https://github.com/gammasim/simtools/tree/main/data/>`_ directory:
+Auxiliary parameter files include example configurations and array layouts:
 
 1. `data/parameters <https://github.com/gammasim/simtools/tree/main/data/parameters/>`_: parameter type and unit definitions (e.g., defining the units for zenith angle for configuration parameters for CORSIKA)
 2. `data/layout <https://github.com/gammasim/simtools/tree/main/data/layout/>`_: layout definitions for single telescope or simple 4-telescope grid layouts (used e.g., for trigger simulations)
 
-All data files related to the Monte Carlo are read from the :ref:`Model Parameters DB`.
+Data files (e.g., quantum efficiency tables or camera trigger definitions) are stored in the simulation model database, see :ref:`Model Parameters DB`.
+
+Integration and unit tests provide a rich set of examples for the usage of the simulation tools.
+The configuration and data files located in `tests/resources <https://github.com/gammasim/simtools/tree/main/tests/resources/>`_ are used for the tests.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,8 @@ html_theme_options = {
     "path_to_docs": "docs",
     "repository_url": "https://github.com/gammasim/simtools",
     "repository_branch": "main",
-    "show_toc_level": 2,
+    "use_issues_button": True,
+    "show_toc_level": 1,
     "announcement": (
         "simtools is under rapid development with continuous changes. "
         "Please contact the developers before using it."
@@ -165,6 +166,7 @@ html_theme_options = {
             "type": "url",
         },
     ],
+    "home_page_in_toc": True,
     "use_source_button": True,
     "use_download_button": True,
     "navigation_with_keys": False,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,11 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# simtools configuration for sphinx
-# This file does only contain a selection of the most common options. For a
-#
-# full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
-
+# Configuration files for the Sphinx documentation build for simtools.
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -60,7 +53,7 @@ def get_python_version_from_pyproject():
 # -- Project information -----------------------------------------------------
 
 project = "simtools"
-copyright = "2023, gammasim-tools, simtools developers"
+copyright = "2024, gammasim-tools, simtools developers"
 author = get_authors_from_citation_file()
 rst_epilog = f"""
 .. |author| replace:: {author}
@@ -110,7 +103,6 @@ autodoc_mock_imports = [
 ]
 
 # Change the look of autodoc classes
-# napoleon_use_ivar = True
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.
@@ -118,7 +110,6 @@ templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-#
 source_suffix = [".rst"]
 
 # The master toctree document.
@@ -145,9 +136,7 @@ default_role = "py:obj"
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = "sphinx_rtd_theme"
-# html_theme = "bizstyle"
-html_theme = "alabaster"
+html_theme = "sphinx_book_theme"
 
 html_title = f"{project} v{version} Manual"
 
@@ -155,44 +144,36 @@ html_title = f"{project} v{version} Manual"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": f"Simulation Tools for CTA v{version}",
-    "github_user": "gammasim",
-    "github_repo": "simtools",
-    "fixed_sidebar": True,
-    "show_powered_by": False,
+    "path_to_docs": "docs",
+    "repository_url": "https://github.com/gammasim/simtools",
+    "repository_branch": "main",
+    "show_toc_level": 2,
+    "announcement": (
+        "simtools is under rapid development with continuous changes. "
+        "Please contact the developers before using it."
+    ),
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/gammasim/simtools",
+            "icon": "fa-brands fa-github",
+        },
+        {
+            "name": "PyPI",
+            "url": "https://pypi.org/project/gammasimtools/",
+            "icon": "https://badge.fury.io/py/gammasimtools.svg",
+            "type": "url",
+        },
+    ],
+    "use_source_button": True,
+    "use_download_button": True,
+    "navigation_with_keys": False,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
-
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# The default sidebars (for documents that don't match any pattern) are
-# defined by theme itself.  Builtin themes are using these templates by
-# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
-# 'searchbox.html']``.
-#
-# html_sidebars = {}
-html_sidebars = {
-    "**": [
-        "about.html",
-        "navigation.html",
-        "relations.html",
-        "searchbox.html",
-        "sourcelink.html",
-    ]
-}
-html_css_files = ["simtools.css"]
-html_file_suffix = ".html"
-
-# -- Options for HTMLHelp output ---------------------------------------------
-# "<project> v<release> documentation".
-html_title = f"{project} v{release}"
-
-html_show_copyright = False
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "simtoolsdoc"

--- a/docs/source/corsika.rst
+++ b/docs/source/corsika.rst
@@ -13,6 +13,32 @@ corsika_config
 .. automodule:: corsika.corsika_config
    :members:
 
+corsika_default_config
+----------------------
+
+.. _corsika_default_config:
+
+.. automodule:: corsika.corsika_default_config
+   :members:
+
+
+corsika_histograms
+------------------
+
+.. _corsika_histograms:
+
+.. automodule:: corsika.corsika_histograms
+   :members:
+
+
+corsika_histograms_visualize
+----------------------------
+
+.. _corsika_histograms_visualize:
+
+.. automodule:: corsika.corsika_histograms_visualize
+   :members:
+
 corsika_runner
 --------------
 

--- a/docs/source/data_model.rst
+++ b/docs/source/data_model.rst
@@ -6,6 +6,22 @@ Data Model
 Modules in the ``data_model`` sections provide functionality for reading, writing, and validation of data.
 Data products ingested or produced by simtools generally follows the CTA data model.
 
+.. _datareader:
+
+data_reader
+-----------
+
+.. automodule:: data_model.data_reader
+   :members:
+
+.. _datamodelmetadatacollector:
+
+metadata_collector
+------------------
+
+.. automodule:: data_model.metadata_collector
+   :members:
+
 .. _datamodelmetadatamodel:
 
 metadata_model
@@ -28,12 +44,4 @@ validate_data
 -------------
 
 .. automodule:: data_model.validate_data
-   :members:
-
-.. _datamodelvalidateschema:
-
-metadata_collector
-------------------
-
-.. automodule:: data_model.metadata_collector
    :members:

--- a/docs/source/databases.rst
+++ b/docs/source/databases.rst
@@ -11,4 +11,5 @@ Access to the DB is handled via a dedicated API module. Access to the DB is rest
 Model Parameters DB
 ===================
 
-The Model Parameters DB contains the parameters defining the telescopes in the simulation software. Logically, the DB is organised such that for each telescope, a list of parameters and their values is stored per version of the telescope model. Additional fields are stored as well, such units, value type, etc. Files relevant to the telescope model are directly saved in the DB and can be extracted using the file name.
+The Model Parameters DB contains the parameters defining the telescopes in the simulation software.
+Logically, the DB is organized such that for each telescope, a list of parameters and their values is stored per version of the telescope model. Additional fields are stored as well, such units, value type, etc. Files relevant to the telescope model are directly saved in the DB and can be extracted using the file name.

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -85,14 +85,16 @@ The git installation method requires to install CORSIKA/sim_telarray separately,
 
 .. _DockerInstallation:
 
-Docker Installation
--------------------
+Container Installation
+----------------------
 
-The docker container ``simtools-prod`` includes all software required to run simtools applications:
+The container ``simtools-prod`` includes all software required to run simtools applications:
 
 * corsika and sim\_telarray
 * python packages required by simtools
 * simtools
+
+Containers are tested with docker, podman, and apptainer. Replace ``docker`` with the container system of your choice.
 
 To run bash in the `simtools-prod container  <https://github.com/gammasim/simtools/pkgs/container/simtools-prod>`_:
 
@@ -154,7 +156,7 @@ CTA users can download both packages from the `sim_telarray webpage <https://www
     $ tar -czf corsika7.7_simtelarray.tar.gz
     $ ./build_all prod5 qgs2 gsl
 
-The environmental variable ``$SIM_TELPATH`` should point towards the CORSIKA/sim_telarray installation
+The environmental variable ``$SIMTOOLS_SIMTEL_PATH`` should point towards the CORSIKA/sim_telarray installation
 (recommended to include it in the \.env file with all other environment variables).
 
 
@@ -171,8 +173,7 @@ The docker container has python packages, CORSIKA, and sim_telarray pre-installe
 Setting up a system to run simtools applications or tests should be a matter of minutes.
 
 Install Docker and start the Docker application (see
-`Docker installation page <https://docs.docker.com/engine/install/>`_). Other container systems like
-Apptainer, Singularity, Buildah/Podman, should work, but are not thoroughly tested.
+`Docker installation page <https://docs.docker.com/engine/install/>`_).
 
 Clone simtools from GitHub into a directory ``external/simtools``:
 
@@ -192,7 +193,7 @@ Start up a container (the image will be downloaded, if it is not available in yo
         bash -c "source /workdir/env/bin/activate && cd /workdir/external/simtools && pip install -e . && bash"
 
 The container includes a CORSIKA and sim_telarray installation;
-the environmental variable ``$SIM_TELPATH`` and those for the database access are automatically set
+the environmental variable ``$SIMTOOLS_SIMTEL_PATH`` and those for the database access are automatically set
 (if variables are set correctly in the \.env` file).
 
 Test your installation following the instructions in :ref:`this section <TestingInstallation>`.

--- a/docs/source/mc_model.rst
+++ b/docs/source/mc_model.rst
@@ -38,12 +38,29 @@ mirrors
    :members:
 
 
+model_parameter
+---------------
+
+.. _modelparameters:
+
+.. automodule:: model.model_parameter
+   :members:
+
+
 model utilities
 ---------------
 
 .. _model_utils:
 
 .. automodule:: model.model_utils
+   :members:
+
+site_model
+----------
+
+.. _site_model:
+
+.. automodule:: model.site_model
    :members:
 
 telescope_model

--- a/docs/source/sim_telarray.rst
+++ b/docs/source/sim_telarray.rst
@@ -5,6 +5,14 @@ sim_telarray
 
 Support modules for running sim_telarray.
 
+simtel_config_reader
+--------------------
+
+.. _simtel_config_reader:
+
+.. automodule:: simtel.simtel_config_reader
+   :members:
+
 simtel_config_writer
 --------------------
 
@@ -43,6 +51,14 @@ simtel_runner_array
 .. _simtel_runner_array:
 
 .. automodule:: simtel.simtel_runner_array
+   :members:
+
+simtel_runner_camera_efficiency
+-------------------------------
+
+.. _simtel_runner_camera_efficiency:
+
+.. automodule:: simtel.simtel_runner_camera_efficiency
    :members:
 
 simtel_runner_ray_tracing

--- a/docs/source/simtools-configuration.rst
+++ b/docs/source/simtools-configuration.rst
@@ -6,11 +6,11 @@ Configuration
 Applications in simtools can be configured by the following four approaches, which are all equivalent:
 
 #. command line arguments;
-#. configuration file (in yaml format);
+#. configuration files (in yaml format);
 #. configuration dictionary when calling the :ref:`Configurator <configurationconfigurator>` class;
 #. environment variables.
 
-To illustrate this, e.g., set the path pointing towards the directory for all data products.
+To illustrate this, the example below sets the path pointing towards the directory for all data products.
 
 Set the output directory using a command line argument:
 
@@ -34,7 +34,7 @@ Configuration parameter read from a environmental variable:
 
 .. code-block:: console
 
-   $ EXPORT OUTPUT_PATH="<path name>"
+   $ EXPORT SIMTOOLS_OUTPUT_PATH="<path name>"
 
 Configuration methods can be combined; conflicting configuration settings raise an Exception.
 Configuration parameters are generally expected in lower-case snake-make case.

--- a/docs/source/simulation_software.rst
+++ b/docs/source/simulation_software.rst
@@ -3,7 +3,7 @@
 Simulation Software
 *******************
 
-Simulation software is external to simtools and used by several applications.
+Simulation software is external to simtools and used by several simtools applications.
 This includes the main software tools CORSIKA and sim_telarray, and several other tools listed in the following
 
 CORSIKA

--- a/docs/source/utils.rst
+++ b/docs/source/utils.rst
@@ -17,6 +17,15 @@ general
 .. automodule:: utils.general
    :members:
 
+
+.. _utilsgeometry:
+
+geometry
+--------
+
+.. automodule:: utils.geometry
+   :members:
+
 .. _utilsnames:
 
 names

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   - pyyaml
   - scipy
   - sphinx
-  - sphinx_rtd_theme
+  - sphinx-book-theme
   - toml
   - pip:
       - pytest-random-order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
 "doc" = [
   "numpydoc",
   "sphinx",
-  "sphinx_rtd_theme",
+  "sphinx-book-theme",
 ]
 "tests" = [
   "pytest",

--- a/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/simtools/applications/convert_model_parameter_from_simtel.py
@@ -28,11 +28,11 @@
 
     .. code-block:: console
 
-       simtools-convert-model-parameter-from-simtel \
-          --simtel_telescope_name CT1\
-          --telescope LSTN-01\
-          --schema tests/resources/num_gains.schema.yml\
-          --simtel_cfg_file tests/resources/simtel_config_test_la_palma.cfg\
+       simtools-convert-model-parameter-from-simtel \\
+          --simtel_telescope_name CT1 \\
+          --telescope LSTN-01 \\
+          --schema tests/resources/num_gains.schema.yml \\
+          --simtel_cfg_file tests/resources/simtel_config_test_la_palma.cfg \\
           --output_file num_gains.json
 
 """

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -110,7 +110,7 @@ class CorsikaHistograms:
         """
         Property for the hdf5 file name.
         The idea of this property is to allow setting (or changing) the name of the hdf5 file
-         even after creating the class instance.
+        even after creating the class instance.
         """
         return self._hdf5_file_name
 
@@ -1381,14 +1381,14 @@ class CorsikaHistograms:
         self, event_header_element, bins=50, hist_range=None, overwrite=False
     ):
         """
-        Export to a hdf5 file the 1D histogram for the key `event_header_element` from the CORSIKA
+        Export to a hdf5 file the 1D histogram for the key 'event_header_element' from the CORSIKA
         event header.
 
         Parameters
         ----------
         event_header_element: str
             The key to the CORSIKA event header element.
-            Possible choices are stored in `self.all_event_keys`.
+            Possible choices are stored in 'self.all_event_keys'.
         bins: float
             Number of bins for the histogram.
         hist_range: 2-tuple
@@ -1430,8 +1430,8 @@ class CorsikaHistograms:
         overwrite=False,
     ):
         """
-        Export to a hdf5 file the 2D histogram for the key `event_header_element_1` and
-        `event_header_element_2`from the CORSIKA event header.
+        Export to a hdf5 file the 2D histogram for the key 'event_header_element_1' and
+        'event_header_element_2'from the CORSIKA event header.
 
         Parameters
         ----------
@@ -1439,14 +1439,15 @@ class CorsikaHistograms:
             The key to the CORSIKA event header element.
         event_header_element_2: str
             The key to the CORSIKA event header element.
-            Possible choices for `event_header_element_1` and `event_header_element_2` are stored
-            in `self.all_event_keys`.
+            Possible choices for 'event_header_element_1' and 'event_header_element_2' are stored
+            in 'self.all_event_keys'.
         bins: float
             Number of bins for the histogram.
         hist_range: 2-tuple
             Tuple to define the range of the histogram.
         overwrite: bool
             If True overwrites the histograms already saved in the hdf5 file.
+
         """
         hist, x_bin_edges, y_bin_edges = self.event_2d_histogram(
             event_header_element_1, event_header_element_2, bins=bins, hist_range=hist_range

--- a/simtools/data_model/data_reader.py
+++ b/simtools/data_model/data_reader.py
@@ -20,8 +20,8 @@ def read_table_from_file(file_name, schema_file=None, validate=False, metadata_f
     Schema for validation can be given as argument, or is determined
     from the metadata associated to the file.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     file_name: str or Path
         Name of file to be read.
     schema_file: str or Path
@@ -31,8 +31,8 @@ def read_table_from_file(file_name, schema_file=None, validate=False, metadata_f
     metadata_file: str or Path
         Name of metadata file to be read.
 
-    Returns:
-    --------
+    Returns
+    -------
     astropy Table
         Table read from file.
 
@@ -79,8 +79,8 @@ def read_value_from_file(file_name, schema_file=None, validate=False):
     Schema for validation can be given as argument, or is determined
     from the metadata associated to the file.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     file_name: str or Path
         Name of file to be read.
     schema_file: str or Path
@@ -88,8 +88,8 @@ def read_value_from_file(file_name, schema_file=None, validate=False):
     validate: bool
         Validate data against schema (if true).
 
-    Returns:
-    --------
+    Returns
+    -------
     astro quantity or str
         Value read from file. If units are given, return an astropy quantity, otherwise a string.
         Return None if no value is found in the file.


### PR DESCRIPTION
This PR deals adds missing applications and modules to the documentation. 

In detail:

- minor text updates to the main readme and documentation text (mostly removing duplications).
- adding of missing applications and modules
- fix of a couple of bugs in docstrings leading to sphinx errors or warnings
- simplified theme (note theme change!), allow to remove a couple of items from conf.py. This theme looks a bit nicer, is pydata-thema based (as those of many other cta tools)
 
