### PR TITLE
Replace ArrayLayout by ArrayModel for retrieving telescope positions in light emission package

### DIFF
--- a/simtools/applications/light_emission.py
+++ b/simtools/applications/light_emission.py
@@ -322,7 +322,7 @@ def default_le_configs(le_application):
             "z_pos_ILLN-01": {
                 "len": 1,
                 "unit": u.Unit("m"),
-                "default": 229500 * u.cm,
+                "default": 13700 * u.cm,
                 "names": ["z_position"],
             },
             "direction": {
@@ -447,6 +447,7 @@ def main():
             default_le_config["x_pos"]["real"] = xyz[0]
             default_le_config["y_pos"]["real"] = xyz[1]
             default_le_config["z_pos"]["real"] = xyz[2]
+            print("Coordinates ground", xyz)
         except KeyError as exc:
             logger.error(f"Telescope {args_dict['telescope']} not found in array model")
             raise exc

--- a/simtools/applications/light_emission.py
+++ b/simtools/applications/light_emission.py
@@ -441,8 +441,8 @@ def main():
             array_elements_file=args_dict["telescope_file"],
         )
         try:
-            xyz = array_model.telescope_model[args_dict["telescope"]].get_coordinates(
-                coordinates="ground"
+            xyz = array_model.telescope_model[args_dict["telescope"]].position(
+                coordinate_system="ground"
             )
             default_le_config["x_pos"]["real"] = xyz[0]
             default_le_config["y_pos"]["real"] = xyz[1]

--- a/simtools/applications/light_emission.py
+++ b/simtools/applications/light_emission.py
@@ -1,10 +1,8 @@
 #!/usr/bin/python3
 
 """
-    Summary
-    -------
-
     Simulate calibration devices using the light emission package.
+
     Run the application in the command line.
     There are two ways this application can be executed:
 
@@ -133,7 +131,7 @@ import astropy.units as u
 import simtools.utils.general as gen
 from simtools.configuration import configurator
 from simtools.corsika.corsika_histograms_visualize import save_figs_to_pdf
-from simtools.layout.array_layout import ArrayLayout
+from simtools.model.array_model import ArrayModel
 from simtools.model.calibration_model import CalibrationModel
 from simtools.model.site_model import SiteModel
 from simtools.model.telescope_model import TelescopeModel
@@ -141,10 +139,7 @@ from simtools.simtel.simtel_light_emission import SimulatorLightEmission
 
 
 def _parse(label):
-    """
-    Parse command line configuration
-    """
-
+    """Parse command line configuration."""
     config = configurator.Configurator(
         label=label,
         description=(
@@ -250,6 +245,19 @@ def _parse(label):
 
 
 def distance_list(arg):
+    """
+    Convert distance list to astropy quantities.
+
+    Parameters
+    ----------
+    arg: list
+        List of distances.
+
+    Returns
+    -------
+    values: list
+        List of distances as astropy quantities.
+    """
     try:
         values = [float(x) * u.m for x in arg]
         return values
@@ -259,12 +267,24 @@ def distance_list(arg):
 
 def default_le_configs(le_application):
     """
+    Define default light emission configurations.
+
     Predefined angular distribution names not requiring to read any table are
     "Isotropic", "Gauss:<rms>", "Rayleigh", "Cone:<angle>", and "FilledCone:<angle>", "Parallel",
     with all angles given in degrees, all with respect to the given direction vector
     (vertically downwards if missing). If the light source has a non-zero length and velocity
     (in units of the vacuum speed of light), it is handled as a moving source,
     in the given direction.
+
+    Parameters
+    ----------
+    le_application: str
+        Light emission application.
+
+    Returns
+    -------
+    default_config: dict
+        Default light emission configuration.
     """
     default_config = {}
     if le_application in ("xyzls", "ls-beam"):
@@ -316,6 +336,19 @@ def default_le_configs(le_application):
 
 
 def select_application(args_dict):
+    """
+    Select sim_telarray application for light emission simulations.
+
+    Parameters
+    ----------
+    args_dict: dict
+        Dictionary with command line arguments.
+
+    Returns
+    -------
+    le_application: str
+        Light emission application.
+    """
     le_application = None
     if args_dict["light_source_type"] == "led":
         le_application = "xyzls"
@@ -326,7 +359,7 @@ def select_application(args_dict):
 
 
 def main():
-
+    """Simulate light emission."""
     label = Path(__file__).stem
     args_dict, db_config = _parse(label)
     le_application = select_application(args_dict)
@@ -401,21 +434,22 @@ def main():
 
         # TODO: Here we use coordinates from the telescope list, change as soon as
         # coordinates are in DB i.e. calibration_model.coordinate, telescope_model.coordinate
-        layout = ArrayLayout(
+        array_model = ArrayModel(
             mongo_db_config=db_config,
             model_version=args_dict["model_version"],
             site=args_dict["site"],
-            telescope_list_file=args_dict["telescope_file"],
+            array_elements_file=args_dict["telescope_file"],
         )
-        layout.convert_coordinates()
-
-        for telescope in layout._telescope_list:  # pylint: disable=protected-access
-            if telescope.name == args_dict["telescope"]:
-                xx, yy, zz = telescope.get_coordinates(crs_name="ground")
-
-        default_le_config["x_pos"]["real"] = xx
-        default_le_config["y_pos"]["real"] = yy
-        default_le_config["z_pos"]["real"] = zz
+        try:
+            xyz = array_model.telescope_model[args_dict["telescope"]].get_coordinates(
+                coordinates="ground"
+            )
+            default_le_config["x_pos"]["real"] = xyz[0]
+            default_le_config["y_pos"]["real"] = xyz[1]
+            default_le_config["z_pos"]["real"] = xyz[2]
+        except KeyError as exc:
+            logger.error(f"Telescope {args_dict['telescope']} not found in array model")
+            raise exc
 
         le = SimulatorLightEmission.from_kwargs(
             telescope_model=telescope_model,

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -9,7 +9,7 @@ from astropy.table import Table
 import simtools.utils.general as gen
 from simtools.model.camera import Camera
 from simtools.model.mirrors import Mirrors
-from simtools.model.model_parameter import ModelParameter
+from simtools.model.model_parameter import InvalidModelParameterError, ModelParameter
 from simtools.utils import names
 
 __all__ = ["TelescopeModel"]
@@ -344,13 +344,13 @@ class TelescopeModel(ModelParameter):
         table.write(file_to_write_to, format="ascii.commented_header", overwrite=True)
         return file_to_write_to.absolute()
 
-    def get_coordinates(self, coordinates="ground"):
+    def position(self, coordinate_system="ground"):
         """
         Get coordinates in the given system.
 
         Parameters
         ----------
-        coordinates : str
+        coordinate_system: str
             Coordinates system. Default is 'ground'.
 
         Returns
@@ -364,7 +364,7 @@ class TelescopeModel(ModelParameter):
             If the coordinate system is not found.
         """
         try:
-            return self.get_parameter_value_with_unit(f"array_element_position_{coordinates}")
-        except KeyError:
-            self._logger.error(f"Coordinate system {coordinates} not found.")
-            return None
+            return self.get_parameter_value_with_unit(f"array_element_position_{coordinate_system}")
+        except InvalidModelParameterError as exc:
+            self._logger.error(f"Coordinate system {coordinate_system} not found.")
+            raise exc

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -1,3 +1,5 @@
+"""MC model of a telescope."""
+
 import logging
 
 import astropy.io.ascii
@@ -41,9 +43,7 @@ class TelescopeModel(ModelParameter):
         model_version,
         label=None,
     ):
-        """
-        Initialize TelescopeModel.
-        """
+        """Initialize TelescopeModel."""
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init TelescopeModel %s %s", site, telescope_name)
         ModelParameter.__init__(
@@ -62,18 +62,14 @@ class TelescopeModel(ModelParameter):
 
     @property
     def mirrors(self):
-        """
-        Load the mirror information if the class instance hasn't done it yet.
-        """
+        """Load the mirror information if the class instance hasn't done it yet."""
         if self._mirrors is None:
             self._load_mirrors()
         return self._mirrors
 
     @property
     def camera(self):
-        """
-        Load the camera information if the class instance hasn't done it yet.
-        """
+        """Load the camera information if the class instance hasn't done it yet."""
         if self._camera is None:
             self._load_camera()
         return self._camera
@@ -145,8 +141,9 @@ class TelescopeModel(ModelParameter):
 
     def get_telescope_effective_focal_length(self, unit="m", return_focal_length_if_zero=False):
         """
-        Return effective focal length. Ensure backwards compatibility with older
-        sim-telarray versions.
+        Return effective focal length.
+
+        The function ensures backwards compatibility with older sim-telarray versions.
 
         Parameters
         ----------
@@ -175,7 +172,7 @@ class TelescopeModel(ModelParameter):
         return eff_focal_length
 
     def _load_camera(self):
-        """Loading camera attribute by creating a Camera object with the camera config file."""
+        """Load camera attribute by creating a Camera object with the camera config file."""
         camera_config_file = self.get_parameter_value("camera_config_file")
         focal_length = self.get_telescope_effective_focal_length("cm", True)
         try:
@@ -221,6 +218,7 @@ class TelescopeModel(ModelParameter):
     def read_two_dim_wavelength_angle(self, file_name):
         """
         Read a two dimensional distribution of wavelength and angle (z-axis can be anything).
+
         Return a dictionary with three arrays, wavelength, angles, z (can be transmission,
         reflectivity, etc.)
 
@@ -234,7 +232,6 @@ class TelescopeModel(ModelParameter):
         dict:
             dict of three arrays, wavelength, degrees, z.
         """
-
         _file = self.config_file_directory.joinpath(file_name)
         self._logger.debug("Reading two dimensional distribution from %s", _file)
         line_to_start_from = 0
@@ -255,7 +252,6 @@ class TelescopeModel(ModelParameter):
 
     def get_on_axis_eff_optical_area(self):
         """Return the on-axis effective optical area (derived previously for this telescope)."""
-
         ray_tracing_data = astropy.io.ascii.read(
             self.config_file_directory.joinpath(self.get_parameter_value("optics_properties"))
         )
@@ -281,7 +277,6 @@ class TelescopeModel(ModelParameter):
         incidence_angle_dist: astropy.table.Table
             Instance of astropy.table.Table with the incidence angle distribution.
         """
-
         self._logger.debug(
             "Reading incidence angle distribution from %s",
             self.config_file_directory.joinpath(incidence_angle_dist_file),
@@ -294,8 +289,10 @@ class TelescopeModel(ModelParameter):
     @staticmethod
     def calc_average_curve(curves, incidence_angle_dist):
         """
-        Calculate an average curve from a set of curves, using as weights the distribution of \
-        incidence angles provided in incidence_angle_dist.
+        Calculate an average curve from a set of curves.
+
+        The calculation uses weights the distribution of incidence angles provided in
+        incidence_angle_dist.
 
         Parameters
         ----------
@@ -312,7 +309,6 @@ class TelescopeModel(ModelParameter):
         average_curve: astropy.table.Table
             Instance of astropy.table.Table with the averaged curve.
         """
-
         weights = []
         for angle_now in curves["Angle"]:
             weights.append(
@@ -344,7 +340,31 @@ class TelescopeModel(ModelParameter):
         Path:
             Path to the file exported.
         """
-
         file_to_write_to = self._config_file_directory.joinpath(file_name)
         table.write(file_to_write_to, format="ascii.commented_header", overwrite=True)
         return file_to_write_to.absolute()
+
+    def get_coordinates(self, coordinates="ground"):
+        """
+        Get coordinates in the given system.
+
+        Parameters
+        ----------
+        coordinates : str
+            Coordinates system. Default is 'ground'.
+
+        Returns
+        -------
+        list :
+            List of telescope position in the requested coordinate system.
+
+        Raises
+        ------
+        KeyError
+            If the coordinate system is not found.
+        """
+        try:
+            return self.get_parameter_value_with_unit(f"array_element_position_{coordinates}")
+        except KeyError:
+            self._logger.error(f"Coordinate system {coordinates} not found.")
+            return None

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -6,6 +6,8 @@ import logging
 import numpy as np
 import pytest
 
+from simtools.model.model_parameter import InvalidModelParameterError
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
@@ -94,3 +96,22 @@ def test_get_telescope_effective_focal_length(telescope_model_lst, telescope_mod
     assert tel_model_sst.get_telescope_effective_focal_length("m", True) == pytest.approx(2.15)
     tel_model_sst._parameters["effective_focal_length"]["value"] = None
     assert tel_model_sst.get_telescope_effective_focal_length("m", True) == pytest.approx(2.15)
+
+
+def test_position(telescope_model_lst, caplog):
+    tel_model = telescope_model_lst
+    xyz = tel_model.position(coordinate_system="ground")
+    assert pytest.approx(xyz[0].value) == -70.91
+    assert pytest.approx(xyz[1].value) == -52.35
+    assert pytest.approx(xyz[2].value) == 45.0
+    utm_xyz = tel_model.position(coordinate_system="utm")
+    assert pytest.approx(utm_xyz[0].value) == 217659.6
+    assert pytest.approx(utm_xyz[1].value) == 3184995.1
+    assert pytest.approx(utm_xyz[2].value) == 2185.0
+
+    with pytest.raises(InvalidModelParameterError):
+        tel_model.position(coordinate_system="invalid")
+
+    assert any(
+        "Coordinate system invalid not found." in message for message in caplog.text.splitlines()
+    )

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -4,7 +4,6 @@ import logging
 
 import pytest
 
-from simtools.layout.array_layout import ArrayLayout
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 
 logger = logging.getLogger()
@@ -22,17 +21,8 @@ def simtel_config_writer():
     return simtel_config_writer
 
 
-@pytest.fixture()
-def layout(io_handler, db_config, model_version):
-    layout = ArrayLayout.from_array_layout_name(
-        mongo_db_config=db_config, model_version=model_version, array_layout_name="South-4LST"
-    )
-    return layout
-
-
-# @pytest.mark.skip(reason="TODO :test_write_array_config_file - KeyError: 'Released'")
 def test_write_array_config_file(
-    simtel_config_writer, layout, telescope_model_lst, io_handler, file_has_text, site_model_north
+    simtel_config_writer, telescope_model_lst, io_handler, file_has_text, site_model_north
 ):
     file = io_handler.get_output_file(file_name="simtel-config-writer_array.txt", dir_type="test")
     telescope_model = {

--- a/tests/unit_tests/simtel/test_simtel_light_emission.py
+++ b/tests/unit_tests/simtel/test_simtel_light_emission.py
@@ -292,7 +292,7 @@ def test_make_light_emission_script(
         f" -o {mock_output_path}/xyzls.iact.gz\n"
     )
 
-    xyz = array_layout_model.telescope_model["LSTN-01"].get_coordinates(coordinates="ground")
+    xyz = array_layout_model.telescope_model["LSTN-01"].position()
     mock_simulator.default_le_config["x_pos"]["real"] = xyz[0]
     mock_simulator.default_le_config["y_pos"]["real"] = xyz[1]
     mock_simulator.default_le_config["z_pos"]["real"] = xyz[2]
@@ -338,7 +338,7 @@ def test_make_light_emission_script_laser(
     mock_output_path,
     io_handler,
 ):
-    xyz = array_layout_model.telescope_model["LSTN-01"].get_coordinates(coordinates="ground")
+    xyz = array_layout_model.telescope_model["LSTN-01"].position()
     mock_simulator_laser.default_le_config["x_pos"]["real"] = xyz[0]
     mock_simulator_laser.default_le_config["y_pos"]["real"] = xyz[1]
     mock_simulator_laser.default_le_config["z_pos"]["real"] = xyz[2]

--- a/tests/unit_tests/simtel/test_simtel_light_emission.py
+++ b/tests/unit_tests/simtel/test_simtel_light_emission.py
@@ -52,7 +52,7 @@ def default_config_fixture():
         "z_pos_ILLN-01": {
             "len": 1,
             "unit": u.Unit("m"),
-            "default": 229500 * u.cm,
+            "default": 15500 * u.cm,
             "names": ["z_position"],
         },
         "direction": {
@@ -292,7 +292,8 @@ def test_make_light_emission_script(
         f" -o {mock_output_path}/xyzls.iact.gz\n"
     )
 
-    xyz = array_layout_model.telescope_model["LSTN-01"].position()
+    xyz = array_layout_model.telescope_model["LSTN-01"].position(coordinate_system="ground")
+
     mock_simulator.default_le_config["x_pos"]["real"] = xyz[0]
     mock_simulator.default_le_config["y_pos"]["real"] = xyz[1]
     mock_simulator.default_le_config["z_pos"]["real"] = xyz[2]
@@ -338,7 +339,7 @@ def test_make_light_emission_script_laser(
     mock_output_path,
     io_handler,
 ):
-    xyz = array_layout_model.telescope_model["LSTN-01"].position()
+    xyz = array_layout_model.telescope_model["LSTN-01"].position(coordinate_system="ground")
     mock_simulator_laser.default_le_config["x_pos"]["real"] = xyz[0]
     mock_simulator_laser.default_le_config["y_pos"]["real"] = xyz[1]
     mock_simulator_laser.default_le_config["z_pos"]["real"] = xyz[2]


### PR DESCRIPTION
The ArrayLayout model is used primarily for coordinate transformations and should not be used to read telescope positions from a file. Replace ArrayModel therefore in the light emission package by ArrayModel. 

ArrayModel has the additional functionality of reading telescope positions from the database.

- [x] unit tests fail - need @tobiaskleiner for help

(also removed an unused fixed in one of the tests related to the array_layout module)