### PR TITLE
Step 3 of ruff integration: add ruff to CI (plus cleanup of different linter stages)

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -47,33 +47,16 @@ jobs:
 
       - name: install packages not included in super-linter
         run: |
-          pip install validate-pyproject restructuredtext-lint
+          pip install validate-pyproject
 
       - name: pyproject.toml
         run: |
           validate-pyproject pyproject.toml
 
-      # RST linter
-      # Note: unclear how to suppress error messages
-      # (use grep -v in this case)
-    #  - name: restructuredtext-lint
-    #    run: |
-    #      rst-lint README.rst docs/source |
-    #       grep -v "Unknown directive type" |
-    #       grep -v "Unknown interpreted text role" |
-    #       grep -v "Cannot analyze code. Pygments package not found."
-
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0
         with:
           args: "--validate"
-
-      - name: yaml_config used by super-linter
-        run: |
-          # TODO - very large line length
-          echo 'rules:' > yaml_config.yaml
-          echo '  line-length:' >> yaml_config.yaml
-          echo '    max: 250' >> yaml_config.yaml
 
       # Dependencies required to avoid errors
       # reported by linters
@@ -100,22 +83,6 @@ jobs:
         uses: super-linter/super-linter@v6
         env:
           VALIDATE_ALL_CODEBASE: false
-          # github actions
-          VALIDATE_GITHUB_ACTIONS: true
-          # yaml
-          VALIDATE_YAML: true
-          YAML_CONFIG_FILE: yaml_config.yaml
-          YAML_ERROR_ON_WARNING: false
-          # isort
-          VALIDATE_PYTHON_ISORT: true
-          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
-          # flake8
-          VALIDATE_PYTHON_FLAKE8: true
-          # black
-          VALIDATE_PYTHON_BLACK: true
-          PYTHON_BLACK_CONFIG_FILE: pyproject.toml
-          # markdown
-          VALIDATE_MARKDOWN: true
           # docker
           VALIDATE_DOCKERFILE_HADOLINT: true
           # .env file
@@ -131,5 +98,5 @@ jobs:
           LOG_FILE: superlinter.log
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # exclude link to markdown files
+          # exclude markdown file with links
           FILTER_REGEX_EXCLUDE: "docs/source/docker_files.md"

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -98,5 +98,3 @@ jobs:
           LOG_FILE: superlinter.log
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # exclude markdown file with links
-          FILTER_REGEX_EXCLUDE: "docs/source/docker_files.md"

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -1,6 +1,6 @@
 ---
 name: CI-unittests
-# Execute unit tests - flake8 and pytest
+# Execute unit tests
 #
 env:
   SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
@@ -91,10 +91,6 @@ jobs:
         if: matrix.install-method == 'mamba'
         run: |
           pip install -e '.[tests,dev,doc]'
-
-      - name: flake8
-        run: |
-          flake8 --max-line-length 100 --per-file-ignores="_version.py:F401 E501" .
 
       - name: Unit tests
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,14 @@ repos:
     rev: "2.1.3"
     hooks:
       - id: pyproject-fmt
-  # hadolint for docker files
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.12.0
-    hooks:
-      - id: hadolint
   # codespell
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:
       - id: codespell
+  # yamlling
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.29.0
+    hooks:
+      - id: yamllint
+        args: ["--strict", "-d", '{rules: {line-length: {max: 250}}}']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
     rev: "2.1.3"
     hooks:
       - id: pyproject-fmt
+  # hadolint for docker files
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
   # codespell
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-  # yamlling
+  # yamllint
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.29.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,47 +1,28 @@
 repos:
-  # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html#integration-with-pre-commit
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
       - id: black
         args: ["--line-length=100"]
-  # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html?highlight=other%20tools#flake8
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff
+    rev: v0.4.5
     hooks:
-      - id: flake8
-        args: ["--max-line-length=100"]
+    - id: ruff
+      args: [ --fix ]
   # https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: local
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint
-        language: system
-        types: [python]
-        exclude: ^tests/|^simtools/applications/db_development_tools/|docs/source/conf.py
-        args:
-          [
-            "-rn",  # Only display messages
-            "-sn",  # Don't display the score
-          ]
   # https://github.com/HunterMcGushion/docstr_coverage
   - repo: https://github.com/HunterMcGushion/docstr_coverage
     rev: v2.3.2  # most recent docstr-coverage release or commit sha
     hooks:
       - id: docstr-coverage
         args: ["--verbose", "2", "--fail-under", "70.", "simtools"]
-  # gitup action
+  # Github action
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.0
     hooks:

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - boost-histogram
   - ctapipe
   - eventio
-  - flake8
   - jsonschema
   - matplotlib-base
   - myst-parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "toml",
 ]
 optional-dependencies."dev" = [
-  "flake8",
   "pre-commit",
   "pylint",
   "ruff",
@@ -148,9 +147,6 @@ lint.per-file-ignores."**/tests/**" = [
 lint.per-file-ignores."**/tests_*.py" = [
   "D",
 ]
-
-[tool.isort]
-profile = "black"
 
 [tool.pylint.main]
 # Good variable names which should always be accepted, separated by a comma.


### PR DESCRIPTION
Integrate ruff as linter and add it to pre-commit. 

Cleanup of linters, see #942.

Pre-commit changes:

- removed flake8 from pre-commit (covered by ruff, see [here](https://docs.astral.sh/ruff/faq/#how-does-ruffs-linter-compare-to-flake8))
- removed pylint from pre-commit (this is too slow for pre-commit; most of it is covered by ruff - anything not picked by ruff will by shown by the CI-linter workflow)
- removed isort from pre-commit (covered by ruff, see [here](https://docs.astral.sh/ruff/faq/#how-does-ruffs-import-sorting-compare-to-isort))
- did not remove black (and do not use the `ruff format` as this introduces some changes)

Github action changes:

- remove flake8 from CI-unittest


Others

- removed flake8 from list of required packages
- removed actionlint, black from superlinter (already in pre-commit)
- removed flake8, isort from superlinter (already in ruff in pre-commit)
- removed markdownlint from superlinter (added to pre-commit in PR #940)
- replaced superlint yamllint by pre-commit yamllint

Closes #942.