### PR TITLE
Step 3 of fuff fixes: Fix D205 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ format.line-ending = "auto"
 format.skip-magic-trailing-comma = false
 lint.extend-select = [
   "COM", # flake8-commas
-  "D",   # pydocstyle (temporary off: use in 2nd step)
+  #  "D",   # pydocstyle (temporary off: use in 2nd step)
   "G",   # logging
   "I",   # isort
   "ICN", # import name conventions

--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python3
 
 r"""
-This application calculates the trigger rate from a simtel_array output file, a list of
+Calculates array or single-telescope trigger rates.
+
+The applications reads from a simtel_array output file, a list of
 simtel_array output files ou from a file containing a list of simtel_array files.
 
 

--- a/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 r"""
-    Convert all simulation model parameters exported from sim_telarray format using
-    schema files. Check value, type, and range, convert units, and write json files
+    Convert all simulation model parameters exported from sim_telarray format using schema files.
+
+    Check value, type, and range, convert units, and write json files
     ready to be submitted to the model database. Prints out parameters which are not found
     in simtel configuration file and parameters which are not found in simtools schema files.
 
@@ -182,7 +183,8 @@ def read_simtel_config_file(args_dict, logger, schema_file, camera_pixels=None):
 
 def get_number_of_camera_pixel(args_dict, logger):
     """
-    Get the number of camera pixels from the simtel configuration file
+    Get the number of camera pixels from the simtel configuration file.
+
     Required to set the dimension some of the parameter correctly, as simtel
     in some cases does not provide the dimension ('all:' in the parameter files).
 
@@ -218,6 +220,7 @@ def get_number_of_camera_pixel(args_dict, logger):
 def read_and_export_parameters(args_dict, logger):
     """
     Read and export parameters from simtel configuration file to json files.
+
     Only applicable parameters are exported to json.
     Provide extensive logging information on the parameters found in the simtel
     configuration file.
@@ -284,8 +287,9 @@ def read_and_export_parameters(args_dict, logger):
 
 def print_parameters_not_found(_parameters_not_in_simtel, _simtel_parameters, args_dict, logger):
     """
-    Print simtel parameters not found in schema files and simtools parameters not found in simtel
-    configuration file. For simtel parameters not found, check if the setting for the chose
+    Print simtel/simtools parameter not found in schema and ocnfiguration files.
+
+    For simtel parameters not found, check if the setting for the chose
     telescope is different from the default values.
 
     Parameters
@@ -337,6 +341,7 @@ def print_parameters_not_found(_parameters_not_in_simtel, _simtel_parameters, ar
 def print_list_of_files(args_dict, logger):
     """
     Print model parameters which describe a file name.
+
     This is useful to find files which are part of the model.
 
     Parameters

--- a/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/simtools/applications/convert_model_parameter_from_simtel.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 r"""
-    Convert simulation model parameter from sim_telarray format using the corresponding
-    schema file. Check value, type, and range and write a json file
-    ready to be submitted to the model database.
+    Convert simulation model parameter from sim_telarray format using the corresponding schema file.
+
+    Check value, type, and range and write a json file ready to be submitted to the model database.
 
     Command line arguments
     ----------------------

--- a/simtools/applications/db_add_value_from_json_to_db.py
+++ b/simtools/applications/db_add_value_from_json_to_db.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 r"""
-    This application adds a new parameter / value to a collection in the DB using a json
-    file as input.
+    Add a new parameter / value to a collection in the DB using a json file as input.
 
     Command line arguments
     ----------------------

--- a/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
+++ b/simtools/applications/db_development_tools/mark_non_optics_parameters_non_applicable.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 """
-    This application is used to modify all non-optics parameters \
-    in the MST-Structure entries in the DB to non-applicable.
+    Modify all non-optics parameters in the MST-Structure entries in the DB to non-applicable.
 
     This application should not be used anymore by anyone.
 

--- a/simtools/applications/db_get_parameter_from_db.py
+++ b/simtools/applications/db_get_parameter_from_db.py
@@ -2,6 +2,7 @@
 
 r"""
     Get a parameter entry from DB for a specific telescope or a site.
+
     The application receives a parameter name, a site, a telescope (if applicable) and \
     optionally a version. It then prints out the parameter entry.
     If no version is provided, the value of the released model is printed..

--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
 r"""
-    Derive the simulation model parameter **mirror_reflection_random_angle**
-    (sometimes called mirror roughness) to match the measured containment diameter
-    of the optical point-spread function (PSF) of individual mirror panels.
+    Derive the simulation model parameter mirror_reflection_random_angle.
+
+    This parameter is sometimes called mirror roughness and used  to match the measured
+    containment diameter of the optical point-spread function (PSF) of individual mirror panels.
 
     Description
     -----------
@@ -214,8 +215,9 @@ def _parse(label):
 
 def _define_telescope_model(label, args_dict, db_config):
     """
-    Define telescope model and update configuration
-    with mirror list and/or random focal length given
+    Define telescope model.
+
+    This includes updating the configuration with mirror list and/or random focal length given
     as input.
 
     Attributes
@@ -254,8 +256,7 @@ def _print_and_write_results(
     args_dict, rnda_start, rnda_opt, mean_d80, sig_d80, results_rnda, results_mean, results_sig
 ):
     """
-    Print results to screen and write metadata and data files
-    in the requested format.
+    Print results to screen and write metadata and data files in the requested format.
 
     """
     containment_fraction_percent = int(args_dict["containment_fraction"] * 100)
@@ -304,8 +305,7 @@ def _print_and_write_results(
 
 def _get_psf_containment(logger, args_dict):
     """
-    Read measured single-mirror point-spread function (containment)
-    from file and return mean and sigma.
+    Read measured single-mirror point-spread function from file and return mean and sigma.
 
     """
     # If this is a test, read just the first few lines since we only simulate those mirrors

--- a/simtools/applications/derive_psf_parameters.py
+++ b/simtools/applications/derive_psf_parameters.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python3
 
 r"""
-    This applications derives the parameters mirror_reflection_random_angle, \
-    mirror_align_random_horizontal and mirror_align_random_vertical using \
-    cumulative PSF measurement.
+    Derives the mirror alignment parameters using cumulative PSF measurement.
+
+    This includes parameters mirror_reflection_random_angle, \
+    mirror_align_random_horizontal and mirror_align_random_vertical.
 
     The telescope zenith angle and the source distance can be set by command line arguments.
 
@@ -301,16 +302,16 @@ def load_and_process_data(args_dict):
 
 def calculate_rmsd(data, sim):
     """
-    Calculates the Root Mean Squared Deviation to be used
-    as metric to find the best parameters.
+    Calculates the Root Mean Squared Deviation to be used as metric to find the best parameters.
     """
     return np.sqrt(np.mean((data - sim) ** 2))
 
 
 def run_pars(tel_model, args_dict, pars, data_to_plot, radius, pdf_pages):
     """
-    Runs the tuning for one set of parameters, add a plot to the pdfPages
-    (if plot=True) and returns the RMSD and the D80.
+    Runs the tuning for one set of parameters, add a plot to the pdfPages and return RMSD and D80.
+
+    Plotting is optional (if plot=True).
     """
     cumulative_psf = "Cumulative PSF"
 

--- a/simtools/applications/generate_corsika_histograms.py
+++ b/simtools/applications/generate_corsika_histograms.py
@@ -1,8 +1,10 @@
 #!/usr/bin/python3
 
 r"""
-    This application generates a set of histograms of the distribution of Cherenkov photons on the
-    ground (at observation level) read from the CORSIKA IACT output file provided as input.
+    Generates a set of histograms Cherenkov photon distributions from CORSIKA output.
+
+    The Cherenkov photons (from observation level) are read from a CORSIKA IACT
+    output file provided as input.
 
     The histograms can be saved both into pdfs and in a hdf5 file.
 
@@ -359,6 +361,7 @@ def _derive_event_2d_histograms(
 ):
     """
     Auxiliary function to derive the histograms for the arguments given by event_1d_histograms.
+
     If an odd number of event header keys are given, the last one is discarded.
 
     Parameters

--- a/simtools/applications/generate_simtel_array_histograms.py
+++ b/simtools/applications/generate_simtel_array_histograms.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 r"""
-    This application allows to write sim_telarray histograms into pdf and hdf5 files.
+    Write sim_telarray histograms into pdf and hdf5 files.
+
     It accepts multiple lists of histograms files, a single list or a histogram file.
     Each histogram is plotted in a page of the pdf file if the --pdf option is activated.
 

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 r"""
-    This application is used to run simulations for productions (typically on the grid).
+    Run simulations for productions (typically on the grid).
+
     It allows to run a Paranal (CTAO-South) or La Palma (CTAO-North) array layout simulation
     with the provided "prod_tag" simulation configuration (e.g., Prod6)
     for a given primary particle, azimuth, and zenith angle.

--- a/simtools/applications/simulate_showers_for_trigger_rates.py
+++ b/simtools/applications/simulate_showers_for_trigger_rates.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 r"""
-    This application simulates showers to be used in trigger rate calculations.
+    Simulate showers to be used in trigger rate calculations.
+
     Arrays with one or four telescopes can be used, in case of \
     mono or stereo trigger configurations, respectively.
 

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -1,8 +1,7 @@
 #!/usr/bin/python3
 
 r"""
-    This application validate the camera efficiency by simulating it using \
-    the testeff program provided by sim_telarray.
+    Validate the camera efficiency by simulating it using the sim_telarray testeff program.
 
     The results of camera efficiency for Cherenkov (left) and NSB light (right) as a function\
     of wavelength are plotted. See examples below.

--- a/simtools/applications/validate_camera_fov.py
+++ b/simtools/applications/validate_camera_fov.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 
 r"""
-    This application calculate the camera FoV of the telescope requested and plot the camera \
-    as seen for an observer facing the camera.
+    Calculate the camera FoV of the telescope requested and plot the camera.
+
+    The orientation for the plotting is "as seen for an observer facing the camera".
 
     An example of the camera plot can be found below.
 

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 r"""
     Validate a file using a schema.
+
     Input files can be metadata, schema, or data files in yaml, json, or ecsv format.
 
     Command line arguments
@@ -102,6 +103,7 @@ def _get_schema_file_name(args_dict, data_dict=None):
 def validate_schema(args_dict, logger):
     """
     Validate a schema file given in yaml or json format.
+
     Schema is either given as command line argument, read from the meta_schema_url or from
     the metadata section of the data dictionary.
 

--- a/simtools/applications/validate_optics.py
+++ b/simtools/applications/validate_optics.py
@@ -1,8 +1,9 @@
 #!/usr/bin/python3
 
 r"""
-    This application validates the optical model parameters through ray tracing simulations \
-    of the whole telescope, assuming a point-like light source. The output includes PSF (D80), \
+    Validate the optical model parameters through ray tracing simulations of the whole telescope.
+
+    A point-like light source is assumed. The output includes PSF (D80), \
     effective mirror area and effective focal length as a function of the off-axis angle. \
 
     The telescope zenith angle and the source distance can be set by command line arguments.

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -223,6 +223,7 @@ class CommandLineParser(argparse.ArgumentParser):
     def initialize_simulation_model_arguments(self, model_options):
         """
         Initialize default arguments for simulation model definition.
+
         Note that the model version is always required.
 
         Parameters
@@ -300,8 +301,7 @@ class CommandLineParser(argparse.ArgumentParser):
     @staticmethod
     def efficiency_interval(value):
         """
-        Argument parser type to check that value is an efficiency
-        in the interval [0,1].
+        Argument parser type to check that value is an efficiency in the interval [0,1].
 
         Parameters
         ----------
@@ -330,6 +330,7 @@ class CommandLineParser(argparse.ArgumentParser):
     def zenith_angle(angle):
         """
         Argument parser type to check that the zenith angle provided is in the interval [0, 180].
+
         We allow here zenith angles larger than 90 degrees in the improbable case
         such simulations are requested. It is not guaranteed that the actual simulation software
         supports such angles!.
@@ -375,6 +376,7 @@ class CommandLineParser(argparse.ArgumentParser):
     def azimuth_angle(angle):
         """
         Argument parser type to check that the azimuth angle provided is in the interval [0, 360].
+
         Other allowed options are north, south, east or west which will be translated to an angle
         where north corresponds to zero.
 

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -105,8 +105,9 @@ class Configurator:
         job_submission=False,
     ):
         """
-        Initialize configuration from command line, configuration file, class config, or \
-        environmental variable.
+        Initialize application configuration.
+
+        Configure from command line, configuration file, class config, or environmental variable.
 
         Priorities in parameter settings.
         1. command line; 2. yaml file; 3. class init; 4. env variables.
@@ -167,6 +168,7 @@ class Configurator:
     def _fill_from_command_line(self, arg_list=None, require_command_line=True):
         """
         Fill configuration parameters from command line arguments.
+
         Triggers a print of the help if no command line arguments are given and
         require_command_line is set.
 
@@ -193,6 +195,7 @@ class Configurator:
     def _reset_required_arguments(self):
         """
         Reset required parser arguments (i.e., arguments added with "required=True").
+
         Includes also mutually exclusive groups.
 
         Access protected attributes of parser (no public method available).
@@ -205,8 +208,9 @@ class Configurator:
 
     def _fill_from_config_dict(self, input_dict, overwrite=False):
         """
-        Fill configuration parameters from dictionary. Enforce that configuration parameter names\
-         are lower case.
+        Fill configuration parameters from dictionary.
+
+        Enforce that configuration parameter names are lower case.
 
         Parameters
         ----------
@@ -229,8 +233,9 @@ class Configurator:
 
     def _check_parameter_configuration_status(self, key, value):
         """
-        Check if a parameter is already configured and not still set to the default value. Allow \
-        configuration with None values.
+        Check if a parameter is already configured and not still set to the default value.
+
+        Allow configuration with None values.
 
         Parameters
         ----------
@@ -302,8 +307,9 @@ class Configurator:
 
     def _fill_from_environmental_variables(self):
         """
-        Fill any configuration parameters which is not already configured (i.e., parameter is None)
-        from environmental variables or from file (default: ".env").
+        Fill any configuration parameters from environmental variables or from file (e.g., ".env").
+
+        Only parameters shich are not already configured are changed (i.e., parameter is None).
 
         """
         _env_dict = {}

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -26,9 +26,10 @@ class InvalidCorsikaInputError(Exception):
 
 class CorsikaConfig:
     """
-    CorsikaConfig deals with configuration for running CORSIKA. User parameters must be given by \
-    the corsika_config_data or corsika_config_file arguments. An example of corsika_config_data
-    follows below.
+    Configuration of CORSIKA simulations.
+
+    User parameters must be given by  the corsika_config_data or corsika_config_file arguments.
+    An example of corsika_config_data follows below.
 
     .. code-block:: python
 
@@ -289,8 +290,7 @@ class CorsikaConfig:
 
     def _convert_primary_input_and_store_primary_name(self, value):
         """
-        Convert a primary name into the proper CORSIKA particle ID and store its name in \
-        the self.primary attribute.
+        Convert a primary name into the proper CORSIKA particle ID.
 
         Parameters
         ----------
@@ -544,6 +544,7 @@ class CorsikaConfig:
     def _convert_to_quantities(self, value_args):
         """
         Convert a list of value, unit pairs into a list of astropy quantities.
+
         (note similarity to simtools.general.validate_config_data; unfortunately
         minor differences are required as CORSIKA is very specific about the
         input parameter representation).

--- a/simtools/corsika/corsika_default_config.py
+++ b/simtools/corsika/corsika_default_config.py
@@ -6,8 +6,9 @@ from scipy.interpolate import interp1d
 
 class CorsikaDefaultConfig:
     """
-    This class contains the default configuration for CORSIKA parameters for
-    the various primary particles. It includes all basic dependencies on zenith angles, etc.
+    Default configuration for CORSIKA parameters for the various primary particles.
+
+    It includes all basic dependencies on zenith angles, etc.
     The default values defined in this class assume the full CTAO arrays are simulated,
     including full CTAO energy range and number of events optimized to run for roughly 24 hours
     on a single node on the grid.
@@ -109,6 +110,7 @@ class CorsikaDefaultConfig:
     def _define_hardcoded_energy_ranges(self):
         """
         Define the hardcoded energy ranges for the various primaries.
+
         These energy ranges are for the full CTAO energy range (for both sites).
 
         Returns
@@ -263,6 +265,7 @@ class CorsikaDefaultConfig:
     def view_cone_for_primary(self):
         """
         Get the view cone for the primary particle.
+
         All diffuse primaries have a view cone of 10 deg by default.
 
         Returns

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -27,8 +27,8 @@ class HistogramNotCreatedError(Exception):
 
 
 class CorsikaHistograms:
-    """CorsikaHistograms extracts the Cherenkov photons information from a CORSIKA IACT file
-     using pyeventio.
+    """
+    Extracts the Cherenkov photons information from a CORSIKA IACT file.
 
     Parameters
     ----------
@@ -109,6 +109,7 @@ class CorsikaHistograms:
     def hdf5_file_name(self):
         """
         Property for the hdf5 file name.
+
         The idea of this property is to allow setting (or changing) the name of the hdf5 file
         even after creating the class instance.
         """
@@ -189,6 +190,7 @@ class CorsikaHistograms:
     def read_event_information(self):
         """
         Read the information about the events from their headers and save as a class instance.
+
         The main information can also be fetched individually through the functions below.
         For the remaining information (such as px, py, pz), use this function.
 
@@ -272,6 +274,7 @@ class CorsikaHistograms:
     def telescope_indices(self, telescope_new_indices):
         """
         Set the telescope index (or indices).
+
         If self.individual_telescopes is True, the indices of the telescopes passed are analyzed
         individually (different histograms for each telescope) even if all telescopes are listed.
 
@@ -322,6 +325,7 @@ class CorsikaHistograms:
     def hist_config(self, input_config):
         """
         Set the configuration for the histograms (e.g., bin size, min and max values, etc).
+
         The input is allowed either through a yaml file or a dictionary. If nothing is given,
         the dictionary is created with default values.
 
@@ -359,8 +363,9 @@ class CorsikaHistograms:
 
     def _create_histogram_default_config(self):
         """
-        Create a dictionary with the configuration necessary to create the histograms. It is used
-        only in case the configuration is not provided in a yaml file or dict.
+        Create a dictionary with the configuration necessary to create the histograms.
+
+        It is used only in case the configuration is not provided in a yaml file or dict.
 
         Three histograms are created: hist_position with 3 dimensions (x, y positions and the
         wavelength), hist_direction with 2 dimensions (direction cosines in x and y directions),
@@ -521,10 +526,11 @@ class CorsikaHistograms:
             )
 
     def _fill_histograms(self, photons, rotation_around_z_axis=None, rotation_around_y_axis=None):
-        """Fill all the histograms created by self._create_histogram with the information of the
-         photons on the ground.
-         If the azimuth and zenith angles are provided, the Cherenkov photon's coordinates are
-         filled in the plane perpendicular to the incoming direction of the particle.
+        """
+        Fill histograms with the information of the photons on the ground.
+
+        if the azimuth and zenith angles are provided, the Cherenkov photon's coordinates are
+        filled in the plane perpendicular to the incoming direction of the particle.
 
         Parameters
         ----------
@@ -596,8 +602,7 @@ class CorsikaHistograms:
 
     def set_histograms(self, telescope_indices=None, individual_telescopes=None, hist_config=None):
         """
-        Extract the information of the Cherenkov photons from a CORSIKA output IACT file, create
-         and fill the histograms.
+        Create and fill Cherenkov photons histograms using information from the CORSIKA IACT file.
 
         Parameters
         ----------
@@ -662,8 +667,7 @@ class CorsikaHistograms:
     @individual_telescopes.setter
     def individual_telescopes(self, new_individual_telescopes: bool):
         """
-        The following lines allow individual_telescopes to be defined before using this function
-        but if any parameter is passed in this function, it overwrites the class attribute.
+        Define individual telescopes.
 
         Parameters
         ----------
@@ -765,8 +769,9 @@ class CorsikaHistograms:
 
     def get_2d_photon_density_distr(self):
         """
-        Get 2D histograms of position of the Cherenkov photons on the ground. It returns the photon
-        density per square meter.
+        Get 2D histograms of position of the Cherenkov photons on the ground.
+
+        It returns the photon density per square meter.
 
         Returns
         -------
@@ -811,8 +816,10 @@ class CorsikaHistograms:
 
     def get_2d_num_photons_distr(self):
         """
-        Get the distribution of Cherenkov photons per event per telescope. It returns the 2D array
-        accounting for the events from the telescopes given by self.telescope_indices.
+        Get the distribution of Cherenkov photons per event per telescope.
+
+        It returns the 2D array accounting for the events from the telescopes given
+        by self.telescope_indices.
 
         Returns
         -------
@@ -875,8 +882,8 @@ class CorsikaHistograms:
         return np.array(hist_1d_list), np.array(x_bin_edges_list)
 
     def _get_bins_max_dist(self, bins=None, max_dist=None):
-        """Auxiliary function to get the number of bins and the max distance to generate the
-        radial and the density histograms.
+        """
+        Get the number of bins and the max distance to generate the radial and density histograms.
 
         Parameters
         ----------
@@ -912,8 +919,7 @@ class CorsikaHistograms:
 
     def get_photon_radial_distr(self, bins=None, max_dist=None):
         """
-        Get the radial distribution of the photons on the ground in relation to the center of the
-        array.
+        Get the phton radial distribution on the ground in relation to the center of the array.
 
         Parameters
         ----------
@@ -949,8 +955,7 @@ class CorsikaHistograms:
 
     def get_photon_density_distr(self, bins=None, max_dist=None):
         """
-        Get the density distribution of the photons on the ground in relation to the center of the
-        array.
+        Get the photon density distribution on the ground in relation to the center of the array.
 
         Parameters
         ----------
@@ -1001,9 +1006,10 @@ class CorsikaHistograms:
 
     def get_photon_time_of_emission_distr(self):
         """
-        Get the distribution of the emitted time of the Cherenkov photons. The clock starts when the
-         particle crosses the top of the atmosphere (CORSIKA-defined) if
-         self.event_first_interaction_heights is positive or at first interaction if otherwise.
+        Get the distribution of the emitted time of the Cherenkov photons.
+
+        The clock starts when the particle crosses the top of the atmosphere (CORSIKA-defined) if
+        self.event_first_interaction_heights is positive or at first interaction if otherwise.
 
         Returns
         -------
@@ -1046,8 +1052,9 @@ class CorsikaHistograms:
     @property
     def num_photons_per_event(self):
         """
-        Get the distribution of the number of photons amongst the events,
-         including the telescopes indicated by self.telescope_indices.
+        Get the the number of photons per events.
+
+        Includes the telescopes indicated by self.telescope_indices.
 
         Returns
         -------
@@ -1377,8 +1384,7 @@ class CorsikaHistograms:
         self, event_header_element, bins=50, hist_range=None, overwrite=False
     ):
         """
-        Export to a hdf5 file the 1D histogram for the key 'event_header_element' from the CORSIKA
-        event header.
+        Exports 'event_header_element' from CORSIKA to hd5 for a 1D histogram.
 
         Parameters
         ----------
@@ -1425,7 +1431,9 @@ class CorsikaHistograms:
         overwrite=False,
     ):
         """
