### PR TITLE
Integration of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  # Ruff
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+      - id: ruff-format
   # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
@@ -6,7 +12,7 @@ repos:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
-    rev: 24.4.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: ["--line-length=100"]
@@ -22,33 +28,20 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        exclude: ^tests/|^simtools/applications/db_development_tools/
-        args:
-          [
-            "-rn",  # Only display messages
-            "-sn",  # Don't display the score
-          ]
   # https://github.com/HunterMcGushion/docstr_coverage
   - repo: https://github.com/HunterMcGushion/docstr_coverage
-    rev: v2.3.1  # most recent docstr-coverage release or commit sha
+    rev: v2.3.2  # most recent docstr-coverage release or commit sha
     hooks:
       - id: docstr-coverage
         args: ["--verbose", "2", "--fail-under", "70.", "simtools"]
   # gitup action
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.27
+    rev: v1.7.0
     hooks:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "1.7.0"
+    rev: "2.1.1"
     hooks:
       - id: pyproject-fmt
   # codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,23 +2,16 @@
 build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=65",
-  "setuptools_scm[toml]>=6.2",
+  "setuptools-scm[toml]>=6.2",
 ]
-
-[tool.setuptools]
-packages=["simtools"]
-include-package-data = true
-
-[tool.setuptools_scm]
-write_to = "simtools/_version.py"
 
 [project]
 name = "gammasimtools"
 description = "Tools for the Simulation System of the CTA Observatory"
 readme = "README.rst"
-license = { file="LICENSE" }
+license = { file = "LICENSE" }
 authors = [
-  { name="simtools developers", email="simtools-developer@desy.de" }
+  { name = "simtools developers", email = "simtools-developer@desy.de" },
 ]
 requires-python = ">=3.11"
 classifiers = [
@@ -48,18 +41,17 @@ dependencies = [
   "scipy",
   "toml",
 ]
-[project.optional-dependencies]
-"dev" = [
+optional-dependencies."dev" = [
   "flake8",
   "pre-commit",
   "pylint",
 ]
-"doc" = [
+optional-dependencies."doc" = [
   "numpydoc",
   "sphinx",
   "sphinx-book-theme",
 ]
-"tests" = [
+optional-dependencies."tests" = [
   "pytest",
   "pytest-cov",
   "pytest-profiling",
@@ -67,67 +59,160 @@ dependencies = [
   "pytest-repeat",
   "pytest-xdist",
 ]
-[project.urls]
-"bug tracker" = "https://github.com/gammasim/simtools/issues"
-"documentation" = "https://gammasim.github.io/simtools/"
-"repository" = "https://github.com/gammasim/simtools"
-[project.scripts]
-simtools-add-file-to-db = "simtools.applications.add_file_to_db:main"
-simtools-add-value-from-json-to-db = "simtools.applications.add_value_from_json_to_db:main"
-simtools-compare-cumulative-psf = "simtools.applications.compare_cumulative_psf:main"
-simtools-convert-all-model-parameters-from-simtel = "simtools.applications.convert_all_model_parameters_from_simtel:main"
-simtools-convert-model-parameter-from-simtel = "simtools.applications.convert_model_parameter_from_simtel:main"
-simtools-derive-mirror-rnda = "simtools.applications.derive_mirror_rnda:main"
-simtools-generate-corsika-histograms = "simtools.applications.generate_corsika_histograms:main"
-simtools-generate-default-metadata = "simtools.applications.generate_default_metadata:main"
-simtools-generate-simtel-array-histograms = "simtools.applications.generate_simtel_array_histograms:main"
-simtools-get-file-from-db = "simtools.applications.get_file_from_db:main"
-simtools-get-parameter = "simtools.applications.get_parameter:main"
-simtools-make-regular-arrays = "simtools.applications.make_regular_arrays:main"
-simtools-plot-array-layout = "simtools.applications.plot_array_layout:main"
-simtools-plot-simtel-histograms = "simtools.applications.plot_simtel_histograms:main"
-simtools-print-array-elements = "simtools.applications.print_array_elements:main"
-simtools-produce-array-config = "simtools.applications.produce_array_config:main"
-simtools-production = "simtools.applications.production:main"
-simtools-sim-showers-for-trigger-rates = "simtools.applications.sim_showers_for_trigger_rates:main"
-simtools-simulate-prod = "simtools.applications.simulate_prod:main"
-simtools-submit-data-from-external = "simtools.applications.submit_data_from_external:main"
-simtools-tune-psf = "simtools.applications.tune_psf:main"
-simtools-validate-camera-efficiency = "simtools.applications.validate_camera_efficiency:main"
-simtools-validate-camera-fov = "simtools.applications.validate_camera_fov:main"
-simtools-validate-file-using-schema = "simtools.applications.validate_file_using_schema:main"
-simtools-validate-optics = "simtools.applications.validate_optics:main"
+urls."bug tracker" = "https://github.com/gammasim/simtools/issues"
+urls."documentation" = "https://gammasim.github.io/simtools/"
+urls."repository" = "https://github.com/gammasim/simtools"
+scripts.simtools-add-file-to-db = "simtools.applications.add_file_to_db:main"
+scripts.simtools-add-value-from-json-to-db = "simtools.applications.add_value_from_json_to_db:main"
+scripts.simtools-compare-cumulative-psf = "simtools.applications.compare_cumulative_psf:main"
+scripts.simtools-convert-all-model-parameters-from-simtel = "simtools.applications.convert_all_model_parameters_from_simtel:main"
+scripts.simtools-convert-model-parameter-from-simtel = "simtools.applications.convert_model_parameter_from_simtel:main"
+scripts.simtools-derive-mirror-rnda = "simtools.applications.derive_mirror_rnda:main"
+scripts.simtools-generate-corsika-histograms = "simtools.applications.generate_corsika_histograms:main"
+scripts.simtools-generate-default-metadata = "simtools.applications.generate_default_metadata:main"
+scripts.simtools-generate-simtel-array-histograms = "simtools.applications.generate_simtel_array_histograms:main"
+scripts.simtools-get-file-from-db = "simtools.applications.get_file_from_db:main"
+scripts.simtools-get-parameter = "simtools.applications.get_parameter:main"
+scripts.simtools-make-regular-arrays = "simtools.applications.make_regular_arrays:main"
+scripts.simtools-plot-array-layout = "simtools.applications.plot_array_layout:main"
+scripts.simtools-plot-simtel-histograms = "simtools.applications.plot_simtel_histograms:main"
+scripts.simtools-print-array-elements = "simtools.applications.print_array_elements:main"
+scripts.simtools-produce-array-config = "simtools.applications.produce_array_config:main"
+scripts.simtools-production = "simtools.applications.production:main"
+scripts.simtools-sim-showers-for-trigger-rates = "simtools.applications.sim_showers_for_trigger_rates:main"
+scripts.simtools-simulate-prod = "simtools.applications.simulate_prod:main"
+scripts.simtools-submit-data-from-external = "simtools.applications.submit_data_from_external:main"
+scripts.simtools-tune-psf = "simtools.applications.tune_psf:main"
+scripts.simtools-validate-camera-efficiency = "simtools.applications.validate_camera_efficiency:main"
+scripts.simtools-validate-camera-fov = "simtools.applications.validate_camera_fov:main"
+scripts.simtools-validate-file-using-schema = "simtools.applications.validate_file_using_schema:main"
+scripts.simtools-validate-optics = "simtools.applications.validate_optics:main"
+
+[tool.setuptools]
+packages = [
+  "simtools",
+]
+include-package-data = true
+
+[tool.setuptools_scm]
+write_to = "simtools/_version.py"
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+indent-width = 4
+exclude = [
+  "__init__.py",
+  "pyproject.toml",
+  "simtools/_version.py",
+]
+
+format.indent-style = "space"
+format.quote-style = "double"
+format.line-ending = "auto"
+# no documentation linting for test files
+format.skip-magic-trailing-comma = false
+lint.extend-select = [
+  "COM", # flake8-commas
+  #  "D",   # pydocstyle
+  "G",   # logging
+  "I",   # isort
+  "ICN", # import name conventions
+  "ISC", # implicit string concat rules
+  "N",   # pep8 naming
+  "NPY", # numpy
+  "PT",  # pytest
+  "UP",  # pyupgrade
+]
+lint.per-file-ignores."**/tests/**" = [
+  "D",
+]
+lint.per-file-ignores."**/tests_*.py" = [
+  "D",
+]
+# lint.pydocstyle.convention = "numpy"
+lint.ignore = [
+  "COM812", # incompatible with ruff format
+  "D208",   # over-indentation (incompatible with sphinx)
+  "D214",   # section-not-over-indented
+  "D215",   # section-underline-not-over-indented
+  "G004",   # Logging statement uses f-string
+  "ISC001", # incompatible with ruff format
+]
+
+[tool.isort]
+profile = "black"
 
 [tool.pylint.main]
 # Good variable names which should always be accepted, separated by a comma.
 good-names = [
-    "e", "i", "j", "k", "x", "y", "n", "f", "r", "ex", "db", "im", "sh", "ax", "ce", "xx", "yy", "zz",
-    "C1", "C2", "C3", "C4", "C4x", "N1", "N2", "N3", "N4", "N4x",
-    "lst", "mst", "sst", "sct", "hess", "magic", "veritas",
-    ]
+  "e",
+  "i",
+  "j",
+  "k",
+  "x",
+  "y",
+  "n",
+  "f",
+  "r",
+  "ex",
+  "db",
+  "im",
+  "sh",
+  "ax",
+  "ce",
+  "xx",
+  "yy",
+  "zz",
+  "C1",
+  "C2",
+  "C3",
+  "C4",
+  "C4x",
+  "N1",
+  "N2",
+  "N3",
+  "N4",
+  "N4x",
+  "lst",
+  "mst",
+  "sst",
+  "sct",
+  "hess",
+  "magic",
+  "veritas",
+]
 # Ignore files
 ignore = [
-    "__init__.py", "scm_version.py", "_version.py",
-    "legend_handlers.py",
-    "version.py",
+  "__init__.py",
+  "scm_version.py",
+  "_version.py",
+  "legend_handlers.py",
+  "version.py",
 ]
 
 # See discussion in issue 521
 # Agreed to not have module docstring (missing-module-docstring)
 # Pylint cannot handle overload (used in pyproj; unpacking-non-sequence)
 disable = [
-    "missing-module-docstring",
-    "unpacking-non-sequence",
-    "logging-format-interpolation",
-    "fixme",
-    "missing-function-docstring",
-    "R0801",   # duplications
-    "logging-fstring-interpolation",
+  "missing-module-docstring",
+  "unpacking-non-sequence",
+  "logging-format-interpolation",
+  "fixme",
+  "missing-function-docstring",
+  "R0801",                         # duplications
+  "logging-fstring-interpolation",
 ]
 # see https://github.com/pylint-dev/pylint/issues/2289
-generated-members = ["gist_heat_r"]
+generated-members = [
+  "gist_heat_r",
+]
 # see https://stackoverflow.com/questions/49846940/incorrect-pylint-errors-on-astropy-in-vscode
-ignored-classes=["astropy.units"]
+ignored-classes = [
+  "astropy.units",
+]
 
 # Maximum number of characters on a single line.
 max-line-length = 100
@@ -146,19 +231,17 @@ max-statements = 80
 # Maximum number of public methods for a class (see R0904). (default=20)
 max-public-methods = 50
 
-[tool.black]
-line-length = 100
-
-[tool.isort]
-profile = "black"
-
-[tool.pytest.ini_options]
-minversion="6.0"
-norecursedirs=["build", "docs/_build", "simtools/applications"]
-addopts="-v --cov=simtools --cov-report=xml --cov-report=term"
-testpaths="tests/unit_tests/"
-# Ignore the warning about fontTools.misc.py23
-filterwarnings="ignore:The py23 module has been deprecated:DeprecationWarning"
-
 [tool.codespell]
 ignore-words = ".codespell-ignores"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+norecursedirs = [
+  "build",
+  "docs/_build",
+  "simtools/applications",
+]
+addopts = "-v --cov=simtools --cov-report=xml --cov-report=term"
+testpaths = "tests/unit_tests/"
+# Ignore the warning about fontTools.misc.py23
+filterwarnings = "ignore:The py23 module has been deprecated:DeprecationWarning"

--- a/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -80,7 +80,6 @@ def _parse(label=None, description=None):
         Command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(
@@ -120,7 +119,6 @@ def get_list_of_parameters_and_schema_files(schema_directory):
         List of schema files found in schema file directory.
 
     """
-
     schema_files = sorted(list(Path(schema_directory).rglob("*.schema.yml")))
     parameters = []
     for schema_file in schema_files:
@@ -146,9 +144,8 @@ def get_list_of_simtel_parameters(simtel_config_file, logger):
         List of parameters found in simtel configuration file.
 
     """
-
     simtel_parameter_set = set()
-    with open(simtel_config_file, "r", encoding="utf-8") as file:
+    with open(simtel_config_file, encoding="utf-8") as file:
         for line in file:
             parts_of_lines = re.split(r",\s*|\s+", line.strip())
             simtel_parameter_set.add(parts_of_lines[1].lower())
@@ -172,7 +169,6 @@ def read_simtel_config_file(args_dict, logger, schema_file, camera_pixels=None):
         Number of camera pixels.
 
     """
-
     simtel_config_reader = SimtelConfigReader(
         schema_file=schema_file,
         simtel_config_file=args_dict["simtel_cfg_file"],
@@ -205,7 +201,6 @@ def get_number_of_camera_pixel(args_dict, logger):
         Number of camera pixels (None if file is not found)
 
     """
-
     try:
         simtel_config_reader = SimtelConfigReader(
             schema_file=Path(args_dict["schema_directory"]) / "camera_pixels.schema.yml",
@@ -244,7 +239,6 @@ def read_and_export_parameters(args_dict, logger):
         List of simtools parameter not found in simtel configuration file.
 
     """
-
     _parameters, _schema_files = get_list_of_parameters_and_schema_files(
         args_dict["schema_directory"]
     )
@@ -258,7 +252,6 @@ def read_and_export_parameters(args_dict, logger):
     _parameters_not_in_simtel = []
 
     for _parameter, _schema_file in zip(_parameters, _schema_files):
-
         logger.info(f"Parameter: {_parameter} Schema file: {_schema_file}")
         simtel_config_reader = read_simtel_config_file(
             args_dict, logger, _schema_file, _camera_pixel
@@ -308,7 +301,6 @@ def print_parameters_not_found(_parameters_not_in_simtel, _simtel_parameters, ar
         Logger object
 
     """
-
     logger.info(
         f"Parameters not found in simtools schema files ({len(_parameters_not_in_simtel)}):"
     )
@@ -356,7 +348,6 @@ def print_list_of_files(args_dict, logger):
         Logger object
 
     """
-
     model_files = sorted(list(Path(args_dict["output_path"]).rglob("*.json")))
     for file in model_files:
         model_dict = gen.collect_data_from_file_or_dict(file_name=file, in_dict=None)
@@ -365,7 +356,6 @@ def print_list_of_files(args_dict, logger):
 
 
 def main():
-
     args_dict, _ = _parse(
         label=Path(__file__).stem,
         description="Convert simulation model parameters from sim_telarray to simtools format.",

--- a/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/simtools/applications/convert_model_parameter_from_simtel.py
@@ -63,7 +63,6 @@ def _parse(label=None, description=None):
         Command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(
@@ -91,7 +90,6 @@ def _parse(label=None, description=None):
 
 
 def main():
-
     args_dict, _ = _parse(
         label=Path(__file__).stem,
         description="Convert simulation model parameter from sim_telarray to simtools format.",

--- a/simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py
@@ -17,7 +17,6 @@
 
     Examples
     --------
-
     Upload a repository to the DB:
 
     .. code-block:: console
@@ -52,7 +51,6 @@ def _parse(label=None, description=None):
     CommandLineParser
         Command line parser object.
     """
-
     config = configurator.Configurator(label=label, description=description)
     config.parser.add_argument(
         "--input_path",

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 """
-    Summary
-    -------
-    This application is used to add a new parameter to the sites collection in the DB.
+Summary
+-------
+This application is used to add a new parameter to the sites collection in the DB.
 
-    This application should not be used by anyone but expert users and not often.
-    Therefore, no additional documentation about this applications will be given.
+This application should not be used by anyone but expert users and not often.
+Therefore, no additional documentation about this applications will be given.
 
 """
 

--- a/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
+++ b/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 
 """
-    Summary
-    -------
-    This application is used to add a unit to parameters in the DB.
+Summary
+-------
+This application is used to add a unit to parameters in the DB.
 
-    This application should not be used by anyone but expert users and only in unusual cases.
-    Therefore, no additional documentation about this applications will be given.
+This application should not be used by anyone but expert users and only in unusual cases.
+Therefore, no additional documentation about this applications will be given.
 
 """
 

--- a/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
+++ b/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
@@ -44,7 +44,7 @@ def main():
 
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
 
-    with open(args_dict["sections"], "r", encoding="utf-8") as stream:
+    with open(args_dict["sections"], encoding="utf-8") as stream:
         parameter_catogeries = yaml.safe_load(stream)
 
     non_optic_catagories = [

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -152,7 +152,6 @@ def _parse(label):
     """
     Parse command line configuration
     """
-
     config = configurator.Configurator(
         description="Derive mirror random reflection angle.", label=label
     )
@@ -238,7 +237,6 @@ def _define_telescope_model(label, args_dict, db_config):
         telescope model
 
     """
-
     tel = TelescopeModel(
         site=args_dict["site"],
         telescope_model_name=args_dict["telescope"],
@@ -264,7 +262,6 @@ def _print_and_write_results(
     in the requested format
 
     """
-
     containment_fraction_percent = int(args_dict["containment_fraction"] * 100)
 
     # Printing results to stdout
@@ -315,7 +312,6 @@ def _get_psf_containment(logger, args_dict):
     from file and return mean and sigma
 
     """
-
     # If this is a test, read just the first few lines since we only simulate those mirrors
     data_end = args_dict["number_of_mirrors_to_test"] + 1 if args_dict["test"] else None
     _psf_list = Table.read(args_dict["psf_measurement"], format="ascii.ecsv", data_end=data_end)

--- a/simtools/applications/generate_corsika_histograms.py
+++ b/simtools/applications/generate_corsika_histograms.py
@@ -295,7 +295,6 @@ def _plot_figures(corsika_histograms_instance, test=False):
     test: bool
         If true plots the figures for the first two functions only.
     """
-
     plot_function_names = [
         plotting_method
         for plotting_method in dir(corsika_histograms_visualize)

--- a/simtools/applications/generate_default_metadata.py
+++ b/simtools/applications/generate_default_metadata.py
@@ -1,27 +1,27 @@
 #!/usr/bin/python3
 """
-    Summary
-    -------
-    Generate a default simtools metadata file from a json schema.
+Summary
+-------
+Generate a default simtools metadata file from a json schema.
 
-    Command line arguments
-    ----------------------
-    schema (str, optional)
-        Schema file describing the input data
-        (default: simtools/schemas/metadata.metaschema.yml)
-    output_file (str, optional)
-        Output file name.
+Command line arguments
+----------------------
+schema (str, optional)
+    Schema file describing the input data
+    (default: simtools/schemas/metadata.metaschema.yml)
+output_file (str, optional)
+    Output file name.
 
-    Example
-    -------
-    .. code-block:: console
+Example
+-------
+.. code-block:: console
 
-        simtools-generate-default-metadata
-            --schema simtools/schemas/metadata.metaschema.yml
-            --output_file default_metadata.yml
+    simtools-generate-default-metadata
+        --schema simtools/schemas/metadata.metaschema.yml
+        --output_file default_metadata.yml
 
 
-    """
+"""
 
 import json
 import logging
@@ -52,7 +52,6 @@ def _parse(label, description):
         Command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(

--- a/simtools/applications/generate_simtel_array_histograms.py
+++ b/simtools/applications/generate_simtel_array_histograms.py
@@ -1,50 +1,50 @@
 #!/usr/bin/python3
 
 """
-    Summary
-    -------
-    This application allows to write sim_telarray histograms into pdf and hdf5 files.
-    It accepts multiple lists of histograms files, a single list or a histogram file.
-    Each histogram is plotted in a page of the pdf file if the --pdf option is activated.
+Summary
+-------
+This application allows to write sim_telarray histograms into pdf and hdf5 files.
+It accepts multiple lists of histograms files, a single list or a histogram file.
+Each histogram is plotted in a page of the pdf file if the --pdf option is activated.
 
 
-    Command line arguments
-    ----------------------
-    hist_file_names (str, optional)
-        Name of the histogram files to be plotted.
-        It can be given as the histogram file names (more than one option allowed) or as a text
-        file with the names of the histogram files in it.
-    figure_name (str, required)
-        File name for the pdf output (without extension).
-    pdf (bool, optional)
-        If set, histograms are saved into pdf files.
-        One pdf file contains all the histograms found in the file.
-        The name of the file is controlled via `output_file_name`.
-    hdf5: bool
-        If true, histograms are saved into hdf5 files.
-        At least one of `pdf` and `hdf5` has to be activated.
-    output_file_name (str, optional)
-        The name of the output hdf5 (and/or pdf) files (without the path).
-        If not given, `output_file_name` takes the name from the (first) input file
-        (`hist_file_names`).
-        If the output `output_file_name.hdf5` file already exists and `hdf5` is set, the tables
-        associated to `hdf5` will be overwritten. The remaining tables, if any, will stay
-        untouched.
-    verbosity (str, optional)
-        Log level to print.
+Command line arguments
+----------------------
+hist_file_names (str, optional)
+    Name of the histogram files to be plotted.
+    It can be given as the histogram file names (more than one option allowed) or as a text
+    file with the names of the histogram files in it.
+figure_name (str, required)
+    File name for the pdf output (without extension).
+pdf (bool, optional)
+    If set, histograms are saved into pdf files.
+    One pdf file contains all the histograms found in the file.
+    The name of the file is controlled via `output_file_name`.
+hdf5: bool
+    If true, histograms are saved into hdf5 files.
+    At least one of `pdf` and `hdf5` has to be activated.
+output_file_name (str, optional)
+    The name of the output hdf5 (and/or pdf) files (without the path).
+    If not given, `output_file_name` takes the name from the (first) input file
+    (`hist_file_names`).
+    If the output `output_file_name.hdf5` file already exists and `hdf5` is set, the tables
+    associated to `hdf5` will be overwritten. The remaining tables, if any, will stay
+    untouched.
+verbosity (str, optional)
+    Log level to print.
 
-    Raises
-    ------
-    TypeError:
-        if argument passed through `hist_file_names` is not a file.
+Raises
+------
+TypeError:
+    if argument passed through `hist_file_names` is not a file.
 
-    Example
-    -------
-    .. code-block:: console
+Example
+-------
+.. code-block:: console
 
-        simtools-generate-simtel-array-histograms --hist_file_names tests/resources/
-            run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst
-            --output_file_name test_hist_hdata --hdf5 --pdf
+    simtools-generate-simtel-array-histograms --hist_file_names tests/resources/
+        run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst
+        --output_file_name test_hist_hdata --hdf5 --pdf
 
 """
 

--- a/simtools/applications/make_regular_arrays.py
+++ b/simtools/applications/make_regular_arrays.py
@@ -1,31 +1,31 @@
 #!/usr/bin/python3
 
 """
-    Summary
-    -------
+Summary
+-------
 
-    This application creates the layout array files (ECSV) of regular arrays
-    with one telescope at the center of the array and with 4 telescopes
-    in a square grid. These arrays are used for trigger rate simulations.
+This application creates the layout array files (ECSV) of regular arrays
+with one telescope at the center of the array and with 4 telescopes
+in a square grid. These arrays are used for trigger rate simulations.
 
-    The array layout files created should be available at the data/layout directory.
+The array layout files created should be available at the data/layout directory.
 
-    Command line arguments
-    ----------------------
-    site (str, required)
-        observatory site (e.g., North or South).
-    model_version (str, optional)
-        Model version to use (e.g., prod6). If not provided, the latest version is used.
-    verbosity (str, optional)
-        Log level to print.
+Command line arguments
+----------------------
+site (str, required)
+    observatory site (e.g., North or South).
+model_version (str, optional)
+    Model version to use (e.g., prod6). If not provided, the latest version is used.
+verbosity (str, optional)
+    Log level to print.
 
-    Example
-    -------
-    Runtime < 10 s.
+Example
+-------
+Runtime < 10 s.
 
-    .. code-block:: console
+.. code-block:: console
 
-        simtools-make-regular-arrays --site=North
+    simtools-make-regular-arrays --site=North
 
 """
 

--- a/simtools/applications/plot_array_layout.py
+++ b/simtools/applications/plot_array_layout.py
@@ -180,7 +180,7 @@ def main():
             if args_dict["figure_name"] is None:
                 plot_file_name = (
                     f"plot_array_layout_{(Path(one_file).name).split('.')[0]}_"
-                    f"{str((round((one_angle.to(u.deg).value))))}deg"
+                    f"{str(round(one_angle.to(u.deg).value))}deg"
                 )
             else:
                 plot_file_name = args_dict["figure_name"]

--- a/simtools/applications/print_array_elements.py
+++ b/simtools/applications/print_array_elements.py
@@ -86,7 +86,6 @@ def _parse(label=None, description=None):
         Command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(

--- a/simtools/applications/production.py
+++ b/simtools/applications/production.py
@@ -103,7 +103,6 @@ def _parse(description=None):
         command line parser object
 
     """
-
     config = configurator.Configurator(description=description)
     config.parser.add_argument(
         "--simulation_configuration",
@@ -189,7 +188,6 @@ def _process_simulation_config_file(config_file, primary_config, logger):
         configuration of array simulations
 
     """
-
     try:
         config_data = gen.collect_data_from_file_or_dict(file_name=config_file, in_dict=None)
     except FileNotFoundError:

--- a/simtools/applications/sim_showers_for_trigger_rates.py
+++ b/simtools/applications/sim_showers_for_trigger_rates.py
@@ -92,7 +92,6 @@ def _parse(label=None, description=None):
         command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
     config.parser.add_argument(
         "--array",

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -120,7 +120,6 @@ def _parse(description=None):
         Command line parser object.
 
     """
-
     config = configurator.Configurator(description=description)
     config.parser.add_argument(
         "--production_config",

--- a/simtools/applications/submit_data_from_external.py
+++ b/simtools/applications/submit_data_from_external.py
@@ -65,7 +65,6 @@ def _parse(label, description):
         Command line parser object
 
     """
-
     config = configurator.Configurator(label=label, description=description)
 
     config.parser.add_argument(

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -56,7 +56,6 @@ def _parse(label, description):
         application configuration
 
     """
-
     config = configurator.Configurator(label=label, description=description)
     config.parser.add_argument("--file_name", help="file to be validated", required=True)
     config.parser.add_argument("--schema", help="json schema file", required=False)
@@ -91,7 +90,6 @@ def _get_schema_file_name(args_dict, data_dict=None):
         schema file name
 
     """
-
     schema_file = args_dict.get("schema")
     if schema_file is None and data_dict is not None:
         schema_file = data_dict.get("meta_schema_url")
@@ -110,7 +108,6 @@ def validate_schema(args_dict, logger):
     the metadata section of the data dictionary.
 
     """
-
     try:
         data = gen.collect_data_from_file_or_dict(file_name=args_dict["file_name"], in_dict=None)
     except FileNotFoundError as exc:

--- a/simtools/applications/validate_optics.py
+++ b/simtools/applications/validate_optics.py
@@ -88,7 +88,6 @@ def _parse(label):
     Parse command line configuratio
 
     """
-
     config = configurator.Configurator(
         label=label,
         description=(

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -51,7 +51,6 @@ class CameraEfficiency:
         """
         Initialize the CameraEfficiency class.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self._simtel_source_path = simtel_source_path
@@ -119,6 +118,7 @@ class CameraEfficiency:
         ----------
         tel: TelescopeModel
             An assumed instance of the TelescopeModel class.
+
         Raises
         ------
         ValueError
@@ -227,7 +227,7 @@ class CameraEfficiency:
 
         # Search for at least 5 consecutive numbers to see that we are in the table
         re_table = re.compile("{0}{0}{0}{0}{0}".format(r"[-+]?[0-9]*\.?[0-9]+\s+"))
-        with open(self._file["simtel"], "r", encoding="utf-8") as file:
+        with open(self._file["simtel"], encoding="utf-8") as file:
             for line in file:
                 if re_table.match(line):
                     words = line.split()
@@ -331,7 +331,6 @@ class CameraEfficiency:
         tel_efficiency: float
             Telescope efficiency
         """
-
         # Sum(C1) from 300 - 550 nm:
         c1_reduced_wl = self._results["C1"][[299 < wl_now < 551 for wl_now in self._results["wl"]]]
         c1_sum = np.sum(c1_reduced_wl)
@@ -353,7 +352,6 @@ class CameraEfficiency:
         cam_efficiency: float
             Wavelength-averaged camera efficiency
         """
-
         # Sum(C1) from 300 - 550 nm:
         c1_reduced_wl = self._results["C1"][[299 < wl_now < 551 for wl_now in self._results["wl"]]]
         c1_sum = np.sum(c1_reduced_wl)
@@ -383,7 +381,6 @@ class CameraEfficiency:
         Float
             Telescope total efficiency including gaps
         """
-
         # Sum(N1) from 300 - 550 nm:
         n1_reduced_wl = self._results["N1"][[299 < wl_now < 551 for wl_now in self._results["wl"]]]
         n1_sum = np.sum(n1_reduced_wl)
@@ -405,7 +402,6 @@ class CameraEfficiency:
         Float
             Cherenkov spectrum weighted reflectivity (300-550 nm)
         """
-
         # Sum(C1) from 300 - 550 nm:
         c1_reduced_wl = self._results["C1"][[299 < wl_now < 551 for wl_now in self._results["wl"]]]
         c1_sum = np.sum(c1_reduced_wl)
@@ -428,7 +424,6 @@ class CameraEfficiency:
             NSB pixel rate in p.e./ns for reference conditions
             (https://jama.cta-observatory.org/perspective.req#/items/26694?projectId=11)
         """
-
         nsb_rate_provided_spectrum = (
             np.sum(self._results["N4"])
             * self._telescope_model.camera.get_pixel_active_solid_angle()

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -52,7 +52,6 @@ class CommandLineParser(argparse.ArgumentParser):
         job_submission: bool
             Add job submission configuration parameters to list of args.
         """
-
         self.initialize_simulation_model_arguments(simulation_model)
         if job_submission:
             self.initialize_job_submission_arguments()
@@ -70,7 +69,6 @@ class CommandLineParser(argparse.ArgumentParser):
         Initialize configuration files.
 
         """
-
         _job_group = self.add_argument_group("configuration")
         _job_group.add_argument(
             "--config",
@@ -130,7 +128,6 @@ class CommandLineParser(argparse.ArgumentParser):
         """
         Initialize application output files(s)
         """
-
         _job_group = self.add_argument_group("output")
         _job_group.add_argument(
             "--output_file",
@@ -157,7 +154,6 @@ class CommandLineParser(argparse.ArgumentParser):
         """
         Initialize application execution arguments.
         """
-
         _job_group = self.add_argument_group("execution")
         _job_group.add_argument(
             "--test",
@@ -185,7 +181,6 @@ class CommandLineParser(argparse.ArgumentParser):
         """
         Initialize DB configuration parameters.
         """
-
         _job_group = self.add_argument_group("MongoDB configuration")
         _job_group.add_argument("--db_api_user", help="database user", type=str, required=False)
         _job_group.add_argument("--db_api_pw", help="database password", type=str, required=False)
@@ -249,7 +244,6 @@ class CommandLineParser(argparse.ArgumentParser):
         model_options: list
             Options to be set: "telescope", "site"
         """
-
         if model_options is not None:
             _job_group = self.add_argument_group("simulation model")
             if "site" in model_options or "telescope" in model_options:
@@ -290,7 +284,6 @@ class CommandLineParser(argparse.ArgumentParser):
             for invalid sites
 
         """
-
         names.validate_site_name(str(value))
         return str(value)
 
@@ -315,7 +308,6 @@ class CommandLineParser(argparse.ArgumentParser):
             for invalid telescope
 
         """
-
         names.validate_telescope_name(str(value))
         return str(value)
 
@@ -373,7 +365,6 @@ class CommandLineParser(argparse.ArgumentParser):
 
 
         """
-
         logger = logging.getLogger(__name__)
 
         try:
@@ -418,7 +409,6 @@ class CommandLineParser(argparse.ArgumentParser):
 
 
         """
-
         logger = logging.getLogger(__name__)
         try:
             fangle = float(angle)

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -54,7 +54,6 @@ class Configurator:
         """
         Initialize Configurator.
         """
-
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init Configuration")
 
@@ -85,7 +84,6 @@ class Configurator:
         dict
             Configuration parameters as dict.
         """
-
         self.parser.initialize_default_arguments()
         simulation_model = None
         if arg_list and "--site" in arg_list:
@@ -148,7 +146,6 @@ class Configurator:
            if parameter has already been defined with a different value.
 
         """
-
         self.parser.initialize_default_arguments(
             paths=paths,
             output=output,
@@ -193,7 +190,6 @@ class Configurator:
               invalid configuration.
 
         """
-
         if arg_list is None:
             arg_list = sys.argv[1:]
 
@@ -214,7 +210,6 @@ class Configurator:
         Access protected attributes of parser (no public method available).
 
         """
-
         for group in self.parser._mutually_exclusive_groups:  # pylint: disable=protected-access
             group.required = False
         for action in self.parser._actions:  # pylint: disable=protected-access
@@ -289,7 +284,6 @@ class Configurator:
            if configuration file has not been found.
 
         """
-
         try:
             self._logger.debug(f"Reading configuration from {config_file}")
             _config_dict = gen.collect_data_from_file_or_dict(
@@ -324,7 +318,6 @@ class Configurator:
         from environmental variables or from file (default: ".env").
 
         """
-
         _env_dict = {}
         try:
             load_dotenv(self.config["env_file"])
@@ -396,7 +389,6 @@ class Configurator:
             Dict keys and values as dict.
 
         """
-
         if isinstance(input_var, dict):
             _list_args = []
             for key, value in input_var.items():
@@ -429,7 +421,6 @@ class Configurator:
             Dictionary with values to be converted.
 
         """
-
         for key, value in input_dict.items():
             input_dict[key] = None if value == "None" else value
 
@@ -445,7 +436,6 @@ class Configurator:
             List or dictionary with configuration updates.
 
         """
-
         self.config = self._convert_stringnone_to_none(
             vars(
                 self.parser.parse_args(
@@ -466,7 +456,6 @@ class Configurator:
 
 
         """
-
         _db_dict = {}
         _db_para = (
             "db_api_user",

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -86,7 +86,6 @@ class CorsikaConfig:
         """
         Initialize CorsikaConfig.
         """
-
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init CorsikaConfig")
 
@@ -150,7 +149,6 @@ class CorsikaConfig:
         corsika_parameters: dict
             Dictionary with CORSIKA parameters.
         """
-
         logger = logging.getLogger(__name__)
         logger.debug(f"Loading CORSIKA parameters from file {corsika_parameters_file}")
         corsika_parameters = gen.collect_data_from_file_or_dict(
@@ -189,7 +187,6 @@ class CorsikaConfig:
         MissingRequiredInputInCorsikaConfigData
             If any required user parameter is missing.
         """
-
         self._logger.debug("Setting user parameters from corsika_config_data")
         self._user_parameters = {}
 
@@ -252,7 +249,6 @@ class CorsikaConfig:
         value_args_in: list
             List of values for the parameter.
         """
-
         # Turning value_args into a list, if it is not.
         value_args = self._convert_to_quantities(value_args_in)
 
@@ -373,7 +369,6 @@ class CorsikaConfig:
             Whether to set the CORSIKA Inputs file to pipe
             the output directly to sim_telarray or not.
         """
-
         sub_dir = "corsika_simtel" if use_multipipe else "corsika"
         self._set_output_file_and_directory(sub_dir)
         self._logger.debug(f"Exporting CORSIKA input file to {self.config_file_path}")
@@ -486,7 +481,6 @@ class CorsikaConfig:
         ValueError
             If file_type is unknown or if the run number is not given for file_type==config_tmp.
         """
-
         file_label = f"_{self.label}" if self.label is not None else ""
         view_cone = ""
         if self._user_parameters["VIEWCONE"][0] != 0 or self._user_parameters["VIEWCONE"][1] != 0:
@@ -570,12 +564,12 @@ class CorsikaConfig:
         ----------
         value_args: list
             List of value/unit pairs (e.g., ["10 m", "20 m"])
+
         Returns
         -------
         list
             List of astropy quantities (or strings)
         """
-
         if isinstance(value_args, str):
             return [value_args]
         if isinstance(value_args, dict) and "value" in value_args and "unit" in value_args:

--- a/simtools/corsika/corsika_default_config.py
+++ b/simtools/corsika/corsika_default_config.py
@@ -118,7 +118,6 @@ class CorsikaDefaultConfig:
         energy_ranges: dict
             Dictionary with the default energy ranges for the various primaries.
         """
-
         energy_ranges = defaultdict(dict)
         energy_ranges["gamma"][20] = [3 * u.GeV, 330 * u.TeV]
         energy_ranges["gamma"][40] = [6 * u.GeV, 660 * u.TeV]
@@ -159,7 +158,6 @@ class CorsikaDefaultConfig:
         number_of_showers: dict
             Dictionary with the default number of showers for the various primaries.
         """
-
         number_of_showers = defaultdict(dict)
         number_of_showers["gamma"][20] = 5000
         number_of_showers["gamma"][40] = 5000
@@ -225,7 +223,6 @@ class CorsikaDefaultConfig:
         energy_range: list
             List with the energy range for the primary particle for the given zenith angle.
         """
-
         zenith_angles_to_interpolate = [*self.energy_ranges[self.primary].keys()]
         min_energy_to_interpolate = [
             energy[0].to_value(u.GeV) for energy in self.energy_ranges[self.primary].values()
@@ -256,7 +253,6 @@ class CorsikaDefaultConfig:
         number_of_showers: int
             Number of showers for the primary particle for the given zenith angle.
         """
-
         zenith_angles_to_interpolate = [*self.energy_ranges[self.primary].keys()]
         number_of_showers = [*self.number_of_showers[self.primary].values()]
 

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -136,7 +136,6 @@ class CorsikaHistograms:
         float:
             The version of CORSIKA used to produce the CORSIKA IACT file given by `self.input_file`.
         """
-
         if self._corsika_version is None:
             all_corsika_versions = list(run_header.run_header_types.keys())
             header = list(self.iact_file.header)
@@ -196,7 +195,6 @@ class CorsikaHistograms:
         For the remaining information (such as px, py, pz), use this function.
 
         """
-
         if self.event_information is None:
             with IACTFile(self.input_file) as self.iact_file:
                 self.telescope_positions = np.array(self.iact_file.telescope_positions)
@@ -246,7 +244,6 @@ class CorsikaHistograms:
         dict:
             A dictionary with the astropy units.
         """
-
         # Build a dictionary with astropy units for the unit of the event's (header's) parameters.
         all_event_astropy_units = {}
         for key in parameters[1:]:  # starting at the second
@@ -292,7 +289,6 @@ class CorsikaHistograms:
         TypeError:
             if the indices passed through telescope_index are not of type int.
         """
-
         if telescope_new_indices is None:
             self._telescope_indices = np.arange(self.num_telescopes)
         else:
@@ -356,7 +352,6 @@ class CorsikaHistograms:
             Name of the output file, in which to save the histogram configuration.
 
         """
-
         if file_name is None:
             file_name = "hist_config"
         file_name = Path(file_name).with_suffix(".yml")
@@ -387,7 +382,6 @@ class CorsikaHistograms:
         dict:
             Dictionary with the configuration parameters to create the histograms.
         """
-
         if self.individual_telescopes is False:
             xy_maximum = 1000 * u.m
             xy_bin = 100
@@ -567,7 +561,6 @@ class CorsikaHistograms:
         IndexError:
             If the index or indices passed though telescope_index are out of range.
         """
-
         hist_num = 0
         for i_tel_info, photons_info in np.array(
             list(zip(self.telescope_positions, photons)), dtype=object
@@ -680,7 +673,6 @@ class CorsikaHistograms:
             if False, the histograms are supposed to be filled for all telescopes.
             if True, one histogram is set for each telescope sepparately.
         """
-
         if new_individual_telescopes is None:
             self._individual_telescopes = False
         else:
@@ -695,7 +687,6 @@ class CorsikaHistograms:
         HistogramNotCreated:
             if the histogram was not previously created.
         """
-
         for histogram in self._allowed_histograms:
             if not hasattr(self, histogram) or getattr(self, histogram) is None:
                 msg = (
@@ -728,7 +719,6 @@ class CorsikaHistograms:
         ValueError:
             if label is not valid.
         """
-
         if label not in self._allowed_2d_labels:
             msg = f"label is not valid. Valid entries are {self._allowed_2d_labels}"
             self._logger.error(msg)
@@ -866,7 +856,6 @@ class CorsikaHistograms:
         ValueError:
             if label is not valid.
         """
-
         if label not in self._allowed_1d_labels:
             msg = f"{label} is not valid. Valid entries are {self._allowed_1d_labels}"
             self._logger.error(msg)
@@ -940,7 +929,6 @@ class CorsikaHistograms:
             The bin edges of the 1D histogram in meters with size = int(max_dist/bin_size) + 1,
             usually in meter.
         """
-
         bins, max_dist = self._get_bins_max_dist(bins=bins, max_dist=max_dist)
         bin_edges_1d_list, hist_1d_list = [], []
 
@@ -1111,7 +1099,6 @@ class CorsikaHistograms:
         numpy.array
             Number of photons per telescope.
         """
-
         hist, bin_edges = np.histogram(self.num_photons_per_telescope, bins=bins, range=hist_range)
         return hist.reshape(1, bins), bin_edges.reshape(1, bins + 1)
 
@@ -1137,7 +1124,6 @@ class CorsikaHistograms:
         dict
             Meta dictionary for the hdf5 files with the histograms.
         """
-
         if self.__meta_dict is None:
             self.__meta_dict = {
                 "corsika_version": self.corsika_version,
@@ -1221,7 +1207,6 @@ class CorsikaHistograms:
         overwrite: bool
             If True overwrites the histograms already saved in the hdf5 file.
         """
-
         for _, function_dict in self.dict_1d_distributions.items():
             self._meta_dict["Title"] = sanitize_name(function_dict["title"])
             function = getattr(self, function_dict["function"])
@@ -1398,7 +1383,6 @@ class CorsikaHistograms:
         overwrite: bool
             If True overwrites the histograms already saved in the hdf5 file.
         """
-
         hist, bin_edges = self.event_1d_histogram(
             event_header_element, bins=bins, hist_range=hist_range
         )
@@ -1650,7 +1634,6 @@ class CorsikaHistograms:
         KeyError:
             If parameter is not valid.
         """
-
         if parameter not in self.all_event_keys:
             msg = f"`key` is not valid. Valid entries are {self.all_event_keys}"
             self._logger.error(msg)

--- a/simtools/corsika/corsika_histograms_visualize.py
+++ b/simtools/corsika/corsika_histograms_visualize.py
@@ -409,7 +409,6 @@ def plot_photon_per_event_distr(histograms_instance, log_y=True):
         List of figures for the given telescopes.
 
     """
-
     return _kernel_plot_1d_photons(histograms_instance, "num_photons_per_event", log_y=log_y)
 
 
@@ -430,7 +429,6 @@ def plot_photon_per_telescope_distr(histograms_instance, log_y=True):
         List of figures for the given telescopes.
 
     """
-
     return _kernel_plot_1d_photons(histograms_instance, "num_photons_per_telescope", log_y=log_y)
 
 

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -94,7 +94,6 @@ class CorsikaRunner:
         """
         CorsikaRunner init.
         """
-
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init CorsikaRunner")
 
@@ -123,7 +122,6 @@ class CorsikaRunner:
 
     def _load_corsika_config_data(self, corsika_config_data):
         """Reads corsika_config_data, creates corsika_config and corsika_input_file."""
-
         corsika_data_directory_from_config = corsika_config_data.get("data_directory", None)
         if corsika_data_directory_from_config is None:
             # corsika_data_directory not given (or None).
@@ -149,7 +147,6 @@ class CorsikaRunner:
         Create the CORSIKA config instance.
         This validates the input given in corsika_config_data as well.
         """
-
         try:
             self.corsika_config = CorsikaConfig(
                 mongo_db_config=mongo_db_config,
@@ -342,7 +339,6 @@ class CorsikaRunner:
         ValueError
             If file_type is unknown.
         """
-
         file_label = (
             f"_{kwargs['label']}" if "label" in kwargs and kwargs["label"] is not None else ""
         )
@@ -393,7 +389,6 @@ class CorsikaRunner:
             Run number.
 
         """
-
         info_for_file_name = self.get_info_for_file_name(run_number)
         run_sub_file = self.get_file_name(file_type, **info_for_file_name, mode=mode)
         return Path(run_sub_file).is_file()
@@ -413,7 +408,6 @@ class CorsikaRunner:
             run time and number of simulated events
 
         """
-
         sub_log_file = self.get_file_name(
             file_type="sub_log", **self.get_info_for_file_name(run_number), mode="out"
         )
@@ -423,7 +417,7 @@ class CorsikaRunner:
         _resources = {}
 
         _resources["runtime"] = None
-        with open(sub_log_file, "r", encoding="utf-8") as file:
+        with open(sub_log_file, encoding="utf-8") as file:
             for line in reversed(list(file)):
                 if "RUNTIME" in line:
                     _resources["runtime"] = int(line.split()[1])

--- a/simtools/corsika_simtel/corsika_simtel_runner.py
+++ b/simtools/corsika_simtel/corsika_simtel_runner.py
@@ -79,7 +79,6 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         Path:
             Full path of the run script file.
         """
-
         kwargs = {
             "run_number": None,
             **kwargs,
@@ -106,7 +105,6 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         multipipe_file: str or Path
             The name of the multipipe file which contains all of the multipipe commands.
         """
-
         multipipe_executable = Path(self.corsika_config.config_file_path.parent).joinpath(
             "run_cta_multipipe"
         )
@@ -135,7 +133,6 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
                     run number
 
         """
-
         info_for_file_name = SimtelRunnerArray.get_info_for_file_name(self, kwargs["run_number"])
         weak_pointing = any(pointing in self.label for pointing in ["divergent", "convergent"])
 
@@ -167,7 +164,6 @@ class CorsikaSimtelRunner(CorsikaRunner, SimtelRunnerArray):
         Get a CORSIKA or sim_telarray style file name for various file types.
         See the implementations in CorsikaRunner and SimtelRunnerArray for details.
         """
-
         if file_type in ["output", "log", "histogram"]:
             return SimtelRunnerArray.get_file_name(self, file_type=file_type, **kwargs)
         return CorsikaRunner.get_file_name(

--- a/simtools/data_model/data_reader.py
+++ b/simtools/data_model/data_reader.py
@@ -42,7 +42,6 @@ def read_table_from_file(file_name, schema_file=None, validate=False, metadata_f
         If file does not exist.
 
     """
-
     try:
         data_table = QTable.read(file_name)
     except (FileNotFoundError, IORegistryError) as exc:
@@ -100,7 +99,6 @@ def read_value_from_file(file_name, schema_file=None, validate=False):
         If file does not exist.
 
     """
-
     try:
         data = gen.collect_data_from_file_or_dict(file_name=file_name, in_dict=None)
     except FileNotFoundError as exc:

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -48,7 +48,6 @@ class MetadataCollector:
         Initialize metadata collector.
 
         """
-
         self._logger = logging.getLogger(__name__)
         self.observatory = "cta"
         self.io_handler = io_handler.IOHandler()
@@ -70,7 +69,6 @@ class MetadataCollector:
         Collect and verify product metadata from different sources.
 
         """
-
         self._fill_contact_meta(self.top_level_meta[self.observatory]["contact"])
         self._fill_product_meta(self.top_level_meta[self.observatory]["product"])
         self._fill_activity_meta(self.top_level_meta[self.observatory]["activity"])
@@ -93,7 +91,6 @@ class MetadataCollector:
             Name of schema file.
 
         """
-
         # from command line
         try:
             if self.args_dict["schema"]:
@@ -141,7 +138,6 @@ class MetadataCollector:
             Data model schema dictionary.
 
         """
-
         try:
             return gen.collect_data_from_file_or_dict(file_name=self.schema_file, in_dict=None)
         except gen.InvalidConfigData:
@@ -185,7 +181,6 @@ class MetadataCollector:
             Dictionary for contact metadata fields.
 
         """
-
         if contact_dict.get("name", None) is None:
             contact_dict["name"] = getpass.getuser()
 
@@ -244,7 +239,6 @@ class MetadataCollector:
             if corresponding fields cannot by accessed in the top-level or metadata dictionaries.
 
         """
-
         try:
             self._merge_config_dicts(context_dict, self.input_metadata[self.observatory]["context"])
             for key in ("document", "associated_elements", "associated_data"):
@@ -285,7 +279,6 @@ class MetadataCollector:
             if metadata does not exist
 
         """
-
         metadata_file_name = (
             self.args_dict.get("input_meta", None) or self.args_dict.get("input", None)
             if metadata_file_name is None
@@ -357,7 +350,6 @@ class MetadataCollector:
             if relevant fields are not defined in top level metadata dictionary.
 
         """
-
         self.schema_file = self.get_data_model_schema_file_name()
         self.schema_dict = self.get_data_model_schema_dict()
 
@@ -393,7 +385,6 @@ class MetadataCollector:
             Dictionary for process metadata fields.
 
         """
-
         process_dict["type"] = "simulation"
 
     def _fill_activity_meta(self, activity_dict):
@@ -406,7 +397,6 @@ class MetadataCollector:
             Dictionary for top-level activity metadata.
 
         """
-
         activity_dict["name"] = self.args_dict.get("label", None)
         activity_dict["type"] = "software"
         activity_dict["id"] = self.args_dict.get("activity_id", "UNDEFINED_ACTIVITY_ID")
@@ -430,7 +420,6 @@ class MetadataCollector:
             If true: add fields from dict_low to dict_high, if they don't exist in dict_high
 
         """
-
         if dict_high is None and dict_low:
             dict_high = dict_low
             return
@@ -471,7 +460,6 @@ class MetadataCollector:
             Updated meta list.
 
         """
-
         if len(new_entry_dict) == 0:
             return []
         try:
@@ -499,7 +487,6 @@ class MetadataCollector:
             Metadata dictionary.
 
         """
-
         meta_dict = gen.change_dict_keys_case(meta_dict, True)
         try:
             meta_dict[self.observatory]["product"]["description"] = self._remove_line_feed(
@@ -525,7 +512,6 @@ class MetadataCollector:
         str
             with line feeds removed
         """
-
         return string.replace("\n", " ").replace("\r", "").replace("  ", " ")
 
     def _copy_list_type_metadata(self, context_dict, _input_metadata, key):
@@ -543,7 +529,6 @@ class MetadataCollector:
             Key for metadata entry.
 
         """
-
         try:
             for document in _input_metadata["context"][key]:
                 self._fill_context_sim_list(context_dict[key], document)
@@ -565,7 +550,6 @@ class MetadataCollector:
             True if all entries are None, False otherwise.
 
         """
-
         if not isinstance(input_dict, dict):
             return input_dict is None
 

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -45,7 +45,6 @@ def validate_schema(data, schema_file):
         if validation fails
 
     """
-
     schema, schema_file = _load_schema(schema_file)
 
     try:
@@ -77,7 +76,6 @@ def get_default_metadata_dict(schema_file=None, observatory="CTA"):
 
 
     """
-
     schema, _ = _load_schema(schema_file)
     return _fill_defaults(schema["definitions"], observatory)
 
@@ -100,7 +98,6 @@ def _load_schema(schema_file=None):
         if schema file is not found
 
     """
-
     if schema_file is None:
         schema_file = files("simtools").joinpath(simtools.constants.METADATA_JSON_SCHEMA)
 
@@ -133,7 +130,6 @@ def _add_array_elements(key, schema):
         Schema dictionary with added array elements.
 
     """
-
     _list_of_array_elements = sorted(list(names.array_elements().keys()))
 
     def recursive_search(sub_schema, key):
@@ -214,7 +210,6 @@ def _fill_defaults(schema, observatory="CTA"):
         Dictionary with default values.
 
     """
-
     defaults = {observatory: {}}
 
     schema = _resolve_references(schema[observatory])

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -29,7 +29,6 @@ class ModelDataWriter:
         """
         Initialize model data writer.
         """
-
         self._logger = logging.getLogger(__name__)
         self.io_handler = io_handler.IOHandler()
         if args_dict is not None:
@@ -66,7 +65,6 @@ class ModelDataWriter:
             Schema file used in validation of output data.
 
         """
-
         writer = ModelDataWriter(
             product_data_file=(
                 args_dict.get("output_file", None) if output_file is None else output_file
@@ -94,7 +92,6 @@ class ModelDataWriter:
             Schema file used in validation of output data.
 
         """
-
         _validator = validate_data.DataValidator(
             schema_file=validate_schema_file,
             data_table=product_data,
@@ -118,7 +115,6 @@ class ModelDataWriter:
             if data writing was not successful.
 
         """
-
         if product_data is None:
             return
 
@@ -159,7 +155,6 @@ class ModelDataWriter:
         TypeError
             If yml_file is not defined.
         """
-
         try:
             yml_file = Path(yml_file or self.product_data_file).with_suffix(".metadata.yml")
             with open(yml_file, "w", encoding="UTF-8") as file:
@@ -191,7 +186,6 @@ class ModelDataWriter:
             format identifier
 
         """
-
         if product_data_format == "ecsv":
             product_data_format = "ascii.ecsv"
         return product_data_format

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -47,7 +47,6 @@ class DataValidator:
         Initialize validation class and read required reference data columns
 
         """
-
         self._logger = logging.getLogger(__name__)
 
         self.data_file_name = data_file
@@ -77,7 +76,6 @@ class DataValidator:
             if no data or data table is available
 
         """
-
         if self.data_file_name:
             self.validate_data_file()
         if isinstance(self.data_dict, dict):
@@ -98,7 +96,6 @@ class DataValidator:
         file validation).
 
         """
-
         try:
             if Path(self.data_file_name).suffix in (".yml", ".yaml", ".json"):
                 self.data_dict = gen.collect_data_from_file_or_dict(self.data_file_name, None)
@@ -114,7 +111,6 @@ class DataValidator:
         Validate that file name and key 'parameter_name' in data dict are the same.
 
         """
-
         if not self.data_dict.get("parameter") == Path(self.data_file_name).stem:
             self._logger.error(
                 f"Parameter name in data dict {self.data_dict.get('parameter')} and "
@@ -133,7 +129,6 @@ class DataValidator:
             if data dict does not contain a 'name' or 'parameter' key.
 
         """
-
         if not (_name := self.data_dict.get("name") or self.data_dict.get("parameter")):
             raise KeyError("Data dict does not contain a 'name' or 'parameter' key.")
         self._data_description = self._read_validation_schema(self.schema_file_name, _name)
@@ -167,7 +162,6 @@ class DataValidator:
         Validate tabulated data.
 
         """
-
         try:
             self._data_description = self._read_validation_schema(self.schema_file_name)[0].get(
                 "table_columns", None
@@ -191,7 +185,6 @@ class DataValidator:
         This is not applied to columns of type 'string'.
 
         """
-
         self._check_required_columns()
 
         for col_name in self.data_table.colnames:
@@ -216,7 +209,6 @@ class DataValidator:
             if a required data column is missing
 
         """
-
         for entry in self._data_description:
             if entry.get("required", False):
                 if entry["name"] in self.data_table.columns:
@@ -235,7 +227,6 @@ class DataValidator:
             if no table is defined for sorting
 
         """
-
         _columns_by_which_to_sort = []
         _columns_by_which_to_reverse_sort = []
         for entry in self._data_description:
@@ -270,7 +261,6 @@ class DataValidator:
             checked for unique values.
 
         """
-
         _column_with_unique_requirement = self._get_unique_column_requirement()
         if len(_column_with_unique_requirement) == 0:
             self._logger.debug("No data columns with unique value requirement")
@@ -303,7 +293,6 @@ class DataValidator:
             list of data column with unique value requirement
 
         """
-
         _unique_required_column = []
 
         for entry in self._data_description:
@@ -334,7 +323,6 @@ class DataValidator:
             if column name is not found in reference data columns
 
         """
-
         reference_unit = self._get_data_description(column_name).get("unit", None)
         if reference_unit in ("dimensionless", None, ""):
             return u.dimensionless_unscaled
@@ -358,7 +346,6 @@ class DataValidator:
             if data type is not correct
 
         """
-
         reference_dtype = self._get_data_description(column_name).get("type", None)
         if not gen.validate_data_type(
             reference_dtype=reference_dtype,
@@ -446,7 +433,6 @@ class DataValidator:
             If unit conversions fails
 
         """
-
         self._logger.debug(f"Checking data column '{col_name}'")
 
         reference_unit = self._get_reference_unit(col_name)
@@ -525,7 +511,7 @@ class DataValidator:
         try:
             if not self._interval_check(
                 (col_min, col_max),
-                (_entry[range_type].get("min", np.NINF), _entry[range_type].get("max", np.Inf)),
+                (_entry[range_type].get("min", -np.inf), _entry[range_type].get("max", np.inf)),
                 range_type,
             ):
                 raise ValueError
@@ -533,8 +519,8 @@ class DataValidator:
             self._logger.error(
                 f"Value for column '{col_name}' out of range. "
                 f"([{col_min}, {col_max}], {range_type}: "
-                f"[{_entry[range_type].get('min', np.NINF)}, "
-                f"{_entry[range_type].get('max', np.Inf)}])"
+                f"[{_entry[range_type].get('min', -np.inf)}, "
+                f"{_entry[range_type].get('max', np.inf)}])"
             )
             raise
 
@@ -561,7 +547,6 @@ class DataValidator:
             True if range test is passed
 
         """
-
         if range_type == "allowed_range":
             if data[0] >= axis_range[0] and data[1] <= axis_range[1]:
                 return True
@@ -596,7 +581,6 @@ class DataValidator:
             if 'data' can not be read from dict in schema file
 
         """
-
         try:
             if Path(schema_file).is_dir():
                 return gen.collect_data_from_file_or_dict(
@@ -636,7 +620,6 @@ class DataValidator:
             If data column is not found.
 
         """
-
         self._logger.debug(
             f"Getting reference data column {column_name} " f"from schema {self._data_description}"
         )

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -46,7 +46,6 @@ def update_model_parameters_from_repo(
         Updated dictionary with parameters.
 
     """
-
     logger.info(
         "Updating model parameters from repository for site: %s, telescope: %s",
         site,

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1,4 +1,4 @@
-""" Module to handle interaction with DB. """
+"""Module to handle interaction with DB."""
 
 import logging
 from pathlib import Path
@@ -130,7 +130,6 @@ class DatabaseHandler:
         dict containing the parameters
 
         """
-
         _site, _telescope_model_name, _model_version = self._validate_model_input(
             site, telescope_model_name, model_version
         )
@@ -212,7 +211,6 @@ class DatabaseHandler:
             if a file in parameters.values is not found
 
         """
-
         if self.mongo_db_config:
             self._logger.debug("Exporting model files from MongoDB")
             for info in parameters.values():
@@ -255,7 +253,6 @@ class DatabaseHandler:
         dict containing the parameters
 
         """
-
         _which_tel_labels = [
             self.get_telescope_db_name(
                 telescope_name=telescope_model_name,
@@ -321,7 +318,6 @@ class DatabaseHandler:
             if query returned zero results.
 
         """
-
         collection = DatabaseHandler.db_client[db_name][collection_name]
         _parameters = {}
 
@@ -431,7 +427,6 @@ class DatabaseHandler:
             if query returned zero results.
 
         """
-
         collection = DatabaseHandler.db_client[db_name].sites
         _parameters = {}
 
@@ -491,7 +486,6 @@ class DatabaseHandler:
         Get sim_telarray configuration parameters from the DB for a specific telescope.
 
         """
-
         _, _telescope_model_name, _model_version = self._validate_model_input(
             site, telescope_model_name, model_version
         )
@@ -526,7 +520,6 @@ class DatabaseHandler:
             Version of the model.
 
         """
-
         return (
             names.validate_site_name(site),
             names.validate_telescope_name(telescope_model_name) if telescope_model_name else None,
@@ -556,7 +549,6 @@ class DatabaseHandler:
             If the desired file is not found.
 
         """
-
         db = DatabaseHandler.db_client[db_name]
         file_system = gridfs.GridFS(db)
         if file_system.exists({"filename": file_name}):
@@ -578,7 +570,6 @@ class DatabaseHandler:
         file: GridOut
             A file instance returned by GridFS find_one
         """
-
         db = DatabaseHandler.db_client[db_name]
         fs_output = gridfs.GridFSBucket(db)
         with open(Path(path).joinpath(file.filename), "wb") as output_file:
@@ -621,7 +612,6 @@ class DatabaseHandler:
         BulkWriteError
 
         """
-
         db_name = self._get_db_name(db_name)
         if db_to_copy_to is None:
             db_to_copy_to = db_name
@@ -730,7 +720,6 @@ class DatabaseHandler:
                 }
 
         """
-
         _collection = DatabaseHandler.db_client[db_name][collection]
 
         if "version" in query:
@@ -785,7 +774,6 @@ class DatabaseHandler:
             if field not in allowed fields
 
         """
-
         db_name = self._get_db_name(db_name)
         allowed_fields = ["applicable", "unit", "type", "items", "minimum", "maximum"]
         if field not in allowed_fields:
@@ -887,7 +875,6 @@ class DatabaseHandler:
             If key to collection_name is not valid. Valid entries are: 'telescopes' and 'sites'.
 
         """
-
         db_name = self._get_db_name(db_name)
         collection = DatabaseHandler.db_client[db_name][collection_name]
 
@@ -1024,7 +1011,6 @@ class DatabaseHandler:
             if version not valid. Valid versions are: 'Released' and 'Latest'.
 
         """
-
         if version not in ["Released", "Latest"]:
             raise ValueError('The only default versions are "Released" or "Latest"')
 
@@ -1112,7 +1098,6 @@ class DatabaseHandler:
             If key to collection_name is not valid. Valid entries are: 'telescopes' and 'sites'.
 
         """
-
         collection = DatabaseHandler.db_client[self._get_db_name()][collection_name]
 
         query = {
@@ -1189,7 +1174,6 @@ class DatabaseHandler:
             If the telescope name is not found in the database.
 
         """
-
         if self._available_telescopes is None:
             self._available_telescopes = self.get_all_available_telescopes(model_version)
 

--- a/simtools/io_operations/hdf5_handler.py
+++ b/simtools/io_operations/hdf5_handler.py
@@ -38,7 +38,6 @@ def fill_hdf5_table(hist, x_bin_edges, y_bin_edges, x_label, y_label, meta_data)
     meta_data: dict
         Dictionary with the histogram metadata.
     """
-
     # Complement metadata
     if x_label is not None:
         meta_data["x_bin_edges"] = sanitize_name(x_label)

--- a/simtools/io_operations/io_handler.py
+++ b/simtools/io_operations/io_handler.py
@@ -92,7 +92,6 @@ class IOHandler(metaclass=IOHandlerSingleton):
         TypeError
             raised for errors while creating directory name
         """
-
         if self.use_plain_output_path:
             path = Path(self.output_path)
         else:
@@ -173,7 +172,6 @@ class IOHandler(metaclass=IOHandlerSingleton):
             if data_path is not set
 
         """
-
         if test:
             file_prefix = Path("tests/resources/")
         elif self.data_path is not None:

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -58,7 +58,6 @@ class JobManager:
         MissingWorkloadManager
             if workflow manager is not found.
         """
-
         if self.submit_command is None:
             return
         if self.submit_command.find("qsub") >= 0:
@@ -115,7 +114,6 @@ class JobManager:
             The log file of the actual simulator (CORSIKA or sim_telarray).
             Provided in order to print the log excerpt in case of run time error.
         """
-
         self._logger.info("Running script locally")
 
         shell_command = f"{self.run_script} > {self.run_out_file}.out 2> {self.run_out_file}.err"
@@ -137,7 +135,6 @@ class JobManager:
         Submit a job described by a shell script to HTcondor
 
         """
-
         _condor_file = self.run_script + ".condor"
         self._logger.info(f"Submitting script to HTCondor ({_condor_file})")
         try:
@@ -161,7 +158,6 @@ class JobManager:
         Submit a job described by a shell script to gridengine
 
         """
-
         this_sub_cmd = copy(self.submit_command)
         this_sub_cmd = this_sub_cmd + " -o " + self.run_out_file + ".out"
         this_sub_cmd = this_sub_cmd + " -e " + self.run_out_file + ".err"

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -63,7 +63,6 @@ class ArrayLayout:
         """
         Initialize ArrayLayout.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self.mongo_db_config = mongo_db_config
@@ -117,7 +116,6 @@ class ArrayLayout:
         ArrayLayout
             Instance of the ArrayLayout.
         """
-
         split_name = array_layout_name.split("-")
         site_name = names.validate_site_name(split_name[0])
         array_name = names.validate_array_layout_name(split_name[1])
@@ -184,7 +182,6 @@ class ArrayLayout:
             invalid array center definition.
 
         """
-
         self._array_center = TelescopePosition()
         self._array_center.name = "array_center"
         self._array_center.set_coordinates("ground", 0.0 * u.m, 0.0 * u.m)
@@ -286,7 +283,6 @@ class ArrayLayout:
             in case neither telescope name or asset_code / sequence number are given.
 
         """
-
         tel = TelescopePosition()
         try:
             tel.name = row["telescope_name"]
@@ -392,7 +388,6 @@ class ArrayLayout:
         astropy.table.QTable
             Table with the telescope layout information.
         """
-
         self._logger.debug("Initializing array (site and telescope parameters)")
         self._initialize_site_parameters_from_db()
         self._initialize_coordinate_systems()
@@ -433,7 +428,6 @@ class ArrayLayout:
             Instance of TelescopePosition.
 
         """
-
         if names.get_collection_name_from_array_element_name(telescope.name) == "telescopes":
             _telescope_model_name = self.db.get_telescope_db_name(
                 telescope_name=telescope.name, model_version=self.model_version
@@ -479,7 +473,6 @@ class ArrayLayout:
             CORSIKA z-position (requires setting of CORSIKA observation level and telescope sphere\
             center).
         """
-
         tel = TelescopePosition(name=telescope_name)
         self._set_telescope_auxiliary_parameters(tel)
         tel.set_coordinates(crs_name, xx, yy)
@@ -504,7 +497,6 @@ class ArrayLayout:
             Metadata header for array element list export.
 
         """
-
         _meta = {}
         if self._array_center:
             (
@@ -534,7 +526,6 @@ class ArrayLayout:
             Astropy table with the telescope layout information.
 
         """
-
         table = QTable(meta=self._get_export_metadata())
 
         tel_names, asset_code, sequence_number, geo_code = [], [], [], []
@@ -605,7 +596,6 @@ class ArrayLayout:
         str
             Piece of text to be added to the CORSIKA input file.
         """
-
         corsika_list = ""
         for tel in self._telescope_list:
             pos_x, pos_y, pos_z = tel.get_coordinates("ground")
@@ -632,7 +622,6 @@ class ArrayLayout:
             Name of coordinate system to be used for export.
 
         """
-
         for tel in self._telescope_list:
             tel.print_compact_format(
                 crs_name=crs_name,
@@ -644,7 +633,6 @@ class ArrayLayout:
 
     def convert_coordinates(self):
         """Perform all the possible conversions the coordinates of the tel positions."""
-
         self._logger.info("Converting telescope coordinates")
 
         crs_wgs84 = self.geo_coordinates.crs_wgs84()
@@ -673,7 +661,6 @@ class ArrayLayout:
             If the asset list is empty.
 
         """
-
         _n_telescopes = len(self._telescope_list)
         try:
             if len(asset_list) > 0:

--- a/simtools/layout/geo_coordinates.py
+++ b/simtools/layout/geo_coordinates.py
@@ -17,7 +17,6 @@ class GeoCoordinates:
         Initialize GeoCoordinates
 
         """
-
         self._logger = logging.getLogger(__name__)
 
     def crs_utm(self, epsg):
@@ -146,7 +145,6 @@ class GeoCoordinates:
             If reference_point does not have a valid center or UTM system is not defined.
 
         """
-
         try:
             _center_lat, _, _centre_altitude = reference_point.get_coordinates("mercator")
         except AttributeError:
@@ -183,7 +181,6 @@ class GeoCoordinates:
             Ellipsoid radius at given latitude.
 
         """
-
         _lat_rad = np.deg2rad(latitude)
         _numerator = (semi_major_axis**2 * np.cos(_lat_rad)) ** 2 + (
             semi_minor_axis**2 * np.sin(_lat_rad)

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -31,7 +31,6 @@ class TelescopePosition:
         """
         Initialize TelescopePosition.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self.name = name
@@ -91,7 +90,6 @@ class TelescopePosition:
         InvalidCoordSystem
            if coordinate system is not defined.
         """
-
         try:
             _zz = self.crs[crs_name]["zz"]["value"]
             _zz_header = self.crs[crs_name]["zz"]["name"]
@@ -184,7 +182,6 @@ class TelescopePosition:
         ii) return input value without change, if no unit is given
 
         """
-
         if isinstance(value, u.Quantity):
             try:
                 return value.to(unit).value
@@ -215,7 +212,6 @@ class TelescopePosition:
             If coordinate system is not known.
 
         """
-
         try:
             self.crs[crs_name]["xx"]["value"] = self._get_coordinate_value(
                 xx, self.crs[crs_name]["xx"]["unit"]
@@ -256,7 +252,6 @@ class TelescopePosition:
         ----------
         tel_altitude: astropy.Quantity
         """
-
         for _crs in self.crs.values():
             try:
                 _crs["zz"]["value"] = self._get_coordinate_value(tel_altitude, _crs["zz"]["unit"])
@@ -317,7 +312,6 @@ class TelescopePosition:
             Project of coordinate system
 
         """
-
         for _crs_name, _crs in self.crs.items():
             if self.has_coordinates(_crs_name, crs_check=True):
                 return _crs_name, _crs
@@ -473,7 +467,6 @@ class TelescopePosition:
         astropy.units.m
             Z-position of a telescope in CORSIKA system.
         """
-
         return (tel_altitude - corsika_observation_level + telescope_axis_height).to(u.m)
 
     @staticmethod
@@ -514,7 +507,6 @@ class TelescopePosition:
             Pyproj CRS of the utm coordinate system.
 
         """
-
         self._set_coordinate_system("ground", crs_local)
         self._set_coordinate_system("utm", crs_utm)
         self._set_coordinate_system("mercator", crs_wgs84)
@@ -593,7 +585,6 @@ class TelescopePosition:
            coordinate system definition
 
         """
-
         return {
             "ground": {
                 "crs": None,

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -81,7 +81,6 @@ class ArrayModel:
         ----------
         array_config_data: dict
         """
-
         # Validating array_config_data
         # Keys 'site', 'layout_name' and 'default' are mandatory.
         # 'default' must have 'LST', 'MST' and 'SST' (for South site) keys.
@@ -139,7 +138,6 @@ class ArrayModel:
         including reading the parameters from the DB.
 
         """
-
         # Getting site parameters from DB
         self._logger.debug("Getting site parameters from DB")
         self._site_model = SiteModel(
@@ -221,7 +219,6 @@ class ArrayModel:
             data: dict or str
                 Piece of the array_config_data for one specific telescope.
             """
-
             if isinstance(data, dict):
                 # Case 0: data is dict
                 if "name" not in data.keys():
@@ -248,7 +245,6 @@ class ArrayModel:
 
     def print_telescope_list(self):
         """Print out the list of telescopes for quick inspection."""
-
         for tel_data, tel_model in zip(self.layout, self._telescope_model):
             print(f"Name: {tel_data.name}\t Model: {tel_model.name}")
 
@@ -256,7 +252,6 @@ class ArrayModel:
         """
         Export sim_telarray config files for all the telescopes into the output model directory.
         """
-
         exported_models = []
         for tel_model in self._telescope_model:
             name = tel_model.name + (
@@ -275,7 +270,6 @@ class ArrayModel:
         """
         Export sim_telarray config file for the array into the output model directory.
         """
-
         # Setting file name and the location
         config_file_name = names.simtel_config_file_name(
             array_name=self.layout_name,
@@ -306,7 +300,6 @@ class ArrayModel:
         Export sim_telarray config file for the array and for each individual telescope into the \
         output model directory.
         """
-
         if not self._telescope_model_files_exported:
             self.export_simtel_telescope_config_files()
         if not self._array_model_file_exported:
@@ -322,7 +315,6 @@ class ArrayModel:
         Path
             Path of the exported config file for sim_telarray.
         """
-
         self.export_all_simtel_config_files()
         return self._config_file_path
 

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -36,7 +36,6 @@ class Camera:
         Initialize Camera class, defining pixel layout including rotation, finding neighbor pixels,
         calculating FoV and plotting the camera.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self.telescope_model_name = telescope_model_name
@@ -76,7 +75,6 @@ class Camera:
         The hexagonal shapes differ in their orientation, where those denoted as 3 are rotated
         clockwise by 30 degrees with respect to those denoted as 1.
         """
-
         pixels = {}
         pixels["pixel_diameter"] = 9999
         pixels["pixel_shape"] = 9999
@@ -89,7 +87,7 @@ class Camera:
         pixels["pix_id"] = []
         pixels["pix_on"] = []
 
-        with open(camera_config_file, "r", encoding="utf-8") as dat_file:
+        with open(camera_config_file, encoding="utf-8") as dat_file:
             for line in dat_file:
                 pix_info = line.split()
                 if line.startswith("PixType"):
@@ -144,7 +142,6 @@ class Camera:
             The pixels orientation for plotting is added to the dictionary in pixels['orientation'].
             The orientation is determined by the pixel shape (see read_pixel_list for details).
         """
-
         rotate_angle = pixels["rotate_angle"] * u.rad  # So not to change the original angle
         # The original pixel list is given such that
         # x -> North, y -> West, z -> Up in the ground system.
@@ -179,7 +176,6 @@ class Camera:
         int
             number of pixels.
         """
-
         return len(self.pixels["x"])
 
     def get_pixel_diameter(self):
@@ -191,7 +187,6 @@ class Camera:
         float
             Pixel diameter (usually in cm).
         """
-
         return self.pixels["pixel_diameter"]
 
     def get_pixel_active_solid_angle(self):
@@ -203,7 +198,6 @@ class Camera:
         float
             active solid angle of a pixel in sr.
         """
-
         pixel_area = self.get_pixel_diameter() ** 2
         # In case we have hexagonal pixels:
         if self.get_pixel_shape() == 1 or self.get_pixel_shape() == 3:
@@ -231,7 +225,6 @@ class Camera:
         str
             File name of the light guide efficiency as a function of incidence angle.
         """
-
         return self.pixels["lightguide_efficiency_angle_file"]
 
     def get_lightguide_efficiency_wavelength_file_name(self):
@@ -254,7 +247,6 @@ class Camera:
         float
             The camera fill factor.
         """
-
         if self.pixels["pixel_spacing"] == 9999:
             points = np.array([self.pixels["x"], self.pixels["y"]]).T
             pixel_distances = distance.cdist(points, points, "euclidean")
@@ -280,7 +272,6 @@ class Camera:
         -----
         The x,y pixel positions and focal length are assumed to have the same unit (usually cm)
         """
-
         self._logger.debug("Calculating the FoV")
 
         return self._calc_fov(
@@ -317,7 +308,6 @@ class Camera:
         -----
         The x,y pixel positions and focal length are assumed to have the same unit (usually cm)
         """
-
         self._logger.debug("Calculating the FoV")
 
         average_edge_distance = 0
@@ -350,7 +340,6 @@ class Camera:
         neighbours: numpy.array_like
             Array of neighbour indices in a list for each e.g., pixel.
         """
-
         points = np.array([x_pos, y_pos]).T
         indices = np.arange(len(x_pos))
         kdtree = KDTree(points)
@@ -384,7 +373,6 @@ class Camera:
         neighbours: numpy.array_like
             Array of neighbour indices in a list for each pixel
         """
-
         # First find the neighbours with the usual method and the original radius
         # which does not allow for diagonal neighbours.
         neighbours = self._find_neighbours(x_pos, y_pos, radius)
@@ -427,7 +415,6 @@ class Camera:
         neighbours: numpy.array_like
             Array of neighbour indices in a list for each pixel
         """
-
         self._logger.debug("Searching for neighbour pixels")
 
         if pixels["pixel_shape"] == 1 or pixels["pixel_shape"] == 3:
@@ -466,7 +453,6 @@ class Camera:
         neighbours: numpy.array_like
             Array of neighbour indices in a list for each pixel.
         """
-
         if self._neighbours is None:
             if pixels is None:
                 pixels = self.pixels
@@ -490,7 +476,6 @@ class Camera:
         edge_pixel_indices: numpy.array_like
             Array of edge pixel indices.
         """
-
         self._logger.debug("Searching for edge pixels")
 
         edge_pixel_indices = []
@@ -523,7 +508,6 @@ class Camera:
         edge_pixel_indices: numpy.array_like
             Array of edge pixel indices.
         """
-
         if self._edge_pixel_indices is None:
             if pixels is None:
                 pixels = self.pixels

--- a/simtools/model/mirrors.py
+++ b/simtools/model/mirrors.py
@@ -45,7 +45,6 @@ class Mirrors:
         Read the mirror lists from disk and store the data. Allow reading of mirror lists in \
         sim_telarray and ecsv format
         """
-
         if str(self._mirror_list_file).find("ecsv") > 0:
             self._read_mirror_list_from_ecsv()
         else:
@@ -60,7 +59,6 @@ class Mirrors:
         InvalidMirrorListFile
             If number of mirrors is 0.
         """
-
         self._logger.debug(f"Reading mirror properties from {self._mirror_list_file}")
         self.mirror_table = Table.read(self._mirror_list_file, format="ascii.ecsv")
 
@@ -130,7 +128,6 @@ class Mirrors:
         InvalidMirrorListFile
             If number of mirrors is 0.
         """
-
         self._logger.debug(f"Reading mirror properties from {self._mirror_list_file}")
 
         try:
@@ -195,7 +192,6 @@ class Mirrors:
         (pos_x, pos_y, mirror_diameter, focal_length, shape_type): tuple of float
             X, Y positions, mirror_diameter, focal length and shape_type.
         """
-
         mask = self.mirror_table["mirror_panel_id"] == number
         if not np.any(mask):
             self._logger.debug(f"Mirror id{number} not in table, using first mirror instead")

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -135,7 +135,6 @@ class ModelParameter:
         KeyError
             If par_name does not match any parameter in this model.
         """
-
         parameter_dict = parameter_dict if parameter_dict else self._get_parameter_dict(par_name)
         try:
             _parameter = parameter_dict["value"]
@@ -247,7 +246,6 @@ class ModelParameter:
 
     def _export_derived_files(self):
         """Write to disk a file from the derived values DB."""
-
         for par_now in self.derived.values():
             if par_now.get("File") or par_now.get("file"):
                 self.db.export_file_db(
@@ -266,7 +264,6 @@ class ModelParameter:
         Set and create the directory and the name of the config file.
 
         """
-
         if self.name is None:
             return
 
@@ -293,7 +290,6 @@ class ModelParameter:
         Read parameters from DB and store them in _parameters.
 
         """
-
         if self.db is None:
             return
 
@@ -337,7 +333,6 @@ class ModelParameter:
         extra_label: str
             Extra label to be appended to the original label.
         """
-
         self._extra_label = extra_label
         self._set_config_file_directory_and_name()
 
@@ -466,7 +461,6 @@ class ModelParameter:
 
     def export_model_files(self):
         """Exports the model files into the config file directory."""
-
         # Removing parameter files added manually (which are not in DB)
         pars_from_db = copy(self._parameters)
         if self._added_parameter_files is not None:
@@ -478,7 +472,6 @@ class ModelParameter:
 
     def export_config_file(self):
         """Export the config file used by sim_telarray."""
-
         # Exporting model file
         if not self._is_exported_model_files_up_to_date:
             self.export_model_files()

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -27,7 +27,6 @@ def compute_telescope_transmission(pars, off_axis):
     float
         Telescope transmission.
     """
-
     _deg_to_rad = math.pi / 180.0
     if pars[1] == 0:
         return pars[0]
@@ -50,7 +49,6 @@ def is_two_mirror_telescope(telescope_model_name):
     bool
         True if the telescope is a two mirror one.
     """
-
     tel_type = names.get_telescope_type_from_telescope_name(telescope_model_name)
     if "SST" in tel_type or "SCT" in tel_type:
         return True

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -53,7 +53,6 @@ class SiteModel(ModelParameter):
         dict
             Reference point coordinates as dict
         """
-
         return {
             "center_altitude": self.get_parameter_value_with_unit("reference_point_altitude"),
             "center_northing": self.get_parameter_value_with_unit("reference_point_utm_north"),
@@ -77,7 +76,6 @@ class SiteModel(ModelParameter):
             Site-related CORSIKA parameters as dict
 
         """
-
         # backwards compatibility to `corsika_parameters.yml` (temporary TODO)
         if config_file_style:
             _atmosphere_id = 26 if self.site == "North" else 36

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -213,7 +213,7 @@ class TelescopeModel(ModelParameter):
             return False
 
         file = self.config_file_directory.joinpath(file_name)
-        with open(file, "r", encoding="utf-8") as f:
+        with open(file, encoding="utf-8") as f:
             is_2d = "@RPOL@" in f.read()
         return is_2d
 
@@ -233,11 +233,10 @@ class TelescopeModel(ModelParameter):
         dict:
             dict of three arrays, wavelength, degrees, z.
         """
-
         _file = self.config_file_directory.joinpath(file_name)
         self._logger.debug("Reading two dimensional distribution from %s", _file)
         line_to_start_from = 0
-        with open(_file, "r", encoding="utf-8") as f:
+        with open(_file, encoding="utf-8") as f:
             for i_line, line in enumerate(f):
                 if line.startswith("ANGLE"):
                     degrees = np.array(line.strip().split("=")[1].split(), dtype=np.float16)
@@ -254,7 +253,6 @@ class TelescopeModel(ModelParameter):
 
     def get_on_axis_eff_optical_area(self):
         """Return the on-axis effective optical area (derived previously for this telescope)."""
-
         ray_tracing_data = astropy.io.ascii.read(
             self.config_file_directory.joinpath(self.get_parameter_value("optics_properties"))
         )
@@ -280,7 +278,6 @@ class TelescopeModel(ModelParameter):
         incidence_angle_dist: astropy.table.Table
             Instance of astropy.table.Table with the incidence angle distribution.
         """
-
         self._logger.debug(
             "Reading incidence angle distribution from %s",
             self.config_file_directory.joinpath(incidence_angle_dist_file),
@@ -311,7 +308,6 @@ class TelescopeModel(ModelParameter):
         average_curve: astropy.table.Table
             Instance of astropy.table.Table with the averaged curve.
         """
-
         weights = []
         for angle_now in curves["Angle"]:
             weights.append(
@@ -343,7 +339,6 @@ class TelescopeModel(ModelParameter):
         Path:
             Path to the file exported.
         """
-
         file_to_write_to = self._config_file_directory.joinpath(file_name)
         table.write(file_to_write_to, format="ascii.commented_header", overwrite=True)
         return file_to_write_to.absolute()

--- a/simtools/psf_analysis.py
+++ b/simtools/psf_analysis.py
@@ -39,7 +39,6 @@ class PSFImage:
         """
         Initialize PSFImage class.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self._total_photons = None
@@ -420,7 +419,6 @@ class PSFImage:
         -------
         (radius, intensity)
         """
-
         if radius is not None:
             radius_all = radius.to(u.cm).value
         else:
@@ -441,7 +439,8 @@ class PSFImage:
         Parameters
         ----------
         **kwargs:
-            image_* for the histogram plot and psf_* for the psf circle."""
+            image_* for the histogram plot and psf_* for the psf circle.
+        """
         data = self.get_cumulative_data()
         plt.plot(data["Radius [cm]"], data["Cumulative PSF"], **kwargs)
 

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -61,7 +61,6 @@ class RayTracing:
         """
         Initialize RayTracing class.
         """
-
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Initializing RayTracing class")
 
@@ -247,7 +246,6 @@ class RayTracing:
             Containment fraction for PSF containment calculation. Allowed values are in the
             interval [0,1]
         """
-
         do_analyze = not self._file_results.exists() or force
 
         focal_length = float(self._telescope_model.get_parameter_value("focal_length"))
@@ -353,7 +351,6 @@ class RayTracing:
         (containment_diameter_cm, x_mean, y_mean, eff_area)
 
         """
-
         try:
             rx_output = subprocess.Popen(  # pylint: disable=consider-using-with
                 shlex.split(
@@ -411,7 +408,6 @@ class RayTracing:
         KeyError
             If key is not among the valid options.
         """
-
         self._logger.info(f"Plotting {key} vs off-axis angle")
 
         try:

--- a/simtools/simtel/simtel_config_reader.py
+++ b/simtools/simtel/simtel_config_reader.py
@@ -142,7 +142,6 @@ class SimtelConfigReader:
             Dictionary to export.
 
         """
-
         try:
             dict_to_write["value"] = gen.convert_list_to_string(dict_to_write["value"])
             dict_to_write["unit"] = gen.convert_list_to_string(dict_to_write["unit"], True)
@@ -168,7 +167,6 @@ class SimtelConfigReader:
         in 'default' and 'limits' entries.
 
         """
-
         for data_type in ["default", "limits"]:
             _from_simtel = self.parameter_dict.get(data_type)
             # ignore limits checks for boolean
@@ -233,14 +231,13 @@ class SimtelConfigReader:
             Dictionary with the parameter values.
 
         """
-
         self._logger.debug(
             f"Reading simtel config file {simtel_config_file} "
             f"for parameter {self.parameter_name}"
         )
         matching_lines = {}
         try:
-            with open(simtel_config_file, "r", encoding="utf-8") as file:
+            with open(simtel_config_file, encoding="utf-8") as file:
                 for line in file:
                     # split line into parts (space, tabs, comma separated)
                     parts_of_lines = re.split(r",\s*|\s+", line.strip())
@@ -290,7 +287,6 @@ class SimtelConfigReader:
             List of resolved strings.
 
         """
-
         # don't do anything if all string items in column do not start with 'all'
         if not any(isinstance(item, str) and item.startswith("all") for item in column):
             return column, {}
@@ -385,7 +381,6 @@ class SimtelConfigReader:
             Type and dimension.
 
         """
-
         if column[0].lower() == "text" or column[0].lower() == "func":
             return "str", 1
         if column[0].lower() == "ibool":
@@ -410,7 +405,6 @@ class SimtelConfigReader:
             Parameter name as used in sim_telarray.
 
         """
-
         try:
             for sim_soft in self.schema_dict["simulation_software"]:
                 if sim_soft["name"] == "sim_telarray":
@@ -438,7 +432,6 @@ class SimtelConfigReader:
             True if parameter is applicable to telescope.
 
         """
-
         try:
             if telescope_name in self.schema_dict["instrument"]["type"]:
                 return True
@@ -461,7 +454,6 @@ class SimtelConfigReader:
             True if parameter is a file.
 
         """
-
         try:
             return self.schema_dict["data"][0]["type"] == "file"
         except (KeyError, IndexError):
@@ -501,7 +493,6 @@ class SimtelConfigReader:
             Validated dictionary (possibly converted to reference units).
 
         """
-
         self._logger.debug(
             f"Validating parameter dictionary {parameter_dict} using {self.schema_file}"
         )

--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -101,7 +101,6 @@ class SimtelConfigWriter:
             Dictionary with simtel metadata.
 
         """
-
         parameters = {}
         parameters["config_release"] = (
             f"{self._model_version} written by " f"simtools v{simtools.version.__version__}"

--- a/simtools/simtel/simtel_events.py
+++ b/simtools/simtel/simtel_events.py
@@ -72,7 +72,6 @@ class SimtelEvents:
         Read MC header from sim_telarray files and store it into _mc_header. Also fills \
         summary_events with energy and core radius of triggered events.
         """
-
         self._number_of_files = len(self.input_files)
         keys_to_grab = [
             "obsheight",

--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -115,7 +115,8 @@ class SimtelHistograms:
     @property
     def combined_hists(self):
         """Add the values of the same type of histogram from the various lists into a single
-        histogram list."""
+        histogram list.
+        """
         # Processing and combining histograms from multiple files
         if self._combined_hists is None:
             self._combined_hists = []
@@ -230,7 +231,6 @@ class SimtelHistograms:
         hists: list
             List with the final trigger rate for each histogram.
         """
-
         list_of_integrated_hists = []
         for _, hist in enumerate(hists):
             energy_axis = np.logspace(hist["lower_y"], hist["upper_y"], hist["n_bins_y"])
@@ -268,7 +268,6 @@ class SimtelHistograms:
         ax: matplotlib.axes.Axes
             Instance of matplotlib.axes.Axes in which to plot the histogram.
         """
-
         hist = self.combined_hists[i_hist]
         ax.set_title(hist["title"])
 
@@ -350,7 +349,6 @@ class SimtelHistograms:
         dict
             Meta dictionary for the hdf5 files with the histograms.
         """
-
         if self.__meta_dict is None:
             self.__meta_dict = {
                 "simtools_version": version.__version__,

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -37,7 +37,6 @@ class SimtelRunner:
         """
         Initialize SimtelRunner.
         """
-
         self._logger = logging.getLogger(__name__)
 
         self._simtel_source_path = Path(simtel_source_path)
@@ -206,7 +205,6 @@ class SimtelRunner:
         ------
         SimtelExecutionError
         """
-
         if hasattr(self, "_log_file"):
             msg = gen.get_log_excerpt(self._log_file)
         else:

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -86,7 +86,6 @@ class SimtelRunnerArray(SimtelRunner):
         be used. A sub directory simtel-data will be created and sub directories for
         log and data will be created inside it.
         """
-
         if self.config.simtel_data_directory is None:
             # Default config value
             simtel_base_dir = self._base_directory
@@ -160,7 +159,6 @@ class SimtelRunnerArray(SimtelRunner):
         ValueError
             If file_type is unknown.
         """
-
         file_label = (
             f"_{kwargs['label']}" if "label" in kwargs and kwargs["label"] is not None else ""
         )
@@ -197,7 +195,6 @@ class SimtelRunnerArray(SimtelRunner):
         mode: str
             Mode.
         """
-
         info_for_file_name = self.get_info_for_file_name(run_number)
         run_sub_file = self.get_file_name(file_type, **info_for_file_name, mode=mode)
         return Path(run_sub_file).is_file()
@@ -217,7 +214,6 @@ class SimtelRunnerArray(SimtelRunner):
             run time of job in seconds.
 
         """
-
         info_for_file_name = self.get_info_for_file_name(run_number)
         sub_log_file = self.get_file_name("sub_log", **info_for_file_name, mode="out")
 
@@ -226,7 +222,7 @@ class SimtelRunnerArray(SimtelRunner):
         _resources = {}
 
         _resources["runtime"] = None
-        with open(sub_log_file, "r", encoding="utf-8") as file:
+        with open(sub_log_file, encoding="utf-8") as file:
             for line in reversed(list(file)):
                 if "RUNTIME" in line:
                     _resources["runtime"] = int(line.split()[1])
@@ -258,7 +254,6 @@ class SimtelRunnerArray(SimtelRunner):
                     run number
 
         """
-
         run_number = kwargs["run_number"] if "run_number" in kwargs else 1
         info_for_file_name = self.get_info_for_file_name(run_number)
         self._log_file = self.get_file_name(file_type="log", **info_for_file_name)

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -73,7 +73,6 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         """
         Prepare the command used to run testeff
         """
-
         self._logger.debug("Preparing the command to run testeff")
 
         # Processing camera pixel features
@@ -221,11 +220,10 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         This function makes sure the file has at least three columns,
         by copying the second column to the third.
         """
-
         validated_nsb_spectrum_file = (
             self._telescope_model.config_file_directory / Path(nsb_spectrum_file).name
         )
-        with open(nsb_spectrum_file, "r", encoding="utf-8") as file:
+        with open(nsb_spectrum_file, encoding="utf-8") as file:
             lines = file.readlines()
         with open(validated_nsb_spectrum_file, "w", encoding="utf-8") as file:
             for line in lines:

--- a/simtools/simtel/simtel_runner_ray_tracing.py
+++ b/simtools/simtel/simtel_runner_ray_tracing.py
@@ -99,7 +99,6 @@ class SimtelRunnerRayTracing(SimtelRunner):
         Which file are required for running depends on the mode.
         Here we define and write some information into these files. Log files are always required.
         """
-
         # This file is not actually needed and does not exist in simtools.
         # However, we need to provide the name of a CORSIKA input file to sim_telarray
         # so it is set up here.
@@ -157,7 +156,6 @@ class SimtelRunnerRayTracing(SimtelRunner):
 
     def _make_run_command(self, **kwargs):  # pylint: disable=unused-argument
         """Return the command to run simtel_array."""
-
         if self.config.single_mirror_mode:
             _mirror_focal_length = float(
                 self.telescope_model.get_parameter_value("mirror_focal_length")
@@ -251,7 +249,6 @@ class SimtelRunnerRayTracing(SimtelRunner):
             Default configuration for ray tracing.
 
         """
-
         return {
             "zenith_angle": {
                 "len": 1,

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -162,7 +162,6 @@ class Simulator:
         gen.InvalidConfigData
 
         """
-
         if simulator not in ["simtel", "corsika", "corsika_simtel"]:
             raise gen.InvalidConfigData
         self._simulator = simulator.lower()
@@ -202,7 +201,6 @@ class Simulator:
             Dict with simulator configuration data.
 
         """
-
         self._corsika_config_data = copy(config_data)
 
         try:
@@ -265,7 +263,6 @@ class Simulator:
             Configuration of array simulations.
 
         """
-
         common = copy(config_data.pop("common", {}))
         config_showers = copy(config_data.pop("showers", {})) | common
         config_arrays = copy(config_data.pop("array", {})) | common
@@ -439,7 +436,6 @@ class Simulator:
             Single file or list of files of shower simulations.
 
         """
-
         self._logger.info(f"Submission command: {self._submit_command}")
 
         runs_and_files_to_submit = self._get_runs_and_files_to_submit(
@@ -479,7 +475,6 @@ class Simulator:
             Single file or list of files of shower simulations.
 
         """
-
         runs_and_files_to_submit = self._get_runs_and_files_to_submit(
             input_file_list=input_file_list
         )
@@ -507,7 +502,6 @@ class Simulator:
             file name as value
 
         """
-
         _runs_and_files = {}
 
         if self.simulator == "simtel":
@@ -566,7 +560,6 @@ class Simulator:
             run number
 
         """
-
         info_for_file_name = self._simulation_runner.get_info_for_file_name(run)
         self._results["output"].append(
             str(self._simulation_runner.get_file_name(file_type="output", **info_for_file_name))
@@ -709,7 +702,6 @@ class Simulator:
            Dictionary with reports on computing resources
 
         """
-
         if len(self._results["sub_out"]) == 0:
             if input_file_list is None:
                 return {"Walltime/run [sec]": np.nan}
@@ -790,7 +782,6 @@ class Simulator:
             file type (e.g., log)
 
         """
-
         if which not in self._results:
             self._logger.error(f"Invalid file type {which}")
             raise KeyError

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -89,7 +89,6 @@ def validate_config_data(config_data, parameters, ignore_unidentified=False):
     namedtuple:
         Containing the validated config data entries.
     """
-
     # Dict to be filled and returned
     out_data = {}
 
@@ -169,7 +168,6 @@ def _validate_and_convert_value_without_units(value, value_keys, par_name, par_i
         validated and converted input data
 
     """
-
     _, undefined_length = _check_value_entry_length(value, par_name, par_info)
 
     # Checking if values have unit and raising error, if so.
@@ -208,7 +206,6 @@ def _check_value_entry_length(value, par_name, par_info):
         state of input list
 
     """
-
     # Checking the entry length
     value_length = len(value)
     _logger.debug(f"Value len of {par_name}: {value_length}")
@@ -246,7 +243,6 @@ def _validate_and_convert_value_with_units(value, value_keys, par_name, par_info
         validated and converted input data
 
     """
-
     value_length, undefined_length = _check_value_entry_length(value, par_name, par_info)
 
     par_unit = copy_as_list(par_info["unit"])
@@ -296,7 +292,6 @@ def _validate_and_convert_value(par_name, par_info, value_in):
     Validate input user parameter and convert it to the right units, if needed.
     Returns the validated arguments in a list.
     """
-
     if isinstance(value_in, dict):
         value = [d for (k, d) in value_in.items()]
         value_keys = [k for (k, d) in value_in.items()]
@@ -349,7 +344,6 @@ def is_url(url):
         True if url is a valid URL.
 
     """
-
     try:
         result = urlparse(url)
         return all([result.scheme, result.netloc])
@@ -380,7 +374,6 @@ def collect_data_from_http(url):
         If downloading the yaml file fails.
 
     """
-
     try:
         with tempfile.NamedTemporaryFile(mode="w+t") as tmp_file:
             urllib.request.urlretrieve(url, tmp_file.name)
@@ -429,7 +422,6 @@ def collect_data_from_file_or_dict(file_name, in_dict, allow_empty=False):
     data: dict or list
         Data as dict or list.
     """
-
     if file_name is not None:
         if in_dict is not None:
             _logger.warning("Both in_dict and file_name were given - file_name will be used")
@@ -471,6 +463,7 @@ def collect_kwargs(label, in_kwargs):
         Label to be collected in kwargs.
     in_kwargs: dict
         kwargs.
+
     Returns
     -------
     dict
@@ -577,7 +570,6 @@ def get_log_level_from_user(log_level):
     logging.LEVEL
         The requested logging level to be used as input to logging.setLevel().
     """
-
     possible_levels = {
         "info": logging.INFO,
         "debug": logging.DEBUG,
@@ -695,7 +687,6 @@ def find_file(name, loc):
     FileNotFoundError
         If the desired file is not found.
     """
-
     all_locations = copy.copy(loc)
     all_locations = [all_locations] if not isinstance(all_locations, list) else all_locations
 
@@ -750,7 +741,6 @@ def get_log_excerpt(log_file, n_last_lines=30):
     str
         Excerpt from log file with header/footer
     """
-
     return (
         "\n\nRuntime error - See below the relevant part of the log/err file.\n\n"
         f"{log_file}\n"
@@ -787,7 +777,6 @@ def change_dict_keys_case(data_dict, lower_case=True):
     lower_case: bool
         Change keys to lower (upper) case if True (False).
     """
-
     _return_dict = {}
     try:
         for key in data_dict.keys():
@@ -861,12 +850,12 @@ def sort_arrays(*args):
     ----------
     *args
         Arguments to be sorted.
+
     Returns
     -------
     list
         Sorted args.
     """
-
     if len(args) == 0:
         return args
     order_array = copy.copy(args[0])
@@ -917,7 +906,6 @@ def get_value_unit_type(value, unit_str=None):
         Value, unit in string representation (to_string())),
         and string representation of the type of the value.
     """
-
     base_unit = None
     if isinstance(value, (str, u.Quantity)):
         try:
@@ -1102,7 +1090,6 @@ def convert_string_to_list(data_string, is_float=True):
         Return data_string if conversion fails.
 
     """
-
     try:
         if is_float:
             return [float(v) for v in data_string.split()]

--- a/simtools/utils/geometry.py
+++ b/simtools/utils/geometry.py
@@ -41,7 +41,6 @@ def convert_2d_to_radial_distr(hist_2d, xaxis, yaxis, bins=50, max_dist=1000):
         The bin edges of the 1D histogram with size = int(max_dist/bin_size) + 1.
 
     """
-
     # Check if the histogram will make sense
     bins_step = 2 * max_dist / bins  # in the 2d array, the positive and negative direction count.
     for axis in [xaxis, yaxis]:
@@ -126,7 +125,6 @@ def rotate(x, y, rotation_around_z_axis, rotation_around_y_axis=0):
     UnitsError:
         If the unit of x and y are different.
     """
-
     allowed_types = (list, np.ndarray, u.Quantity, float, int)
     if not all(isinstance(variable, (allowed_types)) for variable in [x, y]):
         raise TypeError("x and y types are not valid! Cannot perform transformation.")

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -1,7 +1,7 @@
 import glob
 import logging
 import re
-from functools import lru_cache
+from functools import cache
 from pathlib import Path
 
 import yaml
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 
-@lru_cache(maxsize=None)
+@cache
 def array_elements():
     """
     Load array elements from reference files and keep in cache.
@@ -35,7 +35,7 @@ def array_elements():
         Array elements.
     """
     base_path = Path(__file__).parent
-    with open(base_path / "../schemas/array_elements.yml", "r", encoding="utf-8") as file:
+    with open(base_path / "../schemas/array_elements.yml", encoding="utf-8") as file:
         return yaml.safe_load(file)["data"]
 
 
@@ -80,12 +80,12 @@ array_layout_names = {
 }
 
 
-@lru_cache(maxsize=None)
+@cache
 def load_model_parameters(class_key_list):
     model_parameters = {}
     schema_files = glob.glob(str(Path(__file__).parent / "../schemas/model_parameters") + "/*.yml")
     for schema_file in schema_files:
-        with open(schema_file, "r", encoding="utf-8") as f:
+        with open(schema_file, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         try:
             if data["instrument"]["class"] in class_key_list:
@@ -125,7 +125,6 @@ def validate_telescope_id_name(name):
     ValueError
         If name is not valid.
     """
-
     if isinstance(name, int) or name.isdigit():
         return f"{int(name):02d}"
     if name.lower() in ("design", "test"):
@@ -198,6 +197,7 @@ def _validate_name(name, all_names):
         Name to validate.
     all_names: dict
         Dictionary with valid names.
+
     Returns
     -------
     str
@@ -208,7 +208,6 @@ def _validate_name(name, all_names):
     ValueError
         If name is not valid.
     """
-
     for key in all_names.keys():
         if isinstance(all_names[key], list) and name.lower() in [
             item.lower() for item in all_names[key]
@@ -339,7 +338,6 @@ def get_collection_name_from_array_element_name(name):
     str
         Collection name .
     """
-
     return array_elements()[get_telescope_type_from_telescope_name(name)]["collection"]
 
 
@@ -370,7 +368,6 @@ def get_simulation_software_name_from_parameter_name(
     str
         Simtel parameter name.
     """
-
     _parameter_names = {}
     if search_telescope_parameters:
         _parameter_names.update(telescope_parameters())
@@ -407,7 +404,6 @@ def get_parameter_name_from_simtel_name(simtel_name):
     str
         Model parameter name.
     """
-
     _parameters = {**telescope_parameters(), **site_parameters()}
 
     for par_name, par_info in _parameters.items():
@@ -599,7 +595,6 @@ def sanitize_name(name):
     ValueError:
         if the string `name` can not be sanitized.
     """
-
     # Convert to lowercase
     sanitized = name.lower()
 

--- a/simtools/visualization/legend_handlers.py
+++ b/simtools/visualization/legend_handlers.py
@@ -36,7 +36,7 @@ magic = "MAGIC"
 veritas = "VERITAS"
 
 
-class TelescopeHandler(object):
+class TelescopeHandler:
     """
     Telescope handler that centralizes the telescope information. Individual telescopes handlers
     inherit from this class.
@@ -69,51 +69,51 @@ class TelescopeHandler(object):
         }
 
 
-class PixelObject(object):
+class PixelObject:
     """Pixel Object."""
 
 
-class EdgePixelObject(object):
+class EdgePixelObject:
     """Edge-Pixel Object."""
 
 
-class OffPixelObject(object):
+class OffPixelObject:
     """Off-Pixel Object."""
 
 
-class LSTObject(object):
+class LSTObject:
     """LST Object."""
 
 
-class MSTObject(object):
+class MSTObject:
     """MST Object."""
 
 
-class SCTObject(object):
+class SCTObject:
     """SCT Object."""
 
 
-class SSTObject(object):
+class SSTObject:
     """SST Object."""
 
 
-class HESSObject(object):
+class HESSObject:
     """HESS Object."""
 
 
-class MAGICObject(object):
+class MAGICObject:
     """MAGIC Object."""
 
 
-class VERITASObject(object):
+class VERITASObject:
     """VERITAS Object."""
 
 
-class MeanRadiusOuterEdgeObject(object):
+class MeanRadiusOuterEdgeObject:
     """Object for Mean radius outer edge."""
 
 
-class HexPixelHandler(object):
+class HexPixelHandler:
     """
     Legend handler class to plot a hexagonal "on" pixel.
     """
@@ -135,7 +135,7 @@ class HexPixelHandler(object):
         return patch
 
 
-class HexEdgePixelHandler(object):
+class HexEdgePixelHandler:
     """
     Legend handler class to plot a hexagonal "edge" pixel.
     """
@@ -160,7 +160,7 @@ class HexEdgePixelHandler(object):
         return patch
 
 
-class HexOffPixelHandler(object):
+class HexOffPixelHandler:
     """
     Legend handler class to plot a hexagonal "off" pixel.
     """
@@ -185,7 +185,7 @@ class HexOffPixelHandler(object):
         return patch
 
 
-class SquarePixelHandler(object):
+class SquarePixelHandler:
     """
     Legend handler class to plot a square "on" pixel.
     """
@@ -206,7 +206,7 @@ class SquarePixelHandler(object):
         return patch
 
 
-class SquareEdgePixelHandler(object):
+class SquareEdgePixelHandler:
     """
     Legend handler class to plot a square "edge" pixel.
     """
@@ -227,7 +227,7 @@ class SquareEdgePixelHandler(object):
         return patch
 
 
-class SquareOffPixelHandler(object):
+class SquareOffPixelHandler:
     """
     Legend handler class to plot a square "off" pixel.
     """
@@ -406,7 +406,7 @@ class VERITASHandler(TelescopeHandler):
         return patch
 
 
-class MeanRadiusOuterEdgeHandler(object):
+class MeanRadiusOuterEdgeHandler:
     """
     Legend handler class to plot a the mean radius outer edge of the dish.
     """

--- a/simtools/visualization/plot_camera.py
+++ b/simtools/visualization/plot_camera.py
@@ -34,7 +34,6 @@ def plot_pixel_layout(camera, camera_in_sky_coor=False, pixels_id_to_print=50):
     fig: plt.figure instance
         Figure with the pixel layout.
     """
-
     logger.info(f"Plotting the {camera.telescope_model_name} camera")
 
     fig, ax = plt.subplots()
@@ -213,7 +212,6 @@ def _plot_axes_def(camera, plot, rotate_angle):
     rotate_angle: float
         The rotation angle applied
     """
-
     invert_yaxis = False
     x_left = 0.7  # Position of the left most axis
     if not is_two_mirror_telescope(camera.telescope_model_name):
@@ -297,7 +295,6 @@ def _plot_one_axis_def(plot, **kwargs):
             invert_yaxis: bool
             Flag to invert the y-axis (for dual mirror telescopes).
     """
-
     x_title = kwargs["x_title"]
     y_title = kwargs["y_title"]
     x_pos, y_pos = (kwargs["x_pos"], kwargs["y_pos"])

--- a/simtools/visualization/visualize.py
+++ b/simtools/visualization/visualize.py
@@ -139,7 +139,6 @@ def _add_unit(title, array):
     str
         Title with units.
     """
-
     unit = ""
     if isinstance(array, u.Quantity):
         unit = str(array[0].unit)
@@ -187,7 +186,6 @@ def set_style(palette="default", big_plot=False):
     KeyError
         if provided palette does not exist.
     """
-
     if palette not in COLORS:
         raise KeyError(f"palette must be one of {', '.join(COLORS)}")
 
@@ -238,7 +236,6 @@ def get_colors(palette="default"):
     KeyError
         if provided palette does not exist.
     """
-
     if palette not in COLORS:
         raise KeyError(f"palette must be one of {', '.join(COLORS)}")
 
@@ -254,7 +251,6 @@ def get_markers():
     list
         List with markers.
     """
-
     return MARKERS
 
 
@@ -267,7 +263,6 @@ def get_lines():
     list
         List with line styles.
     """
-
     return LINES
 
 
@@ -318,7 +313,6 @@ def plot_1d(data, **kwargs):
     ValueError
         if asked to plot a ratio or difference with just one set of data
     """
-
     palette = kwargs.get("palette", "default")
     kwargs.pop("palette", None)
     big_plot = kwargs.get("big_plot", False)
@@ -471,7 +465,6 @@ def plot_table(table, y_title, **kwargs):
     ValueError
         if table has less than two columns.
     """
-
     if len(table.keys()) < 2:
         raise ValueError("Table has to have at least two columns")
 
@@ -502,7 +495,6 @@ def plot_hist_2d(data, **kwargs):
         Instance of pyplot.figure in which the plot was produced.
 
     """
-
     cmap = plt.cm.gist_heat_r
     if "title" in kwargs:
         title = kwargs["title"]
@@ -620,7 +612,6 @@ def plot_array(telescopes, rotate_angle=0, show_tel_label=False):
         Instance of plt.figure with the array of telescopes plotted.
 
     """
-
     fig, ax = plt.subplots(1)
     legend_objects = []
     legend_labels = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from simtools.model.telescope_model import TelescopeModel
 logger = logging.getLogger()
 
 
-@pytest.fixture
+@pytest.fixture()
 def tmp_test_directory(tmpdir_factory):
     """
     Sets test directories.
@@ -35,7 +35,7 @@ def tmp_test_directory(tmpdir_factory):
     return tmp_test_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def io_handler(tmp_test_directory):
     tmp_io_handler = simtools.io_operations.io_handler.IOHandler()
     tmp_io_handler.set_paths(
@@ -46,7 +46,7 @@ def io_handler(tmp_test_directory):
     return tmp_io_handler
 
 
-@pytest.fixture
+@pytest.fixture()
 def mock_settings_env_vars(tmp_test_directory):
     """
     Removes all environment variable from the test system.
@@ -73,7 +73,7 @@ def mock_settings_env_vars(tmp_test_directory):
         yield
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_path():
     """
     This fixture does not really set the sim_telarray path because it is used only
@@ -82,7 +82,7 @@ def simtel_path():
     return Path("")
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_path_no_mock():
     load_dotenv(".env")
     simtel_path = Path(os.path.expandvars("$SIMTOOLS_SIMTEL_PATH"))
@@ -91,7 +91,7 @@ def simtel_path_no_mock():
     return ""
 
 
-@pytest.fixture
+@pytest.fixture()
 def args_dict(tmp_test_directory, simtel_path):
     return Configurator().default_config(
         (
@@ -105,7 +105,7 @@ def args_dict(tmp_test_directory, simtel_path):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def args_dict_site(tmp_test_directory, simtel_path):
     return Configurator().default_config(
         (
@@ -125,7 +125,7 @@ def args_dict_site(tmp_test_directory, simtel_path):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def configurator(tmp_test_directory, mock_settings_env_vars, simtel_path):
     config = Configurator()
     config.default_config(
@@ -134,7 +134,7 @@ def configurator(tmp_test_directory, mock_settings_env_vars, simtel_path):
     return config
 
 
-@pytest.fixture
+@pytest.fixture()
 def db_config():
     """
     Read DB configuration from tests from .env file and from environmental variables.
@@ -162,7 +162,7 @@ def db_config():
     return mongo_db_config
 
 
-@pytest.fixture
+@pytest.fixture()
 def simulation_model_url(db_config):
     if (
         db_config["db_simulation_model_url"] is None
@@ -175,13 +175,13 @@ def simulation_model_url(db_config):
     return db_config["db_simulation_model_url"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def db(db_config):
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
     return db
 
 
-@pytest.fixture
+@pytest.fixture()
 def db_no_config_file():
     """
     Same as db above, but without DB variable defined,
@@ -197,7 +197,7 @@ def pytest_addoption(parser):
     parser.addoption("--model_version", action="store", default=None)
 
 
-@pytest.fixture
+@pytest.fixture()
 def model_version():
     """
     Simulation model version used in tests.
@@ -205,7 +205,7 @@ def model_version():
     return "2024-02-01"
 
 
-@pytest.fixture
+@pytest.fixture()
 def site_model_south(db_config, model_version):
     return SiteModel(
         site="South",
@@ -215,7 +215,7 @@ def site_model_south(db_config, model_version):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def site_model_north(db_config, model_version):
     return SiteModel(
         site="North",
@@ -225,7 +225,7 @@ def site_model_north(db_config, model_version):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_model_lst(db_config, io_handler, model_version):
     telescope_model_LST = TelescopeModel(
         site="North",
@@ -237,7 +237,7 @@ def telescope_model_lst(db_config, io_handler, model_version):
     return telescope_model_LST
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_model_mst(db_config, io_handler, model_version):
     tel = TelescopeModel(
         site="South",
@@ -250,7 +250,7 @@ def telescope_model_mst(db_config, io_handler, model_version):
     return tel
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_model_sst(db_config, io_handler, model_version):
     telescope_model_SST = TelescopeModel(
         site="South",
@@ -263,7 +263,7 @@ def telescope_model_sst(db_config, io_handler, model_version):
 
 
 # TODO - keep prod5 until a complete prod6 model is in the DB
-@pytest.fixture
+@pytest.fixture()
 def telescope_model_sst_prod5(db_config, io_handler):
     telescope_model_SST = TelescopeModel(
         site="South",
@@ -275,51 +275,51 @@ def telescope_model_sst_prod5(db_config, io_handler):
     return telescope_model_SST
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_layout_north_instance(io_handler, db_config, model_version):
     return ArrayLayout(
         site="North", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_layout_south_instance(io_handler, db_config, model_version):
     return ArrayLayout(
         site="South", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_north_with_calibration_devices_test_file():
     return "tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv"
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_north_test_file():
     return "tests/resources/telescope_positions-North-ground.ecsv"
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_north_utm_test_file():
     return "tests/resources/telescope_positions-North-utm.ecsv"
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_north_mercator_test_file():
     return "tests/resources/telescope_positions-North-mercator.ecsv"
 
 
-@pytest.fixture
+@pytest.fixture()
 def telescope_south_test_file():
     return "tests/resources/telescope_positions-South-ground.ecsv"
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_output_file_name():
     return "tests/resources/tel_output_10GeV-2-gamma-20deg-CTAO-South.corsikaio"
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_histograms_instance(io_handler, corsika_output_file_name):
     from simtools.corsika.corsika_histograms import CorsikaHistograms
 
@@ -328,13 +328,13 @@ def corsika_histograms_instance(io_handler, corsika_output_file_name):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_histograms_instance_set_histograms(db, io_handler, corsika_histograms_instance):
     corsika_histograms_instance.set_histograms()
     return corsika_histograms_instance
 
 
-@pytest.fixture
+@pytest.fixture()
 def simulator_config_data(tmp_test_directory, model_version):
     return {
         "common": {
@@ -358,17 +358,17 @@ def simulator_config_data(tmp_test_directory, model_version):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_config_data(simulator_config_data):
     return simulator_config_data["common"] | simulator_config_data["array"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def shower_config_data(simulator_config_data):
     return simulator_config_data["common"] | simulator_config_data["showers"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def file_has_text():
     def wrapper(file, text):
         try:

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -196,14 +196,14 @@ def assert_file_type(file_type, file_name):
 
     if file_type == "json":
         try:
-            with open(file_name, "r", encoding="utf-8") as file:
+            with open(file_name, encoding="utf-8") as file:
                 json.load(file)
             return True
         except (json.JSONDecodeError, FileNotFoundError):
             return False
     if file_type == "yaml" or file_type == "yml":
         try:
-            with open(file_name, "r", encoding="utf-8") as file:
+            with open(file_name, encoding="utf-8") as file:
                 yaml.safe_load(file)
             return True
         except (yaml.YAMLError, FileNotFoundError):

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -104,7 +104,6 @@ def test_azimuth_angle(caplog):
 
 
 def test_initialize_default_arguments():
-
     # default arguments
     _parser_1 = parser.CommandLineParser()
     _parser_1.initialize_default_arguments()

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -16,7 +16,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_config_data():
     return {
         "nshow": 100,
@@ -31,7 +31,7 @@ def corsika_config_data():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_config(io_handler, db_config, corsika_config_data, model_version):
     corsika_config = CorsikaConfig(
         mongo_db_config=db_config,
@@ -70,7 +70,7 @@ def test_export_input_file(corsika_config):
     corsika_config.export_input_file()
     input_file = corsika_config.get_input_file()
     assert input_file.exists()
-    with open(input_file, "r") as f:
+    with open(input_file) as f:
         assert "TELFIL |" not in f.read()
 
 
@@ -79,7 +79,7 @@ def test_export_input_file_multipipe(corsika_config):
     corsika_config.export_input_file(use_multipipe=True)
     input_file = corsika_config.get_input_file()
     assert input_file.exists()
-    with open(input_file, "r") as f:
+    with open(input_file) as f:
         assert "TELFIL |" in f.read()
 
 
@@ -226,7 +226,6 @@ def test_get_file_name(corsika_config, io_handler):
 
 
 def test_convert_to_quantities(corsika_config):
-
     assert corsika_config._convert_to_quantities("10 m") == [10 * u.m]
     assert corsika_config._convert_to_quantities("simple_string") == ["simple_string"]
     assert corsika_config._convert_to_quantities({"value": 10, "unit": "m"}) == [10 * u.m]

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_config_data(tmp_test_directory):
     return {
         "data_directory": f"{str(tmp_test_directory)}/test-output",
@@ -27,7 +27,7 @@ def corsika_config_data(tmp_test_directory):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_runner(corsika_config_data, io_handler, simtel_path, db_config, model_version):
     corsika_runner = CorsikaRunner(
         mongo_db_config=db_config,
@@ -41,7 +41,7 @@ def corsika_runner(corsika_config_data, io_handler, simtel_path, db_config, mode
     return corsika_runner
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_file(io_handler):
     corsika_file = io_handler.get_input_data_file(
         file_name="run1_proton_za20deg_azm0deg_North_1LST_test-lst-array.corsika.zst", test=True
@@ -55,7 +55,7 @@ def test_prepare_run_script(corsika_runner):
     script = corsika_runner.prepare_run_script()
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content
@@ -66,7 +66,7 @@ def test_prepare_run_script(corsika_runner):
     script = corsika_runner.prepare_run_script(run_number=run_number)
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content
@@ -85,7 +85,7 @@ def test_prepare_run_script_with_extra(corsika_runner, file_has_text):
     script = corsika_runner.prepare_run_script(run_number=3, extra_commands=extra)
 
     assert file_has_text(script, "testing-extra-2")
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content
@@ -96,7 +96,7 @@ def test_prepare_run_script_without_pfp(corsika_runner):
     script = corsika_runner.prepare_run_script(use_pfp=False)
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content

--- a/tests/unit_tests/corsika_simtel/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/corsika_simtel/test_corsika_simtel_runner.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def common_args(simtel_path):
     return {
         "label": "test-corsika-simtel-runner",
@@ -20,7 +20,7 @@ def common_args(simtel_path):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_model(array_config_data, io_handler, db_config, common_args, model_version):
     return ArrayModel(
         label=common_args["label"],
@@ -30,7 +30,7 @@ def array_model(array_config_data, io_handler, db_config, common_args, model_ver
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_args(array_model, shower_config_data, db_config, array_config_data, model_version):
     # Remove the keys which are not necessary for general CORSIKA configuration
     for key_to_pop in ["site", "run_list", "run_range", "layout_name"]:
@@ -45,7 +45,7 @@ def corsika_args(array_model, shower_config_data, db_config, array_config_data, 
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_config_data(tmp_test_directory, array_config_data):
     return {
         "simtel_data_directory": str(tmp_test_directory) + "/test-output",
@@ -55,12 +55,12 @@ def simtel_config_data(tmp_test_directory, array_config_data):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_args(array_model, simtel_config_data):
     return {"array_model": array_model, "config_data": simtel_config_data}
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_simtel_runner(common_args, corsika_args, simtel_args):
     corsika_simtel_runner = CorsikaSimtelRunner(
         common_args=common_args, corsika_args=corsika_args, simtel_args=simtel_args
@@ -74,7 +74,7 @@ def test_prepare_run_script(corsika_simtel_runner):
     script = corsika_simtel_runner.prepare_run_script()
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content
@@ -85,7 +85,7 @@ def test_prepare_run_script(corsika_simtel_runner):
     script = corsika_simtel_runner.prepare_run_script(run_number=run_number)
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "/usr/bin/env bash" in script_content
         assert "corsika_autoinputs" in script_content
@@ -106,7 +106,7 @@ def test_export_multipipe_script(corsika_simtel_runner):
     )
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "bin/sim_telarray" in script_content
         assert "-C telescope_theta=20" in script_content
@@ -125,7 +125,7 @@ def test_export_multipipe_executable(corsika_simtel_runner):
     )
 
     assert script.exists()
-    with open(script, "r") as f:
+    with open(script) as f:
         script_content = f.read()
         assert "bin/multipipe_corsika" in script_content
         assert f"-c {multipipe_file}" in script_content

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -113,6 +113,8 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     with open(tmp_test_directory / "test_read_value_from_file_1.json", "w", encoding="utf-8") as f:
         json.dump(test_dict_1, f)
     with pytest.raises(jsonschema.exceptions.ValidationError):
-        data_reader.read_value_from_file(
-            tmp_test_directory / "test_read_value_from_file_1.json", validate=True
-        ),
+        (
+            data_reader.read_value_from_file(
+                tmp_test_directory / "test_read_value_from_file_1.json", validate=True
+            ),
+        )

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -121,7 +121,6 @@ def test_resolve_references():
 
 
 def test_add_array_elements():
-
     test_dict_1 = {"data": {"InstrumentTypeElement": {"enum": ["LSTN", "MSTN"]}}}
     test_dict_added = metadata_model._add_array_elements("InstrumentTypeElement", test_dict_1)
     assert len(test_dict_added["data"]["InstrumentTypeElement"]["enum"]) > 2

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -58,7 +58,6 @@ def test_validate_data_file(caplog):
 
 
 def test_validate_parameter_and_file_name():
-
     data_validator = validate_data.DataValidator()
     data_validator.data_file_name = "tests/resources/num_gains.json"
     data_validator.schema_file_name = "tests/resources/num_gains.schema.yml"
@@ -498,7 +497,6 @@ def test_read_validation_schema(tmp_test_directory):
 
 # incomplete test
 def test_validate_data_dict():
-
     schema_dir = files("simtools").joinpath("schemas/model_parameters/")
 
     # parameter with unit

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -38,7 +38,6 @@ def db_cleanup_file_sandbox(db_no_config_file, random_id):
 
 
 def test_reading_db_lst_without_simulation_repo(db, model_version):
-
     db_copy = copy.deepcopy(db)
     db_copy.mongo_db_config["db_simulation_model_url"] = None
     pars = db.get_model_parameters("North", "LSTN-01", model_version)
@@ -100,7 +99,6 @@ def test_get_derived_values(db, model_version):
 
 
 def test_get_sim_telarray_configuration_parameters(db, model_version):
-
     _pars = db.get_sim_telarray_configuration_parameters("North", "LSTN-01", model_version)
     assert "min_photoelectrons" in _pars
 
@@ -156,7 +154,6 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version)
 
 
 def test_add_tagged_version(db, random_id, db_cleanup, io_handler, model_version):
-
     db.add_tagged_version(
         db_name=f"sandbox_{random_id}",
         released_version="2020-06-28",
@@ -486,13 +483,11 @@ def test_get_telescope_db_name(db):
 
 
 def test_parameter_cache_key(db):
-
     assert db._parameter_cache_key("North", "LSTN-01", "Prod5") == "North-LSTN-01-Prod5"
     assert db._parameter_cache_key("North", None, "Prod5") == "North-Prod5"
 
 
 def test_get_tagged_version(db):
-
     with pytest.raises(ValueError):
         db._get_tagged_version(version="NotReleased")
 

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -8,7 +8,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def label():
     return "test-shower-simulator"
 

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def north_layout_center_data_dict():
     return {
         "center_lon": -17.8920302 * u.deg,
@@ -26,7 +26,7 @@ def north_layout_center_data_dict():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def south_layout_center_data_dict():
     return {
         "center_lon": -70.316345 * u.deg,
@@ -38,7 +38,7 @@ def south_layout_center_data_dict():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_layout_north_four_LST_instance(db_config, model_version):
     return ArrayLayout(
         site="North",
@@ -49,7 +49,7 @@ def array_layout_north_four_LST_instance(db_config, model_version):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_layout_south_four_LST_instance(db_config, model_version):
     return ArrayLayout(
         site="South",

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -14,12 +14,12 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def crs_wgs84():
     return pyproj.CRS("EPSG:4326")
 
 
-@pytest.fixture
+@pytest.fixture()
 def crs_local():
     center_lon = -17.8920302
     center_lat = 28.7621661
@@ -29,7 +29,7 @@ def crs_local():
     return pyproj.CRS.from_proj4(proj4_string)
 
 
-@pytest.fixture
+@pytest.fixture()
 def crs_utm():
     return pyproj.CRS.from_user_input(32628)
 

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_model(db_config, io_handler, model_version):
     array_config_data = {
         "site": "North",
@@ -95,6 +95,5 @@ def test_exporting_config_files(db_config, io_handler, model_version):
     ]
 
     for model_file in list_of_export_files:
-
         logger.info("Checking file: %s", model_file)
         assert Path(am.get_config_directory()).joinpath(model_file).exists()

--- a/tests/unit_tests/model/test_mirrors.py
+++ b/tests/unit_tests/model/test_mirrors.py
@@ -10,7 +10,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def mirror_template_ecsv(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated.ecsv",
@@ -21,7 +21,7 @@ def mirror_template_ecsv(io_handler):
     return mirror_template_ecsv
 
 
-@pytest.fixture
+@pytest.fixture()
 def mirror_template_simtel(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated_simtel.dat",
@@ -32,7 +32,7 @@ def mirror_template_simtel(io_handler):
     return mirror_template_simtel
 
 
-@pytest.fixture
+@pytest.fixture()
 def mirror_table_template(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated.ecsv",

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def lst_config_file():
     """Return the path to test config file for LSTN-01"""
     return "tests/resources/CTA-North-LSTN-01-Released_test-telescope-model.cfg"

--- a/tests/unit_tests/model/test_model_utils.py
+++ b/tests/unit_tests/model/test_model_utils.py
@@ -6,7 +6,6 @@ from simtools.model import model_utils
 
 
 def test_is_two_mirror_telescope():
-
     assert not model_utils.is_two_mirror_telescope("LSTN-01")
     assert not model_utils.is_two_mirror_telescope("MSTN-01")
     assert not model_utils.is_two_mirror_telescope("MSTS-01")
@@ -15,7 +14,6 @@ def test_is_two_mirror_telescope():
 
 
 def test_compute_telescope_transmission():
-
     pars = [0.8, 0, 0.0, 0.0, 0.0]
     off_axis = 0.0
     assert pytest.approx(model_utils.compute_telescope_transmission(pars, off_axis)) == pars[0]

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -13,22 +13,22 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_config_file():
     return "tests/resources/simtel_config_test_la_palma.cfg"
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_num_gains():
     return "tests/resources/num_gains.schema.yml"
 
 
-@pytest.fixture
+@pytest.fixture()
 def schema_telescope_transmission():
     return "tests/resources/telescope_transmission.schema.yml"
 
 
-@pytest.fixture
+@pytest.fixture()
 def config_reader_num_gains(simtel_config_file, schema_num_gains):
     return SimtelConfigReader(
         schema_file=schema_num_gains,
@@ -37,7 +37,7 @@ def config_reader_num_gains(simtel_config_file, schema_num_gains):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def config_reader_telescope_transmission(simtel_config_file, schema_telescope_transmission):
     return SimtelConfigReader(
         schema_file=schema_telescope_transmission,
@@ -69,7 +69,6 @@ def test_simtel_config_reader_num_gains(config_reader_num_gains):
 def test_simtel_config_reader_telescope_transmission(
     config_reader_telescope_transmission, simtel_config_file, schema_telescope_transmission
 ):
-
     _config = config_reader_telescope_transmission
     assert isinstance(_config.parameter_dict, dict)
     assert _config.parameter_name == "telescope_transmission"
@@ -85,7 +84,6 @@ def test_simtel_config_reader_telescope_transmission(
 
 
 def test_get_validated_parameter_dict(config_reader_num_gains):
-
     _config = config_reader_num_gains
     assert _config.get_validated_parameter_dict(telescope_name="MSTN-01", model_version="Test") == {
         "parameter": "num_gains",
@@ -101,7 +99,6 @@ def test_get_validated_parameter_dict(config_reader_num_gains):
 
 
 def test_export_parameter_dict_to_json(tmp_test_directory, config_reader_num_gains):
-
     _config = config_reader_num_gains
     _json_file = tmp_test_directory / "num_gains.json"
     _config.export_parameter_dict_to_json(
@@ -115,7 +112,6 @@ def test_export_parameter_dict_to_json(tmp_test_directory, config_reader_num_gai
 def test_compare_simtel_config_with_schema(
     config_reader_num_gains, config_reader_telescope_transmission, caplog
 ):
-
     _config_ng = config_reader_num_gains
 
     # no differences; should result in no output
@@ -155,7 +151,6 @@ def test_compare_simtel_config_with_schema(
 
 
 def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, caplog):
-
     _config_ng = config_reader_num_gains
 
     with pytest.raises(FileNotFoundError):
@@ -175,7 +170,6 @@ def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, ca
 
 
 def test_get_type_and_dimension_from_simtel_cfg(config_reader_num_gains):
-
     _config = copy.deepcopy(config_reader_num_gains)
 
     assert _config._get_type_and_dimension_from_simtel_cfg(["Int", "1"]) == ("int64", 1)
@@ -192,7 +186,6 @@ def test_get_type_and_dimension_from_simtel_cfg(config_reader_num_gains):
 
 
 def test_resolve_all_in_column(config_reader_num_gains):
-
     _config = config_reader_num_gains
 
     # empty
@@ -211,7 +204,6 @@ def test_resolve_all_in_column(config_reader_num_gains):
 
 
 def test_add_value_from_simtel_cfg(config_reader_num_gains):
-
     _config = config_reader_num_gains
 
     # None
@@ -249,7 +241,6 @@ def test_add_value_from_simtel_cfg(config_reader_num_gains):
 
 
 def test_get_simtel_parameter_name(config_reader_num_gains):
-
     _config = copy.deepcopy(config_reader_num_gains)
     assert _config._get_simtel_parameter_name("num_gains") == "NUM_GAINS"
     assert _config._get_simtel_parameter_name("telescope_transmission") == "TELESCOPE_TRANSMISSION"
@@ -260,7 +251,6 @@ def test_get_simtel_parameter_name(config_reader_num_gains):
 
 
 def test_check_parameter_applicability(schema_num_gains, simtel_config_file):
-
     _config = SimtelConfigReader(
         schema_file=schema_num_gains,
         simtel_config_file=simtel_config_file,
@@ -283,7 +273,6 @@ def test_check_parameter_applicability(schema_num_gains, simtel_config_file):
 
 
 def test_parameter_is_a_file(schema_num_gains, simtel_config_file):
-
     _config = SimtelConfigReader(
         schema_file=schema_num_gains,
         simtel_config_file=simtel_config_file,
@@ -303,7 +292,6 @@ def test_parameter_is_a_file(schema_num_gains, simtel_config_file):
 
 
 def test_get_unit_from_schema(schema_num_gains, simtel_config_file):
-
     _config = SimtelConfigReader(
         schema_file=schema_num_gains,
         simtel_config_file=simtel_config_file,
@@ -323,7 +311,6 @@ def test_get_unit_from_schema(schema_num_gains, simtel_config_file):
 
 
 def test_validate_parameter_dict(config_reader_num_gains, caplog):
-
     _config = config_reader_num_gains
 
     _temp_dict = {
@@ -346,7 +333,6 @@ def test_validate_parameter_dict(config_reader_num_gains, caplog):
 
 
 def test_jsonnumpy_encoder():
-
     encoder = JsonNumpyEncoder()
     assert isinstance(encoder.default(np.float64(3.14)), float)
     assert isinstance(encoder.default(np.int64(3.14)), int)

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_config_writer():
     simtel_config_writer = SimtelConfigWriter(
         site="North",
@@ -22,7 +22,7 @@ def simtel_config_writer():
     return simtel_config_writer
 
 
-@pytest.fixture
+@pytest.fixture()
 def layout(io_handler, db_config, model_version):
     layout = ArrayLayout.from_array_layout_name(
         mongo_db_config=db_config, model_version=model_version, array_layout_name="South-4LST"
@@ -55,7 +55,6 @@ def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
 
 
 def test_get_simtel_metadata(simtel_config_writer):
-
     _tel = simtel_config_writer._get_simtel_metadata("telescope")
     assert len(_tel) == 8
     assert _tel["camera_config_name"] == simtel_config_writer._telescope_model_name

--- a/tests/unit_tests/simtel/test_simtel_events.py
+++ b/tests/unit_tests/simtel/test_simtel_events.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_files(io_handler):
     test_files = list()
     test_files.append(

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -18,7 +18,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_array_histograms_file(io_handler, corsika_output_file_name):
     return io_handler.get_input_data_file(
         file_name="run1_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
@@ -26,7 +26,7 @@ def simtel_array_histograms_file(io_handler, corsika_output_file_name):
     )
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_array_histograms_instance(simtel_array_histograms_file):
     instance = SimtelHistograms(histogram_files=simtel_array_histograms_file, test=True)
     return instance

--- a/tests/unit_tests/simtel/test_simtel_runner.py
+++ b/tests/unit_tests/simtel/test_simtel_runner.py
@@ -10,7 +10,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_runner(simtel_path):
     simtel_runner = SimtelRunner(simtel_source_path=simtel_path)
     return simtel_runner

--- a/tests/unit_tests/simtel/test_simtel_runner_array.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_array.py
@@ -14,7 +14,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_config_data():
     return {
         "site": "North",
@@ -24,7 +24,7 @@ def array_config_data():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_model(array_config_data, io_handler, db_config, model_version):
     array_model = ArrayModel(
         label="test-lst-array",
@@ -35,7 +35,7 @@ def array_model(array_config_data, io_handler, db_config, model_version):
     return array_model
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_runner(array_model, simtel_path):
     simtel_runner = SimtelRunnerArray(
         array_model=array_model,
@@ -49,7 +49,7 @@ def simtel_runner(array_model, simtel_path):
     return simtel_runner
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_file(io_handler):
     corsika_file = io_handler.get_input_data_file(
         file_name="run1_proton_za20deg_azm0deg_North_1LST_test-lst-array.corsika.zst", test=True

--- a/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
@@ -11,9 +11,8 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def camera_efficiency_sst(telescope_model_sst, simtel_path, site_model_south):
-
     telescope_model_sst.export_model_files()
     camera_efficiency_sst = CameraEfficiency(
         telescope_model=telescope_model_sst,
@@ -24,7 +23,7 @@ def camera_efficiency_sst(telescope_model_sst, simtel_path, site_model_south):
     return camera_efficiency_sst
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_runner_camera_efficiency(camera_efficiency_sst, telescope_model_sst, simtel_path):
     simtel_runner_camera_efficiency = SimtelRunnerCameraEfficiency(
         simtel_source_path=simtel_path,
@@ -87,7 +86,6 @@ def test_check_run_result(simtel_runner_camera_efficiency):
 
 
 def test_get_one_dim_distribution(site_model_south, simtel_path, telescope_model_sst_prod5):
-
     logger.warning(
         "Running test_get_one_dim_distribution using prod5 model "
         " (prod6 model with 1D transmission function)"
@@ -131,7 +129,7 @@ def test_validate_or_fix_nsb_spectrum_file_format(simtel_runner_camera_efficienc
         # Test that the first 3 non-comment lines are the following values:
         wavelengths = [300.00, 315.00, 330.00]
         NSBs = [0, 0.612, 1.95]
-        with open(file, "r", encoding="utf-8") as file:
+        with open(file, encoding="utf-8") as file:
             for line in file:
                 if line.startswith("#"):
                     continue

--- a/tests/unit_tests/simtel/test_simtel_runner_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_ray_tracing.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def ray_tracing_sst(telescope_model_sst, simtel_path):
     # telescope_model_sst.export_model_files()
 
@@ -33,7 +33,7 @@ def ray_tracing_sst(telescope_model_sst, simtel_path):
     return ray_tracing_sst
 
 
-@pytest.fixture
+@pytest.fixture()
 def simtel_runner_ray_tracing(ray_tracing_sst, telescope_model_sst, simtel_path):
     simtel_runner_ray_tracing = SimtelRunnerRayTracing(
         simtel_source_path=simtel_path,

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def camera_efficiency_lst(telescope_model_lst, site_model_north, simtel_path):
     camera_efficiency_lst = CameraEfficiency(
         telescope_model=telescope_model_lst,
@@ -25,7 +25,7 @@ def camera_efficiency_lst(telescope_model_lst, site_model_north, simtel_path):
     return camera_efficiency_lst
 
 
-@pytest.fixture
+@pytest.fixture()
 def camera_efficiency_sst(telescope_model_sst, site_model_south, simtel_path):
     camera_efficiency_sst = CameraEfficiency(
         telescope_model=telescope_model_sst,
@@ -37,7 +37,7 @@ def camera_efficiency_sst(telescope_model_sst, site_model_south, simtel_path):
     return camera_efficiency_sst
 
 
-@pytest.fixture
+@pytest.fixture()
 def results_file(io_handler):
     test_file_name = (
         "tests/resources/"

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -10,7 +10,7 @@ from simtools.ray_tracing import RayTracing
 from simtools.utils import names
 
 
-@pytest.fixture
+@pytest.fixture()
 def ray_tracing_lst(telescope_model_lst, simtel_path, io_handler):
     """A RayTracing instance with results read in that were simulated before"""
     config_data = {

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -19,28 +19,28 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture
+@pytest.fixture()
 def label():
     return "test"
 
 
-@pytest.fixture
+@pytest.fixture()
 def input_file_list():
     return ["run1", "abc_run22", "def_run02_and"]
 
 
-@pytest.fixture
+@pytest.fixture()
 def shower_array_config_data(shower_config_data, array_config_data):
     # Any common entries are taken from the array_config_data
     return shower_config_data | array_config_data
 
 
-@pytest.fixture
+@pytest.fixture()
 def corsika_file():
     return "run1_proton_za20deg_azm0deg_North_1LST_test.corsika.zst"
 
 
-@pytest.fixture
+@pytest.fixture()
 def array_simulator(label, array_config_data, io_handler, db_config, model_version, simtel_path):
     array_simulator = Simulator(
         simulator="simtel",
@@ -53,7 +53,7 @@ def array_simulator(label, array_config_data, io_handler, db_config, model_versi
     return array_simulator
 
 
-@pytest.fixture
+@pytest.fixture()
 def shower_simulator(label, shower_config_data, io_handler, db_config, model_version, simtel_path):
     shower_simulator = Simulator(
         simulator="corsika",
@@ -66,7 +66,7 @@ def shower_simulator(label, shower_config_data, io_handler, db_config, model_ver
     return shower_simulator
 
 
-@pytest.fixture
+@pytest.fixture()
 def shower_array_simulator(
     label, simulator_config_data, io_handler, db_config, model_version, simtel_path
 ):

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -782,7 +782,6 @@ def test_user_confirm_no(mock_input):
 
 
 def test_validate_data_type():
-
     test_cases = [
         # Test exact data type match
         ("int", 5, None, False, True),
@@ -791,11 +790,11 @@ def test_validate_data_type():
         ("str", "hello", None, False, True),
         ("bool", True, None, False, True),
         ("bool", 1, None, False, False),
-        ("int", None, type(5), False, True),
-        ("float", None, type(3.14), False, True),
-        ("str", None, type("hello"), False, True),
-        ("bool", None, type(True), False, True),
-        ("bool", None, type(True), False, True),
+        ("int", None, int, False, True),
+        ("float", None, float, False, True),
+        ("str", None, str, False, True),
+        ("bool", None, bool, False, True),
+        ("bool", None, bool, False, True),
         # Test allow_subtypes=True
         ("float", 5, None, True, True),
         ("float", [1, 2, 3], None, True, True),
@@ -827,7 +826,6 @@ def test_validate_data_type():
 
 
 def test_convert_list_to_string():
-
     assert gen.convert_list_to_string(None) is None
     assert gen.convert_list_to_string("a") == "a"
     assert gen.convert_list_to_string(5) == 5
@@ -837,7 +835,6 @@ def test_convert_list_to_string():
 
 
 def test_convert_string_to_list():
-
     t_1 = gen.convert_string_to_list("1 2 3 4")
     assert len(t_1) == 4
     assert pytest.approx(t_1[1]) == 2.0

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -171,7 +171,6 @@ def test_get_telescope_type_from_telescope_name():
 
 
 def test_generate_file_name_camera_efficiency():
-
     site = "South"
     telescope_model_name = "LSTS-01"
     zenith_angle = 20


### PR DESCRIPTION
**This is for discussions**

Ruff provides quite powerful linting for both code and docstrings and we should discuss to use it.

- a lot of the error messages reported by ruff (see below) make sense and will improve the code
- for below, I have excluded all docstring related issues (commented out "D" and `lint.pydocstyle.convention = "numpy"` in the pyproject.toml file)
- as far as I can see this would replace also the necessary for a numpy docstring validatator (#issue 886)

I suggest that all of you look at the issues reported below and give feedback if we want to have these changes. It is a bit of work, but we will have better code.

Note that I have applied fixes ruff can do on its own by using the `--fix` command line option.

Output of `ruff check simtools`:

```
simtools/applications/plot_array_layout.py:43:8: ICN001 `matplotlib` should be imported as `mpl`
simtools/applications/tune_psf.py:233:16: NPY002 Replace legacy `np.random.uniform` call with `np.random.Generator`
simtools/applications/tune_psf.py:234:15: NPY002 Replace legacy `np.random.uniform` call with `np.random.Generator`
simtools/applications/tune_psf.py:235:17: NPY002 Replace legacy `np.random.uniform` call with `np.random.Generator`
simtools/applications/tune_psf.py:236:15: NPY002 Replace legacy `np.random.uniform` call with `np.random.Generator`
simtools/camera_efficiency.py:237:21: N806 Variable `C1` in function should be lowercase
simtools/camera_efficiency.py:238:21: N806 Variable `C2` in function should be lowercase
simtools/camera_efficiency.py:239:21: N806 Variable `C3` in function should be lowercase
simtools/camera_efficiency.py:240:21: N806 Variable `C4` in function should be lowercase
simtools/camera_efficiency.py:241:21: N806 Variable `C4x` in function should be lowercase
simtools/camera_efficiency.py:247:21: N806 Variable `N1` in function should be lowercase
simtools/camera_efficiency.py:248:21: N806 Variable `N2` in function should be lowercase
simtools/camera_efficiency.py:249:21: N806 Variable `N3` in function should be lowercase
simtools/camera_efficiency.py:250:21: N806 Variable `N4` in function should be lowercase
simtools/camera_efficiency.py:251:21: N806 Variable `N4x` in function should be lowercase
simtools/configuration/configurator.py:20:7: N818 Exception name `InvalidConfigurationParameter` should be named with an Error suffix
simtools/corsika/corsika_config.py:21:7: N818 Exception name `MissingRequiredInputInCorsikaConfigData` should be named with an Error suffix
simtools/corsika/corsika_config.py:25:7: N818 Exception name `InvalidCorsikaInput` should be named with an Error suffix
simtools/corsika/corsika_histograms.py:25:7: N818 Exception name `HistogramNotCreated` should be named with an Error suffix
simtools/corsika/corsika_histograms.py:295:20: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/corsika/corsika_histograms.py:298:24: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/corsika/corsika_runner.py:17:7: N818 Exception name `MissingRequiredEntryInCorsikaConfig` should be named with an Error suffix
simtools/data_model/validate_data.py:139:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/data_model/validate_data.py:144:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/data_model/validate_data.py:451:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/data_model/validate_data.py:454:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/io_operations/io_handler.py:9:7: N818 Exception name `IncompleteIOHandlerInit` should be named with an Error suffix
simtools/io_operations/io_handler.py:22:40: UP008 Use `super()` instead of `super(__class__, self)`
simtools/job_execution/job_manager.py:11:7: N818 Exception name `MissingWorkloadManager` should be named with an Error suffix
simtools/layout/array_layout.py:20:7: N818 Exception name `InvalidTelescopeListFile` should be named with an Error suffix
simtools/layout/array_layout.py:24:7: N818 Exception name `InvalidCoordinateDataType` should be named with an Error suffix
simtools/layout/telescope_position.py:10:7: N818 Exception name `InvalidCoordSystem` should be named with an Error suffix
simtools/model/array_model.py:15:7: N818 Exception name `InvalidArrayConfigData` should be named with an Error suffix
simtools/model/array_model.py:120:25: ISC003 Explicitly concatenated string should be implicitly concatenated
simtools/model/mirrors.py:11:7: N818 Exception name `InvalidMirrorListFile` should be named with an Error suffix
simtools/model/model_parameter.py:18:7: N818 Exception name `InvalidModelParameter` should be named with an Error suffix
simtools/simtel/simtel_config_reader.py:29:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/simtel/simtel_config_reader.py:195:25: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/simtel/simtel_config_writer.py:69:17: ISC003 Explicitly concatenated string should be implicitly concatenated
simtools/simtel/simtel_config_writer.py:82:26: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/simtel/simtel_events.py:12:7: N818 Exception name `InconsistentInputFile` should be named with an Error suffix
simtools/simtel/simtel_histograms.py:17:7: N818 Exception name `InconsistentHistogramFormat` should be named with an Error suffix
simtools/simtel/simtel_runner.py:20:7: N818 Exception name `InvalidOutputFile` should be named with an Error suffix
simtools/simulator.py:25:7: N818 Exception name `InvalidRunsToSimulate` should be named with an Error suffix
simtools/utils/general.py:43:7: N818 Exception name `UnableToIdentifyConfigEntry` should be named with an Error suffix
simtools/utils/general.py:47:7: N818 Exception name `MissingRequiredConfigEntry` should be named with an Error suffix
simtools/utils/general.py:51:7: N818 Exception name `InvalidConfigEntry` should be named with an Error suffix
simtools/utils/general.py:55:7: N818 Exception name `InvalidConfigData` should be named with an Error suffix
simtools/utils/general.py:910:8: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/utils/general.py:1020:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/utils/general.py:1069:28: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/utils/geometry.py:132:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/utils/geometry.py:134:12: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
simtools/visualization/plot_camera.py:3:22: ICN001 `matplotlib` should be imported as `mpl`
```

Output of `ruff check tests`:

```
tests/conftest.py:50:5: PT004 Fixture `mock_settings_env_vars` does not return anything, add leading underscore
tests/conftest.py:230:5: N806 Variable `telescope_model_LST` in function should be lowercase
tests/conftest.py:255:5: N806 Variable `telescope_model_SST` in function should be lowercase
tests/conftest.py:268:5: N806 Variable `telescope_model_SST` in function should be lowercase
tests/integration_tests/test_applications_from_config.py:181:5: PT015 Assertion always fails, replace with `pytest.fail()`
tests/integration_tests/test_ray_tracing.py:69:5: N806 Variable `plot_file_PSF` in function should be lowercase
tests/integration_tests/test_ray_tracing.py:193:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/integration_tests/test_ray_tracing.py:196:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/configuration/test_commandline_parser.py:69:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/configuration/test_commandline_parser.py:98:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/configuration/test_commandline_parser.py:101:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:90:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:91:9: N806 Variable `corsika_test_Config` in function should be lowercase
tests/unit_tests/corsika/test_corsika_config.py:106:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:107:9: N806 Variable `corsika_test_Config` in function should be lowercase
tests/unit_tests/corsika/test_corsika_config.py:122:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:123:9: N806 Variable `corsika_test_Config` in function should be lowercase
tests/unit_tests/corsika/test_corsika_config.py:138:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:139:9: N806 Variable `corsika_test_Config` in function should be lowercase
tests/unit_tests/corsika/test_corsika_config.py:154:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_config.py:155:9: N806 Variable `corsika_test_Config` in function should be lowercase
tests/unit_tests/corsika/test_corsika_config.py:211:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_config.py:224:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_default_config.py:18:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_default_config.py:18:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_default_config.py:31:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_default_config.py:31:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_default_config.py:43:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_default_config.py:43:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_histograms.py:127:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_histograms.py:188:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms.py:188:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_histograms.py:283:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms.py:292:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms.py:292:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_histograms.py:701:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms.py:718:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms_visualize.py:41:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms_visualize.py:41:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_histograms_visualize.py:96:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/corsika/test_corsika_histograms_visualize.py:96:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_runner.py:79:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika/test_corsika_runner.py:151:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/corsika_simtel/test_corsika_simtel_runner.py:98:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_metadata_collector.py:148:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/data_model/test_metadata_model.py:48:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/data_model/test_validate_data.py:67:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:192:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:236:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:241:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:278:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/data_model/test_validate_data.py:285:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/data_model/test_validate_data.py:435:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:437:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:439:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:448:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/data_model/test_validate_data.py:450:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_from_repo_handler.py:64:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:21:5: PT004 Fixture `db_cleanup` does not return anything, add leading underscore
tests/unit_tests/db/test_db_handler.py:32:5: PT004 Fixture `db_cleanup_file_sandbox` does not return anything, add leading underscore
tests/unit_tests/db/test_db_handler.py:97:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:145:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:299:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:478:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:481:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/db/test_db_handler.py:491:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/io_operations/test_hdf5_handler.py:8:5: N802 Function name `test_fill_hdf5_table_1D` should be lowercase
tests/unit_tests/io_operations/test_hdf5_handler.py:28:5: N802 Function name `test_fill_hdf5_table_2D` should be lowercase
tests/unit_tests/layout/test_array_layout.py:42:5: N802 Function name `array_layout_north_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:53:5: N802 Function name `array_layout_south_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:84:9: PT018 Assertion should be broken down into multiple parts
tests/unit_tests/layout/test_array_layout.py:95:9: N806 Variable `_E` in function should be lowercase
tests/unit_tests/layout/test_array_layout.py:95:13: N806 Variable `_N` in function should be lowercase
tests/unit_tests/layout/test_array_layout.py:158:5: N803 Argument name `array_layout_north_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:159:5: N803 Argument name `array_layout_south_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:247:46: N803 Argument name `array_layout_north_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:261:46: N803 Argument name `array_layout_south_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:276:5: N803 Argument name `array_layout_north_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:276:43: N803 Argument name `array_layout_south_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:298:5: N803 Argument name `array_layout_north_four_LST_instance` should be lowercase
tests/unit_tests/layout/test_array_layout.py:298:43: N803 Argument name `array_layout_south_four_LST_instance` should be lowercase
tests/unit_tests/model/test_mirrors.py:144:5: N802 Function name `test_read_mirror_list_from_ecsv_no_DB` should be lowercase
tests/unit_tests/model/test_model_parameter.py:109:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/model/test_model_parameter.py:109:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/model/test_model_parameter.py:113:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/model/test_model_parameter.py:113:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/model/test_model_parameter.py:126:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/model/test_model_parameter.py:126:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/simtel/test_simtel_config_reader.py:330:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/simtel/test_simtel_config_writer.py:68:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/simtel/test_simtel_histograms.py:86:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/simtel/test_simtel_runner_array.py:94:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py:131:9: N806 Variable `NSBs` in function should be lowercase
tests/unit_tests/test_camera_efficiency.py:71:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/test_ray_tracing.py:132:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/test_ray_tracing.py:132:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/test_ray_tracing.py:177:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/test_ray_tracing.py:204:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/test_ray_tracing.py:208:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/test_ray_tracing.py:212:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/test_simulator.py:343:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:51:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:119:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:214:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:222:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:231:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:439:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_general.py:611:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_general.py:653:5: PT006 Wrong type passed to first argument of `@pytest.mark.parametrize`; expected `tuple`
tests/unit_tests/utils/test_general.py:824:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_geometry.py:19:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
tests/unit_tests/utils/test_geometry.py:21:16: UP038 Use `X | Y` in `isinstance` call instead of `(X, Y)`
tests/unit_tests/utils/test_geometry.py:49:5: PT012 `pytest.raises()` block should contain a single simple statement
tests/unit_tests/utils/test_geometry.py:74:5: N806 Variable `distance_to_center_2D` in function should be lowercase
tests/unit_tests/utils/test_geometry.py:76:5: N806 Variable `distance_to_center_1D` in function should be lowercase
tests/unit_tests/utils/test_names.py:79:32: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:88:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:96:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:114:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:116:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:130:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:137:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:146:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:157:24: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
tests/unit_tests/utils/test_names.py:169:28: PT011 `pytest.raises(ValueError)` is too broad, set the `match` parameter or use a more specific exception
Found 125 errors.
```