### PR TITLE
Set schema paths using importlib

### DIFF
--- a/simtools/constants.py
+++ b/simtools/constants.py
@@ -2,8 +2,3 @@
 
 # Path to metadata jsonschema
 METADATA_JSON_SCHEMA = "schemas/metadata.metaschema.yml"
-
-# URL to the schema repository
-SCHEMA_URL = (
-    "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/"
-)

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -9,6 +9,7 @@ implementation of the metadata model.
 import datetime
 import getpass
 import logging
+from importlib.resources import files
 from pathlib import Path
 
 from astropy.table import Table
@@ -115,7 +116,7 @@ class MetadataCollector:
         # from data model name
         if self.data_model_name:
             self._logger.debug(f"Schema file from data model name: {self.data_model_name}")
-            return f"{simtools.constants.SCHEMA_URL}{self.data_model_name}.schema.yml"
+            return f"{files('simtools')}/schemas/model_parameters/{self.data_model_name}.schema.yml"
 
         # from input metadata
         try:

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from pathlib import Path
+from importlib.resources import files
 
 import astropy.units as u
 import jsonschema
@@ -98,7 +98,7 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
         assert "Successful validation of yaml/json file" in caplog.text
 
     # schema explicitly given
-    schema_dir = Path(__file__).parent / "../../../simtools/schemas/model_parameters/"
+    schema_dir = files("simtools").joinpath("schemas/model_parameters/")
     schema_file = str(schema_dir) + "/reference_point_altitude.schema.yml"
     with caplog.at_level(logging.DEBUG):
         data_reader.read_value_from_file(

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -4,6 +4,8 @@ import copy
 import getpass
 import json
 import logging
+from importlib.resources import files
+from pathlib import Path
 
 import pytest
 
@@ -45,9 +47,9 @@ def test_get_data_model_schema_file_name():
     # from data model_name
     _collector.data_model_name = "array_coordinates"
     schema_file = _collector.get_data_model_schema_file_name()
-    url = "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/"
-    url += "model_parameters/array_coordinates.schema.yml"
-    assert schema_file == url
+    assert Path(schema_file) == (
+        files("simtools") / "schemas/model_parameters" / "array_coordinates.schema.yml"
+    )
 
     # from input metadata
     _collector.input_metadata = {

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -3,7 +3,7 @@
 import logging
 import shutil
 import sys
-from pathlib import Path
+from importlib.resources import files
 
 import numpy as np
 import pytest
@@ -499,7 +499,7 @@ def test_read_validation_schema(tmp_test_directory):
 # incomplete test
 def test_validate_data_dict():
 
-    schema_dir = Path(__file__).parent / "../../../simtools/schemas/model_parameters/"
+    schema_dir = files("simtools").joinpath("schemas/model_parameters/")
 
     # parameter with unit
     data_validator = validate_data.DataValidator(


### PR DESCRIPTION
Follow the guidelines for python packages to set package internal directories (see [here]( https://setuptools.pypa.io/en/latest/userguide/datafiles.html)) with `importlib.resources.files`.

Remove `SCHEMA_URL` as all schemas are now part of the simtools package (we have set `include-package-data = true` in pyproject.toml, which means that all non-python files in the simtools directory are included as package data).