### PR TITLE
Step 2 of ruff integration: fix issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,8 @@ lint.ignore = [
   "D215",   # section-underline-not-over-indented
   "G004",   # Logging statement uses f-string
   "ISC001", # incompatible with ruff format
+  "PT011",  # TODO - fix
+  "PT012",  # TODO - fix
 ]
 lint.per-file-ignores."**/tests/**" = [
   "D",

--- a/simtools/applications/plot_array_layout.py
+++ b/simtools/applications/plot_array_layout.py
@@ -40,7 +40,7 @@
 import logging
 from pathlib import Path
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from astropy import units as u
 
@@ -153,7 +153,7 @@ def main():
 
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
-    matplotlib.use("Agg")
+    mpl.use("Agg")
     telescope_file = None
     if args_dict["telescope_list"] is not None:
         logger.info("Plotting array from telescope list file(s).")

--- a/simtools/applications/tune_psf.py
+++ b/simtools/applications/tune_psf.py
@@ -230,10 +230,11 @@ def main():
         mrf_range = 0.1
         mrra2_range = 0.03
         mar_range = 0.005
-        mrra = np.random.uniform(max(mrra_0 - mrra_range, 0), mrra_0 + mrra_range)
-        mrf = np.random.uniform(max(mfr_0 - mrf_range, 0), mfr_0 + mrf_range)
-        mrra2 = np.random.uniform(max(mrra2_0 - mrra2_range, 0), mrra2_0 + mrra2_range)
-        mar = np.random.uniform(max(mar_0 - mar_range, 0), mar_0 + mar_range)
+        rng = np.random.default_rng()
+        mrra = rng.uniform(max(mrra_0 - mrra_range, 0), mrra_0 + mrra_range)
+        mrf = rng.uniform(max(mfr_0 - mrf_range, 0), mfr_0 + mrf_range)
+        mrra2 = rng.uniform(max(mrra2_0 - mrra2_range, 0), mrra2_0 + mrra2_range)
+        mar = rng.uniform(max(mar_0 - mar_range, 0), mar_0 + mar_range)
         add_parameters(mrra, mar, mrf, mrra2)
 
     # Loading measured cumulative PSF

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -234,21 +234,21 @@ class CameraEfficiency:
                     numbers = [float(w) for w in words]
                     for i in range(len(eff_pars) - 10):
                         _results[eff_pars[i]].append(numbers[i])
-                    C1 = numbers[8] * (400 / numbers[0]) ** 2
-                    C2 = C1 * numbers[4] * numbers[5]
-                    C3 = C2 * numbers[6] * numbers[7]
-                    C4 = C3 * numbers[3]
-                    C4x = C1 * numbers[3] * numbers[6] * numbers[7]
+                    C1 = numbers[8] * (400 / numbers[0]) ** 2  # noqa: N806
+                    C2 = C1 * numbers[4] * numbers[5]  # noqa: N806
+                    C3 = C2 * numbers[6] * numbers[7]  # noqa: N806
+                    C4 = C3 * numbers[3]  # noqa: N806
+                    C4x = C1 * numbers[3] * numbers[6] * numbers[7]  # noqa: N806
                     _results["C1"].append(C1)
                     _results["C2"].append(C2)
                     _results["C3"].append(C3)
                     _results["C4"].append(C4)
                     _results["C4x"].append(C4x)
-                    N1 = numbers[14]
-                    N2 = N1 * numbers[4] * numbers[5]
-                    N3 = N2 * numbers[6] * numbers[7]
-                    N4 = N3 * numbers[3]
-                    N4x = N1 * numbers[3] * numbers[6] * numbers[7]
+                    N1 = numbers[14]  # noqa: N806
+                    N2 = N1 * numbers[4] * numbers[5]  # noqa: N806
+                    N3 = N2 * numbers[6] * numbers[7]  # noqa: N806
+                    N4 = N3 * numbers[3]  # noqa: N806
+                    N4x = N1 * numbers[3] * numbers[6] * numbers[7]  # noqa: N806
                     _results["N1"].append(N1)
                     _results["N2"].append(N2)
                     _results["N3"].append(N3)

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -13,11 +13,11 @@ from simtools.utils import general as gen
 
 __all__ = [
     "Configurator",
-    "InvalidConfigurationParameter",
+    "InvalidConfigurationParameterError",
 ]
 
 
-class InvalidConfigurationParameter(Exception):
+class InvalidConfigurationParameterError(Exception):
     """Exception for Invalid configuration parameter."""
 
 
@@ -142,11 +142,6 @@ class Configurator:
         dict
             Dictionary with DB parameters
 
-        Raises
-        ------
-        InvalidConfigurationParameter
-           if parameter has already been defined with a different value.
-
         """
 
         self.parser.initialize_default_arguments(
@@ -186,11 +181,6 @@ class Configurator:
             List of arguments.
         require_command_line: bool
             Require at least one command line argument.
-
-        Raises
-        ------
-        InvalidConfigurationParameter
-              invalid configuration.
 
         """
 
@@ -257,7 +247,7 @@ class Configurator:
 
         Raises
         ------
-        InvalidConfigurationParameter
+        InvalidConfigurationParameterError
            if parameter has already been defined with a different value.
 
 
@@ -272,7 +262,7 @@ class Configurator:
                 f"Inconsistent configuration parameter ({key}) definition "
                 f"({self.config[key]} vs {value})"
             )
-            raise InvalidConfigurationParameter
+            raise InvalidConfigurationParameterError
 
     def _fill_from_config_file(self, config_file):
         """

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -11,16 +11,16 @@ from simtools.utils.general import collect_data_from_file_or_dict
 
 __all__ = [
     "CorsikaConfig",
-    "MissingRequiredInputInCorsikaConfigData",
-    "InvalidCorsikaInput",
+    "MissingRequiredInputInCorsikaConfigDataError",
+    "InvalidCorsikaInputError",
 ]
 
 
-class MissingRequiredInputInCorsikaConfigData(Exception):
+class MissingRequiredInputInCorsikaConfigDataError(Exception):
     """Exception for missing required input in corsika config data."""
 
 
-class InvalidCorsikaInput(Exception):
+class InvalidCorsikaInputError(Exception):
     """Exception for invalid corsika input."""
 
 
@@ -160,10 +160,10 @@ class CorsikaConfig:
 
         Raises
         ------
-        InvalidCorsikaInput
+        InvalidCorsikaInputError
             If any parameter given as input has wrong len, unit or
             an invalid name.
-        MissingRequiredInputInCorsikaConfigData
+        MissingRequiredInputInCorsikaConfigDataError
             If any required user parameter is missing.
         """
 
@@ -190,7 +190,7 @@ class CorsikaConfig:
             if not is_identified:
                 msg = f"Argument {key_args} cannot be identified."
                 self._logger.error(msg)
-                raise InvalidCorsikaInput(msg)
+                raise InvalidCorsikaInputError(msg)
 
         # Checking for parameters with default option
         # If it is not given, filling it with the default value
@@ -205,7 +205,7 @@ class CorsikaConfig:
             else:
                 msg = f"Required parameters {par_name} was not given (there may be more)."
                 self._logger.error(msg)
-                raise MissingRequiredInputInCorsikaConfigData(msg)
+                raise MissingRequiredInputInCorsikaConfigDataError(msg)
 
         # Converting AZM to CORSIKA reference (PHIP)
         phip = 180.0 - self._user_parameters["AZM"][0]
@@ -249,7 +249,7 @@ class CorsikaConfig:
         if len(value_args) != par_info["len"]:
             msg = f"CORSIKA input entry with wrong len: {par_name}"
             self._logger.error(msg)
-            raise InvalidCorsikaInput(msg)
+            raise InvalidCorsikaInputError(msg)
 
         if "unit" not in par_info.keys():
             return value_args
@@ -270,11 +270,11 @@ class CorsikaConfig:
             if not isinstance(arg, u.quantity.Quantity):
                 msg = f"CORSIKA input given without unit: {par_name}"
                 self._logger.error(msg)
-                raise InvalidCorsikaInput(msg)
+                raise InvalidCorsikaInputError(msg)
             if not arg.unit.is_equivalent(unit):
                 msg = f"CORSIKA input given with wrong unit: {par_name}"
                 self._logger.error(msg)
-                raise InvalidCorsikaInput(msg)
+                raise InvalidCorsikaInputError(msg)
 
             value_args_with_units.append(arg.to(unit).value)
 
@@ -306,7 +306,7 @@ class CorsikaConfig:
                 return [prim_info["number"]]
         msg = f"Primary not valid: {value}"
         self._logger.error(msg)
