### PR TITLE
Fix complexity issue in simtel_config_writer and add unit test

### DIFF
--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -71,20 +71,36 @@ class SimtelConfigWriter:
             )
             file.write("#endif\n\n")
 
-            if config_parameters is not None:
+            if config_parameters:
                 parameters.update(config_parameters)
 
             for _simtel_name, value in parameters.items():
-                if _simtel_name is not None:
-                    value = "none" if value is None else value  # simtel requires 'none'
-                    if isinstance(value, bool):
-                        value = 1 if value else 0
-                    elif isinstance(value, (list, np.ndarray)):  # noqa: UP038
-                        value = gen.convert_list_to_string(value)
-                    file.write(f"{_simtel_name} = {value}\n")
+                if _simtel_name:
+                    file.write(f"{_simtel_name} = {self._get_value_string_for_simtel(value)}\n")
             _config_meta = self._get_simtel_metadata("telescope")
             for _simtel_name, value in _config_meta.items():
                 file.write(f"{_simtel_name} = {value}\n")
+
+    def _get_value_string_for_simtel(self, value):
+        """
+        Return a value string for simtel.
+
+        Parameters
+        ----------
+        value: any
+            Value to convert to string.
+
+        Returns
+        -------
+        str
+            Value string for simtel.
+        """
+        value = "none" if value is None else value  # simtel requires 'none'
+        if isinstance(value, bool):
+            value = 1 if value else 0
+        elif isinstance(value, (list, np.ndarray)):  # noqa: UP038
+            value = gen.convert_list_to_string(value)
+        return value
 
     def _get_simtel_metadata(self, config_type):
         """

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import numpy as np
 import pytest
 
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
@@ -63,3 +64,13 @@ def test_get_simtel_metadata(simtel_config_writer):
 
     with pytest.raises(ValueError):
         simtel_config_writer._get_simtel_metadata("unknown")
+
+
+def test_get_value_string_for_simtel(simtel_config_writer):
+
+    assert simtel_config_writer._get_value_string_for_simtel(None) == "none"
+    assert simtel_config_writer._get_value_string_for_simtel(True) == 1
+    assert simtel_config_writer._get_value_string_for_simtel(False) == 0
+    assert simtel_config_writer._get_value_string_for_simtel([1, 2, 3]) == "1 2 3"
+    assert simtel_config_writer._get_value_string_for_simtel(np.array([1, 2, 3])) == "1 2 3"
+    assert simtel_config_writer._get_value_string_for_simtel(5) == 5


### PR DESCRIPTION
Address the complexity issue: https://sonar-cta-dpps.zeuthen.desy.de/project/issues?resolved=false&pullRequest=969&id=gammasim_simtools_AY_ssha9WiFxsX-2oy_w&open=AZALqF5Y-Rsd-Q9KQnor

Actually a good point - moving this into a separate function is actually a good point and allows as well to test the string treatment.