-        Export to a hdf5 file the 2D histogram for the key 'event_header_element_1' and
+        Export event_header of a 2D histogram to a hdf5 file.
+
+        Searches the 2D histogram for the key 'event_header_element_1' and
         'event_header_element_2'from the CORSIKA event header.
 
         Parameters
@@ -1474,8 +1482,7 @@ class CorsikaHistograms:
     @property
     def num_photons_per_telescope(self):
         """
-        The number of photons per event, considering the telescopes given by
-        self.telescope_indices.
+        The number of photons per event, considering the telescopes given by self.telescope_indices.
 
         Returns
         -------
@@ -1504,6 +1511,7 @@ class CorsikaHistograms:
     def telescope_positions(self):
         """
         The telescope positions found in the CORSIKA output file.
+
         It does not depend on the telescope_indices attribute.
 
         Returns
@@ -1586,8 +1594,9 @@ class CorsikaHistograms:
     def event_first_interaction_heights(self):
         """
         Get the height of the first interaction in astropy units of km.
-        If negative, tracking starts at margin of atmosphere, see TSTART in the CORSIKA 7 user guide
-        .
+
+        If negative, tracking starts at margin of atmosphere,
+        see TSTART in the CORSIKA 7 user guide.
 
         Returns
         -------
@@ -1605,6 +1614,7 @@ class CorsikaHistograms:
     def magnetic_field(self):
         """
         Get the Earth magnetic field from the events header in astropy units of microT.