-        raise InvalidCorsikaInput(msg)
+        raise InvalidCorsikaInputError(msg)
 
     def get_user_parameter(self, par_name):
         """

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -22,7 +22,7 @@ from simtools.utils.geometry import convert_2d_to_radial_distr, rotate
 from simtools.utils.names import sanitize_name
 
 
-class HistogramNotCreated(Exception):
+class HistogramNotCreatedError(Exception):
     """Exception for histogram not created."""
 
 
@@ -296,10 +296,10 @@ class CorsikaHistograms:
         if telescope_new_indices is None:
             self._telescope_indices = np.arange(self.num_telescopes)
         else:
-            if not isinstance(telescope_new_indices, (list, np.ndarray)):
+            if not isinstance(telescope_new_indices, list | np.ndarray):
                 telescope_new_indices = np.array([telescope_new_indices])
             for i_telescope in telescope_new_indices:
-                if not isinstance(i_telescope, (int, np.integer)):
+                if not isinstance(i_telescope, int | np.integer):
                     msg = "The index or indices given are not of type int."
                     self._logger.error(msg)
                     raise TypeError
@@ -692,7 +692,7 @@ class CorsikaHistograms:
 
         Raises
         ------
-        HistogramNotCreated:
+        HistogramNotCreatedError:
             if the histogram was not previously created.
         """
 
@@ -703,7 +703,7 @@ class CorsikaHistograms:
                     "histograms from the CORSIKA output file."
                 )
                 self._logger.error(msg)
-                raise HistogramNotCreated
+                raise HistogramNotCreatedError
 
     def _get_hist_2d_projection(self, label):
         """

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -5,14 +5,14 @@ from pathlib import Path
 
 from simtools.corsika.corsika_config import (
     CorsikaConfig,
-    MissingRequiredInputInCorsikaConfigData,
+    MissingRequiredInputInCorsikaConfigDataError,
 )
 from simtools.io_operations import io_handler
 
-__all__ = ["CorsikaRunner", "MissingRequiredEntryInCorsikaConfig"]
+__all__ = ["CorsikaRunner", "MissingRequiredEntryInCorsikaConfigError"]
 
 
-class MissingRequiredEntryInCorsikaConfig(Exception):
+class MissingRequiredEntryInCorsikaConfigError(Exception):
     """Exception for missing required entry in corsika config."""
 
 
@@ -141,7 +141,7 @@ class CorsikaRunner:
             )
             # CORSIKA input file used as template for all runs
             self._corsika_input_file = self.corsika_config.get_input_file(use_multipipe)
-        except MissingRequiredInputInCorsikaConfigData:
+        except MissingRequiredInputInCorsikaConfigDataError:
             msg = "corsika_config_data is missing required entries."
             self._logger.error(msg)
             raise

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -144,7 +144,7 @@ class MetadataCollector:
 
         try:
             return gen.collect_data_from_file_or_dict(file_name=self.schema_file, in_dict=None)
-        except gen.InvalidConfigData:
+        except gen.InvalidConfigDataError:
             self._logger.debug(f"No valid schema file provided ({self.schema_file}).")
         return {}
 
@@ -279,7 +279,7 @@ class MetadataCollector:
 
         Raises
         ------
-        gen.InvalidConfigData, FileNotFoundError
+        gen.InvalidConfigDataError, FileNotFoundError
             if metadata cannot be read from file.
         KeyError:
             if metadata does not exist
@@ -313,8 +313,8 @@ class MetadataCollector:
                     self._logger.error(
                         "More than one metadata entry found in %s", metadata_file_name
                     )
-                    raise gen.InvalidConfigData
-            except (gen.InvalidConfigData, FileNotFoundError):
+                    raise gen.InvalidConfigDataError
+            except (gen.InvalidConfigDataError, FileNotFoundError):
                 self._logger.error("Failed reading metadata from %s", metadata_file_name)
                 raise
         # metadata from table meta in ecsv file
@@ -332,7 +332,7 @@ class MetadataCollector:
                 raise
         else:
             self._logger.error("Unknown metadata file format: %s", metadata_file_name)
-            raise gen.InvalidConfigData
+            raise gen.InvalidConfigDataError
 
         metadata_model.validate_schema(_input_metadata, None)
 

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -141,12 +141,12 @@ class DataValidator:
         # validation assumes lists for values and units - convert to list if required
         value_as_list = (
             self.data_dict.get("value")
-            if isinstance(self.data_dict["value"], (list, np.ndarray))
+            if isinstance(self.data_dict["value"], list | np.ndarray)
             else [self.data_dict["value"]]
         )
         unit_as_list = (
             self.data_dict.get("unit")
-            if isinstance(self.data_dict["unit"], (list, np.ndarray))
+            if isinstance(self.data_dict["unit"], list | np.ndarray)
             else [self.data_dict["unit"]]
         )
         for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
@@ -462,10 +462,10 @@ class DataValidator:
             f"'{reference_unit}' and data unit '{unit}'"
         )
         try:
-            if isinstance(data, (u.Quantity, Column)):
+            if isinstance(data, u.Quantity | Column):
                 data = data.to(reference_unit)
                 return data, reference_unit
-            if isinstance(data, (list, np.ndarray)):
+            if isinstance(data, list | np.ndarray):
                 return [
                     (
                         u.Unit(_to_unit).to(reference_unit) * d

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -87,7 +87,7 @@ def update_model_parameters_from_repo(
         _parameter_file = gen.join_url_or_path(_file_path, f"{key}.json")
         try:
             _tmp_par = gen.collect_data_from_file_or_dict(file_name=_parameter_file, in_dict=None)
-        except (FileNotFoundError, gen.InvalidConfigData):
+        except (FileNotFoundError, gen.InvalidConfigDataError):
             # use design telescope model in case there is no model defined for this telescope ID
             # accept errors, as not all parameters are defined in the repository
             try:
@@ -101,7 +101,7 @@ def update_model_parameters_from_repo(
                 _tmp_par = gen.collect_data_from_file_or_dict(
                     file_name=gen.join_url_or_path(_file_path, f"{key}.json"), in_dict=None
                 )
-            except (FileNotFoundError, TypeError, gen.InvalidConfigData):
+            except (FileNotFoundError, TypeError, gen.InvalidConfigDataError):
                 pass
         if _tmp_par.get("version") == model_version:
             parameters[key] = _tmp_par

--- a/simtools/io_operations/io_handler.py
+++ b/simtools/io_operations/io_handler.py
@@ -6,7 +6,7 @@ from pathlib import Path
 __all__ = ["IOHandlerSingleton", "IOHandler"]
 
 
-class IncompleteIOHandlerInit(Exception):
+class IncompleteIOHandlerInitError(Exception):
     """Exception raised when IOHandler is not initialized"""
 
 
@@ -19,7 +19,7 @@ class IOHandlerSingleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(IOHandlerSingleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 
@@ -169,7 +169,7 @@ class IOHandler(metaclass=IOHandlerSingleton):
 
         Raises
         ------
-        IncompleteIOHandlerInit
+        IncompleteIOHandlerInitError
             if data_path is not set
 
         """
@@ -179,5 +179,5 @@ class IOHandler(metaclass=IOHandlerSingleton):
         elif self.data_path is not None:
             file_prefix = Path(self.data_path).joinpath(parent_dir)
         else:
-            raise IncompleteIOHandlerInit
+            raise IncompleteIOHandlerInitError
         return file_prefix.joinpath(file_name).absolute()

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 import simtools.utils.general as gen
 
-__all__ = ["JobManager", "MissingWorkloadManager", "JobExecutionError"]
+__all__ = ["JobManager", "MissingWorkloadManagerError", "JobExecutionError"]
 
 
-class MissingWorkloadManager(Exception):
+class MissingWorkloadManagerError(Exception):
     """Exception for missing work load manager."""
 
 
@@ -29,7 +29,7 @@ class JobManager:
 
     Raises
     ------
-    MissingWorkloadManager
+    MissingWorkloadManagerError
         if requested workflow manager not found.
     """
 
@@ -45,7 +45,7 @@ class JobManager:
 
         try:
             self.test_submission_system()
-        except MissingWorkloadManager:
+        except MissingWorkloadManagerError:
             self._logger.error(f"Requested workflow manager not found: {self.submit_command}")
             raise
 
@@ -55,7 +55,7 @@ class JobManager:
 
         Raises
         ------
-        MissingWorkloadManager
+        MissingWorkloadManagerError
             if workflow manager is not found.
         """
 
@@ -64,15 +64,15 @@ class JobManager:
         if self.submit_command.find("qsub") >= 0:
             if gen.program_is_executable("qsub"):
                 return
-            raise MissingWorkloadManager
+            raise MissingWorkloadManagerError
         if self.submit_command.find("condor_submit") >= 0:
             if gen.program_is_executable("condor_submit"):
                 return
-            raise MissingWorkloadManager
+            raise MissingWorkloadManagerError
         if self.submit_command.find("local") >= 0:
             return
 
-        raise MissingWorkloadManager
+        raise MissingWorkloadManagerError
 
     def submit(self, run_script=None, run_out_file=None, log_file=None):
         """

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -13,14 +13,14 @@ from simtools.model.site_model import SiteModel
 from simtools.model.telescope_model import TelescopeModel
 from simtools.utils import names
 
-__all__ = ["InvalidTelescopeListFile", "ArrayLayout"]
+__all__ = ["InvalidTelescopeListFileError", "ArrayLayout"]
 
 
-class InvalidTelescopeListFile(Exception):
+class InvalidTelescopeListFileError(Exception):
     """Exception for invalid telescope list file."""
 
 
-class InvalidCoordinateDataType(Exception):
+class InvalidCoordinateDataTypeError(Exception):
     """Exception for low-precision coordinate data type."""
 
 
@@ -272,7 +272,7 @@ class ArrayLayout:
 
         Raises
         ------
-        InvalidTelescopeListFile
+        InvalidTelescopeListFileError
             in case neither telescope name or asset_code / sequence number are given.
 
         """
