### PR TITLE
Improvements to simulate for trigger rate

### DIFF
--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -180,7 +180,10 @@ def main():
             "data_directory": Path(args_dict["data_directory"]) / label,
             "site": args_dict["site"],
             "layout_name": args_dict["array_layout_name"],
-            "run_range": [args_dict["run_number"], args_dict["run_number"] + args_dict["nruns"]],
+            "run_range": [
+                args_dict["run_number"],
+                args_dict["run_number"] + args_dict["nruns"] - 1,
+            ],
             "nshow": args_dict["nevents"],
             "primary": args_dict["primary"],
             "zenith": args_dict["zenith"] * u.deg,
@@ -207,6 +210,11 @@ def main():
         mongo_db_config=db_config,
         model_version=args_dict.get("model_version", None),
     )
+
+    if args_dict["array_layout_name"] in ["1MST", "1LST", "1SST"]:
+        shower_simulator.array_model.site_model.change_parameter(
+            "array_triggers", "array_trigger_1MST_lapalma.dat"
+        )
 
     shower_simulator.simulate()
 

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -38,8 +38,6 @@
         View cone in deg.
     scatter_x (float, optional)
         Scatter distance (X axis) in m.
-    scatter_y (float, optional)
-        Scatter distance (Y axis) in m.
     num_use (int, optional)
         Number of use for each shower.
     energy_min (float, optional)
@@ -130,11 +128,9 @@ def _parse(label=None, description=None):
     config.parser.add_argument(
         "--scatter_x", help="Scatter distance (X axis) in m", type=float, default=1500
     )
+
     config.parser.add_argument(
-        "--scatter_y", help="Scatter radius  (Y axis) in m", type=float, default=0
-    )
-    config.parser.add_argument(
-        "--num_use", help="Number of use for each shower", type=int, default=20
+        "--num_use", help="Number of use for each shower", type=int, default=10
     )
     config.parser.add_argument(
         "--energy_min", help="Energy threshold (TeV)", type=float, default=0.01
@@ -158,6 +154,16 @@ def _parse(label=None, description=None):
 
 
 def print_list_into_file(list_of_files, file_name):
+    """
+    Print the list of output files from the simulation into a log file.
+
+    Parameters
+    ----------
+    list_of_files: list
+        list of files to be printed out.
+    file_name: str
+        name of the output file.
+    """
     with open(file_name, "w", encoding="utf-8") as f:
         for line in list_of_files:
             f.write(line + "\n")
@@ -196,7 +202,7 @@ def main():
             "cscat": [
                 args_dict["num_use"],
                 args_dict["scatter_x"] * u.m,
-                args_dict["scatter_y"] * u.m,
+                0 * u.m,
             ],
         },
     }
@@ -210,8 +216,7 @@ def main():
         mongo_db_config=db_config,
         model_version=args_dict.get("model_version", None),
     )
-
-    if args_dict["array_layout_name"] in ["1MST", "1LST", "1SST"]:
+    if shower_simulator.array_model.number_of_telescopes == 1:
         shower_simulator.array_model.site_model.change_parameter(
             "array_triggers", "array_trigger_1MST_lapalma.dat"
         )

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -180,7 +180,7 @@ def main():
             "data_directory": Path(args_dict["data_directory"]) / label,
             "site": args_dict["site"],
             "layout_name": args_dict["array_layout_name"],
-            "run_range": [args_dict["run_number"], args_dict["nruns"]],
+            "run_range": [args_dict["run_number"], args_dict["run_number"] + args_dict["nruns"]],
             "nshow": args_dict["nevents"],
             "primary": args_dict["primary"],
             "zenith": args_dict["zenith"] * u.deg,

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -124,6 +124,12 @@ def _parse(label=None, description=None):
     return config.initialize(simulation_model="telescope", job_submission=True, db_config=True)
 
 