+
         A tuple with Earth's magnetic field in the x and z directions are returned.
 
         Returns
@@ -1622,8 +1632,10 @@ class CorsikaHistograms:
 
     def get_event_parameter_info(self, parameter):
         """
-        Get specific information (i.e. any parameter) of the events. The parameter is passed through
-        the key word parameter. Available options are to be found under self.all_event_keys.
+        Get specific information (i.e. any parameter) of the events.
+
+        The parameter is passed through the key word parameter.
+        Available options are to be found under self.all_event_keys.
         The unit of the parameter, if any, is given according to the CORSIKA version
         (please see user guide in this case).
 
@@ -1651,8 +1663,10 @@ class CorsikaHistograms:
 
     def get_run_info(self, parameter):
         """
-        Get specific information (i.e. any parameter) of the run. The parameter is passed through
-        the key word parameter. Available options are to be found under self.all_run_keys.
+        Get specific information (i.e. any parameter) of the run.
+
+        The parameter is passed through the key word parameter.
+        Available options are to be found under self.all_run_keys.
         The unit of the parameter, if any, is given according to the CORSIKA version
         (please see user guide in this case).
 
@@ -1676,6 +1690,7 @@ class CorsikaHistograms:
     def event_1d_histogram(self, key, bins=50, hist_range=None):
         """
         Create a histogram for the all events using key as parameter.
+
         Valid keys are stored in self.all_event_keys (CORSIKA defined).
 
         Parameters
@@ -1715,6 +1730,7 @@ class CorsikaHistograms:
     def event_2d_histogram(self, key_1, key_2, bins=50, hist_range=None):
         """
         Create a 2D histogram for the all events using key_1 and key_2 as parameters.
