### PR TITLE
Disable fail fast for integration tests

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -25,6 +25,7 @@ jobs:
       image: ghcr.io/gammasim/simtools-dev:latest
       options: --user 0
     strategy:
+      fail-fast: false
       matrix:
         type: ['2024-02-01', 'prod5']
 


### PR DESCRIPTION
We run integration tests for several (two) different model versions. 

This PR disables `fail fast` (meaning that all matrix jobs are canceled if one fails), so that we understand better if integration tests generally fail or for a certain model version only.

This workflow setting is described [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast).