### PR TITLE
Add a small tool to inspect databases

### DIFF
--- a/database_scripts/README.md
+++ b/database_scripts/README.md
@@ -14,4 +14,41 @@ For testing and development, it might be useful to work with a local copy of the
 
 ### Prerequisites
 
-Access to a database dump of the production database is required.
+Access to a database dump of the production database is required. It is assumed that the dumps
+are located in the directory `database_scripts/dumps`.
+
+The script `./dump_remote_db.sh` can be used to create a dump of the production database (requires access to this DB and the `mongodump` tool).
+
+### Startup and fill local database instance
+
+The scripts `setup_local_db.sh` generates a local database instance in a container:
+
+* downloads a mongoDB docker image
+* starts a container with the image and initialize a new database
+* add a user 'api' with 'readWrite' role
+* import the database dumps
+
+Note that for unknown reasons, the script needs to be executed twice (!!), in case error messages are shown during the first run.
+
+### Using the local database instance
+
+This requires the following changes to the settings of the environmental variables in `.evn`:
+
+```console
+# Environmental variables
+SIMTOOLS_DB_API_PORT=27017 #Port on the MongoDB server
+SIMTOOLS_DB_SERVER='localhost'
+SIMTOOLS_DB_API_USER='api' # username for MongoDB
+SIMTOOLS_DB_API_PW='password' # Password for MongoDB
+SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+```
+
+`SIMTOOLS_DB_SIMULATION_MODEL` is set as an example here to `Staging-CTA-Simulation-Model-v0-3-0` and should be changed accordingly.
+
+
+### Purge the local database instance and all networks, images, containers
+
+The script `purge_local_db.sh` stops and removes the container and deletes all networks, images, and containers.
+
+**Attention: this script removes all local docker containers, images, and networks without awaiting confirmation.**

--- a/database_scripts/README.md
+++ b/database_scripts/README.md
@@ -12,25 +12,35 @@ For testing and development, it might be useful to work with a local copy of the
 
 **The following steps are "experimental" and need further testing.**
 
-### Prerequisites
-
-Access to a database dump of the production database is required. It is assumed that the dumps
-are located in the directory `database_scripts/dumps`.
-
-The script `./dump_remote_db.sh` can be used to create a dump of the production database (requires access to this DB and the `mongodump` tool).
-
-### Startup and fill local database instance
+### Startup and configure local data base instance
 
 The scripts `setup_local_db.sh` generates a local database instance in a container:
 
 * downloads a mongoDB docker image
 * starts a container with the image and initialize a new database
 * add a user 'api' with 'readWrite' role
-* import the database dumps
 
-Note that for unknown reasons, the script needs to be executed twice (!!), in case error messages are shown during the first run.
+Note that for unknown reason, the script needs to be executed twice (!!), in case error messages are shown during the first run.
 
-### Using the local database instance
+### Fill local database from remote DB dump
+
+Access to a database dump of the production database is required. It is assumed that the dumps
+are located in the directory `database_scripts/dumps`.
+
+The script `./dump_remote_db.sh` can be used to create a dump of the production database (requires access to this DB and the `mongodump` tool).
+
+Use then the `upload_dump_to_local_db.sh` to upload this dump to the local database instance.
+
+Note that database names are hardcoded in the scripts and need to be adjusted accordingly.
+
+### Fill local database from model parameter repository
+
+The script `upload_from_model_repository_to_local_db.sh` uses the model parameter repository from the CTAO gitlab and
+uploads its contents to the local database instance.
+
+Note that database names are hardcoded in the scripts and need to be adjusted accordingly.
+
+## Using the local database instance
 
 This requires the following changes to the settings of the environmental variables in `.evn`:
 