+def print_list_into_file(list_of_files, file_name):
+    with open(file_name, "w", encoding="utf-8") as f:
+        for line in list_of_files:
+            f.write(line + "\n")
+
+
 def main():
     label = Path(__file__).stem
     args_dict, db_config = _parse(
@@ -148,10 +154,10 @@ def main():
             "azimuth": args_dict["azimuth"] * u.deg,
         },
         "showers": {
-            "erange": [10 * u.GeV, 300 * u.TeV],
+            "erange": [100 * u.GeV, 300 * u.TeV],
             "eslope": -2,
-            "viewcone": 10 * u.deg,
-            "cscat": [20, 1500 * u.m, 0],
+            "viewcone": 0 * u.deg,
+            "cscat": [20, 0 * u.m, 0],
         },
     }
 
@@ -176,11 +182,6 @@ def main():
     # Exporting the list of output/log/input files into the application folder
     output_file_list = output_dir.joinpath(f"output_files_{args_dict['primary']}.list")
     log_file_list = output_dir.joinpath(f"log_files_{args_dict['primary']}.list")
-
-    def print_list_into_file(list_of_files, file_name):
-        with open(file_name, "w", encoding="utf-8") as f:
-            for line in list_of_files:
-                f.write(line + "\n")
 
     logger.info(f"List of output files exported to {output_file_list}")
     print_list_into_file(shower_simulator.get_list_of_output_files(), output_file_list)

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -36,9 +36,6 @@
         The location of the output directories corsika-data.
         the label is added to the data_directory, such that the output
         will be written to data_directory/label/corsika-data.
-    test (activation mode, optional)
-        If activated, no job will be submitted. Instead, an example of the \
-        run script will be printed.
     verbosity (str, optional)
         Log level to print.
 
@@ -49,7 +46,7 @@
     .. code-block:: console
 
         simtools-simulate-showers-for-trigger-rates --array 4LST --site North --primary \\
-        proton --nruns 2 --nevents 10000 --test --submit_command local
+        proton --nruns 2 --nevents 10000 --submit_command local
 
     The output is saved in simtools-output/simulate_showers_for_trigger_rates.
 
@@ -167,17 +164,11 @@ def main():
         simulator_source_path=args_dict.get("simtel_path", None),
         config_data=shower_config_data,
         submit_command=args_dict.get("submit_command", ""),
-        test=args_dict["test"],
         mongo_db_config=db_config,
         model_version=args_dict.get("model_version", None),
     )
 
-    if not args_dict["test"]:
-        shower_simulator.simulate()
-    else:
-        logger.info("Test flag is on - it will not submit any job.")
-        logger.info("This is an example of the run script:")
-        shower_simulator.simulate()
+    shower_simulator.simulate()
 
     # Exporting the list of output/log/input files into the application folder
     output_file_list = output_dir.joinpath(f"output_files_{args_dict['primary']}.list")

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -32,6 +32,20 @@
         Zenith angle in deg.
     azimuth (float, optional)
         Azimuth angle in deg.
+    view_cone (float, optional)
+        View cone in deg.
+    scatter_x (float, optional)
+        Scatter distance (X axis) in m.
+    scatter_y (float, optional)
+        Scatter distance (Y axis) in m.
+    num_use (int, optional)
+        Number of use for each shower.
+    energy_min (float, optional)
+        Energy threshold (TeV).
+    energy_max (float, optional)
+        Maximum energy (TeV).
+    e_slope (int, optional)
+        Energy slope (spectral index).
     data_directory (str, optional)
         The location of the output directories corsika-data.
         the label is added to the data_directory, such that the output

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -163,7 +163,7 @@ def main():
 
     shower_simulator = Simulator(
         label=label,
-        simulation_software="corsika",
+        simulation_software="corsika_simtel",
         simulator_source_path=args_dict.get("simtel_path", None),
         config_data=shower_config_data,
         submit_command=args_dict.get("submit_command", ""),

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -26,6 +26,8 @@
         Name of the primary particle (proton, helium ...).
     nruns (int, optional)
         Number of runs to be simulated.
+    run_number (int, optional)
+        Run number of the starting run.
     nevents (int, optional)
         Number of events simulated per run.
     zenith (float, optional)
@@ -118,6 +120,9 @@ def _parse(label=None, description=None):
         required=True,
     )
     config.parser.add_argument("--nruns", help="Number of runs", type=int, default=100)