+
         Valid keys are stored in self.all_event_keys (CORSIKA defined).
 
         Parameters

--- a/simtools/corsika/corsika_histograms_visualize.py
+++ b/simtools/corsika/corsika_histograms_visualize.py
@@ -12,8 +12,7 @@ _logger = logging.getLogger(__name__)
 
 def _kernel_plot_2d_photons(histograms_instance, property_name, log_z=False):
     """
-    The next functions below are used by the the CorsikaHistograms class to plot all sort of
-    information from the Cherenkov photons saved.
+    Helper functions for plotting of distributions of Cherenkov photons saved in CorsikaHistograms.
 
     Create the figure of a 2D plot. The parameter name indicate which plot.
     Choices are "counts", "density", "direction", "time_altitude", and "num_photons_per_telescope".

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -18,8 +18,10 @@ class MissingRequiredEntryInCorsikaConfigError(Exception):
 
 class CorsikaRunner:
     """
-    CorsikaRunner is responsible for running CORSIKA, through the corsika_autoinputs program \
-    provided by the sim_telarray package. It provides shell scripts to be run externally or by \
+    CorsikaRunner is responsible for running CORSIKA.
+
+    Uses the corsika_autoinputs program provided by the sim_telarray package.
+    It provides shell scripts to be run externally or by \
     the module simulator. Same instance can be used to generate scripts for any given run number.
 
     It uses CorsikaConfig to manage the CORSIKA configuration. User parameters must be given by the\
@@ -124,6 +126,7 @@ class CorsikaRunner:
     def _define_corsika_config(self, use_multipipe=False):
         """
         Create the CORSIKA config instance.
+
         This validates the input given in corsika_config_data as well.
         """
         try:
