### PR TITLE
Allow hist file into trigger rate application

### DIFF
--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -88,6 +88,25 @@ def _parse(label, description):
         action="store_true",
     )
 
+    config.parser.add_argument(
+        "--energy_range",
+        help="Energy range (TeV) passed as a list of floats, the minimum and maximum, "
+        "respectively.",
+        required=False,
+        nargs=2,
+        type=str,
+        default=None,
+    )
+
+    config.parser.add_argument(
+        "--view_cone",
+        help="View cone (deg) passed as two floats, the minimum and maximum, respectively.",
+        nargs=2,
+        required=False,
+        type=str,
+        default=None,
+    )
+
     config_parser, _ = config.initialize(db_config=False, paths=True)
 
     return config_parser
@@ -120,8 +139,24 @@ def main():
             logger.error(msg)
             raise FileNotFoundError from exc
 
+    if config_parser["energy_range"] is not None:
+        emin = float(config_parser["energy_range"][0])
+        emax = float(config_parser["energy_range"][1])
+        energy_range = [emin, emax]
+    else:
+        energy_range = None
+    if config_parser["view_cone"] is not None:
+        cone_min = float(config_parser["view_cone"][0])
+        cone_max = float(config_parser["view_cone"][1])
+        view_cone = [cone_min, cone_max]
+    else:
+        view_cone = None
+
     histograms = SimtelIOHistograms(
-        simtel_array_files, area_from_distribution=config_parser["area_from_distribution"]
+        simtel_array_files,
+        area_from_distribution=config_parser["area_from_distribution"],
+        energy_range=energy_range,
+        view_cone=view_cone,
     )
 
     logger.info("Calculating simulated and triggered event rate")

--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -112,6 +112,39 @@ def _parse(label, description):
     return config_parser
 
 
