### PR TITLE
Step 5 of ruff fixes: D404 - docstrings should not start with "This"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ format.line-ending = "auto"
 format.skip-magic-trailing-comma = false
 lint.extend-select = [
   "COM", # flake8-commas
-  "D",   # pydocstyle (temporary off: use in 2nd step)
+  #  "D",   # pydocstyle (temporary off: use in 2nd step)
   "G",   # logging
   "I",   # isort
   "ICN", # import name conventions

--- a/simtools/applications/db_add_file_to_db.py
+++ b/simtools/applications/db_add_file_to_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 """
-    This application adds a file to a DB.
+    Add a file to a DB.
 
     The name and location of the file are required.
     This application should complement the ones for updating parameters, \

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 """
-    This application is used to add a new parameter to the sites collection in the DB.
+    Add a new parameter to the sites collection in the DB.
 
     This application should not be used by anyone but expert users and not often.
     Therefore, no additional documentation about this applications will be given.

--- a/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
+++ b/simtools/applications/db_development_tools/add_unit_to_parameter_in_db.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 """
-    This application is used to add a unit to parameters in the DB.
+    Add a unit to parameters in the DB.
 
     This application should not be used by anyone but expert users and only in unusual cases.
     Therefore, no additional documentation about this applications will be given.

--- a/simtools/applications/validate_cumulative_psf.py
+++ b/simtools/applications/validate_cumulative_psf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 """
-    This application simulates the cumulative PSF and compare with data (if available).
+    Simulate the cumulative PSF and compare with data (if available).
 
     The telescope zenith angle and the source distance can be set by command line arguments.
 


### PR DESCRIPTION
Fixes D404 - https://docs.astral.sh/ruff/rules/docstring-starts-with-this/