@@ -415,8 +418,10 @@ class CorsikaRunner:
 
     def _validate_run_number(self, run_number):
         """
-        Returns the run number from corsika_config in case run_number is None, Raise ValueError if\
-        run_number is not valid (< 1) or returns run_number if it is a valid value.
+        Returns the run number from corsika_config in case run_number is None.
+
+        Raise ValueError if run_number is not valid (< 1) or returns run_number
+        if it is a valid value.
         """
         if run_number is None:
             return self.corsika_config.get_user_parameter("RUNNR")

--- a/simtools/data_model/data_reader.py
+++ b/simtools/data_model/data_reader.py
@@ -16,6 +16,7 @@ _logger = logging.getLogger(__name__)
 def read_table_from_file(file_name, schema_file=None, validate=False, metadata_file=None):
     """
     Read astropy table from file and validate against schema.
+
     Metadata is read from metadata file or from the metadata section of the data file.
     Schema for validation can be given as argument, or is determined
     from the metadata associated to the file.
@@ -71,7 +72,9 @@ def read_table_from_file(file_name, schema_file=None, validate=False, metadata_f
 
 def read_value_from_file(file_name, schema_file=None, validate=False):
     """
-    Read value from file and validate against schema. Expect data to follow the convention for
+    Read value from file and validate against schema.
+
+    Expect data to follow the convention for
     how simulation model parameters are stored in the simulation model database: to be a single
     value stored in the 'value' field (with possible units in the 'units' field).
     Metadata is read from metadata file or from the metadata section of the data file.

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -26,11 +26,10 @@ __all__ = ["MetadataCollector"]
 
 class MetadataCollector:
     """
-    Collects and combines metadata associated to describe the current
-    simtools activity and its data products. Collect as much metadata
-    as possible from command line configuration, input data, environment,
-    schema descriptions.
-    Depends on the CTAO top-level metadata definition.
+    Collects and combines metadata to describe the current simtools activity and its data products.
+
+    Collect as much metadata as possible from command line configuration, input data, environment,
+    schema descriptions.  Depends on the CTAO top-level metadata definition.
 
     Parameters
     ----------
@@ -75,6 +74,7 @@ class MetadataCollector:
     def get_data_model_schema_file_name(self):
         """
         Return data model schema file name.
+
         The schema file name is taken (in this order) from the command line,
         from the metadata file, from the data model name, or from the input
         metadata file.
@@ -251,9 +251,10 @@ class MetadataCollector:
 
     def _read_input_metadata_from_file(self, metadata_file_name=None):
         """
-        Read and validate input metadata from file. In case of an ecsv file including a
-        table, the metadata is read from the table meta data. Returns empty dict in case
-        no file is given.
+        Read and validate input metadata from file.
+
+        In case of an ecsv file including a table, the metadata is read from the table meta data.
+        Returns empty dict in case no file is given.
 
         Parameter
         ---------
@@ -330,8 +331,10 @@ class MetadataCollector:
 
     def _fill_product_meta(self, product_dict):
         """
-        Fill metadata for data products fields. If a schema file is given for the data products,
-        try and read product:data:model metadata from there.
+        Fill metadata for data products fields.
+
+        If a schema file is given for the data products, try and read product:data:model metadata
+        from there.
 
         Parameters
         ----------
@@ -401,8 +404,9 @@ class MetadataCollector:
 
     def _merge_config_dicts(self, dict_high, dict_low, add_new_fields=False):
         """
-        Merge two config dicts and replace values in dict_high which are Nonetype. Priority to \
-         dict_high in case of conflicting entries.
+        Merge two config dicts and replace values in dict_high which are Nonetype.
+
+        Priority to dict_high in case of conflicting entries.
 
         Parameters
         ----------
@@ -438,8 +442,9 @@ class MetadataCollector:
 
     def _fill_context_sim_list(self, meta_list, new_entry_dict):
         """
-        Fill list-type entries into metadata. Take into account the first list entry is the default
-        value filled with Nones.
+        Fill list-type entries into metadata.
+
+        Take into account the first list entry is the default value filled with Nones.
 
         Parameters
         ----------
@@ -468,6 +473,7 @@ class MetadataCollector:
     def _process_metadata_from_file(self, meta_dict):
         """
         Process metadata from file to ensure compatibility with metadata model.
+
         Changes keys to lower case and removes line feeds from description fields.
 
         Parameters
@@ -511,6 +517,7 @@ class MetadataCollector:
     def _copy_list_type_metadata(self, context_dict, _input_metadata, key):
         """
         Copy list-type metadata from file.
+
         Very fine tuned.
 
         Parameters

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -1,5 +1,6 @@
 """
 Definition of metadata model for input to and output of simtools.
+
 Follows CTAO top-level data model definition.
 
 * data products submitted to SimPipe ('input')
@@ -60,6 +61,7 @@ def validate_schema(data, schema_file):
 def get_default_metadata_dict(schema_file=None, observatory="CTA"):
     """
     Returns metadata schema with default values.
+
     Follows the CTA Top-Level Data Model.
 
     Parameters
@@ -115,6 +117,7 @@ def _load_schema(schema_file=None):
 def _add_array_elements(key, schema):
     """
     Add list of array elements to schema.
+
     This assumes an element [key]['enum'] is a list of elements.
 
     Parameters

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -15,8 +15,7 @@ __all__ = ["DataValidator"]
 
 class DataValidator:
     """
-    Validate data for type and units following a describing schema; converts or
-    transform data if required.
+    Validate data for type and units following a describing schema; converts or transform data.
 
     Data can be of table or dict format (internally, all data is converted to astropy tables).
 
@@ -88,10 +87,9 @@ class DataValidator:
 
     def validate_data_file(self):
         """
-        Open data file and read data from file
-        (doing this successfully is understood as
-        file validation).
+        Open data file and read data from file.
 
+        Doing this successfully is understood as file validation.
         """
         try:
             if Path(self.data_file_name).suffix in (".yml", ".yaml", ".json"):
@@ -114,8 +112,10 @@ class DataValidator:
 
     def _validate_data_dict(self):
         """
-        Validate values in a dictionary. Handles different types of naming in data dicts
-        (using 'name' or 'parameter' keys for name fields).
+        Validate values in a dictionary.
+
+        Handles different types of naming in data dicts (using 'name' or 'parameter'
+        keys for name fields).
 
         Raises
         ------
@@ -171,7 +171,10 @@ class DataValidator:
 
     def _validate_data_columns(self):
         """
-        Validate that
+        Validate that data columns.
+
+        This includes:
+
         - required data columns are available
         - columns are in the correct units (if necessary apply a unit conversion)
         - ranges (minimum, maximum) are correct.
@@ -212,8 +215,9 @@ class DataValidator:
 
     def _sort_data(self):
         """
-        Sort data according to one data column (if required by any column attribute). Data is
-         either sorted or reverse sorted.
+        Sort data according to one data column (if required by any column attribute).
+
+        Data is either sorted or reverse sorted.
 
         Raises
         ------
@@ -398,8 +402,9 @@ class DataValidator:
 
     def _check_and_convert_units(self, data, unit, col_name):
         """
-        Check that input data have an allowed unit. Convert to reference unit (e.g., Angstrom to
-        nm).
+        Check that input data have an allowed unit.
+
+        Convert to reference unit (e.g., Angstrom to nm).
 
         Note on dimensionless columns:
 