+def _get_simulation_parameters(config_parser):
+    """
+    Get the energy range and view cone in the correct form to use in the simtel classes.
+
+    Parameters
+    ----------
+    CommandLineParser:
+        Command line parser object as derived by the _parse function.
+
+    Returns
+    -------
+    list:
+        The energy range used in the simulation.
+    list:
+        The view cone used in the simulation.
+
+    """
+    if config_parser["energy_range"] is not None:
+        emin = float(config_parser["energy_range"][0])
+        emax = float(config_parser["energy_range"][1])
+        energy_range = [emin, emax]
+    else:
+        energy_range = None
+    if config_parser["view_cone"] is not None:
+        cone_min = float(config_parser["view_cone"][0])
+        cone_max = float(config_parser["view_cone"][1])
+        view_cone = [cone_min, cone_max]
+    else:
+        view_cone = None
+
+    return energy_range, view_cone
+
+
 def main():
     label = Path(__file__).stem
     description = (
@@ -139,18 +172,7 @@ def main():
             logger.error(msg)
             raise FileNotFoundError from exc
 
-    if config_parser["energy_range"] is not None:
-        emin = float(config_parser["energy_range"][0])
-        emax = float(config_parser["energy_range"][1])
-        energy_range = [emin, emax]
-    else:
-        energy_range = None
-    if config_parser["view_cone"] is not None:
-        cone_min = float(config_parser["view_cone"][0])
-        cone_max = float(config_parser["view_cone"][1])
-        view_cone = [cone_min, cone_max]
-    else:
-        view_cone = None
+    energy_range, view_cone = _get_simulation_parameters(config_parser)
 
     histograms = SimtelIOHistograms(
         simtel_array_files,

--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -109,7 +109,7 @@ def _parse(label, description):
 
     config.parser.add_argument(
         "--view_cone",
-        help="View cone (deg) passed as two floats, the minimum and maximum, respectively.",
+        help="View cone radius (deg) passed as two floats, the minimum and maximum, respectively.",
         nargs=2,
         required=False,
         type=str,
@@ -128,7 +128,7 @@ def _get_simulation_parameters(config_parser):
     Parameters
     ----------
     CommandLineParser:
-        Command line parser object as derived by the _parse function.
+        Command line parser object as defined by the _parse function.
 
     Returns
     -------

--- a/simtools/applications/generate_regular_arrays.py
+++ b/simtools/applications/generate_regular_arrays.py
@@ -21,7 +21,7 @@
 
     .. code-block:: console
 
-        simtools-make-regular-arrays --site=North
+        simtools-generate-regular-arrays --site=North
 """
 
 import logging
@@ -45,7 +45,7 @@ def _parse():
     config = configurator.Configurator(
         label=Path(__file__).stem,
         description=(
-            "Make a regular array of telescope and save as astropy table.\n"
+            "Generate a regular array of telescope and save as astropy table.\n"
             "Default telescope distances for 4 telescope square arrays are: \n"
             f"  LST: {telescope_distance['LST']}\n"
             f"  MST: {telescope_distance['MST']}\n"

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -237,7 +237,7 @@ class SimtelIOHistogram:
             except TypeError as exc:
                 msg = (
                     "view_cone needs to be passed as argument (minimum and maximum of the "
-                    "viewcone radius in deg)."
+                    "view cone radius in deg)."
                 )
                 self._logger.error(msg)
                 raise ValueError(msg) from exc

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -50,7 +50,16 @@ class SimtelIOHistogram:
         calculating trigger rate for individual telescopes.
         If false, the area thrown is estimated based on the maximum distance as given in
         the simulation configuration.
-
+    energy_range: list
+        The energy range used in the simulation. It must be passed as a list of floats and the
+        energy must be in TeV (as in the CORSIKA configuration).
+        This argument is only needed and used if histogram_file is a .hdata file, in which case the
+        energy range cannot be retrieved directly from the file.
+    view_cone: list
+        The view cone used in the simulation. It must be passed as a list of floats and the
+        view cone must be in deg (as in the CORSIKA configuration).
+        This argument is only needed and used if histogram_file is a .hdata file, in which case the
+        view cone cannot be retrieved directly from the file.
     """
 
     def __init__(
@@ -63,13 +72,14 @@ class SimtelIOHistogram:
             msg = f"File {histogram_file} does not exist."
             self._logger.error(msg)
             raise FileNotFoundError
-        self._config = None
         self.view_cone = view_cone
         self._set_view_cone()
-        self._total_area = None
-        self._solid_angle = None
         self.energy_range = energy_range
         self._set_energy_range()
+
+        self._config = None
+        self._total_area = None
+        self._solid_angle = None
         self._total_num_simulated_events = None
         self._total_num_triggered_events = None
         self._histogram = None
@@ -129,7 +139,7 @@ class SimtelIOHistogram:
         if self._config is None:
             # If the file is a .hdata or .hdata.zst, config will continue to be None.
             with EventIOFile(self.histogram_file) as f:
-                # Try to find configuration from .simtel file.
+                # Try to find configuration from .simtel file. If .hdata, config will be None
                 for obj in f:
                     if isinstance(obj, MCRunHeader):
                         self._config = obj.parse()

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -230,10 +230,10 @@ class SimtelIOHistogram:
         if self.view_cone is None:
             try:
                 self.view_cone = self.config["viewcone"] * u.deg
-            except KeyError as exc:
+            except TypeError as exc:
                 msg = "view_cone needs to be passed as argument (a list of cone in deg)."
                 self._logger.error(msg)
-                raise ValueError from exc
+                raise ValueError(msg) from exc
         else:
             if not isinstance(self.view_cone, u.Quantity):
                 self.view_cone = self.view_cone * u.deg
@@ -302,10 +302,10 @@ class SimtelIOHistogram:
                     self.config["E_range"][0] * u.TeV,
                     self.config["E_range"][1] * u.TeV,
                 ]
-            except KeyError as exc:  # E_range not in self.config
+            except TypeError as exc:  # E_range not in self.config
                 msg = "energy_range needs to be passed as argument (a list of energies in TeV)."
                 self._logger.error(msg)
-                raise ValueError from exc
+                raise ValueError(msg) from exc
         else:
             if not isinstance(self.energy_range, u.Quantity):
                 self.energy_range = self.energy_range * u.TeV

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -86,7 +86,6 @@ class SimtelIOHistogram:
         self.energy_axis = None
         self.radius_axis = None
         self.area_from_distribution = area_from_distribution
-        self.suffix = "".join(Path(self.histogram_file).suffixes)
 
         self.view_cone = view_cone
         self._set_view_cone()

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -545,7 +545,7 @@ class SimtelIOHistogram:
         spectral_distribution = copy.copy(IRFDOC_PROTON_SPECTRUM)
         try:
             spectral_distribution.index = self.config["spectral_index"]
-        except KeyError as exc:
+        except TypeError as exc:
             msg = (
                 "spectral_index not found in the configuration of the file. "
                 "Consider using a .simtel file instead."

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -57,7 +57,7 @@ class SimtelIOHistogram:
         energy range cannot be retrieved directly from the file.
     view_cone: list
         The view cone used in the simulation. It must be passed as a list of floats and the
-        view cone must be in deg (as in the CORSIKA configuration).
+        view cone must be in deg.
         This argument is only needed and used if histogram_file is a .hdata file, in which case the
         view cone cannot be retrieved directly from the file.
     """

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -503,10 +503,11 @@ class SimtelIOHistogram:
         Get the particle distribution function.
 
         This depends  on whether one wants the reference CR distribution or the distribution
-        used in the simulation.This is controlled by label.
+        used in the simulation. This is controlled by label.
         By using label="reference", one gets the distribution function according to a pre-defined CR
         distribution, while by using label="simulation", the spectral index of the distribution
-        function from the simulation is used.
+        function from the simulation is used. Naturally, label="simulation" only works when the
+        input file is a .simtel file and not a .hdata file.
 
         Parameters
         ----------
@@ -537,9 +538,21 @@ class SimtelIOHistogram:
         -------
         ctao_cr_spectra.spectral.PowerLaw
             The function describing the spectral distribution.
+        Raises
+        ------
+        ValueError:
+            if input parameter is missing.
         """
         spectral_distribution = copy.copy(IRFDOC_PROTON_SPECTRUM)
-        spectral_distribution.index = self.config["spectral_index"]
+        try:
+            spectral_distribution.index = self.config["spectral_index"]
+        except KeyError as exc:
+            msg = (
+                "spectral_index not found in the configuration of the file. "
+                "Consider using a .simtel file instead."
+            )
+            self._logger.error(msg)
+            raise ValueError from exc
         return spectral_distribution
 
     def estimate_observation_time(self, stacked_num_simulated_events=None):

--- a/simtools/simtel/simtel_io_histograms.py
+++ b/simtools/simtel/simtel_io_histograms.py
@@ -51,14 +51,33 @@ class SimtelIOHistograms:
         calculating trigger rate for individual telescopes.
         If false, the area thrown is estimated based on the maximum distance as given in
         the simulation configuration.
+    energy_range: list
+        The energy range used in the simulation. It must be passed as a list of floats and the
+        energy must be in TeV (as in the CORSIKA configuration).
+        This argument is only needed and used if histogram_file is a .hdata file, in which case the
+        energy range cannot be retrieved directly from the file.
+    view_cone: list
+        The view cone used in the simulation. It must be passed as a list of floats and the
+        view cone must be in deg (as in the CORSIKA configuration).
+        This argument is only needed and used if histogram_file is a .hdata file, in which case the
+        view cone cannot be retrieved directly from the file.
     """
 
-    def __init__(self, histogram_files, test=False, area_from_distribution=False):
+    def __init__(
+        self,
+        histogram_files,
+        test=False,
+        area_from_distribution=False,
+        energy_range=None,
+        view_cone=None,
+    ):
         """Initialize SimtelIOHistograms."""
         self._logger = logging.getLogger(__name__)
         if not isinstance(histogram_files, list):
             histogram_files = [histogram_files]
         self.histogram_files = histogram_files
+        self.view_cone = view_cone
+        self.energy_range = energy_range
         self._is_test = test
         self._combined_hists = None
         self._list_of_histograms = None
@@ -164,7 +183,10 @@ class SimtelIOHistograms:
         stacked_num_triggered_events = 0
         for _, file in enumerate(self.histogram_files):
             simtel_hist_instance = SimtelIOHistogram(
-                file, area_from_distribution=self.area_from_distribution
+                file,
+                area_from_distribution=self.area_from_distribution,
+                energy_range=self.energy_range,
+                view_cone=self.view_cone,
             )
             stacked_num_simulated_events += simtel_hist_instance.total_num_simulated_events
             stacked_num_triggered_events += simtel_hist_instance.total_num_triggered_events
@@ -191,7 +213,10 @@ class SimtelIOHistograms:
         # Using a dummy instance of SimtelIOHistogram to calculate the trigger rate for the
         # stacked files
         simtel_hist_instance = SimtelIOHistogram(
-            self.histogram_files[0], area_from_distribution=self.area_from_distribution
+            self.histogram_files[0],
+            area_from_distribution=self.area_from_distribution,
+            energy_range=self.energy_range,
+            view_cone=self.view_cone,
         )
 
         stacked_num_simulated_events, stacked_num_triggered_events = self.get_stacked_num_events()
@@ -245,7 +270,10 @@ class SimtelIOHistograms:
         triggered_event_rate_uncertainties = []
         for i_file, file in enumerate(self.histogram_files):
             simtel_hist_instance = SimtelIOHistogram(
-                file, area_from_distribution=self.area_from_distribution
+                file,
+                area_from_distribution=self.area_from_distribution,
+                energy_range=self.energy_range,
+                view_cone=self.view_cone,
             )
             if print_info:
                 simtel_hist_instance.print_info()

--- a/tests/integration_tests/config/calculate_trigger_rate_one_file_hdata.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_one_file_hdata.yml
@@ -1,0 +1,12 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-calculate-trigger-rate
+  TEST_NAME: one_file_hdata
+  CONFIGURATION:
+    SIMTEL_FILE_NAMES: |
+      ./tests/resources/run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst
+    VIEW_CONE:
+      - "0"
+      - "10"
+    ENERGY_RANGE:
+      - "0.008"
+      - "300"

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -49,11 +49,11 @@ def test_init_errors(simtel_io_file_hdata, caplog):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError):
             _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
-    assert "view_cone needs to be passed as argument (a list of cone in deg)" in caplog.text
+    assert "view_cone needs to be passed as argument" in caplog.text
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError):
             _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
-    assert "energy_range needs to be passed as argument (a list of energies in TeV)" in caplog.text
+    assert "energy_range needs to be passed as argument" in caplog.text
 
 
 def test_file_does_not_exist(caplog):

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -165,7 +165,7 @@ def test_view_cone(simtel_hist_io_instance, simtel_hist_hdata_io_instance):
     view_cone = simtel_hist_io_instance.view_cone
     assert (view_cone == [0, 10] * u.deg).all()
 
-    assert simtel_hist_hdata_io_instance.view_cone == [0, 10] * u.deg
+    assert (simtel_hist_hdata_io_instance.view_cone == [0, 10] * u.deg).all()
 
 
 def test_compute_system_trigger_rate_and_table(simtel_hist_io_instance):
@@ -239,7 +239,7 @@ def test_energy_range(simtel_hist_io_instance, simtel_hist_hdata_io_instance):
     assert energy_range[0].unit == u.TeV
     assert energy_range[1].value > energy_range[0].value
 
-    assert simtel_hist_hdata_io_instance.energy_range == [0.008, 300] * u.TeV
+    assert (simtel_hist_hdata_io_instance.energy_range == [0.008, 300] * u.TeV).all()
 
 
 def test_solid_angle(simtel_hist_io_instance):

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture()
-def simtel_array_histograms_file(io_handler, corsika_output_file_name):
+def simtel_io_file(io_handler):
     return io_handler.get_input_data_file(
         file_name="run201_proton_za20deg_azm0deg_North_test_layout_test-prod.simtel.zst",
         test=True,
@@ -24,8 +24,24 @@ def simtel_array_histograms_file(io_handler, corsika_output_file_name):
 
 
 @pytest.fixture()
-def simtel_array_histogram_instance(simtel_array_histograms_file):
-    instance = SimtelIOHistogram(histogram_file=simtel_array_histograms_file)
+def simtel_io_file_hdata(io_handler):
+    return io_handler.get_input_data_file(
+        file_name="run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
+        test=True,
+    )
+
+
+@pytest.fixture()
+def simtel_hist_io_instance(simtel_io_file):
+    instance = SimtelIOHistogram(histogram_file=simtel_io_file)
+    return instance
+
+
+@pytest.fixture()
+def simtel_hist_hdata_io_instance(simtel_io_file_hdata):
+    instance = SimtelIOHistogram(
+        histogram_file=simtel_io_file_hdata, view_cone=[0, 10], energy_range=[0.008, 300]
+    )
     return instance
 
 
@@ -36,43 +52,43 @@ def test_file_does_not_exist(caplog):
     assert "does not exist." in caplog.text
 
 
-def test_number_of_histogram_types(simtel_array_histogram_instance):
-    assert simtel_array_histogram_instance.number_of_histogram_types == 10
+def test_number_of_histogram_types(simtel_hist_io_instance):
+    assert simtel_hist_io_instance.number_of_histogram_types == 10
 
 
-def test_get_histogram_type_title(simtel_array_histogram_instance):
-    title = simtel_array_histogram_instance.get_histogram_type_title(histogram_index=0)
+def test_get_histogram_type_title(simtel_hist_io_instance):
+    title = simtel_hist_io_instance.get_histogram_type_title(histogram_index=0)
     assert title == "Events, without weights (Ra, log10(E))"
 
 
-def test_config(simtel_array_histogram_instance):
-    config = simtel_array_histogram_instance.config
+def test_config(simtel_hist_io_instance):
+    config = simtel_hist_io_instance.config
     assert config is not None
     assert "B_declination" in config
 
 
-def test_total_num_simulated_events(simtel_array_histogram_instance):
-    total_num_simulated_events = simtel_array_histogram_instance.total_num_simulated_events
+def test_total_num_simulated_events(simtel_hist_io_instance):
+    total_num_simulated_events = simtel_hist_io_instance.total_num_simulated_events
     assert total_num_simulated_events == 2000
 
 
-def test_total_num_triggered_events(simtel_array_histogram_instance):
-    total_num_triggered_events = simtel_array_histogram_instance.total_num_triggered_events
+def test_total_num_triggered_events(simtel_hist_io_instance):
+    total_num_triggered_events = simtel_hist_io_instance.total_num_triggered_events
     assert total_num_triggered_events == 1.0
 
 
-def test_fill_event_histogram_dicts(simtel_array_histogram_instance, caplog):
+def test_fill_event_histogram_dicts(simtel_hist_io_instance, caplog):
     (
         events_histogram,
         triggered_events_histogram,
-    ) = simtel_array_histogram_instance.fill_event_histogram_dicts()
+    ) = simtel_hist_io_instance.fill_event_histogram_dicts()
     assert events_histogram is not None
     assert events_histogram["content_inside"] == 2000.0
     assert triggered_events_histogram is not None
     assert triggered_events_histogram["content_inside"] == 1.0
 
     # Test defect histograms
-    new_instance = copy.copy(simtel_array_histogram_instance)
+    new_instance = copy.copy(simtel_hist_io_instance)
     for histogram_index, hist in enumerate(
         new_instance.histogram
     ):  # altering intentionally the ids
@@ -86,11 +102,11 @@ def test_fill_event_histogram_dicts(simtel_array_histogram_instance, caplog):
     assert "Histograms ids not found. Please check your files." in caplog.text
 
 
-def test_produce_triggered_to_sim_fraction_hist(simtel_array_histogram_instance):
+def test_produce_triggered_to_sim_fraction_hist(simtel_hist_io_instance):
     events_histogram = {"data": np.array([[10, 20, 30], [40, 50, 60]])}
     triggered_events_histogram = {"data": np.array([[5, 10, 15], [20, 25, 30]])}
 
-    result = simtel_array_histogram_instance._produce_triggered_to_sim_fraction_hist(
+    result = simtel_hist_io_instance._produce_triggered_to_sim_fraction_hist(
         events_histogram, triggered_events_histogram
     )
     expected_result = np.array([0.5, 0.5])
@@ -102,7 +118,7 @@ def test_produce_triggered_to_sim_fraction_hist(simtel_array_histogram_instance)
     assert np.all(result <= 1)  # Check if all values are less than or equal to 1
 
 
-def test_initialize_histogram_axes(simtel_array_histogram_instance):
+def test_initialize_histogram_axes(simtel_hist_io_instance):
     events_histogram = {
         "lower_x": 0,
         "upper_x": 10,
@@ -111,16 +127,16 @@ def test_initialize_histogram_axes(simtel_array_histogram_instance):
         "upper_y": 3,
         "n_bins_y": 4,
     }
-    simtel_array_histogram_instance._initialize_histogram_axes(events_histogram)
+    simtel_hist_io_instance._initialize_histogram_axes(events_histogram)
     expected_radius_axis = np.linspace(0, 10, 6)
     expected_energy_axis = np.logspace(1, 3, 5)
-    assert np.array_equal(simtel_array_histogram_instance.radius_axis, expected_radius_axis)
-    assert np.array_equal(simtel_array_histogram_instance.energy_axis, expected_energy_axis)
+    assert np.array_equal(simtel_hist_io_instance.radius_axis, expected_radius_axis)
+    assert np.array_equal(simtel_hist_io_instance.energy_axis, expected_energy_axis)
 
 
-def test_get_particle_distribution_function(simtel_array_histogram_instance):
+def test_get_particle_distribution_function(simtel_hist_io_instance):
     # Test reference distribution function
-    reference_function = simtel_array_histogram_instance.get_particle_distribution_function(
+    reference_function = simtel_hist_io_instance.get_particle_distribution_function(
         label="reference"
     )
     assert isinstance(
@@ -128,53 +144,53 @@ def test_get_particle_distribution_function(simtel_array_histogram_instance):
     )  # Assuming PowerLaw is the expected type for the reference function
 
     # Test simulation distribution function
-    simulation_function = simtel_array_histogram_instance.get_particle_distribution_function(
+    simulation_function = simtel_hist_io_instance.get_particle_distribution_function(
         label="simulation"
     )
     assert simulation_function.index == -2.0
 
     # Test invalid label
     with pytest.raises(ValueError):
-        simtel_array_histogram_instance.get_particle_distribution_function(label="invalid_label")
+        simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
 
 
-def test_integrate_in_energy_bin(simtel_array_histogram_instance):
-    result = simtel_array_histogram_instance._integrate_in_energy_bin(
+def test_integrate_in_energy_bin(simtel_hist_io_instance):
+    result = simtel_hist_io_instance._integrate_in_energy_bin(
         IRFDOC_PROTON_SPECTRUM, np.array([1, 10])
     )
     assert pytest.approx(result.value, 0.1) == 5.9e-06
 
 
-def test_view_cone(simtel_array_histogram_instance):
-    view_cone = simtel_array_histogram_instance.view_cone
+def test_view_cone(simtel_hist_io_instance, simtel_hist_hdata_io_instance):
+    view_cone = simtel_hist_io_instance.view_cone
     assert (view_cone == [0, 10] * u.deg).all()
 
+    assert simtel_hist_hdata_io_instance.view_cone == [0, 10] * u.deg
 
-def test_compute_system_trigger_rate_and_table(simtel_array_histogram_instance):
 
-    assert simtel_array_histogram_instance.trigger_rate is None
-    assert simtel_array_histogram_instance.trigger_rate_uncertainty is None
-    assert simtel_array_histogram_instance.trigger_rate_per_energy_bin is None
-    simtel_array_histogram_instance.compute_system_trigger_rate()
-    assert pytest.approx(simtel_array_histogram_instance.trigger_rate.value, 0.1) == 9006
-    assert simtel_array_histogram_instance.trigger_rate.unit == 1 / u.s
-    assert (
-        pytest.approx(simtel_array_histogram_instance.trigger_rate_uncertainty.value, 0.1) == 9008
-    )
-    assert simtel_array_histogram_instance.trigger_rate_uncertainty.unit == 1 / u.s
-    assert len(simtel_array_histogram_instance.trigger_rate_per_energy_bin.value) == 120
+def test_compute_system_trigger_rate_and_table(simtel_hist_io_instance):
+
+    assert simtel_hist_io_instance.trigger_rate is None
+    assert simtel_hist_io_instance.trigger_rate_uncertainty is None
+    assert simtel_hist_io_instance.trigger_rate_per_energy_bin is None
+    simtel_hist_io_instance.compute_system_trigger_rate()
+    assert pytest.approx(simtel_hist_io_instance.trigger_rate.value, 0.1) == 9006
+    assert simtel_hist_io_instance.trigger_rate.unit == 1 / u.s
+    assert pytest.approx(simtel_hist_io_instance.trigger_rate_uncertainty.value, 0.1) == 9008
+    assert simtel_hist_io_instance.trigger_rate_uncertainty.unit == 1 / u.s
+    assert len(simtel_hist_io_instance.trigger_rate_per_energy_bin.value) == 120
 
     events_histogram, triggered_events_histogram = (
-        simtel_array_histogram_instance.fill_event_histogram_dicts()
+        simtel_hist_io_instance.fill_event_histogram_dicts()
     )
-    simtel_array_histogram_instance._initialize_histogram_axes(events_histogram)
-    table = simtel_array_histogram_instance.trigger_info_in_table()
+    simtel_hist_io_instance._initialize_histogram_axes(events_histogram)
+    table = simtel_hist_io_instance.trigger_info_in_table()
     assert table["Energy (TeV)"].value[0] == 1.00000000e-03
 
 
-def test_compute_system_trigger_rate_with_input(simtel_array_histogram_instance):
+def test_compute_system_trigger_rate_with_input(simtel_hist_io_instance):
 
-    new_instance = copy.copy(simtel_array_histogram_instance)
+    new_instance = copy.copy(simtel_hist_io_instance)
     events_histogram, triggered_events_histogram = new_instance.fill_event_histogram_dicts()
     new_events_histogram = copy.copy(events_histogram)
     new_events_histogram["data"] = 1e-9 * new_events_histogram["data"]
@@ -187,74 +203,72 @@ def test_compute_system_trigger_rate_with_input(simtel_array_histogram_instance)
     assert new_instance.trigger_rate_uncertainty.unit == 1 / u.s
 
 
-def test_produce_trigger_meta_data(simtel_array_histogram_instance, simtel_array_histograms_file):
+def test_produce_trigger_meta_data(simtel_hist_io_instance, simtel_io_file):
 
     trigger_rate = 1000  # Hz
 
-    simtel_array_histogram_instance.histogram_file = simtel_array_histograms_file
-    simtel_array_histogram_instance.trigger_rate = (
-        trigger_rate * u.Hz
-    )  # Convert to astropy Quantity
+    simtel_hist_io_instance.histogram_file = simtel_io_file
+    simtel_hist_io_instance.trigger_rate = trigger_rate * u.Hz  # Convert to astropy Quantity
 
-    result = simtel_array_histogram_instance.produce_trigger_meta_data()
+    result = simtel_hist_io_instance.produce_trigger_meta_data()
 
     expected_result = {
-        "simtel_array_file": simtel_array_histograms_file,
-        "simulation_input": simtel_array_histogram_instance.print_info(mode="silent"),
+        "simtel_array_file": simtel_io_file,
+        "simulation_input": simtel_hist_io_instance.print_info(mode="silent"),
         "system_trigger_rate (Hz)": trigger_rate,
     }
     assert result == expected_result
 
 
-def test_print_info(simtel_array_histogram_instance):
-    info_dict = simtel_array_histogram_instance.print_info(mode=None)
+def test_print_info(simtel_hist_io_instance):
+    info_dict = simtel_hist_io_instance.print_info(mode=None)
     assert "view_cone" in info_dict
     assert "energy_range" in info_dict
 
 
-def test_total_area(simtel_array_histogram_instance, simtel_array_histograms_file):
-    total_area = simtel_array_histogram_instance.total_area
+def test_total_area(simtel_hist_io_instance, simtel_io_file):
+    total_area = simtel_hist_io_instance.total_area
     assert total_area.unit == u.cm**2
     assert pytest.approx(total_area.value, 0.05) == 1.25e11
-    new_instance = SimtelIOHistogram(
-        histogram_file=simtel_array_histograms_file, area_from_distribution=True
-    )
+    new_instance = SimtelIOHistogram(histogram_file=simtel_io_file, area_from_distribution=True)
     assert pytest.approx(new_instance.total_area.value, 0.05) == 1.3e11
 
 
-def test_energy_range(simtel_array_histogram_instance):
-    energy_range = simtel_array_histogram_instance.energy_range
+def test_energy_range(simtel_hist_io_instance, simtel_hist_hdata_io_instance):
+    energy_range = simtel_hist_io_instance.energy_range
     assert energy_range[0].unit == u.TeV
     assert energy_range[1].value > energy_range[0].value
 
+    assert simtel_hist_hdata_io_instance.energy_range == [0.008, 300] * u.TeV
 
-def test_solid_angle(simtel_array_histogram_instance):
-    solid_angle = simtel_array_histogram_instance.solid_angle
+
+def test_solid_angle(simtel_hist_io_instance):
+    solid_angle = simtel_hist_io_instance.solid_angle
     assert pytest.approx(solid_angle.value, 0.1) == 0.095
 
 
-def test_estimate_observation_time(simtel_array_histogram_instance):
-    observation_time = simtel_array_histogram_instance.estimate_observation_time()
+def test_estimate_observation_time(simtel_hist_io_instance):
+    observation_time = simtel_hist_io_instance.estimate_observation_time()
     assert observation_time.unit == u.s
     assert pytest.approx(observation_time.value, 0.1) == 9.4e-5
-    observation_time = simtel_array_histogram_instance.estimate_observation_time(
+    observation_time = simtel_hist_io_instance.estimate_observation_time(
         stacked_num_simulated_events=100
     )
     assert observation_time.unit == u.s
     assert pytest.approx(observation_time.value, 0.1) == 4.7e-6
 
 
-def test_estimate_trigger_rate_uncertainty(simtel_array_histogram_instance):
+def test_estimate_trigger_rate_uncertainty(simtel_hist_io_instance):
 
-    simtel_array_histogram_instance.compute_system_trigger_rate()
-    trigger_rate_uncertainty = simtel_array_histogram_instance.estimate_trigger_rate_uncertainty(
-        simtel_array_histogram_instance.trigger_rate,
-        simtel_array_histogram_instance.total_num_simulated_events,
-        simtel_array_histogram_instance.total_num_triggered_events,
+    simtel_hist_io_instance.compute_system_trigger_rate()
+    trigger_rate_uncertainty = simtel_hist_io_instance.estimate_trigger_rate_uncertainty(
+        simtel_hist_io_instance.trigger_rate,
+        simtel_hist_io_instance.total_num_simulated_events,
+        simtel_hist_io_instance.total_num_triggered_events,
     )
     assert trigger_rate_uncertainty.unit == 1 / u.s
     assert pytest.approx(trigger_rate_uncertainty.value, 0.1) == 9008
-    trigger_rate_uncertainty = simtel_array_histogram_instance.estimate_trigger_rate_uncertainty(
+    trigger_rate_uncertainty = simtel_hist_io_instance.estimate_trigger_rate_uncertainty(
         1e4 / u.s, 100, 10
     )
     assert trigger_rate_uncertainty.unit == 1 / u.s

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 
+import astropy.units as u
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -22,7 +23,7 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture()
-def simtel_array_histograms_file(io_handler):
+def simtel_io_file(io_handler):
     return io_handler.get_input_data_file(
         file_name="run201_proton_za20deg_azm0deg_North_test_layout_test-prod.simtel.zst",
         test=True,
@@ -30,7 +31,15 @@ def simtel_array_histograms_file(io_handler):
 
 
 @pytest.fixture()
-def simtel_array_histograms_file_list(io_handler):
+def simtel_io_file_hdata(io_handler):
+    return io_handler.get_input_data_file(
+        file_name="run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
+        test=True,
+    )
+
+
+@pytest.fixture()
+def simtel_io_file_list(io_handler):
     return io_handler.get_input_data_file(
         file_name="simtel_output_files.txt",
         test=True,
@@ -38,16 +47,22 @@ def simtel_array_histograms_file_list(io_handler):
 
 
 @pytest.fixture()
-def simtel_array_histograms_instance(simtel_array_histograms_file):
+def simtel_hists_hdata_io_instance(simtel_io_file_hdata):
     instance = SimtelIOHistograms(
-        histogram_files=[simtel_array_histograms_file, simtel_array_histograms_file], test=True
+        histogram_files=simtel_io_file_hdata, view_cone=[0, 10], energy_range=[0.001, 300]
     )
     return instance
 
 
 @pytest.fixture()
-def simtel_array_histograms_instance_file_list(simtel_array_histograms_file_list):
-    instance = SimtelIOHistograms(histogram_files=simtel_array_histograms_file_list, test=True)
+def simtel_array_histograms_instance(simtel_io_file):
+    instance = SimtelIOHistograms(histogram_files=[simtel_io_file, simtel_io_file], test=True)
+    return instance
+
+
+@pytest.fixture()
+def simtel_array_histograms_instance_file_list(simtel_io_file_list):
+    instance = SimtelIOHistograms(histogram_files=simtel_io_file_list, test=True)
     return instance
 
 
@@ -59,9 +74,11 @@ def test_file_does_not_exist(caplog):
 
 
 def test_calculate_trigger_rates(
-    simtel_array_histograms_instance, simtel_array_histograms_instance_file_list, caplog
+    simtel_array_histograms_instance,
+    simtel_array_histograms_instance_file_list,
+    simtel_hists_hdata_io_instance,
+    caplog,
 ):
-    import astropy.units as u
 
     with caplog.at_level(logging.INFO):
         (
@@ -80,6 +97,8 @@ def test_calculate_trigger_rates(
     assert "Estimated equivalent observation time corresponding to the number of" in caplog.text
     assert "System trigger event rate" in caplog.text
 
+
+def test_calculate_trigger_rates_file_list(simtel_array_histograms_instance, caplog):
     with caplog.at_level(logging.INFO):
         (
             sim_event_rates,
@@ -92,6 +111,20 @@ def test_calculate_trigger_rates(
         second_sim_event_rates, _, _, _ = simtel_array_histograms_instance._rates_for_each_file()
         assert second_sim_event_rates == [sim_event_rates, sim_event_rates]
     assert "System trigger event rate for stacked files" in caplog.text
+
+
+def test_calculate_trigger_rates_hdata(simtel_hists_hdata_io_instance):
+    # Test the trigger rate estimate for input hdata file
+    (
+        sim_event_rates,
+        triggered_event_rates,
+        triggered_event_rate_uncertainties,
+        trigger_rate_in_tables,
+    ) = simtel_hists_hdata_io_instance.calculate_trigger_rates(print_info=False)
+    assert pytest.approx(sim_event_rates[0].value, 0.2) == 2.5e9
+    assert sim_event_rates[0].unit == 1 / u.s
+    assert pytest.approx(triggered_event_rate_uncertainties[0].value, 0.1) == 70000
+    assert trigger_rate_in_tables[0]["Energy (TeV)"][0] == 0.001 * u.TeV
 
 
 def test_rates_for_each_file(simtel_array_histograms_instance):
@@ -177,14 +210,12 @@ def test_list_of_histograms(simtel_array_histograms_instance):
     assert len(list_of_histograms) == 2
 
 
-def test_combine_histogram_files(simtel_array_histograms_file, caplog):
+def test_combine_histogram_files(simtel_io_file, caplog):
     # Reading one histogram file
-    instance_alone = SimtelIOHistograms(histogram_files=simtel_array_histograms_file, test=True)
+    instance_alone = SimtelIOHistograms(histogram_files=simtel_io_file, test=True)
 
     # Passing the same file twice
-    instance_all = SimtelIOHistograms(
-        histogram_files=[simtel_array_histograms_file, simtel_array_histograms_file], test=True
-    )
+    instance_all = SimtelIOHistograms(histogram_files=[simtel_io_file, simtel_io_file], test=True)
     assert (
         2 * instance_alone.combined_hists[0]["data"] == instance_all.combined_hists[0]["data"]
     ).all()


### PR DESCRIPTION
In this PR, I implemented some improvements to the trigger rate tool that allows it to calculate the trigger rate for a given an input .hdata.zst file (and not only an .simtel.zst file as it is in main now). However, the configuration used for the simulation is not propagated to the .hdata.zst as it is to the .simtel.zst, which means we do not have the view cone and the energy range used, which are both necessary for the operation of this tool. Therefore, if passing a .hdata to the tool, `--energy_range` and `--view_cone` also have to be passed. One can test this with the new integration test `simtools-calculate-trigger-rate --config tests/integration_tests/config/calculate_trigger_rate_one_file_hdata.yml`. Not passing `--energy_range` or `--view_cone` for an input .hdata file will lead to error, which is tested in the unit tests.

I believe the low coverage by sonarqube is due to the changes in the application itself, which we do not test with unit tests at the moment, so I suggest to ignore it.

Closes #934.