### PR TITLE
python 311 in pyproject.tom

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,12 @@ license = { file="LICENSE" }
 authors = [
   { name="simtools developers", email="simtools-developer@desy.de" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Astronomy",


### PR DESCRIPTION
Changed the minimum python version from 3.9 to 3.11 in the pyproject.toml file. 

We have done this in the environment.yml file quite a while ago and forgot to update the pyproject file (the documentation will be updated automatically, is it reads the python version from the pyproject.toml file).
 
