### PR TITLE
Re-enable pylint in precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,20 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+  # pylint
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+        exclude: ^tests/|^simtools/applications/db_development_tools/
+        args:
+          [
+            "-rn",  # Only display messages
+            "-sn",  # Don't display the score
+          ]
   # https://github.com/pre-commit/pre-commit-hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0


### PR DESCRIPTION
Pylint is very very slow and we decided therefore to not use it anymore in pre-commit and rely on ruff.

However, ruff is not as complete and I have realized now a couple of times that it doesn't not find obvious things like those here: https://github.com/gammasim/simtools/actions/runs/9353065377/job/25742667319 (`Unexpected keyword argument 'array_elements_file' in constructor call `).  I am a bit surprised.

Anyway, this PR puts pylint back into precommit.