@@ -302,7 +302,7 @@ class ArrayLayout:
         if tel.name is None:
             msg = "Missing required row with telescope_name or asset_code/sequence_number"
             self._logger.error(msg)
-            raise InvalidTelescopeListFile(msg)
+            raise InvalidTelescopeListFileError(msg)
 
         return tel
 

--- a/simtools/layout/telescope_position.py
+++ b/simtools/layout/telescope_position.py
@@ -4,10 +4,10 @@ import astropy.units as u
 import numpy as np
 import pyproj
 
-__all__ = ["InvalidCoordSystem", "TelescopePosition"]
+__all__ = ["InvalidCoordSystemErrorError", "TelescopePosition"]
 
 
-class InvalidCoordSystem(Exception):
+class InvalidCoordSystemErrorError(Exception):
     """Exception for invalid coordinate system."""
 
 
@@ -88,7 +88,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
            if coordinate system is not defined.
         """
 
@@ -129,7 +129,7 @@ class TelescopePosition:
             print(tel_str)
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
     def get_coordinates(self, crs_name, coordinate_field=None):
         """
@@ -149,7 +149,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
            if coordinate system is not defined
 
         """
@@ -162,7 +162,7 @@ class TelescopePosition:
                 )
             except KeyError as e:
                 self._logger.error(f"Invalid coordinate system ({crs_name})")
-                raise InvalidCoordSystem from e
+                raise InvalidCoordSystemErrorError from e
         else:
             try:
                 return (
@@ -175,7 +175,7 @@ class TelescopePosition:
                     f"Invalid coordinate system ({crs_name}) "
                     f"or coordinate field ({coordinate_field})"
                 )
-                raise InvalidCoordSystem from e
+                raise InvalidCoordSystemErrorError from e
 
     def _get_coordinate_value(self, value, unit):
         """
@@ -211,7 +211,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
             If coordinate system is not known.
 
         """
@@ -229,7 +229,7 @@ class TelescopePosition:
                 )
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
     def get_altitude(self):
         """ "
@@ -339,7 +339,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
             If coordinate system is not known.
 
 
@@ -348,7 +348,7 @@ class TelescopePosition:
             return "crs" in self.crs[crs_name]
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
     def has_coordinates(self, crs_name, crs_check=False):
         """
@@ -368,7 +368,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
             If coordinate system is not known.
         """
         if not self.is_coordinate_system(crs_name):
@@ -378,7 +378,7 @@ class TelescopePosition:
                 return False
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
         return np.all(
             np.isfinite(
@@ -406,7 +406,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
             If coordinate system is not known
 
         """
@@ -426,7 +426,7 @@ class TelescopePosition:
             )
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
     def _set_coordinate_system(self, crs_name, crs_system):
         """
@@ -441,7 +441,7 @@ class TelescopePosition:
 
         Raises
         ------
-        InvalidCoordSystem
+        InvalidCoordSystemErrorError
             If coordinate system is not known.
 
         """
@@ -449,7 +449,7 @@ class TelescopePosition:
             self.crs[crs_name]["crs"] = crs_system
         except KeyError as e:
             self._logger.error(f"Invalid coordinate system ({crs_name})")
-            raise InvalidCoordSystem from e
+            raise InvalidCoordSystemErrorError from e
 
     @staticmethod
     @u.quantity_input(tel_altitude=u.m, corsika_observation_level=u.m, telescope_axis_height=u.m)

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -7,10 +7,10 @@ from simtools.model.telescope_model import TelescopeModel
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 from simtools.utils import general, names
 
-__all__ = ["ArrayModel", "InvalidArrayConfigData"]
+__all__ = ["ArrayModel", "InvalidArrayConfigDataError"]
 
 
-class InvalidArrayConfigData(Exception):
+class InvalidArrayConfigDataError(Exception):
     """Exception for invalid array configuration data."""
 
 
@@ -226,7 +226,7 @@ class ArrayModel:
                 if "name" not in data.keys():
                     msg = "ArrayConfig has no name for a telescope"
                     self._logger.error(msg)
-                    raise InvalidArrayConfigData(msg)
+                    raise InvalidArrayConfigDataError(msg)
                 pars_to_change = {k: v for (k, v) in data.items() if k != "name"}
                 self._logger.debug(
                     "Grabbing tel data as dict - " f"{len(pars_to_change)} pars to change"
@@ -239,7 +239,7 @@ class ArrayModel:
             # Case 2: data has a wrong type
             msg = "ArrayConfig has wrong input for a telescope"
             self._logger.error(msg)
-            raise InvalidArrayConfigData(msg)
+            raise InvalidArrayConfigDataError(msg)
 
         if array_config_data and tel_name in array_config_data.keys():
             return _process_single_telescope(array_config_data[tel_name])

--- a/simtools/model/mirrors.py
+++ b/simtools/model/mirrors.py
@@ -5,10 +5,10 @@ import astropy.units as u
 import numpy as np
 from astropy.table import Table
 
-__all__ = ["InvalidMirrorListFile", "Mirrors"]
+__all__ = ["InvalidMirrorListFileError", "Mirrors"]
 
 
-class InvalidMirrorListFile(Exception):
+class InvalidMirrorListFileError(Exception):
     """Exception for invalid mirror list file."""
 
 
@@ -57,7 +57,7 @@ class Mirrors:
 
         Raises
         ------
-        InvalidMirrorListFile
+        InvalidMirrorListFileError
             If number of mirrors is 0.
         """
 
@@ -70,7 +70,7 @@ class Mirrors:
         if self.number_of_mirrors == 0:
             msg = "Problem reading mirror list file"
             self._logger.error(msg)
-            raise InvalidMirrorListFile
+            raise InvalidMirrorListFileError
 
         try:
             self.mirror_diameter = u.Quantity(self.mirror_table["mirror_diameter"])[0]
@@ -127,7 +127,7 @@ class Mirrors:
 
         Raises
         ------
-        InvalidMirrorListFile
+        InvalidMirrorListFileError
             If number of mirrors is 0.
         """
 

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -12,10 +12,10 @@ from simtools.io_operations import io_handler
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 from simtools.utils import names
 
-__all__ = ["InvalidModelParameter", "ModelParameter"]
+__all__ = ["InvalidModelParameterError", "ModelParameter"]
 
 
-class InvalidModelParameter(Exception):
+class InvalidModelParameterError(Exception):
     """Exception for invalid model parameter."""
 
 
@@ -107,7 +107,7 @@ class ModelParameter:
 
         Raises
         ------
-        InvalidModelParameter
+        InvalidModelParameterError
             If par_name does not match any parameter in this model.
         """
         try:
@@ -119,7 +119,7 @@ class ModelParameter:
         except (KeyError, ValueError) as e:
             msg = f"Parameter {par_name} was not found in the model"
             self._logger.error(msg)
-            raise InvalidModelParameter(msg) from e
+            raise InvalidModelParameterError(msg) from e
 
     def get_parameter_value(self, par_name, parameter_dict=None):
         """
@@ -156,7 +156,7 @@ class ModelParameter:
             _is_float = False
             try:
                 _is_float = self.get_parameter_type(par_name).startswith("float")
-            except (InvalidModelParameter, TypeError):  # float - in case we don't know
+            except (InvalidModelParameterError, TypeError):  # float - in case we don't know
                 _is_float = True
             _parameter = gen.convert_string_to_list(_parameter, is_float=_is_float)
             _parameter = _parameter if len(_parameter) > 1 else _parameter[0]
@@ -408,13 +408,13 @@ class ModelParameter:
 
         Raises
         ------
-        InvalidModelParameter
+        InvalidModelParameterError
             If the parameter to be changed does not exist in this model.
         """
         if par_name not in self._parameters:
             msg = f"Parameter {par_name} not in the model"
             self._logger.error(msg)
-            raise InvalidModelParameter(msg)
+            raise InvalidModelParameterError(msg)
 
         if isinstance(value, str):
             value = gen.convert_string_to_list(value)

--- a/simtools/simtel/simtel_config_reader.py
+++ b/simtools/simtel/simtel_config_reader.py
@@ -26,7 +26,7 @@ class JsonNumpyEncoder(json.JSONEncoder):
             return int(o)
         if isinstance(o, np.ndarray):
             return o.tolist()
-        if isinstance(o, (u.core.CompositeUnit, u.core.IrreducibleUnit, u.core.Unit)):
+        if isinstance(o, u.core.CompositeUnit | u.core.IrreducibleUnit | u.core.Unit):
             return str(o) if o != u.dimensionless_unscaled else None
         if np.issubdtype(type(o), np.bool_):
             return bool(o)
@@ -193,10 +193,7 @@ class SimtelConfigReader:
                 _from_schema = np.array(_from_schema, dtype=np.dtype(self.parameter_dict["type"]))
 
             try:
-                if (
-                    not isinstance(_from_schema, (list, np.ndarray))
-                    and _from_simtel == _from_schema
-                ):
+                if not isinstance(_from_schema, list | np.ndarray) and _from_simtel == _from_schema:
                     self._logger.debug(f"Values for {data_type} match")
                     continue
             except ValueError:

--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -67,7 +67,7 @@ class SimtelConfigWriter:
             file.write("#ifdef TELESCOPE\n")
             file.write(
                 f"   echo Configuration for {self._telescope_model_name}"
-                + " - TELESCOPE $(TELESCOPE)\n"
+                " - TELESCOPE $(TELESCOPE)\n"
             )
             file.write("#endif\n\n")
 
@@ -79,7 +79,7 @@ class SimtelConfigWriter:
                     value = "none" if value is None else value  # simtel requires 'none'
                     if isinstance(value, bool):
                         value = 1 if value else 0
-                    elif isinstance(value, (list, np.ndarray)):
+                    elif isinstance(value, list | np.ndarray):
                         value = gen.convert_list_to_string(value)
                     file.write(f"{_simtel_name} = {value}\n")
             _config_meta = self._get_simtel_metadata("telescope")

--- a/simtools/simtel/simtel_events.py
+++ b/simtools/simtel/simtel_events.py
@@ -6,10 +6,10 @@ import astropy.units as u
 import numpy as np
 from eventio.simtel import SimTelFile
 
-__all__ = ["InconsistentInputFile", "SimtelEvents"]
+__all__ = ["InconsistentInputFileError", "SimtelEvents"]
 
 
-class InconsistentInputFile(Exception):
+class InconsistentInputFileError(Exception):
     """Exception for inconsistent input file."""
 
 
@@ -119,7 +119,7 @@ class SimtelEvents:
                     if not _are_headers_consistent(self._mc_header, f.mc_run_headers[0]):
                         msg = "MC header pamameters from different files are inconsistent"
                         self._logger.error(msg)
-                        raise InconsistentInputFile(msg)
+                        raise InconsistentInputFileError(msg)
 
                 is_first_file = False
 

--- a/simtools/simtel/simtel_histogram.py
+++ b/simtools/simtel/simtel_histogram.py
@@ -12,17 +12,17 @@ from eventio.search_utils import yield_toplevel_of_type
 from eventio.simtel import MCRunHeader
 
 __all__ = [
-    "InconsistentHistogramFormat",
-    "HistogramIdNotFound",
+    "InconsistentHistogramFormatError",
+    "HistogramIdNotFoundError",
     "SimtelHistogram",
 ]
 
 
-class InconsistentHistogramFormat(Exception):
+class InconsistentHistogramFormatError(Exception):
     """Exception for bad histogram format."""
 
 
-class HistogramIdNotFound(Exception):
+class HistogramIdNotFoundError(Exception):
     """Exception for histogram ID not found."""
 
 
@@ -184,7 +184,7 @@ class SimtelHistogram:
 
         Raises
         ------
-        HistogramIdNotFound:
+        HistogramIdNotFoundError:
             if histogram ids not found. Problem with the file.
         """
         # Save the appropriate histograms to variables
@@ -205,7 +205,7 @@ class SimtelHistogram:
         msg = "Histograms ids not found. Please check your files."
 
         self._logger.error(msg)
-        raise HistogramIdNotFound
+        raise HistogramIdNotFoundError
 
     @property
     def view_cone(self):

--- a/simtools/simtel/simtel_histograms.py
+++ b/simtools/simtel/simtel_histograms.py
@@ -9,8 +9,8 @@ from eventio.search_utils import yield_toplevel_of_type
 from simtools import version
 from simtools.io_operations.hdf5_handler import fill_hdf5_table
 from simtools.simtel.simtel_histogram import (
-    HistogramIdNotFound,
-    InconsistentHistogramFormat,
+    HistogramIdNotFoundError,
+    InconsistentHistogramFormatError,
     SimtelHistogram,
 )
 from simtools.utils.names import sanitize_name
@@ -125,7 +125,7 @@ class SimtelHistograms:
 
         Raises
         ------
-        HistogramIdNotFound:
+        HistogramIdNotFoundError:
             if histogram ids not found. Problem with the file.
         """
         sim_hist = None
@@ -142,7 +142,7 @@ class SimtelHistograms:
                 " Please check your simtel_array files!"
             )
             self._logger.error(msg)
-            raise HistogramIdNotFound
+            raise HistogramIdNotFoundError
 
         return sim_hist, trig_hist
 
@@ -309,7 +309,7 @@ class SimtelHistograms:
 
         Raises
         ------
-        InconsistentHistogramFormat:
+        InconsistentHistogramFormatError:
             if the format of the histograms have inconsistent dimensions.
         """
         for key_to_test in [
@@ -321,7 +321,7 @@ class SimtelHistograms:
             if first_hist_file[key_to_test] != second_hist_file[key_to_test]:
                 msg = "Trying to add histograms with inconsistent dimensions"
                 self._logger.error(msg)
-                raise InconsistentHistogramFormat
+                raise InconsistentHistogramFormatError
 
     @property
     def list_of_histograms(self):

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -6,7 +6,7 @@ import simtools.utils.general as gen
 from simtools.model.array_model import ArrayModel
 from simtools.model.telescope_model import TelescopeModel
 
-__all__ = ["InvalidOutputFile", "SimtelExecutionError", "SimtelRunner"]
+__all__ = ["InvalidOutputFileError", "SimtelExecutionError", "SimtelRunner"]
 
 # pylint: disable=no-member
 # The line above is needed because there are methods which are used in this class
@@ -17,7 +17,7 @@ class SimtelExecutionError(Exception):
     """Exception for simtel_array execution error."""
 
 
-class InvalidOutputFile(Exception):
+class InvalidOutputFileError(Exception):
     """Exception for invalid output file."""
 
 

--- a/simtools/simtel/simtel_runner_array.py
+++ b/simtools/simtel/simtel_runner_array.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import simtools.utils.general as gen
 from simtools.io_operations import io_handler
-from simtools.simtel.simtel_runner import InvalidOutputFile, SimtelRunner
+from simtools.simtel.simtel_runner import InvalidOutputFileError, SimtelRunner
 
 __all__ = ["SimtelRunnerArray"]
 
@@ -290,5 +290,5 @@ class SimtelRunnerArray(SimtelRunner):
         if not output_file.exists():
             msg = "sim_telarray output file does not exist."
             self._logger.error(msg)
-            raise InvalidOutputFile(msg)
+            raise InvalidOutputFileError(msg)
         self._logger.debug(f"simtel_array output file {output_file} exists.")

--- a/simtools/simtel/simtel_runner_camera_efficiency.py
+++ b/simtools/simtel/simtel_runner_camera_efficiency.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from simtools.model.model_parameter import InvalidModelParameter
+from simtools.model.model_parameter import InvalidModelParameterError
 from simtools.simtel.simtel_runner import SimtelRunner
 
 __all__ = ["SimtelRunnerCameraEfficiency"]
@@ -88,7 +88,7 @@ class SimtelRunnerCameraEfficiency(SimtelRunner):
         mirror_class = 1
         try:
             mirror_class = self._telescope_model.get_parameter_value("mirror_class")
-        except InvalidModelParameter:
+        except InvalidModelParameterError:
             pass
 
         # Processing camera transmission

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -18,11 +18,11 @@ from simtools.utils import names
 
 __all__ = [
     "Simulator",
-    "InvalidRunsToSimulate",
+    "InvalidRunsToSimulateError",
 ]
 
 
-class InvalidRunsToSimulate(Exception):
+class InvalidRunsToSimulateError(Exception):
     """Exception for invalid runs to simulate."""
 
 
@@ -155,12 +155,12 @@ class Simulator:
 
         Raises
         ------
-        gen.InvalidConfigData
+        gen.InvalidConfigDataError
 
         """
 
         if simulator not in ["simtel", "corsika", "corsika_simtel"]:
-            raise gen.InvalidConfigData
+            raise gen.InvalidConfigDataError
         self._simulator = simulator.lower()
 
     def _load_configuration_and_simulation_model(self, config_data):
@@ -260,7 +260,7 @@ class Simulator:
             if not all(isinstance(r, int) for r in run_list):
                 msg = "run_list must contain only integers."
                 self._logger.error(msg)
-                raise InvalidRunsToSimulate
+                raise InvalidRunsToSimulateError
 
             self._logger.debug(f"run_list: {run_list}")
             validated_runs = list(run_list)
@@ -269,7 +269,7 @@ class Simulator:
             if not all(isinstance(r, int) for r in run_range) or len(run_range) != 2:
                 msg = "run_range must contain two integers only."
                 self._logger.error(msg)
-                raise InvalidRunsToSimulate
+                raise InvalidRunsToSimulateError
 
             run_range = np.arange(run_range[0], run_range[1] + 1)
             self._logger.debug(f"run_range: {run_range}")

--- a/simtools/utils/geometry.py
+++ b/simtools/utils/geometry.py
@@ -131,9 +131,9 @@ def rotate(x, y, rotation_around_z_axis, rotation_around_y_axis=0):
     if not all(isinstance(variable, (allowed_types)) for variable in [x, y]):
         raise TypeError("x and y types are not valid! Cannot perform transformation.")
 
-    if not isinstance(x, (list, np.ndarray)):
+    if not isinstance(x, list | np.ndarray):
         x = [x]
-    if not isinstance(y, (list, np.ndarray)):
+    if not isinstance(y, list | np.ndarray):
         y = [y]
 
     if (

--- a/simtools/visualization/plot_camera.py
+++ b/simtools/visualization/plot_camera.py
@@ -1,6 +1,6 @@
 import logging
 
-import matplotlib as mlp
+import matplotlib as mpl
 import matplotlib.colors as mcolors
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
@@ -109,13 +109,13 @@ def plot_pixel_layout(camera, camera_in_sky_coor=False, pixels_id_to_print=50):
     legend_objects = [leg_h.PixelObject(), leg_h.EdgePixelObject()]
     legend_labels = ["Pixel", "Edge pixel"]
     legend_handler_map = {}
-    if isinstance(on_pixels[0], mlp.patches.RegularPolygon):
+    if isinstance(on_pixels[0], mpl.patches.RegularPolygon):
         legend_handler_map = {
             leg_h.PixelObject: leg_h.HexPixelHandler(),
             leg_h.EdgePixelObject: leg_h.HexEdgePixelHandler(),
             leg_h.OffPixelObject: leg_h.HexOffPixelHandler(),
         }
-    elif isinstance(on_pixels[0], mlp.patches.Rectangle):
+    elif isinstance(on_pixels[0], mpl.patches.Rectangle):
         legend_handler_map = {
             leg_h.PixelObject: leg_h.SquarePixelHandler(),
             leg_h.EdgePixelObject: leg_h.SquareEdgePixelHandler(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def io_handler(tmp_test_directory):
 
 
 @pytest.fixture()
-def mock_settings_env_vars(tmp_test_directory):
+def _mock_settings_env_vars(tmp_test_directory):
     """
     Removes all environment variable from the test system.
     Explicitly sets those needed.
@@ -127,7 +127,7 @@ def args_dict_site(tmp_test_directory, simtel_path):
 
 
 @pytest.fixture()
-def configurator(tmp_test_directory, mock_settings_env_vars, simtel_path):
+def configurator(tmp_test_directory, _mock_settings_env_vars, simtel_path):
     config = Configurator()
     config.default_config(
         ("--output_path", str(tmp_test_directory), "--simtel_path", str(simtel_path))
@@ -252,14 +252,14 @@ def site_model_north(db_config, model_version):
 
 @pytest.fixture()
 def telescope_model_lst(db_config, io_handler, model_version):
-    telescope_model_LST = TelescopeModel(
+    telescope_model_lst = TelescopeModel(
         site="North",
         telescope_name="LSTN-01",
         model_version=model_version,
         mongo_db_config=db_config,
         label="test-telescope-model-lst",
     )
-    return telescope_model_LST
+    return telescope_model_lst
 
 
 @pytest.fixture()
@@ -277,27 +277,27 @@ def telescope_model_mst(db_config, io_handler, model_version):
 
 @pytest.fixture()
 def telescope_model_sst(db_config, io_handler, model_version):
-    telescope_model_SST = TelescopeModel(
+    telescope_model_sst = TelescopeModel(
         site="South",
         telescope_name="SSTS-design",
         model_version=model_version,
         mongo_db_config=db_config,
         label="test-telescope-model-sst",
     )
-    return telescope_model_SST
+    return telescope_model_sst
 
 
 # TODO - keep prod5 until a complete prod6 model is in the DB
 @pytest.fixture()
 def telescope_model_sst_prod5(db_config, io_handler):
-    telescope_model_SST = TelescopeModel(
+    telescope_model_sst = TelescopeModel(
         site="South",
         telescope_name="SSTS-design",
         model_version="Prod5",
         mongo_db_config=db_config,
         label="test-telescope-model-sst",
     )
-    return telescope_model_SST
+    return telescope_model_sst
 
 
 @pytest.fixture()

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -176,8 +176,7 @@ def compare_files(file1, file2, tolerance=1.0e-5):
         compare_json_files(file1, file2)
         return
 
-    logger.error(f"Failed comparing files: {file1} and {file2} (unknown file type?)")
-    assert False
+    pytest.fail(f"Failed comparing files: {file1} and {file2} (unknown file type?)")
 
 
 def assert_file_type(file_type, file_name):

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -66,10 +66,10 @@ def test_rx(db_config, simtel_path_no_mock, io_handler, telescope_model_lst):
     ray.plot("d80_deg", marker="o", linestyle=":")
     ray_rx.plot("d80_deg", marker="s", linestyle="--")
 
-    plot_file_PSF = io_handler.get_output_file(
+    plot_file_psf = io_handler.get_output_file(
         file_name="d80_test_rx.pdf", sub_dir="plots", dir_type="test"
     )
-    plt.savefig(plot_file_PSF)
+    plt.savefig(plot_file_psf)
 
     # Plotting eff_area
     plt.figure(figsize=(8, 6), tight_layout=True)

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -11,7 +11,7 @@ import yaml
 
 from simtools.configuration.configurator import (
     Configurator,
-    InvalidConfigurationParameter,
+    InvalidConfigurationParameterError,
 )
 from simtools.io_operations import io_handler
 
@@ -155,7 +155,7 @@ def test_check_parameter_configuration_status(configurator, args_dict, tmp_test_
     # parameter changed; should raise Exception
     configurator.config["config"] = "non_default_config_file"
 
-    with pytest.raises(InvalidConfigurationParameter):
+    with pytest.raises(InvalidConfigurationParameterError):
         configurator._check_parameter_configuration_status("config", "abc")
 
 

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -8,8 +8,8 @@ from astropy import units as u
 
 from simtools.corsika.corsika_config import (
     CorsikaConfig,
-    InvalidCorsikaInput,
-    MissingRequiredInputInCorsikaConfigData,
+    InvalidCorsikaInputError,
+    MissingRequiredInputInCorsikaConfigDataError,
 )
 
 logger = logging.getLogger()
@@ -84,65 +84,65 @@ def test_wrong_par_in_config_data(corsika_config, corsika_config_data, array_mod
     logger.info("test_wrong_primary_name")
     new_config_data = copy(corsika_config_data)
     new_config_data["wrong_par"] = 20 * u.m
-    with pytest.raises(InvalidCorsikaInput):
-        corsika_test_Config = CorsikaConfig(
+    with pytest.raises(InvalidCorsikaInputError):
+        corsika_test_config = CorsikaConfig(
             array_model=array_model_north,
             label="test-corsika-config",
             corsika_config_data=new_config_data,
         )
-        corsika_test_Config.print_user_parameters()
+        corsika_test_config.print_user_parameters()
 
 
 def test_units_of_config_data(corsika_config, corsika_config_data, array_model_north):
     logger.info("test_units_of_config_data")
     new_config_data = copy(corsika_config_data)
     new_config_data["zenith"] = 20 * u.m
-    with pytest.raises(InvalidCorsikaInput):
-        corsika_test_Config = CorsikaConfig(
+    with pytest.raises(InvalidCorsikaInputError):
+        corsika_test_config = CorsikaConfig(
             array_model=array_model_north,
             label="test-corsika-config",
             corsika_config_data=new_config_data,
         )
-        corsika_test_Config.print_user_parameters()
+        corsika_test_config.print_user_parameters()
 
 
 def test_len_of_config_data(corsika_config, corsika_config_data, array_model_north):
     logger.info("test_len_of_config_data")
     new_config_data = copy(corsika_config_data)
     new_config_data["erange"] = [20 * u.TeV]
-    with pytest.raises(InvalidCorsikaInput):
-        corsika_test_Config = CorsikaConfig(
+    with pytest.raises(InvalidCorsikaInputError):
+        corsika_test_config = CorsikaConfig(
             array_model=array_model_north,
             label="test-corsika-config",
             corsika_config_data=new_config_data,
         )
-        corsika_test_Config.print_user_parameters()
+        corsika_test_config.print_user_parameters()
 
 
 def test_wrong_primary_name(corsika_config, corsika_config_data, array_model_north):
     logger.info("test_wrong_primary_name")
     new_config_data = copy(corsika_config_data)
     new_config_data["primary"] = "rock"
-    with pytest.raises(InvalidCorsikaInput):
-        corsika_test_Config = CorsikaConfig(
+    with pytest.raises(InvalidCorsikaInputError):
+        corsika_test_config = CorsikaConfig(
             array_model=array_model_north,
             label="test-corsika-config",
             corsika_config_data=new_config_data,
         )
-        corsika_test_Config.print_user_parameters()
+        corsika_test_config.print_user_parameters()
 
 
 def test_missing_input(corsika_config, corsika_config_data, array_model_north):
     logger.info("test_missing_input")
     new_config_data = copy(corsika_config_data)
     new_config_data.pop("primary")
-    with pytest.raises(MissingRequiredInputInCorsikaConfigData):
-        corsika_test_Config = CorsikaConfig(
+    with pytest.raises(MissingRequiredInputInCorsikaConfigDataError):
+        corsika_test_config = CorsikaConfig(
             array_model=array_model_north,
             label="test-corsika-config",
             corsika_config_data=new_config_data,
         )
-        corsika_test_Config.print_user_parameters()
+        corsika_test_config.print_user_parameters()
 
 
 def test_set_user_parameters(corsika_config_data, corsika_config):

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -11,7 +11,10 @@ from astropy import units as u
 from astropy.table import Table
 
 from simtools import version
-from simtools.corsika.corsika_histograms import CorsikaHistograms, HistogramNotCreated
+from simtools.corsika.corsika_histograms import (
+    CorsikaHistograms,
+    HistogramNotCreatedError,
+)
 from simtools.io_operations.hdf5_handler import read_hdf5
 
 
@@ -144,7 +147,7 @@ def test_create_histograms(corsika_histograms_instance):
         assert isinstance(corsika_histograms_instance.hist_time_altitude[0], bh.Histogram)
 
 
-def test_fill_histograms_no_rotation(corsika_output_file_name):
+def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
     # Sample test of photons: 1 telescope, 2 photons
     photons = [
         {
@@ -280,7 +283,7 @@ def test_set_histograms_passing_config(corsika_histograms_instance):
 
 def test_raise_if_no_histogram(corsika_output_file_name, caplog, io_handler):
     corsika_histograms_instance_not_hist = CorsikaHistograms(corsika_output_file_name)
-    with pytest.raises(HistogramNotCreated):
+    with pytest.raises(HistogramNotCreatedError):
         corsika_histograms_instance_not_hist._raise_if_no_histogram()
         assert "The histograms were not created." in caplog
 

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -55,7 +55,7 @@ def test_read_value_from_file(tmp_test_directory):
     with pytest.raises(FileNotFoundError):
         data_reader.read_value_from_file("this_file_does_not_exist.json", validate=True)
 
-    with pytest.raises(gen.InvalidConfigData):
+    with pytest.raises(gen.InvalidConfigDataError):
         data_reader.read_value_from_file(None, validate=False)
 
     test_dict_1 = {"value": 5.0}
@@ -115,4 +115,4 @@ def test_read_value_from_file_and_validate(caplog, tmp_test_directory):
     with pytest.raises(jsonschema.exceptions.ValidationError):
         data_reader.read_value_from_file(
             tmp_test_directory / "test_read_value_from_file_1.json", validate=True
-        ),
+        )

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -129,7 +129,7 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
         metadata_1._read_input_metadata_from_file()
 
     metadata_1.args_dict["input_meta"] = "./file_does_not_exist.not_a_good_suffix"
-    with pytest.raises(gen.InvalidConfigData):
+    with pytest.raises(gen.InvalidConfigDataError):
         metadata_1._read_input_metadata_from_file()
 
     metadata_1.args_dict["input_meta"] = "tests/resources/MLTdata-preproduction.meta.yml"
@@ -145,7 +145,7 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
     with open(tmp_test_directory / "test_read_input_metadata_file.json", "w") as f:
         json.dump(test_dict, f)
     metadata_1.args_dict["input_meta"] = tmp_test_directory / "test_read_input_metadata_file.json"
-    with pytest.raises(gen.InvalidConfigData):
+    with pytest.raises(gen.InvalidConfigDataError):
         metadata_1._read_input_metadata_from_file()
         assert "More than one metadata entry" in caplog.text
 

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -18,7 +18,7 @@ def random_id():
 
 
 @pytest.fixture()
-def db_cleanup(db, random_id):
+def _db_cleanup(db, random_id):
     yield
     # Cleanup
     logger.info(f"dropping the telescopes_{random_id} and metadata_{random_id} collections")
@@ -30,7 +30,7 @@ def db_cleanup(db, random_id):
 
 
 @pytest.fixture()
-def db_cleanup_file_sandbox(db_no_config_file, random_id):
+def _db_cleanup_file_sandbox(db_no_config_file, random_id):
     yield
     # Cleanup
     logger.info("Dropping the temporary files in the sandbox")
@@ -109,7 +109,8 @@ def test_get_sim_telarray_configuration_parameters(db, model_version):
     assert "min_photoelectrons" in _pars
 
 
-def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version):
+@pytest.mark.usefixtures("_db_cleanup")
+def test_copy_telescope_db(db, random_id, io_handler, model_version):
     logger.info("----Testing copying a whole telescope-----")
     db.copy_telescope(
         db_name=None,
@@ -156,7 +157,8 @@ def test_copy_telescope_db(db, random_id, db_cleanup, io_handler, model_version)
         )
 
 
-def test_add_tagged_version(db, random_id, db_cleanup, io_handler, model_version):
+@pytest.mark.usefixtures("_db_cleanup")
+def test_add_tagged_version(db, random_id, io_handler, model_version):
 
     tags = {
         "Released": {"Value": "2020-06-28"},
@@ -174,7 +176,8 @@ def test_add_tagged_version(db, random_id, db_cleanup, io_handler, model_version
     db.db_client[f"sandbox_{random_id}"]["metadata"].drop()
 
 
-def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler, model_version):
+@pytest.mark.usefixtures("_db_cleanup")
+def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     logger.info("----Testing adding a new parameter-----")
     db.copy_telescope(
         db_name=None,
@@ -316,7 +319,8 @@ def test_adding_new_parameter_db(db, random_id, db_cleanup, io_handler, model_ve
         )
 
 
-def test_update_parameter_field_db(db, random_id, db_cleanup, io_handler):
+@pytest.mark.usefixtures("_db_cleanup")
+def test_update_parameter_field_db(db, random_id, io_handler):
     logger.info("----Testing modifying a field of a parameter-----")
     db.copy_telescope(
         db_name=None,
@@ -430,7 +434,8 @@ def test_export_file_db(db, io_handler):
     assert file_to_export.exists()
 
 
-def test_insert_files_db(db, io_handler, db_cleanup_file_sandbox, random_id, caplog):
+@pytest.mark.usefixtures("_db_cleanup_file_sandbox")
+def test_insert_files_db(db, io_handler, random_id, caplog):
     logger.info("----Testing inserting files to the DB-----")
     logger.info(
         "Creating a temporary file in "

--- a/tests/unit_tests/io_operations/test_hdf5_handler.py
+++ b/tests/unit_tests/io_operations/test_hdf5_handler.py
@@ -5,7 +5,7 @@ import numpy as np
 import simtools.io_operations.hdf5_handler as io_hdf5
 
 
-def test_fill_hdf5_table_1D(corsika_histograms_instance_set_histograms):
+def test_fill_hdf5_table_1d(corsika_histograms_instance_set_histograms):
     hist = np.array([1, 2, 3])
     x_bin_edges = np.array([1, 2, 3, 4])
     y_bin_edges = None
@@ -25,7 +25,7 @@ def test_fill_hdf5_table_1D(corsika_histograms_instance_set_histograms):
     assert all(table["values"] == hist)
 
 
-def test_fill_hdf5_table_2D(corsika_histograms_instance_set_histograms):
+def test_fill_hdf5_table_2d(corsika_histograms_instance_set_histograms):
     hist = np.array([[1, 2], [3, 4]])
     x_bin_edges = np.array([1, 2, 3])
     y_bin_edges = np.array([1, 2, 3])

--- a/tests/unit_tests/io_operations/test_io_handler.py
+++ b/tests/unit_tests/io_operations/test_io_handler.py
@@ -116,5 +116,5 @@ def test_get_data_file(args_dict, io_handler):
     )
 
     io_handler.data_path = None
-    with pytest.raises(io_handler_module.IncompleteIOHandlerInit):
+    with pytest.raises(io_handler_module.IncompleteIOHandlerInitError):
         io_handler.get_input_data_file(file_name="test-file.txt")

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -16,5 +16,5 @@ def label():
 def test_test_submission_system(label):
     jm.JobManager(submit_command=None)
     jm.JobManager(submit_command="local")
-    with pytest.raises(jm.MissingWorkloadManager):
+    with pytest.raises(jm.MissingWorkloadManagerError):
         jm.JobManager(submit_command="abc")

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -8,7 +8,10 @@ import numpy as np
 import pyproj
 import pytest
 
-from simtools.layout.telescope_position import InvalidCoordSystem, TelescopePosition
+from simtools.layout.telescope_position import (
+    InvalidCoordSystemErrorError,
+    TelescopePosition,
+)
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -72,9 +75,9 @@ def test_str(crs_wgs84, crs_local, crs_utm):
 def test_get_coordinates(crs_wgs84, crs_local, crs_utm):
     tel = TelescopePosition(name="LSTN-01")
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel.get_coordinates("not_valid_crs")
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel.get_coordinates("not_valid_crs", coordinate_field="value")
 
     tel.set_coordinates("ground", 50, -25.0, 2158.0 * u.m)
@@ -121,7 +124,7 @@ def test_get_coordinate_variable():
 def test_set_coordinates():
     tel = TelescopePosition(name="LSTN-01")
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel.set_coordinates("not_valid_crs", 5.0, 2.0, 3.0)
     tel.set_coordinates("utm", 217611 * u.m, 3185066 * u.m)
     assert tel.crs["utm"]["xx"]["value"] == pytest.approx(217611, 0.1)
@@ -204,7 +207,7 @@ def test_get_reference_system_from(crs_utm):
 def test_has_coordinates(crs_wgs84, crs_local, crs_utm):
     tel = TelescopePosition(name="LSTS-01")
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel.has_coordinates("not_a_system")
 
     assert not tel.has_coordinates("ground")
@@ -226,7 +229,7 @@ def test_has_coordinates(crs_wgs84, crs_local, crs_utm):
 def test_has_altitude():
     tel = TelescopePosition(name="LSTS-01")
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel.has_altitude("not_a_system")
 
     assert not tel.has_altitude("utm")
@@ -248,7 +251,7 @@ def test_has_altitude():
 def test_set_coordinate_system(crs_wgs84):
     tel = TelescopePosition(name="LSTN-01")
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         tel._set_coordinate_system("not_a_system", crs_wgs84)
 
     tel._set_coordinate_system("mercator", crs_wgs84)
@@ -373,5 +376,5 @@ def test_print_compact_format(capsys):
     _output = capsys.readouterr().out
     assert "".join(expected_output.split()) == "".join(_output.split())
 
-    with pytest.raises(InvalidCoordSystem):
+    with pytest.raises(InvalidCoordSystemErrorError):
         telescope.print_compact_format("not_a_crs")

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from astropy import units as u
 
-from simtools.model.array_model import ArrayModel, InvalidArrayConfigData
+from simtools.model.array_model import ArrayModel, InvalidArrayConfigDataError
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -60,7 +60,9 @@ def test_get_single_telescope_info_from_array_config(db_config, model_version, i
             "fadc_pulse_shape": "LST_pulse_shape_7dynode_high_intensity_pix1s.dat",
         },
     }
-    with pytest.raises(InvalidArrayConfigData, match="ArrayConfig has no name for a telescope"):
+    with pytest.raises(
+        InvalidArrayConfigDataError, match="ArrayConfig has no name for a telescope"
+    ):
         ArrayModel(
             label="test",
             site="North",
@@ -91,7 +93,9 @@ def test_get_single_telescope_info_from_array_config(db_config, model_version, i
     invalid_parameters = {
         "MSTN-05": 5.0,
     }
-    with pytest.raises(InvalidArrayConfigData, match="ArrayConfig has wrong input for a telescope"):
+    with pytest.raises(
+        InvalidArrayConfigDataError, match="ArrayConfig has wrong input for a telescope"
+    ):
         ArrayModel(
             label="test",
             site="North",

--- a/tests/unit_tests/model/test_mirrors.py
+++ b/tests/unit_tests/model/test_mirrors.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from simtools.model.mirrors import InvalidMirrorListFile, Mirrors
+from simtools.model.mirrors import InvalidMirrorListFileError, Mirrors
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -137,11 +137,11 @@ def test_read_mirror_list_from_ecsv_empty(io_handler, tmp_test_directory, mirror
     mirror_list_file = write_tmp_mirror_list(
         io_handler, tmp_test_directory, incomplete_mirror_table
     )
-    with pytest.raises(InvalidMirrorListFile):
+    with pytest.raises(InvalidMirrorListFileError):
         Mirrors(mirror_list_file)
 
 
-def test_read_mirror_list_from_ecsv_no_DB(io_handler):
+def test_read_mirror_list_from_ecsv_no_db(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="MLTdata-preproduction.ecsv",
         test=True,

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -7,7 +7,7 @@ import pytest
 from astropy import units as u
 
 import simtools.utils.general as gen
-from simtools.model.model_parameter import InvalidModelParameter
+from simtools.model.model_parameter import InvalidModelParameterError
 from simtools.model.telescope_model import TelescopeModel
 
 logger = logging.getLogger()
@@ -27,7 +27,7 @@ def test_get_parameter_dict(telescope_model_lst):
     assert isinstance(tel_model._get_parameter_dict("telescope_axis_height")["value"], float)
     assert tel_model._get_parameter_dict("telescope_axis_height")["unit"] == "m"
 
-    with pytest.raises(InvalidModelParameter):
+    with pytest.raises(InvalidModelParameterError):
         tel_model._get_parameter_dict("not_a_parameter")
 
 
@@ -96,7 +96,7 @@ def test_handling_parameters(telescope_model_lst):
         pytest.approx(tel_model.get_parameter_value("mirror_reflection_random_angle")[0]) == 0.0080
     )
 
-    with pytest.raises(InvalidModelParameter):
+    with pytest.raises(InvalidModelParameterError):
         tel_model._get_parameter_dict("bla_bla")
 
 

--- a/tests/unit_tests/simtel/test_simtel_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_histogram.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from ctao_cr_spectra.definitions import IRFDOC_PROTON_SPECTRUM
 from ctao_cr_spectra.spectral import PowerLaw
 
-from simtools.simtel.simtel_histogram import HistogramIdNotFound, SimtelHistogram
+from simtools.simtel.simtel_histogram import HistogramIdNotFoundError, SimtelHistogram
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -81,7 +81,7 @@ def test_fill_event_histogram_dicts(simtel_array_histogram_instance, caplog):
         if hist["id"] == 2:
             new_instance.histogram[histogram_index]["id"] = 99
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(HistogramIdNotFound):
+        with pytest.raises(HistogramIdNotFoundError):
             new_instance.fill_event_histogram_dicts()
     assert "Histograms ids not found. Please check your files." in caplog.text
 

--- a/tests/unit_tests/simtel/test_simtel_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_histograms.py
@@ -11,8 +11,8 @@ from matplotlib.collections import QuadMesh
 
 from simtools.io_operations.hdf5_handler import read_hdf5
 from simtools.simtel.simtel_histogram import (
-    HistogramIdNotFound,
-    InconsistentHistogramFormat,
+    HistogramIdNotFoundError,
+    InconsistentHistogramFormatError,
     SimtelHistogram,
 )
 from simtools.simtel.simtel_histograms import SimtelHistograms
@@ -117,7 +117,7 @@ def test_fill_stacked_events(simtel_array_histograms_instance, caplog):
         if hist["id"] == 2:
             new_instance.combined_hists[histogram_index]["id"] = 99
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(HistogramIdNotFound):
+        with pytest.raises(HistogramIdNotFoundError):
             new_instance._fill_stacked_events()
 
 
@@ -146,8 +146,8 @@ def test_check_consistency(simtel_array_histograms_instance):
         "title": "Histogram 2",
     }
 
-    # Test if the method raises InconsistentHistogramFormat exception
-    with pytest.raises(InconsistentHistogramFormat):
+    # Test if the method raises InconsistentHistogramFormatError exception
+    with pytest.raises(InconsistentHistogramFormatError):
         simtel_array_histograms_instance._check_consistency(first_hist_file, second_hist_file)
 
 
@@ -191,7 +191,7 @@ def test_combine_histogram_files(simtel_array_histograms_file, caplog):
 
     # Test inconsistency
     instance_all.combined_hists[0]["lower_x"] = instance_all.combined_hists[0]["lower_x"] + 1
-    with pytest.raises(InconsistentHistogramFormat):
+    with pytest.raises(InconsistentHistogramFormatError):
         instance_all._combined_hists = None
         assert instance_all._combined_hists is None
         _ = instance_all.combined_hists

--- a/tests/unit_tests/simtel/test_simtel_light_emission.py
+++ b/tests/unit_tests/simtel/test_simtel_light_emission.py
@@ -183,14 +183,14 @@ def mock_output_path(label, io_handler):
 
 @pytest.fixture()
 def calibration_model_illn(db_config, io_handler, model_version):
-    calibration_model_ILLN = CalibrationModel(
+    calibration_model_illn = CalibrationModel(
         site="North",
         calibration_device_model_name="ILLN-01",
         mongo_db_config=db_config,
         model_version=model_version,
         label="test-simtel-light-emission",
     )
-    return calibration_model_ILLN
+    return calibration_model_illn
 
 
 def test_initialization(mock_simulator, default_config):

--- a/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simtel_runner_camera_efficiency.py
@@ -130,14 +130,14 @@ def test_validate_or_fix_nsb_spectrum_file_format(simtel_runner_camera_efficienc
     def produced_file_has_expected_values(file):
         # Test that the first 3 non-comment lines are the following values:
         wavelengths = [300.00, 315.00, 330.00]
-        NSBs = [0, 0.612, 1.95]
+        nsbs = [0, 0.612, 1.95]
         with open(file, encoding="utf-8") as file:
             for line in file:
                 if line.startswith("#"):
                     continue
                 entry = line.split()
                 assert float(entry[0]) == pytest.approx(wavelengths.pop(0))
-                assert float(entry[2]) == pytest.approx(NSBs.pop(0))
+                assert float(entry[2]) == pytest.approx(nsbs.pop(0))
                 assert len(entry) == 3
                 if len(wavelengths) == 0:
                     break

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -13,7 +13,7 @@ from simtools.corsika.corsika_runner import CorsikaRunner
 from simtools.corsika_simtel.corsika_simtel_runner import CorsikaSimtelRunner
 from simtools.model.array_model import ArrayModel
 from simtools.simtel.simtel_runner_array import SimtelRunnerArray
-from simtools.simulator import InvalidRunsToSimulate, Simulator
+from simtools.simulator import InvalidRunsToSimulateError, Simulator
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -106,7 +106,7 @@ def test_set_simulator(array_simulator, shower_simulator, shower_array_simulator
     shower_array_simulator.simulator = "corsika_simtel"
     assert shower_array_simulator.simulator == "corsika_simtel"
 
-    with pytest.raises(gen.InvalidConfigData):
+    with pytest.raises(gen.InvalidConfigDataError):
         shower_simulator.simulator = "this_simulator_is_not_there"
 
 
@@ -163,7 +163,7 @@ def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):
             24,
         ]
 
-        with pytest.raises(InvalidRunsToSimulate):
+        with pytest.raises(InvalidRunsToSimulateError):
             simulator_now._validate_run_list_and_range(run_list=[1, "a", 4], run_range=None)
 
         assert simulator_now._validate_run_list_and_range(run_list=None, run_range=[3, 6]) == [
@@ -175,10 +175,10 @@ def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):
 
         assert simulator_now._validate_run_list_and_range(run_list=None, run_range=[6, 3]) == []
 
-        with pytest.raises(InvalidRunsToSimulate):
+        with pytest.raises(InvalidRunsToSimulateError):
             simulator_now._validate_run_list_and_range(run_list=None, run_range=[3, "b"])
 
-        with pytest.raises(InvalidRunsToSimulate):
+        with pytest.raises(InvalidRunsToSimulateError):
             simulator_now._validate_run_list_and_range(run_list=None, run_range=[3, 4, 5])
 
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -15,10 +15,10 @@ import yaml
 
 import simtools.utils.general as gen
 from simtools.utils.general import (
-    InvalidConfigData,
-    InvalidConfigEntry,
-    MissingRequiredConfigEntry,
-    UnableToIdentifyConfigEntry,
+    InvalidConfigDataError,
+    InvalidConfigEntryError,
+    MissingRequiredConfigEntryError,
+    UnableToIdentifyConfigEntryError,
 )
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -48,7 +48,7 @@ def test_collect_dict_data(args_dict, io_handler, tmp_test_directory, caplog) ->
     assert gen.collect_data_from_file_or_dict(None, None, allow_empty=True) is None
     assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
 
-    with pytest.raises(InvalidConfigData):
+    with pytest.raises(InvalidConfigDataError):
         gen.collect_data_from_file_or_dict(None, None, allow_empty=False)
         assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
 
@@ -76,7 +76,7 @@ def test_collect_dict_from_url(io_handler) -> None:
     assert len(_dict) > 0
 
     _url = "https://raw.githubusercontent.com/gammasim/simtools/not_main/"
-    with pytest.raises(gen.InvalidConfigData):
+    with pytest.raises(gen.InvalidConfigDataError):
         gen.collect_data_from_http(_url + _file)
 
     # yaml file with astropy header
@@ -116,7 +116,7 @@ def test_validate_config_data(args_dict, io_handler, caplog) -> None:
         "test_name": 10,
         "dict_par": {"blah": 10, "bleh": 5 * u.m},
     }
-    with pytest.raises(MissingRequiredConfigEntry):
+    with pytest.raises(MissingRequiredConfigEntryError):
         validated_data = gen.validate_config_data(config_data=config_data, parameters=parameters)
         assert "Required entry in config_data" in caplog.text
 
@@ -162,7 +162,7 @@ def test_validate_config_data(args_dict, io_handler, caplog) -> None:
         )
         assert "in config_data cannot be identified" in caplog.text
 
-    with pytest.raises(UnableToIdentifyConfigEntry):
+    with pytest.raises(UnableToIdentifyConfigEntryError):
         gen.validate_config_data(config_data=config_data | {"test": "blah"}, parameters=parameters)
 
 
@@ -173,7 +173,7 @@ def test_check_value_entry_length() -> None:
     _par_info["len"] = None
     assert gen._check_value_entry_length([1, 4], "test_1", _par_info) == (2, True)
     _par_info["len"] = 3
-    with pytest.raises(InvalidConfigEntry):
+    with pytest.raises(InvalidConfigEntryError):
         gen._check_value_entry_length([1, 4], "test_1", _par_info)
     _par_info.pop("len")
     with pytest.raises(KeyError):
@@ -211,7 +211,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
         "unit": [None, u.Unit("m"), u.Unit("m"), u.Unit("m"), None],
         "names": ["scat"],
     }
-    with pytest.raises(InvalidConfigEntry):
+    with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
         assert "Config entry given with wrong unit" in caplog.text
     _parinfo = {
@@ -219,7 +219,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
         "unit": [None, u.Unit("kg"), u.Unit("m"), u.Unit("m"), None],
         "names": ["scat"],
     }
-    with pytest.raises(InvalidConfigEntry):
+    with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
         assert "Config entry given with wrong unit" in caplog.text
     _parinfo = {
@@ -228,7 +228,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
         "names": ["scat"],
     }
     _value = [0, 10 * u.m, 3 * u.km, 4, None]
-    with pytest.raises(InvalidConfigEntry):
+    with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
         assert "Config entry given without unit" in caplog.text
 
@@ -252,7 +252,7 @@ def test_validate_and_convert_value_without_units() -> None:
         "c": 3.0,
     }
     _value = [0, 10.0 * u.m, 3.0]
-    with pytest.raises(InvalidConfigEntry):
+    with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_without_units(_value, None, _parname, _parinfo)
 
     assert (
@@ -561,11 +561,11 @@ def test_collect_data_from_http():
     assert isinstance(data, dict)
 
     file = "tests/resources/simtel_output_files.txt"
-    with pytest.raises(InvalidConfigData):
+    with pytest.raises(InvalidConfigDataError):
         data = gen.collect_data_from_http(url + file)
 
     url = "https://raw.githubusercontent.com/gammasim/simtools/not_right/"
-    with pytest.raises(InvalidConfigData):
+    with pytest.raises(InvalidConfigDataError):
         data = gen.collect_data_from_http(url + file)
 
 
@@ -649,7 +649,7 @@ def test_sort_arrays() -> None:
 
 
 @pytest.mark.parametrize(
-    "input_data, expected_output",
+    ("input_data", "expected_output"),
     [
         (
             {

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -16,9 +16,9 @@ def test_rotate_telescope_position(caplog) -> None:
     def check_results(x_to_test, y_to_test, x_right, y_right, angle, theta=0 * u.deg):
         x_rot, y_rot = transf.rotate(x_to_test, y_to_test, angle, theta)
         x_rot, y_rot = np.around(x_rot, 1), np.around(y_rot, 1)
-        if not isinstance(x_right, (list, np.ndarray)):
+        if not isinstance(x_right, list | np.ndarray):
             x_right = [x_right]
-        if not isinstance(y_right, (list, np.ndarray)):
+        if not isinstance(y_right, list | np.ndarray):
             y_right = [y_right]
         for element, _ in enumerate(x_right):
             assert x_right[element] == x_rot[element]
@@ -71,17 +71,17 @@ def test_convert_2d_to_radial_distr(caplog) -> None:
     xaxis = np.arange(-max_dist, max_dist, step)
     yaxis = np.arange(-max_dist, max_dist, step)
     x2d, y2d = np.meshgrid(xaxis, yaxis)
-    distance_to_center_2D = np.sqrt((x2d) ** 2 + (y2d) ** 2)
+    distance_to_center_2d = np.sqrt((x2d) ** 2 + (y2d) ** 2)
 
-    distance_to_center_1D, radial_bin_edges = transf.convert_2d_to_radial_distr(
-        distance_to_center_2D, xaxis, yaxis, bins=bins, max_dist=max_dist
+    distance_to_center_1d, radial_bin_edges = transf.convert_2d_to_radial_distr(
+        distance_to_center_2d, xaxis, yaxis, bins=bins, max_dist=max_dist
     )
-    difference = radial_bin_edges[:-1] - distance_to_center_1D
+    difference = radial_bin_edges[:-1] - distance_to_center_1d
     assert pytest.approx(difference[:-1], abs=1) == 0  # last value deviates
 
     # Test warning in caplog
     transf.convert_2d_to_radial_distr(
-        distance_to_center_2D, xaxis, yaxis, bins=4 * bins, max_dist=max_dist
+        distance_to_center_2d, xaxis, yaxis, bins=4 * bins, max_dist=max_dist
     )
     msg = "The histogram with number of bins"
     assert msg in caplog.text


### PR DESCRIPTION
**Needs to be reviewed after merging #938**

This is step 2 of the ruff integration which fixes all warnings with the following exceptions:

- simtools/camera_efficiency.py used variables called N1, N2, etc, which are used in this way in the DB and in scripts of sim-telarray. Disabled here ruff (we had it disabled in pyling)
- temporarily disabled these two issues regarding tests:
	- PT011 `pytest.raises(ValueError)` is too broad (I think we should fix those)
	- PT012 `pytest.raises()` block should contain a single simple statement (Not sure if this is absolutely necessary; but easy to fix)

This is with "D" (documentation checks) switched off. Ruff suggest a lot (thousands) of changes to the docstrings and we need to discuss how we do this (also in light of #886). I think we first want to understand how we want our docstrings to look like (I don't like all ruff suggestions.)