### PR TITLE
Add output_path to integration tests with file checks

### DIFF
--- a/tests/integration_tests/config/calculate_trigger_rate_file_list.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_file_list.yml
@@ -5,6 +5,7 @@ CTA_SIMPIPE:
     SIMTEL_FILE_NAMES:
       - './tests/resources/simtel_output_files.txt'
     SAVE_TABLES: true
+    OUTPUT_PATH: simtools-tests
   INTEGRATION_TESTS:
     - OUTPUT_FILE: application-plots/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv
     - OUTPUT_FILE: application-plots/run202_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv

--- a/tests/integration_tests/config/calculate_trigger_rate_more_files.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_more_files.yml
@@ -6,6 +6,7 @@ CTA_SIMPIPE:
       - './tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst'
       - './tests/resources/run202_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst'
     SAVE_TABLES: true
+    OUTPUT_PATH: simtools-tests
   INTEGRATION_TESTS:
     - OUTPUT_FILE: application-plots/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv
     - OUTPUT_FILE: application-plots/run202_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv

--- a/tests/integration_tests/config/calculate_trigger_rate_more_files_save_tables.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_more_files_save_tables.yml
@@ -6,6 +6,7 @@ CTA_SIMPIPE:
       - './tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst'
       - './tests/resources/run202_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst'
     SAVE_TABLES: true
+    OUTPUT_PATH: simtools-tests
   INTEGRATION_TESTS:
     - OUTPUT_FILE: application-plots/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv
     - OUTPUT_FILE: application-plots/run202_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv

--- a/tests/integration_tests/config/calculate_trigger_rate_one_file_save_table.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_one_file_save_table.yml
@@ -5,5 +5,6 @@ CTA_SIMPIPE:
     SIMTEL_FILE_NAMES: |
       ./tests/resources/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.zst
     SAVE_TABLES: true
+    OUTPUT_PATH: simtools-tests
   INTEGRATION_TESTS:
     - OUTPUT_FILE: application-plots/run201_proton_za20deg_azm0deg_North_TestLayout_test-prod.simtel.ecsv

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -344,6 +344,7 @@ def test_applications_from_config(tmp_test_directory, config, monkeypatch, reque
         raise exc
     tmp_output_path.mkdir(parents=True, exist_ok=True)
     logger.info(f"Temporary output path: {tmp_output_path}")
+    logger.info(f"Test configuration from config file: {config}")
     logger.info(f"Model version: {request.config.getoption('--model_version')}")
     if "CONFIGURATION" in config:
         model_version_requested = request.config.getoption("--model_version")
@@ -353,7 +354,6 @@ def test_applications_from_config(tmp_test_directory, config, monkeypatch, reque
                 pytest.skip(
                     "Model version requested {model_version_requested} not supported for this test"
                 )
-
         config_file, config_string, config_file_model_version = prepare_configuration(
             config["CONFIGURATION"],
             output_path=tmp_output_path,


### PR DESCRIPTION
Interesting issue:

- integration tests are working fine in the CI on github
- some fail when running locally, e.g. ` pytest  --no-cov "tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-calculate-trigger-rate_file_list]"`
- they don't fail when adding the model version, e.g., ` pytest --model_version="2024-02-01" --no-cov "tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-calculate-trigger-rate_file_list]"`

Failing are tests which do not have `OUTPUT_PATH` configured, but are using the functionality to locate or compare output files. I tried to understand what happens in `test_applications_from_config.py`, but it is not absolutely clear to me. The easiest fix is to configure explicitly `OUTPUT_PATH` in the test configuration to make sure that tests are written into the temp_test_directory (otherwise tests are writing locally).