+    config.parser.add_argument(
+        "--run_number", help="Run number of the starting run", type=int, default=1
+    )
     config.parser.add_argument("--nevents", help="Number of events/run", type=int, default=100000)
     config.parser.add_argument("--zenith", help="Zenith angle in deg", type=float, default=20)
     config.parser.add_argument("--azimuth", help="Azimuth angle in deg", type=float, default=0)
@@ -175,7 +180,7 @@ def main():
             "data_directory": Path(args_dict["data_directory"]) / label,
             "site": args_dict["site"],
             "layout_name": args_dict["array_layout_name"],
-            "run_range": [1, args_dict["nruns"]],
+            "run_range": [args_dict["run_number"], args_dict["nruns"]],
             "nshow": args_dict["nevents"],
             "primary": args_dict["primary"],
             "zenith": args_dict["zenith"] * u.deg,

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -141,7 +141,7 @@ def main():
             "data_directory": Path(args_dict["data_directory"]) / label,
             "site": args_dict["site"],
             "layout_name": args_dict["array_layout_name"],
-            "run_range": [1, args_dict["nruns"] + 1],
+            "run_range": [1, args_dict["nruns"]],
             "nshow": args_dict["nevents"],
             "primary": args_dict["primary"],
             "zenith": args_dict["zenith"] * u.deg,

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -107,6 +107,23 @@ def _parse(label=None, description=None):
     config.parser.add_argument("--nevents", help="Number of events/run", type=int, default=100000)
     config.parser.add_argument("--zenith", help="Zenith angle in deg", type=float, default=20)
     config.parser.add_argument("--azimuth", help="Azimuth angle in deg", type=float, default=0)
+    config.parser.add_argument("--view_cone", help="View cone in deg", type=float, default=10)
+    config.parser.add_argument(
+        "--scatter_x", help="Scatter distance (X axis) in m", type=float, default=1500
+    )
+    config.parser.add_argument(
+        "--scatter_y", help="Scatter radius  (Y axis) in m", type=float, default=0
+    )
+    config.parser.add_argument(
+        "--num_use", help="Number of use for each shower", type=int, default=20
+    )
+    config.parser.add_argument(
+        "--energy_min", help="Energy threshold (TeV)", type=float, default=0.01
+    )
+    config.parser.add_argument("--energy_max", help="Maximum energy (TeV)", type=float, default=300)
+    config.parser.add_argument(
+        "--e_slope", help="Energy slope (spectral index)", type=float, default=-2
+    )
     config.parser.add_argument(
         "--data_directory",
         help=(
@@ -151,10 +168,14 @@ def main():
             "azimuth": args_dict["azimuth"] * u.deg,
         },
         "showers": {
-            "erange": [100 * u.GeV, 300 * u.TeV],
-            "eslope": -2,
-            "viewcone": 0 * u.deg,
-            "cscat": [20, 0 * u.m, 0],
+            "erange": [args_dict["energy_min"] * u.TeV, args_dict["energy_max"] * u.TeV],
+            "eslope": args_dict["e_slope"],
+            "viewcone": args_dict["view_cone"] * u.deg,
+            "cscat": [
+                args_dict["num_use"],
+                args_dict["scatter_x"] * u.m,
+                args_dict["scatter_y"] * u.m,
+            ],
         },
     }
 

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -176,9 +176,7 @@ class CorsikaConfig:
                     self._raise_missing_required_error(par_name)
 
     def _convert_azm_to_phip(self):
