### PR TITLE
Allow for local database connection

### DIFF
--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -95,7 +95,8 @@ class DatabaseHandler:
                 username=self.mongo_db_config["db_api_user"],
                 password=self.mongo_db_config["db_api_pw"],
                 authSource=self.mongo_db_config.get("db_api_authentication_database", "admin"),
-                ssl=True,
+                directConnection=("localhost" in self.mongo_db_config["db_server"]),
+                ssl=("localhost" not in self.mongo_db_config["db_server"]),
                 tlsallowinvalidhostnames=True,
                 tlsallowinvalidcertificates=True,
             )


### PR DESCRIPTION
`directConnection` should be set to True when running a local mongoDB (and not the instance at DESY).

This is only testable when running a local DB (which is highly experimental at this point), I therefore point the reviewer to https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html .

Note that in 'normal' cases with `db_server` not set to `localhost`, nothing changes.