@@ -465,8 +470,9 @@ class DataValidator:
 
     def _check_range(self, col_name, col_min, col_max, range_type="allowed_range"):
         """
-        Check that column data is within allowed range or required range. Assumes that column and
-        ranges have the same units.
+        Check that column data is within allowed range or required range.
+
+        Assumes that column and ranges have the same units.
 
         Parameters
         ----------
@@ -523,8 +529,10 @@ class DataValidator:
     @staticmethod
     def _interval_check(data, axis_range, range_type):
         """
-        Check that values are inside allowed range (range_type='allowed_range') or span at least
-         the given interval (range_type='required_range').
+        Range checking for a given set of data.
+
+        Check that values are inside allowed range or interval. This(range_type='allowed_range')
+        or span at least the given interval (range_type='required_range').
 
         Parameters
         ----------
@@ -589,6 +597,7 @@ class DataValidator:
     def _get_data_description(self, column_name=None, status_test=False):
         """
         Return data description as provided by the schema file.
+
         For tables (type: 'data_table'), return the description of
         the column named 'column_name'. For other types, return
         all data descriptions.

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -1,5 +1,6 @@
 """
 Module to mimic DB interaction for simulation model DB development.
+
 Read simulation model values from files in simulation model repository.
 
 """
@@ -23,6 +24,7 @@ def update_model_parameters_from_repo(
 ):
     """
     Update model parameters with values from a repository.
+
     Existing entries will be updated, new entries will be added.
 
     Parameters

--- a/simtools/io_operations/hdf5_handler.py
+++ b/simtools/io_operations/hdf5_handler.py
@@ -19,6 +19,7 @@ _logger = logging.getLogger(__name__)
 def fill_hdf5_table(hist, x_bin_edges, y_bin_edges, x_label, y_label, meta_data):
     """
     Create and fill an hdf5 table with the histogram information.
+
     It works for both 1D and 2D distributions.
 
     Parameters

--- a/simtools/job_execution/job_manager.py
+++ b/simtools/job_execution/job_manager.py
@@ -103,8 +103,7 @@ class JobManager:
 
     def _submit_local(self, log_file):
         """
-        Run a job script on the command line
-        (no submission to a workload manager).
+        Run a job script on the command line (no submission to a workload manager).
 
         Parameters
         ----------

--- a/simtools/model/calibration_model.py
+++ b/simtools/model/calibration_model.py
@@ -7,7 +7,8 @@ __all__ = ["CalibrationModel"]
 
 class CalibrationModel(ModelParameter):
     """
-    CalibrationModel represents the MC model of an individual calibration device. \
+    CalibrationModel represents the MC model of an individual calibration device.
+
     It provides functionality to read the required parameters from the DB.
 
     Parameters

--- a/simtools/model/camera.py
+++ b/simtools/model/camera.py
@@ -12,8 +12,9 @@ __all__ = ["Camera"]
 
 class Camera:
     """
-    Camera class, defining pixel layout including rotation, finding neighbor pixels, calculating\
-    FoV and plotting the camera.
+    Camera class, defining pixel layout.
+
+    This includes rotation, finding neighbor pixels, calculating FoV and plotting the camera.
 
     Parameters
     ----------
@@ -33,8 +34,9 @@ class Camera:
 
     def __init__(self, telescope_model_name, camera_config_file, focal_length):
         """
-        Initialize Camera class, defining pixel layout including rotation, finding neighbor pixels,
-        calculating FoV and plotting the camera.
+        Initialize Camera class, defining pixel layout.
+
+        This includes rotation, finding neighbor pixels, calculating FoV and plotting the camera.
         """
         self._logger = logging.getLogger(__name__)
 
@@ -126,6 +128,7 @@ class Camera:
     def _rotate_pixels(self, pixels):
         """
         Rotate the pixels according to the rotation angle given in pixels['rotate_angle'].
+
         Additional rotation is added to get to the camera view of an observer facing the camera.
         The angle for the axes rotation depends on the coordinate system in which the original
         data was provided.
@@ -206,7 +209,9 @@ class Camera:
 
     def get_pixel_shape(self):
         """
-        Get pixel shape code 1, 2 or 3, where 1 and 3 are hexagonal pixels, where one is rotated by\
+        Get pixel shape code 1, 2 or 3.
+
+        Where 1 and 3 are hexagonal pixels, where one is rotated by\
         30 degrees with respect to the other. A square pixel is denoted as 2.
 
         Returns
@@ -322,8 +327,9 @@ class Camera:
     @staticmethod
     def _find_neighbours(x_pos, y_pos, radius):
         """
-        use a KD-Tree to quickly find nearest neighbours (e.g., of the pixels in a camera or mirror\
-        facets).
+        Use a KD-Tree to quickly find nearest neighbours.
+
+        This applies to e.g., of the pixels in a camera or mirror facets.
 
         Parameters
         ----------
@@ -352,8 +358,9 @@ class Camera:
 
     def _find_adjacent_neighbour_pixels(self, x_pos, y_pos, radius, row_coloumn_dist):
         """
-        Find adjacent neighbour pixels in cameras with square pixels. Only directly adjacent \
-        neighbours are allowed, no diagonals.
+        Find adjacent neighbour pixels in cameras with square pixels.
+
+        Only directly adjacent neighbours are allowed, no diagonals.
 
         Parameters
         ----------
@@ -402,8 +409,9 @@ class Camera:
 
     def _calc_neighbour_pixels(self, pixels):
         """
-        Find adjacent neighbour pixels in cameras with hexagonal or square pixels. Only directly \
-        adjacent neighbours are searched for, no diagonals.
+        Find adjacent neighbour pixels in cameras with hexagonal or square pixels.
+
+        Only directly  adjacent neighbours are searched for, no diagonals.
 
         Parameters
         ----------
@@ -439,8 +447,9 @@ class Camera:
 
     def get_neighbour_pixels(self, pixels=None):
         """
-        Get a list of neighbour pixels by calling calc_neighbour_pixels() when necessary. The \
-        purpose of this function is to ensure the calculation occurs only once and only when \
+        Get a list of neighbour pixels by calling calc_neighbour_pixels() when necessary.
+
+        The purpose of this function is to ensure the calculation occurs only once and only when
         necessary.
 
         Parameters

--- a/simtools/model/mirrors.py
+++ b/simtools/model/mirrors.py
@@ -40,8 +40,9 @@ class Mirrors:
 
     def _read_mirror_list(self):
         """
-        Read the mirror lists from disk and store the data. Allow reading of mirror lists in \
-        sim_telarray and ecsv format.
+        Read the mirror lists from disk and store the data.
+
+        Allow reading of mirror lists in sim_telarray and ecsv format.
         """
         if str(self._mirror_list_file).find("ecsv") > 0:
             self._read_mirror_list_from_ecsv()
@@ -119,6 +120,7 @@ class Mirrors:
     def _read_mirror_list_from_sim_telarray(self):
         """
         Read the mirror list in sim_telarray format and store the data.
+
         Allow to read mirror lists with different number of columns.
 
         Raises

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -22,6 +22,7 @@ class InvalidModelParameterError(Exception):
 class ModelParameter:
     """
     Base class for model parameters.