-        """
-        Convert azimuthal angle to phi prime angle.
-        """
+        """Convert azimuthal angle to phi prime angle."""
         phip = 180.0 - self._user_parameters["AZM"][0]
         phip = phip + 360.0 if phip < 0.0 else phip
         phip = phip - 360.0 if phip >= 360.0 else phip

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -116,7 +116,9 @@ class SiteModel(ModelParameter):
         for layout in layouts:
             if layout["name"] == layout_name.lower():
                 return layout["elements"]
-        self._logger.error("Array layout '%s' not found in '%s' site model.")
+        self._logger.error(
+            "Array layout '%s' not found in '%s' site model.", layout_name, self.site
+        )
         raise ValueError
 
     def get_list_of_array_layouts(self):

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -117,7 +117,10 @@ class SiteModel(ModelParameter):
             if layout["name"] == layout_name.lower():
                 return layout["elements"]
         self._logger.error(
-            "Array layout '%s' not found in '%s' site model.", layout_name, self.site
+            "Array layout '%s' not found in '%s' site model. Possible choices are '%s'",
+            layout_name,
+            self.site,
+            [layout["name"] for _, layout in enumerate(layouts)],
         )
         raise ValueError
 

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -116,12 +116,7 @@ class SiteModel(ModelParameter):
         for layout in layouts:
             if layout["name"] == layout_name.lower():
                 return layout["elements"]
-        self._logger.error(
-            "Array layout '%s' not found in '%s' site model. Possible choices are '%s'",
-            layout_name,
-            self.site,
-            [layout["name"] for _, layout in enumerate(layouts)],
-        )
+        self._logger.error("Array layout '%s' not found in '%s' site model.")
         raise ValueError
 
     def get_list_of_array_layouts(self):

--- a/tests/integration_tests/config/simulate_showers_for_trigger_rates_run.yml
+++ b/tests/integration_tests/config/simulate_showers_for_trigger_rates_run.yml
@@ -13,4 +13,4 @@ CTA_SIMPIPE:
     OUTPUT_PATH: simtools-output
   INTEGRATION_TESTS:
     - OUTPUT_FILE: |
-        simulate_showers_for_trigger_rates/corsika-data/North/proton/data/run000001/corsika_run000001_proton_za020deg_azm000deg_North_subsystem_lsts_simulate_showers_for_trigger_rates.zst
+        simulate_showers_for_trigger_rates/simtel-data/North/proton/data/run000001_proton_za020deg_azm000deg_North_subsystem_lsts_simulate_showers_for_trigger_rates.simtel.zst

--- a/tests/integration_tests/config/simulate_showers_for_trigger_rates_run_South.yml
+++ b/tests/integration_tests/config/simulate_showers_for_trigger_rates_run_South.yml
@@ -13,4 +13,4 @@ CTA_SIMPIPE:
     OUTPUT_PATH: simtools-output
   INTEGRATION_TESTS:
     - OUTPUT_FILE: |
-        simulate_showers_for_trigger_rates/corsika-data/South/proton/data/run000001/corsika_run000001_proton_za020deg_azm000deg_South_4MST_simulate_showers_for_trigger_rates.zst
+        simulate_showers_for_trigger_rates/simtel-data/South/proton/data/run000001_proton_za020deg_azm000deg_South_4MST_simulate_showers_for_trigger_rates.simtel.zst


### PR DESCRIPTION
## Summary:
This PR improves and tests the `simtools-simulate-showers-for-trigger-rates` application. It includes also a new file in the DB (see details below). Related to #1001.

