### PR TITLE
Add pre-commit hook to avoid large files updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-added-large-files
+        args: ['--maxkb=500']
   - repo: local
     hooks:
       - id: pylint
@@ -48,11 +50,11 @@ repos:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.1.1"
+    rev: "2.1.3"
     hooks:
       - id: pyproject-fmt
   # codespell
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
       - id: codespell


### PR DESCRIPTION
The reason why the simtools repo is so large is that we have uploaded at some point accidentally some very large files.

To prevent this, introduced a pre-commit to prevent this:

Set the max value to 500 kB. We have a couple (4-5 files) above this value; in this case I am expected that we consciously bypass the pre-commit hook.