@@ -45,7 +55,6 @@ SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
 ```
 
 `SIMTOOLS_DB_SIMULATION_MODEL` is set as an example here to `Staging-CTA-Simulation-Model-v0-3-0` and should be changed accordingly.
-
 
 ### Purge the local database instance and all networks, images, containers
 

--- a/database_scripts/README.md
+++ b/database_scripts/README.md
@@ -1,0 +1,17 @@
+# Collection of database scripts
+
+This directory contains a collection of scripts that can be used to interact with the database:
+
+* dump or copy databases
+* generate a local copy of the model parameter database.
+
+## Running a local copy of the model parameter database
+
+The model parameter database is a mongoDB instance running on a server at DESY.
+For testing and development, it might be useful to work with a local copy of the database.
+
+**The following steps are "experimental" and need further testing.**
+
+### Prerequisites
+
+Access to a database dump of the production database is required.

--- a/database_scripts/README.md
+++ b/database_scripts/README.md
@@ -56,7 +56,7 @@ SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
 
 `SIMTOOLS_DB_SIMULATION_MODEL` is set as an example here to `Staging-CTA-Simulation-Model-v0-3-0` and should be changed accordingly.
 
-### Purge the local database instance and all networks, images, containers
+## Purge the local database instance and all networks, images, containers
 
 The script `purge_local_db.sh` stops and removes the container and deletes all networks, images, and containers.
 

--- a/database_scripts/dump_remote_db.sh
+++ b/database_scripts/dump_remote_db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Dump a remove mongo DB to a local directory
+# uses environment variables from .env file defined in "../.env"
+
+if [ -f ../.env ]; then
+    while IFS='=' read -r key value || [[ -n "$key" ]]; do
+        # Skip lines starting with '#' or lines containing only whitespace
+        if [[ ! "$key" =~ ^\ *# && -n "$key" ]]; then
+            export "$key"="${value%%\#*}"
+        fi
+    done < ../.env
+fi
+
+echo "Dumping simulation model database $SIMTOOLS_DB_SIMULATION_MODEL"
+mkdir -p dump
+
+mongodump --uri="mongodb://${SIMTOOLS_DB_SERVER}:${SIMTOOLS_DB_API_PORT}" \
+ --ssl --tlsInsecure \
+ --username="$SIMTOOLS_DB_USER" --password="$SIMTOOLS_DB_API_PW" \
+ --authenticationDatabase="$SIMTOOLS_DB_API_AUTHENTICATION_DATABASE" \
+ --db="$DB_TO_COPY" --out="./dump/"

--- a/database_scripts/purge_local_db.sh
+++ b/database_scripts/purge_local_db.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Purge local images, containers, networks related to the simtools-mongodb
+# **DANGEROUS; this removes items**
+
+SIMTOOLS_NETWORK="simtools-mongo-network"
+CONTAINER_NAME="simtools-mongodb"
+
+# Check if podman is available, if not use docker
+if command -v podman &> /dev/null; then
+    CMD=podman
+elif command -v docker &> /dev/null; then
+    CMD=docker
+else
+    echo "Error: Neither podman nor docker is available."
+    exit 1
+fi
+
+# Function to remove container
+remove_container() {
+    local container_name=$1
+    if $CMD ps -a --format "{{.Names}}" | grep -q "^${container_name}$"; then
+        echo "Removing existing container $container_name"
+        $CMD rm -f "${container_name}"
+    fi
+}
+
+# Function to remove network
+remove_network() {
+    local network_name=$1
+    if $CMD network exists "$network_name"; then
+        echo "Removing existing network $network_name"
+        $CMD network rm "$network_name"
+    fi
+}
+
+# Cleanup existing containers and network
+remove_container $CONTAINER_NAME
+remove_network $SIMTOOLS_NETWORK
+$CMD image rm -f mongo:latest
+
+rm -rfv mongo-data

--- a/database_scripts/setup_local_db.sh
+++ b/database_scripts/setup_local_db.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Setup a local mongoDB database for the simtools projects
+# Assumes that podman or docker is installed and running
+# Requires a dump directory with the database dump to be present in the current directory
+#
+SIMTOOLS_NETWORK="simtools-mongo-network"
+CONTAINER_NAME="simtools-mongodb"
+HOST_NAME="local-simtools-mongodb"
+
+# Check if podman is available, if not use docker
+if command -v podman &> /dev/null; then
+    CMD=podman
+elif command -v docker &> /dev/null; then
+    CMD=docker
+else
+    echo "Error: Neither podman nor docker is available."
+    exit 1
+fi
+
+echo "Create network $SIMTOOLS_NETWORK"
+$CMD network create $SIMTOOLS_NETWORK
+
+echo "Data directory ./mongo-data"
+mkdir -p "$(pwd)"/mongo-data
+chmod 755 "$(pwd)"/mongo-data
+
+# Start mongoDB
+$CMD run -d \
+  --name $CONTAINER_NAME \
+  --network $SIMTOOLS_NETWORK \
+  --hostname $HOST_NAME \
+  -e MONGO_INITDB_ROOT_USERNAME=root \
+  -e MONGO_INITDB_ROOT_PASSWORD=example \
+  -p 27017:27017 \
+  -v "$(pwd)"/mongo-data:/data/db \
+  mongo:latest
+
+echo "Waiting for MongoDB to start..."
+# Loop until MongoDB is ready
+RETRIES=30
+until $CMD exec $CONTAINER_NAME mongosh --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+  echo "Waiting for MongoDB to be ready... ($((RETRIES--)) retries left)"
+  sleep 2
+done
+if [ $RETRIES -eq 0 ]; then
+  echo "MongoDB did not start in time."
+  exit 1
+fi
+
+# Verify root authentication
+echo "Verifying root authentication..."
+if ! $CMD exec $CONTAINER_NAME mongosh admin -u root -p example --eval "db.runCommand({ connectionStatus: 1 })"; then
+  echo "Error: Root authentication failed."
+  $CMD logs $CONTAINER_NAME
+  exit 1
+fi
+
+# Create user
+echo "Create user"
+$CMD exec -it $CONTAINER_NAME mongosh admin -u root -p example --eval "
+db.createUser({
+  user: 'api',
+  pwd: 'password',
+  roles: [
+    {
+      role: 'dbAdmin',
+    },
+  ]
+});
+"
+
+echo "Upload existing DB dump to DB."
+for db in $(ls dump); do
+  echo "Uploading $db"
+  $CMD run --rm \
+    --network $SIMTOOLS_NETWORK \
+    -v "$(pwd)"/dump:/dump \
+    mongo:latest mongorestore \
+    --host $CONTAINER_NAME \
+    --port 27017 \
+    -u api \
+    -p password \
+    --authenticationDatabase "admin" \
+    -d "$db" \
+    "/dump/$db"
+done

--- a/database_scripts/setup_local_db.sh
+++ b/database_scripts/setup_local_db.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # Setup a local mongoDB database for the simtools projects
 # Assumes that podman or docker is installed and running
-# Requires a dump directory with the database dump to be present in the current directory
-#
+
 SIMTOOLS_NETWORK="simtools-mongo-network"
 CONTAINER_NAME="simtools-mongodb"
 HOST_NAME="local-simtools-mongodb"
@@ -54,34 +53,3 @@ if ! $CMD exec $CONTAINER_NAME mongosh admin -u root -p example --eval "db.runCo
   $CMD logs $CONTAINER_NAME
   exit 1
 fi
-
-# Create user
-echo "Create user"
-$CMD exec -it $CONTAINER_NAME mongosh admin -u root -p example --eval "
-db.createUser({
-  user: 'api',
-  pwd: 'password',
-  roles: [
-    {
-      role: 'readWrite',
-      db: 'Staging-CTA-Simulation-Model-v0-3-0'
-    },
-  ]
-});
-"
-
-echo "Upload existing DB dump to DB."
-for db in $(ls dump); do
-  echo "Uploading $db"
-  $CMD run --rm \
-    --network $SIMTOOLS_NETWORK \
-    -v "$(pwd)"/dump:/dump \
-    mongo:latest mongorestore \
-    --host $CONTAINER_NAME \
-    --port 27017 \
-    -u api \
-    -p password \
-    --authenticationDatabase "admin" \
-    -d "$db" \
-    "/dump/$db"
-done

--- a/database_scripts/setup_local_db.sh
+++ b/database_scripts/setup_local_db.sh
@@ -63,7 +63,8 @@ db.createUser({
   pwd: 'password',
   roles: [
     {
-      role: 'dbAdmin',
+      role: 'readWrite',
+      db: 'Staging-CTA-Simulation-Model-v0-3-0'
     },
   ]
 });

--- a/database_scripts/upload_dump_to_local_db.sh
+++ b/database_scripts/upload_dump_to_local_db.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Upload a local dump of the remote mongoDB to a local mongoDB.
+# Requires a dump directory with the database dump to be present in the current directory.
+# Assumes that podman or docker is installed and running.
+
+SIMTOOLS_NETWORK="simtools-mongo-network"
+CONTAINER_NAME="simtools-mongodb"
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+
+# Check if podman is available, if not use docker
+if command -v podman &> /dev/null; then
+    CMD=podman
+elif command -v docker &> /dev/null; then
+    CMD=docker
+else
+    echo "Error: Neither podman nor docker is available."
+    exit 1
+fi
+
+echo "Create user for DB $SIMTOOLS_DB_SIMULATION_MODEL"
+$CMD exec -it $CONTAINER_NAME mongosh admin -u root -p example --eval "
+db.createUser({
+  user: 'api',
+  pwd: 'password',
+  roles: [
+    {
+      role: 'readWrite',
+      db: $SIMTOOLS_DB_SIMULATION_MODEL,
+    },
+  ]
+});
+"
+
+echo "Upload existing dump of $SIMTOOLS_DB_SIMULATION_MODEL to DB."
+$CMD run --rm \
+  --network $SIMTOOLS_NETWORK \
+  -v "$(pwd)"/dump:/dump \
+  mongo:latest mongorestore \
+  --host $CONTAINER_NAME \
+  --port 27017 \
+  -u api \
+  -p password \
+  --authenticationDatabase "admin" \
+  -d "$SIMTOOLS_DB_SIMULATION_MODEL" \
+  "/dump/$SIMTOOLS_DB_SIMULATION_MODEL"

--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -31,9 +31,8 @@ db.createUser({
 "
 
 echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
-rm -rf ./tmp
-mkdir -p ./tmp
-git clone $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp
+rm -rf ./tmp_model_parameters
+git clone $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
 
 model_directory="./tmp/model_versions/"
 
@@ -52,3 +51,4 @@ for dir in "${model_directory}"*/; do
     --type "model_parameters"
   fi
 done
+rm -rf ./tmp_model_parameters

--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Upload model parameter from repository a local mongoDB.
+# Assumes that podman or docker is installed and running.
+
+CONTAINER_NAME="simtools-mongodb"
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
+
+# Check if podman is available, if not use docker
+if command -v podman &> /dev/null; then
+    CMD=podman
+elif command -v docker &> /dev/null; then
+    CMD=docker
+else
+    echo "Error: Neither podman nor docker is available."
+    exit 1
+fi
+
+echo "Create user for DB $SIMTOOLS_DB_SIMULATION_MODEL"
+$CMD exec -it $CONTAINER_NAME mongosh admin -u root -p example --eval "
+db.createUser({
+  user: 'api',
+  pwd: 'password',
+  roles: [
+    {
+      role: 'readWrite',
+      db: '$SIMTOOLS_DB_SIMULATION_MODEL',
+    },
+  ]
+});
+"
+
+echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
+rm -rf ./tmp
+mkdir -p ./tmp
+git clone $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp
+
+model_directory="./tmp/model_versions/"
+
+for dir in "${model_directory}"*/; do
+  model_version=$(basename "${dir}")
+  if [ "$model_version" = "metadata" ]; then
+    python ./simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py \
+    --input_path "${dir}"/ \
+    --db_name $SIMTOOLS_DB_SIMULATION_MODEL \
+    --type "metadata"
+  else
+    python ./simtools/applications/db_development_tools/add_model_parameters_from_repository_to_db.py \
+    --model_version "${model-version}" \
+    --input_path "${dir}"/verified_model \
+    --db_name $SIMTOOLS_DB_SIMULATION_MODEL \
+    --type "model_parameters"
+  fi
+done

--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -34,7 +34,7 @@ echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
 rm -rf ./tmp_model_parameters
 git clone $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
 
-model_directory="./tmp/model_versions/"
+model_directory="./tmp_model_parameters/model_versions/"
 
 for dir in "${model_directory}"*/; do
   model_version=$(basename "${dir}")
@@ -51,4 +51,5 @@ for dir in "${model_directory}"*/; do
     --type "model_parameters"
   fi
 done
+
 rm -rf ./tmp_model_parameters

--- a/docs/source/applications.md
+++ b/docs/source/applications.md
@@ -41,6 +41,7 @@ calculate_trigger_rate
 compare_cumulative_psf
 convert_all_model_parameters_from_simtel
 convert_model_parameter_from_simtel
+db_inspect_databases
 derive_mirror_rnda
 generate_corsika_histograms
 generate_default_metadata

--- a/docs/source/db_inspect_databases.rst
+++ b/docs/source/db_inspect_databases.rst
@@ -1,0 +1,7 @@
+.. _db_inspect_databases:
+
+db_inspect_databases
+====================
+
+.. automodule:: db_inspect_databases
+   :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ scripts.simtools-calculate-trigger-rate = "simtools.applications.calculate_trigg
 scripts.simtools-compare-cumulative-psf = "simtools.applications.compare_cumulative_psf:main"
 scripts.simtools-convert-all-model-parameters-from-simtel = "simtools.applications.convert_all_model_parameters_from_simtel:main"
 scripts.simtools-convert-model-parameter-from-simtel = "simtools.applications.convert_model_parameter_from_simtel:main"
+scripts.simtools-db-inspect-databases = "simtools.applications.db_inspect_databases:main"
 scripts.simtools-derive-mirror-rnda = "simtools.applications.derive_mirror_rnda:main"
 scripts.simtools-generate-corsika-histograms = "simtools.applications.generate_corsika_histograms:main"
 scripts.simtools-generate-default-metadata = "simtools.applications.generate_default_metadata:main"

--- a/simtools/applications/db_inspect_databases.py
+++ b/simtools/applications/db_inspect_databases.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+"""
+Inspect databases and print (available database names and collections).
+
+Command line arguments
+----------------------
+db_name (str, optional)
+    Inspect a specific database.
+"""
+
+import logging
+
+import simtools.utils.general as gen
+from simtools.configuration import configurator
+from simtools.db import db_handler
+
+
+def main():
+    config = configurator.Configurator(description="Inspect databases")
+    config.parser.add_argument(
+        "--db_name",
+        help="Inspect a specific database (use all to print all databases)",
+        default="all",
+        required=True,
+    )
+    args_dict, db_config = config.initialize(db_config=True, simulation_model="telescope")
+
+    logger = logging.getLogger()
+    logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
+
+    db = db_handler.DatabaseHandler(mongo_db_config=db_config)
+
+    databases = db.db_client.list_database_names()
+
+    for db_name in databases:
+        if args_dict["db_name"] != "all" and db_name != args_dict["db_name"]:
+            continue
+        print("Database:", db_name)
+        collections = db.get_collections(db_name=db_name)
+        print("   Collections:", collections)
+
+
+if __name__ == "__main__":
+    main()

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -95,7 +95,8 @@ class DatabaseHandler:
                 username=self.mongo_db_config["db_api_user"],
                 password=self.mongo_db_config["db_api_pw"],
                 authSource=self.mongo_db_config.get("db_api_authentication_database", "admin"),
-                ssl=True,
+                directConnection=("localhost" in self.mongo_db_config["db_server"]),
+                ssl=("localhost" not in self.mongo_db_config["db_server"]),
                 tlsallowinvalidhostnames=True,
                 tlsallowinvalidcertificates=True,
             )

--- a/tests/integration_tests/config/db_inspect_databases.yml
+++ b/tests/integration_tests/config/db_inspect_databases.yml
@@ -1,0 +1,5 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-db-inspect-databases
+  TEST_NAME: db_inspect_databases
+  CONFIGURATION:
+    DB_NAME: all


### PR DESCRIPTION
Add a simple tool to quickly list the available databases and its collections. I've need this now a couple of times and it is simply faster than opening robot 3T (or something similar). Also means that we reduce the necessity that developers install robot 3T. And the last point is that this is a tool to quickly check the mongoDB status.

This gives e.g. (with my limited local database instance and not the full one running at DESY)

```
python simtools/applications/db_inspect_databases.py --db_name all
Database: Staging-CTA-Simulation-Model-v0-3-0
   Collections: ['configuration_sim_telarray', 'telescopes', 'metadata', 'sites', 'calibration_devices', 'fs.files', 'fs.chunks']
```

