### PR TITLE
Set logging level for pymongo module to warning

### DIFF
--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -17,6 +17,8 @@ from simtools.utils import names
 
 __all__ = ["DatabaseHandler"]
 
+logging.getLogger("pymongo").setLevel(logging.WARNING)
+
 
 # pylint: disable=unsubscriptable-object
 # The above comment is because pylint does not know that DatabaseHandler.db_client is subscriptable

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -110,7 +110,7 @@ class ArrayLayout:
 
         split_name = array_layout_name.split("-")
         site_name = names.validate_site_name(split_name[0])
-        array_name = names.validate_array_layout_name(split_name[1])
+        array_name = split_name[1]
         valid_array_layout_name = site_name + "-" + array_name
 
         telescope_list_file = io_handler.IOHandler().get_input_data_file(

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -54,7 +54,7 @@ class ArrayModel:
         self.mongo_db_config = mongo_db_config
         self.model_version = model_version
         self.label = label
-        self.layout_name = names.validate_array_layout_name(layout_name) if layout_name else None
+        self.layout_name = layout_name if layout_name else None
         self._config_file_path = None
         self._config_file_directory = None
         self.io_handler = io_handler.IOHandler()
@@ -95,7 +95,7 @@ class ArrayModel:
                 "layout",
                 "telescope_positions-"
                 f"{names.validate_site_name(site)}-"
-                f"{names.validate_array_layout_name(self.layout_name)}"
+                f"{self.layout_name}"
                 ".ecsv",
             )
 

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -16,7 +16,6 @@ __all__ = [
     "sanitize_name",
     "simtel_single_mirror_list_file_name",
     "simtel_config_file_name",
-    "validate_array_layout_name",
     "validate_site_name",
     "validate_telescope_id_name",
     "validate_telescope_name",
@@ -54,18 +53,6 @@ def site_names():
     _array_elements = array_elements()
     _sites = set(entry["site"] for entry in _array_elements.values())
     return {site: [site.lower()] for site in _sites}
-
-
-array_layout_names = {
-    "4LST": ["4-lst", "4lst"],
-    "1LST": ["1-lst", "1lst"],
-    "4MST": ["4-mst", "4mst"],
-    "1MST": ["1-mst", "mst"],
-    "4SST": ["4-sst", "4sst"],
-    "1SST": ["1-sst", "sst"],
-    "Prod5": ["prod5", "p5"],
-    "TestLayout": ["test-layout"],
-}
 
 
 @cache
@@ -139,23 +126,6 @@ def validate_site_name(name):
         Validated name.
     """
     return _validate_name(name, site_names())
-
-
-def validate_array_layout_name(name):
-    """
-    Validate array layout name.
-
-    Parameters
-    ----------
-    name: str
-        Layout array name.
-
-    Returns
-    -------
-    str
-        Validated name.
-    """
-    return _validate_name(name, array_layout_names)
 
 
 def _validate_name(name, all_names):

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -1,3 +1,5 @@
+"""Validation of names."""
+
 import glob
 import logging
 import re
@@ -80,7 +82,9 @@ def telescope_parameters():
 
 def validate_telescope_id_name(name):
     """
-    Validate telescope ID. Allowed IDs are
+    Validate telescope ID.
+
+    Allowed IDs are
     - design (for design telescopes or testing)
     - telescope ID (e.g., 1, 5, 15)
     - test (for testing)
@@ -100,7 +104,6 @@ def validate_telescope_id_name(name):
     ValueError
         If name is not valid.
     """
-
     if isinstance(name, int) or name.isdigit():
         return f"{int(name):02d}"
     if name.lower() in ("design", "test"):
@@ -130,8 +133,10 @@ def validate_site_name(name):
 
 def _validate_name(name, all_names):
     """
-    Validate name given the all_names options. For each key in all_names, a list of options is \
-    given. If name is in this list, the key name is returned.
+    Validate name given the all_names options.
+
+    For each key in all_names, a list of options is given.
+    If name is in this list, the key name is returned.
 
     Parameters
     ----------
@@ -139,6 +144,7 @@ def _validate_name(name, all_names):
         Name to validate.
     all_names: dict
         Dictionary with valid names.
+
     Returns
     -------
     str
@@ -149,7 +155,6 @@ def _validate_name(name, all_names):
     ValueError
         If name is not valid.
     """
-
     for key in all_names.keys():
         if isinstance(all_names[key], list) and name.lower() in [
             item.lower() for item in all_names[key]
@@ -268,7 +273,7 @@ def get_site_from_telescope_name(name):
 
 def get_collection_name_from_array_element_name(name):
     """
-    Get collection name(e.g., telescopes, calibration_devices) of array element from name
+    Get collection name (e.g., telescopes, calibration_devices) of array element from name.
 
     Parameters
     ----------
@@ -280,7 +285,6 @@ def get_collection_name_from_array_element_name(name):
     str
         Collection name .
     """
-
     return array_elements()[get_telescope_type_from_telescope_name(name)]["collection"]
 
 
@@ -292,6 +296,7 @@ def get_simulation_software_name_from_parameter_name(
 ):
     """
     Get the name used in the simulation software from the model parameter name.
+
     Name convention is expected to be defined in the schema.
     Returns the parameter name if no simulation software name is found.
 
@@ -311,7 +316,6 @@ def get_simulation_software_name_from_parameter_name(
     str
         Simtel parameter name.
     """
-
     _parameter_names = {}
     if search_telescope_parameters:
         _parameter_names.update(telescope_parameters())
@@ -336,6 +340,7 @@ def get_simulation_software_name_from_parameter_name(
 def get_parameter_name_from_simtel_name(simtel_name):
     """
     Get the model parameter name from the simtel parameter name.
+
     Assumes that both names are equal if not defined otherwise in names.py.
 
     Parameters
@@ -348,7 +353,6 @@ def get_parameter_name_from_simtel_name(simtel_name):
     str
         Model parameter name.
     """
-
     _parameters = {**telescope_parameters(), **site_parameters()}
 
     for par_name, par_info in _parameters.items():
@@ -472,6 +476,7 @@ def generate_file_name(
 ):
     """
     Generate a file name for output, config, or plotting.
+
     Used e.g., to generate camera-efficiency and ray-tracing output files.
 
     Parameters
@@ -540,7 +545,6 @@ def sanitize_name(name):
     ValueError:
         if the string name can not be sanitized.
     """
-
     # Convert to lowercase
     sanitized = name.lower()
 

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -89,14 +89,6 @@ def test_validate_site_name():
         names.validate_site_name("Not a site")
 
 
-def test_validate_array_layout_name():
-    for key, value in names.array_layout_names.items():
-        for test_name in value:
-            assert key == names.validate_array_layout_name(test_name)
-    with pytest.raises(ValueError):
-        names.validate_array_layout_name("Not a layout")
-
-
 def test_validate_telescope_name():
     telescopes = {
         "LSTN-Design": "LSTN-design",


### PR DESCRIPTION
Debugging is hard due to extensive and many debug statements printed by the pymongo module. This is especially true when debugging unit tests.

Suggest to set the logging level for the pymongo module to `WARNING`, independent of the general logging level.