### PR TITLE
Improve import efficiency for UnitsErrors

### DIFF
--- a/simtools/utils/geometry.py
+++ b/simtools/utils/geometry.py
@@ -6,7 +6,7 @@ import logging
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates.errors import UnitsError
+from astropy.units import UnitsError
 
 __all__ = [
     "convert_2d_to_radial_distr",

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -1,7 +1,7 @@
 import astropy.units as u
 import numpy as np
 import pytest
-from astropy.coordinates.errors import UnitsError
+from astropy.units import UnitsError
 
 import simtools.utils.geometry as transf
 


### PR DESCRIPTION
The more directory import of `from astropy.units import UnitsError`  instead of `from astropy.coordinates.errors import UnitsError` improves the import efficiency.