+
     Provides methods to read and manipulate parameters from DB.
 
     Parameters
@@ -91,6 +92,7 @@ class ModelParameter:
     def _get_parameter_dict(self, par_name):
         """
         Get model parameter dictionary as stored in the DB.
+
         No conversion to values are applied for the use in simtools
         (e.g., no conversion from the string representation of lists
         to lists).
@@ -123,10 +125,10 @@ class ModelParameter:
 
     def get_parameter_value(self, par_name, parameter_dict=None):
         """
-        Get the value of a model parameter. List of values stored
-        in strings are returns as lists, so that no knowledge
-        of the database structure is needed when accessing the
-        model parameters.
+        Get the value of a model parameter.
+
+        List of values stored in strings are returns as lists, so that no knowledge
+        of the database structure is needed when accessing the model parameters.
 
         Parameters
         ----------
@@ -164,7 +166,8 @@ class ModelParameter:
 
     def get_parameter_value_with_unit(self, par_name):
         """
-        Get the value of an existing parameter of the model as an Astropy Quantity with its unit.\
+        Get the value of an existing parameter of the model as an Astropy Quantity with its unit.
+
         If no unit is provided in the model, the value is returned without a unit.
 
         Parameters
@@ -187,8 +190,7 @@ class ModelParameter:
 
     def get_parameter_type(self, par_name):
         """
-        Get the type of existing parameter of the model
-        (value of 'type' field of DB entry).
+        Get the type of existing parameter of the model (value of 'type' field of DB entry).
 
         Parameters
         ----------
@@ -210,8 +212,7 @@ class ModelParameter:
 
     def get_parameter_file_flag(self, par_name):
         """
-        Get value of parameter file flag of this database entry
-        (boolean 'file' field of DB entry).
+        Get value of parameter file flag of this database entry (boolean 'file' field of DB entry).
 
         Parameters
         ----------
@@ -377,8 +378,9 @@ class ModelParameter:
 
     def change_parameter(self, par_name, value):
         """
-        Change the value of an existing parameter. This function does not modify the \
-        DB, it affects only the current instance.
+        Change the value of an existing parameter.
+
+        This function does not modify the  DB, it affects only the current instance.
 
         Parameters
         ----------
@@ -426,8 +428,9 @@ class ModelParameter:
 
     def change_multiple_parameters(self, **kwargs):
         """
-        Change the value of multiple existing parameters in the model. This function does not \
-        modify the DB, it affects only the current instance.
+        Change the value of multiple existing parameters in the model.
+
+        This function does not modify the DB, it affects only the current instance.
 
         Parameters
         ----------
@@ -498,8 +501,9 @@ class ModelParameter:
 
     def get_config_file(self, no_export=False):
         """