## Small history of the development:
- Using `simtools-simulate-showers-for-trigger-rates` for a very concentrated energetic (1TeV) beam of protons with `--array_layout_name 1MST` has never lead to triggered events (always 0). 
- The reason turned out to be because the default trigger conditions are configured by the simtel parameter `array_triggers` which points to a file `array_trigger_prod5_lapalma_extended.dat` where the array trigger conditions are defined. In this file, every trigger condition is defined starting with at least 2 telescopes, which explains why it did not work to use this trigger condition for a single telescope;
- I created a new file `array_trigger_1MST_lapalma.dat` with a single line `Trigger 1 of 1` replacing the previous list of trigger conditions and uploaded this file to our currently default DB `Staging-CTA-Simulation-Model-v0-3-0`;
- In the application, I changed the simtel parameter `array_triggers` to point to the new file in the DB. 
- I reran `simtools-simulate-showers-for-trigger-rates` with this command `simtools-simulate-showers-for-trigger-rates --array_layout_name 1MST --primary proton --scatter_x 5 --scatter_y 5 --energy_min 1 --energy_max 2 --site North --nruns 1 --nevents 1 --view_cone 1 --submit_command local --output_path 1MST --use_plain_output_path --run_number 1` and calculated the trigger rate of the resulting simulation with  `simtools-calculate-trigger-rate --simtel_file_names simtools-output/simulate_showers_for_trigger_rates/simtel-data/North/proton/data/run000001_proton_za020deg_azm000deg_North_1MST_simulate_showers_for_trigger_rates.simtel.zst` and finally got all of the simulated events also triggered by the single MST at the center of the array.

## Statistics of the simulation and trigger rate estimate
### MST (North)
- simulated with `time simtools-simulate-showers-for-trigger-rates --array_layout_name 1MST --primary proton --energy_min 0.01 --energy_max 300 --scatter_x 1500 --scatter_y 0 --site North --nruns 1 --nevents 10000 --view_cone 10 --submit_command local --output_path 1MST --use_plain_output_path --run_number 1`. Total time **real	28m1.828s**
- trigger calculated with `simtools-calculate-trigger-rate --simtel_file_names simtools-output/simulate_showers_for_trigger_rates/simtel-data/North/proton/data/run000001_proton_za020deg_azm000deg_North_1MST_simulate_showers_for_trigger_rates.simtel.zst`. Trigger rate **3.9522e+03 ± 4.8656e+02 Hz**

### LST (North)
- simulated with `time simtools-simulate-showers-for-trigger-rates --array_layout_name 1LST --primary proton --energy_min 0.01 --energy_max 300 --scatter_x 1500 --scatter_y 0 --site North --nruns 1 --nevents 10000 --view_cone 10 --submit_command local --output_path 1LST --use_plain_output_path --run_number 2`. Total time **real	41m31.767s**
- trigger calculated with `simtools-calculate-trigger-rate --simtel_file_names simtools-output/simulate_showers_for_trigger_rates/simtel-data/North/proton/data/run000002_proton_za020deg_azm000deg_North_1LST_simulate_showers_for_trigger_rates.simtel.zst`. Trigger rate **4.7178e+03 ± 4.8932e+02 Hz**

### SST (South)
- simulated with `time simtools-simulate-showers-for-trigger-rates --array_layout_name 1SST --primary proton --energy_min 0.01 --energy_max 300 --scatter_x 1500 --scatter_y 0 --site South --nruns 1 --nevents 10000 --view_cone 10 --submit_command local --output_path 1SST --use_plain_output_path --run_number 3`. Total time **real	33m12.787s**
- trigger calculated with `simtools-calculate-trigger-rate --simtel_file_names simtools-output/simulate_showers_for_trigger_rates/simtel-data/South/proton/data/run000003_proton_za020deg_azm000deg_South_1SST_simulate_showers_for_trigger_rates.simtel.zst`. Trigger rate **1.3247e+03 ± 1.9122e+02 Hz**

## Bias curve
- I varied the energy threshold for protons, simulated 1e5 events and calculate the trigger rate (all for a single MST). This turned out not to be the best approach to extract a bias curve, because the simulations get very heavy for higher energies (since I maintained the number of simulated events). But this gives us a good first estimate:

![Screenshot 2024-06-24 at 09 41 17](https://github.com/gammasim/simtools/assets/50831535/674c9e9d-599c-49b9-9c13-02f11fb46751)
Should we perhaps create an application to directly generate bias curves @GernotMaier ?
