### PR TITLE
Prod5 telescope positions

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -7,7 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-2-0"
+  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-3-0"
   SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -7,7 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-2-0"
+  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-3-0"
 
 on:
   workflow_dispatch:

--- a/simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """
-    This application adds all parameters found in a repository to a new database.
+    All parameters found in a model parameter repository to a new database.
 
     Generates a new database with all required collections.
     Follows the structure of the CTAO gitlab model parameters repository.
@@ -19,8 +19,7 @@
 
     Examples
     --------
-
-    Upload a repository to the DB:
+    Upload model data repository to the DB:
 
     .. code-block:: console
 
@@ -28,6 +27,15 @@
             --input_path /path/to/repository \
             --db_name new_db_name \
             --type model_parameters
+
+    Upload metadata from repository to the DB:
+
+    .. code-block:: console
+
+        simtools-add_model-parameters-from-repository-to-db \
+            --input_path /path/to/repository/metadata \
+            --db_name new_db_name \
+            --type metadata
 """
 
 import logging
@@ -55,7 +63,6 @@ def _parse(label=None, description=None):
     CommandLineParser
         Command line parser object.
     """
-
     config = configurator.Configurator(label=label, description=description)
     config.parser.add_argument(
         "--input_path",

--- a/simtools/applications/db_development_tools/write_array_elements_positions_to_repository.py
+++ b/simtools/applications/db_development_tools/write_array_elements_positions_to_repository.py
@@ -90,7 +90,9 @@ def _parse(label=None, description=None):
 def write_utm_array_elements_to_repository(args_dict, logger):
     """
     Write UTM position of array elements to model repository.
-    Read array element positions from file.
+
+    Read array element positions from file. The ecsv row definition might
+    include telescope_name or asset_code and sequence_number.
 
     Parameters
     ----------
@@ -105,7 +107,11 @@ def write_utm_array_elements_to_repository(args_dict, logger):
     for row in array_elements:
         data = {
             "parameter": "array_element_position_utm",
-            "instrument": f"{row['asset_code']}-{row['sequence_number']}",
+            "instrument": (
+                row["telescope_name"]
+                if "telescope_name" in array_elements.colnames
+                else f"{row['asset_code']}-{row['sequence_number']}"
+            ),
             "site": args_dict["site"],
             "version": args_dict["model_version"],
             "value": f"{row['utm_east']} {row['utm_north']} {row['altitude']}",

--- a/tests/integration_tests/config/sim_showers_for_trigger_rates_run_South.yml
+++ b/tests/integration_tests/config/sim_showers_for_trigger_rates_run_South.yml
@@ -1,7 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-sim-showers-for-trigger-rates
   TEST_NAME: run_south
-  MODEL_VERSION_USE_CURRENT: true
   CONFIGURATION:
     ARRAY: 4MST
     SITE: South

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South.yml
@@ -1,7 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-simulate-prod
   TEST_NAME: gamma_20_deg_south
-  MODEL_VERSION_USE_CURRENT: true
   CONFIGURATION:
     PRODUCTION_CONFIG: ./tests/resources/prod_multi_config_test_South.yml
     MODEL_VERSION: prod6

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid_south.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid_south.yml
@@ -1,7 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-simulate-prod
   TEST_NAME: gamma_20_deg_pack_for_grid_south
-  MODEL_VERSION_USE_CURRENT: true
   CONFIGURATION:
     PRODUCTION_CONFIG: ./tests/resources/prod_multi_config_test_South.yml
     MODEL_VERSION: prod6

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -512,10 +512,10 @@ def test_get_all_available_array_elements(db, model_version):
 
 def test_get_telescope_db_name(db):
     assert db.get_telescope_db_name("LSTN-01", model_version="Prod5") == "LSTN-01"
-    assert db.get_telescope_db_name("LSTS-02", model_version="Prod5") == "LSTS-design"
+    assert db.get_telescope_db_name("LSTS-20", model_version="Prod5") == "LSTS-design"
     assert db.get_telescope_db_name("LSTN-design", model_version="Prod5") == "LSTN-design"
     assert db.get_telescope_db_name("LSTS-design", model_version="Prod5") == "LSTS-design"
-    assert db.get_telescope_db_name("SSTS-01", model_version="Prod5") == "SSTS-design"
+    assert db.get_telescope_db_name("SSTS-91", model_version="Prod5") == "SSTS-design"
     assert db.get_telescope_db_name("SSTS-design", model_version="Prod5") == "SSTS-design"
     with pytest.raises(ValueError):
         db.get_telescope_db_name("SSTN-05", model_version="Prod5", collection="telescopes")


### PR DESCRIPTION
A subset of the Prod5 telescope positions have been added to allow to test with two production versions (prod5 and prod6). Re-enabled 3 integration tests to run with prod5.

There is no necessity to add all positions of the large hyperarray in prod5. Most positions are used to study array layout options and are not relevant anymore.

Stress again that this is to test simtools, not to run prod5 simulations.

This uses a new database with the name **Staging-CTA-Simulation-Model-v0-3-0**. 