-        Get the path of the config file for sim_telarray. The config file is produced if the file\
-        is not up to date.
+        Get the path of the config file for sim_telarray.
+
+        The config file is produced if the file is not up to date.
 
         Parameters
         ----------

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -12,8 +12,9 @@ __all__ = [
 
 def compute_telescope_transmission(pars, off_axis):
     """
-    Compute telescope transmission (0 < T < 1) for a given set of parameters as defined by \
-    the MC model and for a given off-axis angle.
+    Compute telescope transmission (0 < T < 1) for a given off-axis angle.
+
+    The telescope transmission depends on the MC model used.
 
     Parameters
     ----------

--- a/simtools/psf_analysis.py
+++ b/simtools/psf_analysis.py
@@ -1,8 +1,7 @@
 """
 Module to analyse psf images (e.g. results from ray tracing simulations).
-Main functionalities are: computing centroids, psf containers etc.
 
-Author: Raul R Prado
+Main functionalities are: computing centroids, psf containers etc.
 
 """
 
@@ -232,6 +231,7 @@ class PSFImage:
     def _find_psf(self, fraction):
         """
         Try to find PSF by a smart algorithm first.
+
         If it fails, _find_radius_by_scanning is called and do it by brute force.
 
         Parameters
@@ -298,8 +298,9 @@ class PSFImage:
 
         def scan(dr, rad_min, rad_max):
             """
-            Scan the image from rad_min to rad_max in steps of dr until
-            it finds target_number photons inside.
+            Scan the image from rad_min to rad_max until it finds target_number photons inside.
+
+            Scanning is done in steps of dr.
 
             Returns
             -------

--- a/simtools/simtel/simtel_config_reader.py
+++ b/simtools/simtel/simtel_config_reader.py
@@ -140,6 +140,7 @@ class SimtelConfigReader:
     def compare_simtel_config_with_schema(self):
         """
         Compare limits and defaults reported by simtel_array with schema.
+
         This is mostly for debugging purposes and includes simple printing.
         Check for differences in 'default' and 'limits' entries.
         """

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -1,5 +1,7 @@
-"""This module reads the content of either a single histogram (.hdata, or .hdata.zst) or a single
-simtel_array output file (.simtel or .simtel.zst).
+"""
+Reads the content of either a single histogram (.hdata) or a single simtel_array output (.simtel).
+
+Files can be zst compressed.
 """
 
 import copy
@@ -32,6 +34,8 @@ class HistogramIdNotFoundError(Exception):
 
 class SimtelIOHistogram:
     """
+    Reads and generates histograms from sim_telarray output.
+
     Read the content of either a single histogram (.hdata, or .hdata.zst) or a single simtel_array
     output file (.simtel or .simtel.zst).
 
@@ -295,6 +299,8 @@ class SimtelIOHistogram:
 
     def _set_energy_range(self, energy_range):
         """
+        Set energy range to be used in the simulations.
+
         Parameters
         ----------
         energy_range: list

--- a/simtools/simtel/simtel_io_histograms.py
+++ b/simtools/simtel/simtel_io_histograms.py
@@ -1,4 +1,7 @@
-"""This module reads the content of either multiple histogram (.hdata, or .hdata.zst) or
+"""
+Reads the content of multiples files from sim_telarray.
+
+Reads the content of either multiple histogram (.hdata, or .hdata.zst) or
 simtel_array output files (.simtel or .simtel.zst). The module is built on top of the
 simtel_io_histogram module and uses its class (SimtelIOHistogram) to read the individual files.
 """
@@ -27,8 +30,8 @@ __all__ = [
 
 class SimtelIOHistograms:
     """
-    Read the content of either multiple histogram (.hdata, or .hdata.zst) or simtel_array
-    output files.
+    Read the content of either multiple histogram (.hdata, or .hdata.zst) or simtel_array files.
+
     Allow both the .hdata.zst histogram and the .simtel.zst output file type.
     It uses the SimtelIOHistogram class to deal with individual files.
     Histogram files are ultimately handled by using eventio library.

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -195,9 +195,9 @@ def _process_default_value(par_name, par_info, out_data, _logger):
 
 def validate_config_data(config_data, parameters, ignore_unidentified=False, _logger=None):
     """
-    Validate a generic config_data dict by using the info
-    given by the parameters dict. The entries will be validated
-    in terms of length, units and names.
+    Validate a generic config_data dict by using the info given by the parameters dict.
+
+    The entries will be validated in terms of length, units and names.
 
     See ./tests/resources/test_parameters.yml for an example of the structure
     of the parameters dict.
@@ -396,6 +396,7 @@ def _validate_and_convert_value_with_units(value, value_keys, par_name, par_info
 def _validate_and_convert_value(par_name, par_info, value_in):
     """
     Validate input user parameter and convert it to the right units, if needed.
+
     Returns the validated arguments in a list.
     """
     if isinstance(value_in, dict):
@@ -414,6 +415,7 @@ def _validate_and_convert_value(par_name, par_info, value_in):
 def join_url_or_path(url_or_path, *args):
     """
     Join URL or path with additional subdirectories and file.
+
     This is the equivalent to Path.join(), with extended functionality
     working also for URLs.
 
@@ -460,6 +462,7 @@ def is_url(url):
 def collect_data_from_http(url):
     """
     Download yaml or json file from url and return it contents as dict.
+
     File is downloaded as a temporary file and deleted afterwards.
 
     Parameters
@@ -738,9 +741,10 @@ def copy_as_list(value):
 
 def separate_args_and_config_data(expected_args, **kwargs):
     """
-    Separate kwargs into the arguments expected for instancing a class and the dict to be given as
-    config_data. This function is specific for methods from_kwargs in classes which use the
-    validate_config_data system.
+    Separate kwargs into arguments expected for class instancing class and the config_data dict.
+
+    This function is specific for methods from_kwargs in classes which use the validate_config_data
+    system.
 
     Parameters
     ----------
@@ -890,8 +894,10 @@ def get_file_age(file_path):
 
 def change_dict_keys_case(data_dict, lower_case=True):
     """
-    Change keys of a dictionary to lower or upper case. Crawls through the dictionary and changes\
-    all keys. Takes into account list of dictionaries, as e.g. found in the top level data model.
+    Change keys of a dictionary to lower or upper case.
+
+    Crawls through the dictionary and changes all keys.
+    Takes into account list of dictionaries, as e.g. found in the top level data model.
 
     Parameters
     ----------
@@ -927,8 +933,10 @@ def change_dict_keys_case(data_dict, lower_case=True):
 
 def remove_substring_recursively_from_dict(data_dict, substring="\n"):
     """
-    Remove substrings from all strings in a dictionary. Recursively crawls through the dictionary
-    This e.g., allows to remove all newline characters from a dictionary.
+    Remove substrings from all strings in a dictionary.
+
+    Recursively crawls through the dictionary This e.g., allows to remove all newline characters
+    from a dictionary.
 
     Parameters
     ----------
@@ -992,6 +1000,7 @@ def sort_arrays(*args):
 def extract_type_of_value(value) -> str:
     """
     Extract the string representation of the the type of a value.
+
     For example, for a string, it returns 'str' rather than '<class 'str'>'.
     Take into account also the case where the value is a numpy type.
     """
@@ -1008,6 +1017,7 @@ def extract_type_of_value(value) -> str:
 def get_value_unit_type(value, unit_str=None):
     """
     Get the value, unit and type of a value.
+
     The value is stripped of its unit and the unit is returned
     in its string form (i.e., to_string()).
     The type is returned as a string representation of the type.
@@ -1117,10 +1127,10 @@ def user_confirm():
 
 def validate_data_type(reference_dtype, value=None, dtype=None, allow_subtypes=True):
     """
-    Validate data type of value (scalar, list, np array) or type object against a
-    reference data type. Allow to check for exact data type or allow sub types
-    (e.g. uint is accepted for int).  Take into account 'file' type as used in the
-    model parameter database.
+    Validate data type of value or type object against a reference data type.
+
+    Allow to check for exact data type or allow sub types (e.g. uint is accepted for int).
+    Take into account 'file' type as used in the model parameter database.
 
     Parameters
     ----------
@@ -1199,6 +1209,7 @@ def convert_list_to_string(data, comma_separated=False):
 def convert_string_to_list(data_string, is_float=True):
     """
     Convert string (as used e.g. in sim_telarray) to list.
+
     Allow coma or space separated strings.
 
     Parameters

--- a/simtools/utils/geometry.py
+++ b/simtools/utils/geometry.py
@@ -91,9 +91,13 @@ def convert_2d_to_radial_distr(hist_2d, xaxis, yaxis, bins=50, max_dist=1000):
 @u.quantity_input(rotation_angle_phi=u.rad, rotation_angle_theta=u.rad)
 def rotate(x, y, rotation_around_z_axis, rotation_around_y_axis=0):
     """
-    Transform the x and y coordinates of the telescopes according to two rotations:
-    rotation_angle_around_z_axis gives the rotation on the observation plane (x, y) and
-    rotation_angle_around_y_axis allows to rotate the observation plane in space.
+    Rotate the x and y coordinates of the telescopes.
+
+    The two rotations are:
+
+    - rotation_angle_around_z_axis gives the rotation on the observation plane (x, y)
+    - rotation_angle_around_y_axis allows to rotate the observation plane in space.
+
     The function returns the rotated x and y values in the same unit given.
     The direction of rotation of the elements in the plane is counterclockwise, i.e.,
     the rotation of the coordinate system is clockwise.

--- a/simtools/visualization/legend_handlers.py
+++ b/simtools/visualization/legend_handlers.py
@@ -61,8 +61,9 @@ def calculate_center(handlebox, width_factor=3, height_factor=3):
 
 class TelescopeHandler:
     """
-    Telescope handler that centralizes the telescope information. Individual telescopes handlers
-    inherit from this class.
+    Telescope handler that centralizes the telescope information.
+
+    Individual telescopes handlers inherit from this class.
     """
 
     def __init__(self, radius=None):

--- a/simtools/visualization/plot_camera.py
+++ b/simtools/visualization/plot_camera.py
@@ -15,9 +15,10 @@ logger = logging.getLogger(__name__)
 
 def plot_pixel_layout(camera, camera_in_sky_coor=False, pixels_id_to_print=50):
     """
-    Plot the pixel layout for an observer facing the camera. Including in the plot edge pixels,\
-    off pixels, pixel ID for the first 50 pixels, coordinate systems, FOV, focal length and the\
-    average edge radius.
+    Plot the pixel layout for an observer facing the camera.
+
+    Including in the plot edge pixels, off pixels, pixel ID for the first 50 pixels,
+    coordinate systems, FOV, focal length and the average edge radius.
 
     Parameters
     ----------
@@ -189,8 +190,10 @@ def plot_pixel_layout(camera, camera_in_sky_coor=False, pixels_id_to_print=50):
 
 def _plot_axes_def(camera, plot, rotate_angle):
     """
-    Plot three axes definitions on the pyplot.plt instance provided. The three axes are Alt/Az,\
-    the camera coordinate system and the original coordinate system the pixel list was provided.
+    Plot three axes definitions on the pyplot.plt instance provided.
+
+    The three axes are Alt/Az, the camera coordinate system and the original coordinate
+    system the pixel list was provided.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR fixes https://docs.astral.sh/ruff/rules/blank-line-after-summary/ :

Checks for docstring summary lines that are not separated from the docstring description by one blank line.

This required in some cases to reformulate the summary line of the docstring.

Removes also the "summary" section headers for applications, which are not part of the numpydoc convention (and not necessary).

(again, no real review is necessary...)
