### PR TITLE
Remove obsolete ArrayLayout.remove_from_array_layout_name

### DIFF
--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -85,49 +85,6 @@ class ArrayLayout:
             validate=validate,
         )
 
-    @classmethod
-    def from_array_layout_name(cls, mongo_db_config, array_layout_name, model_version, label=None):
-        """
-        Read telescope list from file for given layout name (e.g. South-4LST, North-Prod5, ...).
-        Layout definitions are given in the data/layout path.
-
-        Parameters
-        ----------
-        mongo_db_config: dict
-            MongoDB configuration.
-        array_layout_name: str
-            e.g. South-4LST, North-Prod5 ...
-        model_version: str
-            Version of the model (e.g., prod6).
-        label: str
-            Instance label. Important for output file naming.
-
-        Returns
-        -------
-        ArrayLayout
-            Instance of the ArrayLayout.
-        """
-
-        split_name = array_layout_name.split("-")
-        site_name = names.validate_site_name(split_name[0])
-        array_name = split_name[1]
-        valid_array_layout_name = site_name + "-" + array_name
-
-        telescope_list_file = io_handler.IOHandler().get_input_data_file(
-            "layout", f"telescope_positions-{valid_array_layout_name}.ecsv"
-        )
-
-        layout = cls(
-            site=site_name,
-            mongo_db_config=mongo_db_config,
-            name=valid_array_layout_name,
-            model_version=model_version,
-            label=label,
-            telescope_list_file=telescope_list_file,
-        )
-
-        return layout
-
     def __len__(self):
         """
         Return number of telescopes in the layout.

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -74,17 +74,6 @@ def array_layout_south_four_lst_instance(db_config, model_version):
     )
 
 
-def test_from_array_layout_name(io_handler, db_config, model_version):
-    layout = ArrayLayout.from_array_layout_name(
-        mongo_db_config=db_config, model_version=model_version, array_layout_name="South-4LST"
-    )
-    assert 4 == layout.get_number_of_telescopes()
-    layout = ArrayLayout.from_array_layout_name(
-        mongo_db_config=db_config, model_version=model_version, array_layout_name="North-4MST"
-    )
-    assert 4 == layout.get_number_of_telescopes()
-
-
 def test_initialize_coordinate_systems(
     north_layout_center_data_dict,
     array_layout_north_instance,


### PR DESCRIPTION
The functionality of reading and define array layouts is since the merging of #947 in the ArrayModel class. 

The function `ArrayLayout.remove_from_array_layout_name` is therefore obsolete and is removed in this PR to avoid confusion.

