### PR TITLE
Add a section on model parameters to the documentation

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -131,3 +131,5 @@ jobs:
           LOG_FILE: superlinter.log
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # exclude link to markdown files
+          FILTER_REGEX_EXCLUDE: "docs/source/docker_files.md"

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,36 +1,52 @@
-# Docker files for simtools
+# Containers (docker files)
 
-Docker files for [simtools](https://github.com/gammasim/simtools) development and applications. Prepared packages are available through the [simtools package registry](https://github.com/orgs/gammasim/packages?repo_name=simtools).
+Docker files are available for [simtools](https://github.com/gammasim/simtools) for both development and applications. Pre-built container images are available through the [simtools package registry](https://github.com/orgs/gammasim/packages?repo_name=simtools).
 
-[Docker](https://www.docker.com/community-edition#/download) or any compatible software are required to run or build these images.
+[Docker](https://www.docker.com/community-edition#/download) or any compatible software (e.g., [podman](https://podman.io/), [apptainer](https://apptainer.org/)) are required to run or build these images.
 
-Types of dockerfiles and containers available:
+Types of docker files and containers available:
 
 - [simtools users](#container-for-simtools-users): a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
 - [simtools developers](#container-for-simtools-developers): a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
 - [CORSIKA and sim_telarray](#container-for-corsika-and-simtelarray): provides containers with the CORSIKA and sim\_telarray installed (for different sim\_telarray version, hadronic interaction models, CTAO MC productions).
-This provides base images for the previously listed containers. See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for different available containers.
+This provides base images for the previously listed containers.
+
+See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for image prepared for different versions of the simulation software.
+
+## Simtools package registry
+
+Pre-built container images are available through the [simtools package registry](https://github.com/orgs/gammasim/packages?repo_name=simtools).
+
+Follow the [instruction](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) (`docker login`) to authenticate with the GitHub package registry before pulling the first image.
+
+Note: if the docker image already exists in your system, this same image will be used to run the container. This might especially be an issue when using the `latest` tag, which might not be the latest version available in the registry. To force a pull of the latest image, use the `--pull` option, e.g.:
+
+```bash
+docker run --pull always --rm -it ghcr.io/gammasim/simtools-prod:latest bash
+```
+
+Alternatively, delete the image first and pull the latest version from the registry.
 
 ## Container for simtools users
 
-Provide a container for simtools users, which includes:
+Provides a container for simtools users, which includes:
 
 - corsika and sim\_telarray
-- packages required by simtools (from pyproject.toml)
+- packages required by simtools
 - simtools (main branch)
 
 ### Run a simtools-prod container
 
-Prepare a file for the simulation model database access (see simtools documentation) similar to the [template example](https://github.com/gammasim/simtools/blob/main/.env_template) provided with simtools.
+Prerequisite: configure the simulation model database access (see simtools documentation) similar to the [template example](https://github.com/gammasim/simtools/blob/main/.env_template).
 
-To run the container in bash
+To startup a container to use bash
 
 ```bash
 docker run --rm -it --env-file .env -v "$(pwd):/workdir/external" ghcr.io/gammasim/simtools-prod:latest bash
 ```
 
 In the container, simtools applications are installed and can be called directly (e.g., `simtools-print-array-elements -h`).
-This example uses the docker syntax to mount your local directory.
+This example uses the docker syntax to mount your local directory for file access.
 
 The following example runs an application inside the container and writes the output into a directory of the local files system,
 
@@ -48,20 +64,20 @@ Output files can be found `./simtools-output/`.
 
 ### Building a simtools-prod container
 
-To build a new container locally run in the [simtools/docker](simtools/docker) directory::
+To build a new container locally run in the [docker](https://github.com/gammasim/simtools/tree/main/docker) directory::
 
 ```bash
 docker build -f Dockerfile-prod  -t simtools-prod .
 ```
 
-Building will take a while and the image is large (~1.4 GB). For using images build on your own, replace in all examples `ghcr.io/gammasim/simtools-prod:latest` by the local image name `simtools-prod`.
+Building will take a while and the image is large (~2.1 GB). For using images build on your own, replace in all examples `ghcr.io/gammasim/simtools-prod:latest` by the local image name `simtools-prod`.
 
 ## Container for simtools developers
 
 Provide a container for testing and development of simtools, including:
 
 - CORSIKA and sim\_telarray
-- packages required by simtools (from pyproject.toml)
+- packages required by simtools
 
 The container does not include the simtools code, which should be cloned in a separate directory (see below).
 
@@ -78,25 +94,15 @@ mkdir -p simtools-dev && cd simtools-dev
 git clone git@github.com:gammasim/simtools.git
 ```
 
-To download and run a prepared container in bash:
+To download and run a prepared container with bash:
 
 ```bash
 docker run --rm -it -v "$(pwd)/:/workdir/external" ghcr.io/gammasim/simtools-dev:latest bash -c "source /workdir/env/bin/activate && cd /workdir/external/simtools && pip install -e . && bash"
 ```
 
-Remember you need to `docker login` to the GitHub package repository with a personal token in order to download an image (follow [these instructions](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)).
-
-Note: if the docker image already exists in your system, this same image will be used to run the container. Please make sure to update the image regularly by, e.g., removing it **before** running the command above. This can be done by passing the docker id:
-
-```bash
-docker rmi <image ID>
-```
-
-For further useful docker commands, please check [the docker documentation](https://docs.docker.com/reference/cli/docker/).
-
 ### Build a new developers container locally
 
-To build a new container locally run in the [simtools/docker](simtools/docker) directory:
+To build a new container locally run in the [docker](https://github.com/gammasim/simtools/tree/main/docker) directory:
 
 ```bash
 docker build -f Dockerfile-dev -t simtools-dev .
@@ -107,14 +113,16 @@ Use the docker container in the same way as above, replacing `ghcr.io/gammasim/s
 Containers can be built using different build arguments, e.g.,
 
 ```bash
-docker build -f Dockerfile-simtelarray --build-arg="BUILD_OPT=prod5" -t simtel-docker-dev .
+docker build -f Dockerfile-simtelarray \
+  --build-arg="BUILD_OPT=prod5" \
+  -t simtel-docker-dev .
 ```
 
 See the docker files for all available build arguments.
 
 ## Container for CORSIKA and simtelarray
 
-Provide a container including the following the CORSIKA and sim\_telarray simulation software packages.
+This provides a container including the CORSIKA and sim\_telarray simulation software packages.
 
 ### Download from simtools container repository
 
@@ -123,7 +131,10 @@ Packages are available from the [simtools container repository](https://github.c
 To download and run a prepared container in bash using e.g., a container for prod6:
 
 ```bash
-docker run --rm -it -v "$(pwd)/external:/workdir/external" ghcr.io/gammasim/simtools-corsika-sim-telarray-qgs2-prod6-baseline-240318:latest bash
+docker run --rm -it \
+ -v "$(pwd)/external:/workdir/external" \
+ ghcr.io/gammasim/simtools-corsika-sim-telarray-qgs2-prod6-baseline-240318:latest \
+ bash
 ```
 
 ## Build a new container locally

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ Types of docker files and containers available:
 - [simtools users](#container-for-simtools-users): a container with all software installed (CORSIKA, sim\_telarray, simtools python environment, simtools). Pull latest release with: `docker pull ghcr.io/gammasim/simtools-prod:latest`
 - [simtools developers](#container-for-simtools-developers): a container with CORSIKA, sim\_telarray, and simtools conda environment installed. Pull latest release with: `docker pull ghcr.io/gammasim/simtools-dev:latest`
 - [CORSIKA and sim_telarray](#container-for-corsika-and-simtelarray): provides containers with the CORSIKA and sim\_telarray installed (for different sim\_telarray version, hadronic interaction models, CTAO MC productions).
-This provides base images for the previously listed containers.
+This provides a base image for the previously listed containers.
 
 See the [simtools container repository](https://github.com/orgs/gammasim/packages?repo_name=simtools) for image prepared for different versions of the simulation software.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,6 +80,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx.ext.githubpages",
+    "myst_parser",
     "numpydoc",
 ]
 
@@ -188,3 +189,6 @@ intersphinx_mapping = {
     "astropy": ("https://docs.astropy.org/en/latest/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
 }
+
+# myst (markdown options)
+myst_heading_anchors = 3

--- a/docs/source/docker_files.md
+++ b/docs/source/docker_files.md
@@ -1,0 +1,2 @@
+```{include} ../../docker/README.md
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ Documentation
   auxiliary_files
   databases
   simulation_software
+  docker_files
   developer_guidelines
   pull_requests
   coding_guidelines

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ Documentation
   applications
   library
   auxiliary_files
+  model_parameters
   databases
   simulation_software
   docker_files

--- a/docs/source/model_parameters.md
+++ b/docs/source/model_parameters.md
@@ -1,0 +1,203 @@
+# Simulation model parameters
+
+Simulation model parameters describe all relevant site and telescope properties. This includes the atmospheric models (profile, transmission) or geomagnetic field properties for the site, details on optical and mechanical properties of the telescope, plus camera, readout and trigger parameters.
+
+For simplicity, the term parameter is used for values, (multi-dimensional) vectors of values (e.g., the mirror reflectivity vs wavelength and photon incident angle), functions, and algorithms (e.g., the telescope trigger algorithm). Parameters might be fixed in time (e.g., the number of mirrors on a certain telescope), or variable on different time scales (e.g., compare the degradation of the mirror reflectivity over several months with the nightly variability of the atmospheric parameters).
+
+The definition, derivation, verification, and validation of the simulation model is central to the functionality of simtools.
+
+## General setup
+
+The most important features of the simulation model are:
+
+- handled by the `model_parameters` module.
+
+## Schema files for a complete description of simulation model parameter
+
+Schema files describing all simulation model parameters are part of [simtools](https://github.com/gammasim/simtools) and can be found in [simtools/schemas/model_parameters](https://github.com/gammasim/simtools/tree/main/simtools/schemas/model_parameters).
+These files describe the simulation model parameters including (among others fields) name, type, format, applicable telescopes, and parameter description.
+They include information about setting and validation activities, data sources, and simulation software.
+The schema files and especially the model parameter descriptions are derived from (and planned to be synchronized with) the [sim_telarray manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/).
+
+The files are in human readable yaml format and follow a fixed [json-schema](https://json-schema.org/).
+The full description of the schema is in [model_parameter_and_data_schema.metaschema.yml](https://github.com/gammasim/simtools/blob/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml) (found in simtools schema directory).
+
+### Example
+
+The following example is for a single parameter description.
+
+```yaml
+%YAML 1.2
+---
+title: Schema for num_gains model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: num_gains
+description: Number of different gains the input signal gets digitized.
+data:
+  - type: int
+    unit: dimensionless
+    default: 1
+    allowed_range:
+      min: 1
+      max: 2
+instrument:
+  class: Camera
+  type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray
+```
+
+### Valid Keys
+
+Valid keys are described in detail in [model_parameter_and_data_schema.metaschema.yml](https://github.com/gammasim/simtools/blob/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml). The following list gives a short (incomplete) overview of the most important parameters.
+
+#### Header section
+
+- `title`: Title of the schema file.
+- `version`: Version of this schema file.
+- `meta_schema`: Name of the base schema.
+- `meta_schema_url`: URL of the base schema.
+- `meta_schema_version`: Version of the base schema.
+
+#### Parameter description
+
+- `name`: Name of the parameter.
+- `description`: Description of the parameter.
+- `short_description`: Short description of the parameter (optional).
+
+#### Parameter data
+
+The `data` field is used to describe the actual type, format, and allowed values of the parameter.
+
+- `type`: Data type of the parameter.
+- `unit`: Units of the parameter (compatible with astropy units). Note that units are explicitly listed in the jsonschema.yml file.
+- `default`: Default value of the parameter.
+- `allowed_range`: Allowed range of the parameter.
+- `allowed_values`: Allowed values of the parameter. Use if values are not continuous and restricted to a small list of allowed values.
+
+Tables of any dimensions can be described using the `data_table` field. Example:
+
+```yaml
+data:
+  - type: data_table
+    table_columns:
+      - name: wavelength
+        description: Wavelength.
+        required: true
+        unit: nm
+        type: double
+        required_range:
+          min: 300.0
+          max: 700.0
+        input_processing:
+          - remove_duplicates
+          - sort
+      - name: photo_detection_efficiency
+        description: Average quantum or photon detection efficiency.
+        required: true
+        unit: dimensionless
+        type: double
+        allowed_range:
+          min: 0.0
+          max: 1.0
+```
+
+Input processing in form of sorting, removing of duplicates, etc. can be specified using the `input_processing` field.
+
+#### Instrument description
+
+- `class`: Instrument class. Allow values are *Camera*, *Site*, *Structure*, *Telescope*
+- `type`: Instrument type following CTAO Naming.
+- `site`: CTAO site. Allowed values are *North* and *South*.
+
+### Activity description
+
+Describes setting and validation activities. Each activity corresponds to a workflow as described in the [simtools workflows repository](https://github.com/gammasim/workflows).
+
+### Data source description
+
+Describes the source of the data or parameter (e.g., *Calibration*)
+
+### Simulation software description
+
+Describes the simulation software (e.g., *sim_telarray* or *corsika*) the parameter is used for.
+
+```yaml
+simulation_software:
+  - name: corsika
+```
+
+Allowed is here to add the internal simulation software parameter naming (if different than the name used here in the schema).
+This is important to write correct and consistent CORSIKA or sim\_telarray configuration files.
+
+ Example:
+
+```yaml
+simulation_software:
+  - name: sim_telarray
+    internal_parameter_name: secondary_ref_radius
+```
+
+## Export simulation model from model repository to model database
+
+**TO BE ADDED**
+
+## Export simulation model parameters from sim_telarray
+
+All model parameters can be extracted from `sim_telarray` using the following commands.
+
+### Prod6
+
+```bash
+./sim_telarray/bin/sim_telarray \
+   -c sim_telarray/cfg/CTA/CTA-PROD6-LaPalma.cfg \
+   -C limits=no-internal -C initlist=no-internal \
+   -C list=no-internal -C typelist=no-internal \
+   -C maximum_telescopes=30 -DNSB_AUTOSCALE \
+   -DNECTARCAM -DHYPER_LAYOUT -DNUM_TELESCOPES=30 \
+   /dev/null 2>|/dev/null | grep '(@cfg)'  >| all_telescope_config_la_palma.cfg
+
+./sim_telarray/bin/sim_telarray \
+   -c sim_telarray/cfg/CTA/CTA-PROD6-Paranal.cfg \
+   -C limits=no-internal -C initlist=no-internal \
+   -C list=no-internal -C typelist=no-internal \
+   -C maximum_telescopes=87 -DNSB_AUTOSCALE \
+   -DNECTARCAM -DHYPER_LAYOUT -DNUM_TELESCOPES=87 \
+   /dev/null 2>|/dev/null | grep '(@cfg)'  >| all_telescope_config_paranal.cfg
+```
+
+### Prod5
+
+```bash
+./sim_telarray/bin/sim_telarray \
+   -c sim_telarray/cfg/CTA/CTA-PROD5-LaPalma.cfg \
+   -C limits=no-internal -C initlist=no-internal \
+   -C list=no-internal -C typelist=no-internal \
+   -C maximum_telescopes=85 -DNSB_AUTOSCALE \
+   -DNECTARCAM -DHYPER_LAYOUT -DNUM_TELESCOPES=85 \
+   /dev/null 2>|/dev/null | grep '(@cfg)'  >| all_telescope_config_la_palma_prod5.cfg
+
+./sim_telarray/bin/sim_telarray \
+   -c sim_telarray/cfg/CTA/CTA-PROD5-Paranal.cfg \
+   -C limits=no-internal -C initlist=no-internal \
+   -C list=no-internal -C typelist=no-internal \
+   -C maximum_telescopes=120 -DNSB_AUTOSCALE \
+   -DNECTARCAM -DHYPER_LAYOUT -DNUM_TELESCOPES=120 \
+   /dev/null 2>|/dev/null | grep '(@cfg)'  >| all_telescope_config_paranal_prod5.cfg
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 # A conda environment with all useful package for simtools developers
-name: simtools-dev-311
+name: simtools-dev
 channels:
   - conda-forge
 dependencies:

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,5 @@
 # A conda environment with all useful package for simtools developers
-name: simtools-dev
+name: simtools-dev-311
 channels:
   - conda-forge
 dependencies:
@@ -11,6 +11,7 @@ dependencies:
   - flake8
   - jsonschema
   - matplotlib-base
+  - myst-parser
   - numpy
   - numpydoc
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional-dependencies."dev" = [
   "pylint",
 ]
 optional-dependencies."doc" = [
+  "myst-parser",
   "numpydoc",
   "sphinx",
   "sphinx-book-theme",


### PR DESCRIPTION
This adds to the documentation:

- a general description of simulation model parameters
- schemas and their meaning
- organisation of ArrayModel, TelescopeModel, SiteModel, etc
- where and how to add or update new parameters (e.g., that the [model_parameters gitlab](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters) should be used to define model_versions and that there are simtools to upload a gitlab repo to the database)
- how to derive a set of model parameters from sim\_telarray