### PR TITLE
Consistent naming of `simtel_path`

### DIFF
--- a/simtools/applications/derive_mirror_rnda.py
+++ b/simtools/applications/derive_mirror_rnda.py
@@ -354,7 +354,7 @@ def main():  # noqa: D103
                 if args_dict["test"]
                 else "all"
             ),
-            simtel_source_path=args_dict.get("simtel_path", None),
+            simtel_path=args_dict.get("simtel_path", None),
             use_random_focal_length=args_dict["use_random_flen"],
         )
         ray.simulate(test=args_dict["test"], force=True)  # force has to be True, always

--- a/simtools/applications/derive_psf_parameters.py
+++ b/simtools/applications/derive_psf_parameters.py
@@ -320,7 +320,7 @@ def run_pars(tel_model, args_dict, pars, data_to_plot, radius, pdf_pages):
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtel_path"],
+        simtel_path=args_dict["simtel_path"],
         source_distance=args_dict["src_distance"] * u.km,
         zenith_angle=args_dict["zenith"] * u.deg,
         off_axis_angle=[0.0 * u.deg],

--- a/simtools/applications/simulate_light_emission.py
+++ b/simtools/applications/simulate_light_emission.py
@@ -407,7 +407,7 @@ def main():
                 site_model=site_model,
                 default_le_config=le_config,
                 le_application=le_application,
-                simtel_source_path=args_dict["simtel_path"],
+                simtel_path=args_dict["simtel_path"],
                 light_source_type=args_dict["light_source_type"],
             )
             run_script = light_source.prepare_script(generate_postscript=True, **args_dict)
@@ -466,7 +466,7 @@ def main():
             site_model=site_model,
             default_le_config=default_le_config,
             le_application=le_application,
-            simtel_source_path=args_dict["simtel_path"],
+            simtel_path=args_dict["simtel_path"],
             light_source_type=args_dict["light_source_type"],
         )
         run_script = light_source.prepare_script(generate_postscript=True, **args_dict)

--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -153,7 +153,7 @@ def main():  # noqa: D103
     ce = CameraEfficiency(
         telescope_model=tel_model,
         site_model=site_model,
-        simtel_source_path=args_dict["simtel_path"],
+        simtel_path=args_dict["simtel_path"],
         label=label,
         config_data={
             "zenith_angle": args_dict["zenith_angle"],

--- a/simtools/applications/validate_cumulative_psf.py
+++ b/simtools/applications/validate_cumulative_psf.py
@@ -160,7 +160,7 @@ def main():  # noqa: D103
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtel_path"],
+        simtel_path=args_dict["simtel_path"],
         source_distance=args_dict["src_distance"] * u.km,
         zenith_angle=args_dict["zenith"] * u.deg,
         off_axis_angle=[0.0 * u.deg],

--- a/simtools/applications/validate_optics.py
+++ b/simtools/applications/validate_optics.py
@@ -152,7 +152,7 @@ def main():  # noqa: D103
 
     ray = RayTracing.from_kwargs(
         telescope_model=tel_model,
-        simtel_source_path=args_dict["simtel_path"],
+        simtel_path=args_dict["simtel_path"],
         source_distance=args_dict["src_distance"] * u.km,
         zenith_angle=args_dict["zenith"] * u.deg,
         off_axis_angle=np.linspace(

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -28,7 +28,7 @@ class CameraEfficiency:
         Instance of the TelescopeModel class.
     site_model: SiteModel
         Instance of the SiteModel class.
-    simtel_source_path: str (or Path)
+    simtel_path: str (or Path)
         Location of sim_telarray installation.
     label: str
         Instance label, optional.
@@ -44,7 +44,7 @@ class CameraEfficiency:
         self,
         telescope_model,
         site_model,
-        simtel_source_path,
+        simtel_path,
         label=None,
         config_data=None,
         config_file=None,
@@ -53,7 +53,7 @@ class CameraEfficiency:
         """Initialize the CameraEfficiency class."""
         self._logger = logging.getLogger(__name__)
 
-        self._simtel_source_path = simtel_source_path
+        self._simtel_path = simtel_path
         self._telescope_model = self._validate_telescope_model(telescope_model)
         self._site_model = site_model
         self.label = label if label is not None else self._telescope_model.label
@@ -102,7 +102,7 @@ class CameraEfficiency:
                 "telescope_model",
                 "site_model",
                 "label",
-                "simtel_source_path",
+                "simtel_path",
                 "test",
             ],
             **kwargs,
@@ -167,7 +167,7 @@ class CameraEfficiency:
         self._logger.info("Simulating CameraEfficiency")
 
         simtel = SimulatorCameraEfficiency(
-            simtel_source_path=self._simtel_source_path,
+            simtel_path=self._simtel_path,
             telescope_model=self._telescope_model,
             zenith_angle=self.config.zenith_angle,
             file_simtel=self._file["simtel"],

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -61,7 +61,7 @@ class CorsikaConfig:
         data/parameters/corsika_parameters.yml will be used.
     corsika_parameters_file: str
         Name of the yaml file to set remaining CORSIKA parameters.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of source of the sim_telarray/CORSIKA package.
     """
 
@@ -72,7 +72,7 @@ class CorsikaConfig:
         corsika_config_data=None,
         corsika_config_file=None,
         corsika_parameters_file=None,
-        simtel_source_path=None,
+        simtel_path=None,
     ):
         """Initialize CorsikaConfig."""
         self._logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class CorsikaConfig:
         self.eslope = None
         self.config_file_path = None
         self._output_generic_file_name = None
-        self._simtel_source_path = simtel_source_path
+        self._simtel_path = simtel_path
 
         self.io_handler = io_handler.IOHandler()
 
@@ -176,9 +176,7 @@ class CorsikaConfig:
                     self._raise_missing_required_error(par_name)
 
     def _convert_azm_to_phip(self):
-        """
-        Convert azimuthal angle to phi prime angle.
-        """
+        """Convert azimuthal angle to phi prime angle."""
         phip = 180.0 - self._user_parameters["AZM"][0]
         phip = phip + 360.0 if phip < 0.0 else phip
         phip = phip - 360.0 if phip >= 360.0 else phip

--- a/simtools/corsika/corsika_runner.py
+++ b/simtools/corsika/corsika_runner.py
@@ -58,7 +58,7 @@ class CorsikaRunner:
     ----------
     array_model: ArrayModel
         Array model instance.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of source of the sim_telarray/CORSIKA package.
     label: str
         Instance label.
@@ -75,7 +75,7 @@ class CorsikaRunner:
     def __init__(
         self,
         array_model,
-        simtel_source_path,
+        simtel_path,
         label=None,
         keep_seeds=False,
         corsika_parameters_file=None,
@@ -91,7 +91,7 @@ class CorsikaRunner:
 
         self._keep_seeds = keep_seeds
 
-        self._simtel_source_path = Path(simtel_source_path)
+        self._simtel_path = Path(simtel_path)
         self.io_handler = io_handler.IOHandler()
         _runner_directory = "corsika_simtel" if use_multipipe else "corsika"
         self._output_directory = self.io_handler.get_output_directory(self.label, _runner_directory)
@@ -136,7 +136,7 @@ class CorsikaRunner:
                 label=self.label,
                 array_model=self.array_model,
                 corsika_config_data=self._corsika_config_data,
-                simtel_source_path=self._simtel_source_path,
+                simtel_path=self._simtel_path,
                 corsika_parameters_file=self._corsika_parameters_file,
             )
             # CORSIKA input file used as template for all runs
@@ -244,20 +244,20 @@ class CorsikaRunner:
 
     def _get_pfp_command(self, input_tmp_file):
         """Get pfp pre-processor command."""
-        cmd = self._simtel_source_path.joinpath("sim_telarray/bin/pfp")
+        cmd = self._simtel_path.joinpath("sim_telarray/bin/pfp")
         cmd = str(cmd) + f" -V -DWITHOUT_MULTIPIPE - < {self._corsika_input_file}"
         cmd += f" > {input_tmp_file} || exit\n"
         return cmd
 
     def _get_autoinputs_command(self, run_number, input_tmp_file):
         """Get autoinputs command."""
-        corsika_bin_path = self._simtel_source_path.joinpath("corsika-run/corsika")
+        corsika_bin_path = self._simtel_path.joinpath("corsika-run/corsika")
 
         log_file = self.get_file_name(
             file_type="corsika_autoinputs_log", **self.get_info_for_file_name(run_number)
         )
 
-        cmd = self._simtel_source_path.joinpath("sim_telarray/bin/corsika_autoinputs")
+        cmd = self._simtel_path.joinpath("sim_telarray/bin/corsika_autoinputs")
         cmd = str(cmd) + f" --run {corsika_bin_path}"
         cmd += f" -R {run_number}"
         cmd += f" -p {self._corsika_data_dir}"

--- a/simtools/corsika_simtel/corsika_simtel_runner.py
+++ b/simtools/corsika_simtel/corsika_simtel_runner.py
@@ -28,7 +28,7 @@ class CorsikaSimtelRunner(CorsikaRunner, SimulatorArray):
 
         common_args = {
             'label': 'test-production',
-            'simtel_source_path': '/workdir/sim_telarray/',
+            'simtel_path': '/workdir/sim_telarray/',
         }
 
     Parameters
@@ -112,7 +112,7 @@ class CorsikaSimtelRunner(CorsikaRunner, SimulatorArray):
             "run_cta_multipipe"
         )
         with open(multipipe_executable, "w", encoding="utf-8") as file:
-            multipipe_command = Path(self._simtel_source_path).joinpath(
+            multipipe_command = Path(self._simtel_path).joinpath(
                 "sim_telarray/bin/multipipe_corsika "
                 f"-c {multipipe_file}"
                 " || echo 'Fan-out failed'"
@@ -139,7 +139,7 @@ class CorsikaSimtelRunner(CorsikaRunner, SimulatorArray):
         info_for_file_name = SimulatorArray.get_info_for_file_name(self, kwargs["run_number"])
         weak_pointing = any(pointing in self.label for pointing in ["divergent", "convergent"])
 
-        command = str(self._simtel_source_path.joinpath("sim_telarray/bin/sim_telarray"))
+        command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {self.array_model.get_config_file()}"
         command += f" -I{self.array_model.get_config_directory()}"
         command += super()._config_option(

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -37,7 +37,7 @@ class RayTracing:
         Instance of the TelescopeModel class.
     label: str
         Instance label.
-    simtel_source_path: str (or Path)
+    simtel_path: str (or Path)
         Location of sim_telarray installation.
     config_data: dict.
         Dict containing the configurable parameters.
@@ -55,7 +55,7 @@ class RayTracing:
     def __init__(
         self,
         telescope_model,
-        simtel_source_path,
+        simtel_path,
         label=None,
         config_data=None,
         config_file=None,
@@ -64,7 +64,7 @@ class RayTracing:
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Initializing RayTracing class")
 
-        self._simtel_source_path = Path(simtel_source_path)
+        self._simtel_path = Path(simtel_path)
         self._io_handler = io_handler.IOHandler()
 
         self._telescope_model = self._validate_telescope_model(telescope_model)
@@ -142,7 +142,7 @@ class RayTracing:
             expected_args=[
                 "telescope_model",
                 "label",
-                "simtel_source_path",
+                "simtel_path",
             ],
             **kwargs,
         )
@@ -180,7 +180,7 @@ class RayTracing:
                     f"Simulating RayTracing for off_axis={this_off_axis}, mirror={this_mirror}"
                 )
                 simtel = SimulatorRayTracing(
-                    simtel_source_path=self._simtel_source_path,
+                    simtel_path=self._simtel_path,
                     telescope_model=self._telescope_model,
                     test=test,
                     config_data={
@@ -520,8 +520,7 @@ class RayTracing:
         try:
             rx_output = subprocess.Popen(  # pylint: disable=consider-using-with
                 shlex.split(
-                    f"{self._simtel_source_path}/sim_telarray/bin/rx "
-                    f"-f {containment_fraction:.2f} -v"
+                    f"{self._simtel_path}/sim_telarray/bin/rx " f"-f {containment_fraction:.2f} -v"
                 ),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,

--- a/simtools/simtel/simtel_runner.py
+++ b/simtools/simtel/simtel_runner.py
@@ -27,17 +27,17 @@ class SimtelRunner:
 
     Parameters
     ----------
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of sim_telarray installation.
     label: str
         Instance label. Important for output file naming.
     """
 
-    def __init__(self, simtel_source_path, label=None):
+    def __init__(self, simtel_path, label=None):
         """Initialize SimtelRunner."""
         self._logger = logging.getLogger(__name__)
 
-        self._simtel_source_path = Path(simtel_source_path)
+        self._simtel_path = Path(simtel_path)
         self.label = label
         self._script_dir = None
         self._script_file = None

--- a/simtools/simtel/simulator_array.py
+++ b/simtools/simtel/simulator_array.py
@@ -37,7 +37,7 @@ class SimulatorArray(SimtelRunner):
         Instance of ArrayModel class.
     label: str
         Instance label. Important for output file naming.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of sim_telarray installation.
     config_data: dict
         Dict containing the configurable parameters.
@@ -49,7 +49,7 @@ class SimulatorArray(SimtelRunner):
         self,
         array_model,
         label=None,
-        simtel_source_path=None,
+        simtel_path=None,
         config_data=None,
         config_file=None,
     ):
@@ -57,7 +57,7 @@ class SimulatorArray(SimtelRunner):
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init SimulatorArray")
 
-        super().__init__(label=label, simtel_source_path=simtel_source_path)
+        super().__init__(label=label, simtel_path=simtel_path)
 
         self.array_model = array_model
         self.label = label if label is not None else self.array_model.label
@@ -261,7 +261,7 @@ class SimulatorArray(SimtelRunner):
         output_file = self.get_file_name(file_type="output", **info_for_file_name)
 
         # Array
-        command = str(self._simtel_source_path.joinpath("sim_telarray/bin/sim_telarray"))
+        command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {self.array_model.get_config_file()}"
         command += f" -I{self.array_model.get_config_directory()}"
         command += super()._config_option("telescope_theta", self.config.zenith_angle)

--- a/simtools/simtel/simulator_camera_efficiency.py
+++ b/simtools/simtel/simulator_camera_efficiency.py
@@ -19,7 +19,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         Instance of TelescopeModel class.
     label: str
         Instance label. Important for output file naming.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of sim_telarray installation.
     file_simtel: str or Path
         Location of the sim_telarray testeff tool output file.
@@ -33,7 +33,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         self,
         telescope_model,
         label=None,
-        simtel_source_path=None,
+        simtel_path=None,
         file_simtel=None,
         file_log=None,
         zenith_angle=None,
@@ -43,7 +43,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init SimulatorCameraEfficiency")
 
-        super().__init__(label=label, simtel_source_path=simtel_source_path)
+        super().__init__(label=label, simtel_path=simtel_path)
 
         self._telescope_model = telescope_model
         self.label = label if label is not None else self._telescope_model.label
@@ -117,7 +117,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
                 "mirror_reflectivity", "secondary_mirror_incidence_angle"
             )
 
-        command = str(self._simtel_source_path.joinpath("sim_telarray/bin/testeff"))
+        command = str(self._simtel_path.joinpath("sim_telarray/bin/testeff"))
         if self.nsb_spectrum is not None:
             command += f" -fnsb {self.nsb_spectrum}"
         command += " -nm -nsb-extra"
@@ -149,7 +149,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         command += f" >{self._file_simtel}"
 
         # Moving to sim_telarray directory before running
-        return f"cd {self._simtel_source_path.joinpath('sim_telarray')} && {command}"
+        return f"cd {self._simtel_path.joinpath('sim_telarray')} && {command}"
 
     def _check_run_result(self, **kwargs):  # pylint: disable=unused-argument
         """Check run results.

--- a/simtools/simtel/simulator_light_emission.py
+++ b/simtools/simtel/simulator_light_emission.py
@@ -35,7 +35,7 @@ class SimulatorLightEmission(SimtelRunner):
     le_application: str
         Name of the application. Default sim_telarray application running
         the sim_telarray LightEmission package is xyzls.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of sim_telarray installation.
     light_source_type: str
         The light source type.
@@ -56,7 +56,7 @@ class SimulatorLightEmission(SimtelRunner):
         site_model,
         default_le_config,
         le_application,
-        simtel_source_path,
+        simtel_path,
         light_source_type,
         label=None,
         config_data=None,
@@ -64,11 +64,11 @@ class SimulatorLightEmission(SimtelRunner):
         test=False,
     ):
         """Initialize SimtelRunner."""
-        super().__init__(label=label, simtel_source_path=simtel_source_path)
+        super().__init__(label=label, simtel_path=simtel_path)
 
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init SimtelRunnerLightEmission")
-        self._simtel_source_path = simtel_source_path
+        self._simtel_path = simtel_path
 
         self._telescope_model = telescope_model
 
@@ -124,7 +124,7 @@ class SimulatorLightEmission(SimtelRunner):
                 "site_model",
                 "default_le_config",
                 "le_application",
-                "simtel_source_path",
+                "simtel_path",
                 "label",
                 "light_source_type",
             ],
@@ -270,7 +270,7 @@ class SimulatorLightEmission(SimtelRunner):
         """
         command = f" rm {self.output_directory}/"
         command += f"{self.le_application[0]}_{self.le_application[1]}.simtel.gz\n"
-        command += str(self._simtel_source_path.joinpath("sim_telarray/LightEmission/"))
+        command += str(self._simtel_path.joinpath("sim_telarray/LightEmission/"))
         command += f"/{self.le_application[0]}"
 
         if self.light_source_type == "led":
@@ -377,7 +377,7 @@ class SimulatorLightEmission(SimtelRunner):
             The command to run simtel_array
         """
         # LightEmission
-        command = f"{self._simtel_source_path.joinpath('sim_telarray/bin/sim_telarray/')}"
+        command = f"{self._simtel_path.joinpath('sim_telarray/bin/sim_telarray/')}"
         command += f" -c {self._telescope_model.get_config_file()}"
 
         def remove_line_from_config(file_path, line_prefix):
@@ -452,7 +452,7 @@ class SimulatorLightEmission(SimtelRunner):
         postscript_dir = self.output_directory.joinpath("postscripts")
         postscript_dir.mkdir(parents=True, exist_ok=True)
 
-        command = str(self._simtel_source_path.joinpath("hessioxxx/bin/read_cta"))
+        command = str(self._simtel_path.joinpath("hessioxxx/bin/read_cta"))
         command += " --min-tel 1 --min-trg-tel 1"
         command += " -q --integration-scheme 4"
         command += " --integration-window "

--- a/simtools/simtel/simulator_ray_tracing.py
+++ b/simtools/simtel/simulator_ray_tracing.py
@@ -49,7 +49,7 @@ class SimulatorRayTracing(SimtelRunner):
         Instance of TelescopeModel class.
     label: str
         Instance label. Important for output file naming.
-    simtel_source_path: str or Path
+    simtel_path: str or Path
         Location of sim_telarray installation.
     config_data: dict
         Dict containing the configurable parameters.
@@ -63,7 +63,7 @@ class SimulatorRayTracing(SimtelRunner):
         self,
         telescope_model,
         label=None,
-        simtel_source_path=None,
+        simtel_path=None,
         config_data=None,
         config_file=None,
         force_simulate=False,
@@ -73,7 +73,7 @@ class SimulatorRayTracing(SimtelRunner):
         self._logger = logging.getLogger(__name__)
         self._logger.debug("Init SimulatorRayTracing")
 
-        super().__init__(label=label, simtel_source_path=simtel_source_path)
+        super().__init__(label=label, simtel_path=simtel_path)
 
         self.telescope_model = telescope_model
         self.label = label if label is not None else self.telescope_model.label
@@ -108,7 +108,7 @@ class SimulatorRayTracing(SimtelRunner):
         # This file is not actually needed and does not exist in simtools.
         # However, we need to provide the name of a CORSIKA input file to sim_telarray
         # so it is set up here.
-        self._corsika_file = self._simtel_source_path.joinpath("run9991.corsika.gz")
+        self._corsika_file = self._simtel_path.joinpath("run9991.corsika.gz")
 
         # Loop to define and remove existing files.
         # Files will be named _base_file = self.__dict__['_' + base + 'File']
@@ -168,7 +168,7 @@ class SimulatorRayTracing(SimtelRunner):
             )
 
         # RayTracing
-        command = str(self._simtel_source_path.joinpath("sim_telarray/bin/sim_telarray"))
+        command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {self.telescope_model.get_config_file()}"
         command += " -I../cfg/CTA"
         command += f" -I{self.telescope_model.config_file_directory}"

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -311,7 +311,7 @@ class Simulator:
         """Set simulation runners."""
         common_args = {
             "label": self.label,
-            "simtel_source_path": self._simulator_source_path,
+            "simtel_path": self._simulator_source_path,
             "array_model": self.array_model,
         }
         corsika_args = {

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -31,9 +31,7 @@ def test_ssts(telescope_model_name, db_config, simtel_path_no_mock, io_handler, 
         mongo_db_config=db_config,
     )
 
-    ray = RayTracing(
-        telescope_model=tel, simtel_source_path=simtel_path_no_mock, config_data=config_data
-    )
+    ray = RayTracing(telescope_model=tel, simtel_path=simtel_path_no_mock, config_data=config_data)
     ray.simulate(test=True, force=True)
     ray.analyze(force=True)
 
@@ -47,7 +45,7 @@ def test_rx(db_config, simtel_path_no_mock, io_handler, telescope_model_lst):
 
     ray = RayTracing(
         telescope_model=telescope_model_lst,
-        simtel_source_path=simtel_path_no_mock,
+        simtel_path=simtel_path_no_mock,
         config_data=config_data,
     )
 
@@ -95,7 +93,7 @@ def test_plot_image(db_config, simtel_path_no_mock, io_handler, telescope_model_
 
     ray = RayTracing(
         telescope_model=telescope_model_sst,
-        simtel_source_path=simtel_path_no_mock,
+        simtel_path=simtel_path_no_mock,
         config_data=config_data,
     )
 
@@ -121,7 +119,7 @@ def test_single_mirror(db_config, simtel_path_no_mock, io_handler, telescope_mod
 
     ray = RayTracing(
         telescope_model=telescope_model_mst,
-        simtel_source_path=simtel_path_no_mock,
+        simtel_path=simtel_path_no_mock,
         config_data=config_data,
     )
     ray.simulate(test=True, force=True)
@@ -148,7 +146,7 @@ def test_integral_curve(db_config, simtel_path_no_mock, io_handler, telescope_mo
 
     ray = RayTracing(
         telescope_model=telescope_model_lst,
-        simtel_source_path=simtel_path_no_mock,
+        simtel_path=simtel_path_no_mock,
         config_data=config_data,
     )
 
@@ -184,7 +182,7 @@ def test_process_rx(
 
     ray = RayTracing(
         telescope_model=telescope_model_lst,
-        simtel_source_path=simtel_path_no_mock,
+        simtel_path=simtel_path_no_mock,
         config_data=config_data,
         label="empty_file",
     )

--- a/tests/unit_tests/corsika/test_corsika_runner.py
+++ b/tests/unit_tests/corsika/test_corsika_runner.py
@@ -30,7 +30,7 @@ def corsika_config_data(tmp_test_directory):
 @pytest.fixture()
 def corsika_runner(corsika_config_data, io_handler, simtel_path, array_model_south):
     return CorsikaRunner(
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         label="test-corsika-runner",
         corsika_config_data=corsika_config_data,
         array_model=array_model_south,

--- a/tests/unit_tests/corsika_simtel/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/corsika_simtel/test_corsika_simtel_runner.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.DEBUG)
 def common_args(simtel_path):
     return {
         "label": "test-corsika-simtel-runner",
-        "simtel_source_path": simtel_path,
+        "simtel_path": simtel_path,
     }
 
 

--- a/tests/unit_tests/simtel/test_simtel_runner.py
+++ b/tests/unit_tests/simtel/test_simtel_runner.py
@@ -12,7 +12,7 @@ logger.setLevel(logging.DEBUG)
 
 @pytest.fixture()
 def simtel_runner(simtel_path):
-    return SimtelRunner(simtel_source_path=simtel_path)
+    return SimtelRunner(simtel_path=simtel_path)
 
 
 def test_run(simtel_runner):

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -17,7 +17,7 @@ logger.setLevel(logging.DEBUG)
 def simtel_runner(array_model_north, simtel_path):
     return SimulatorArray(
         array_model=array_model_north,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         config_data={
             "primary": "proton",
             "zenith_angle": 20 * u.deg,

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -18,7 +18,7 @@ def camera_efficiency_sst(telescope_model_sst, simtel_path, site_model_south):
     return CameraEfficiency(
         telescope_model=telescope_model_sst,
         site_model=site_model_south,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         test=True,
     )
 
@@ -26,7 +26,7 @@ def camera_efficiency_sst(telescope_model_sst, simtel_path, site_model_south):
 @pytest.fixture()
 def simulator_camera_efficiency(camera_efficiency_sst, telescope_model_sst, simtel_path):
     return SimulatorCameraEfficiency(
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         telescope_model=telescope_model_sst,
         file_simtel=camera_efficiency_sst._file["simtel"],
         label="test-simtel-runner-camera-efficiency",
@@ -96,11 +96,11 @@ def test_get_one_dim_distribution(site_model_south, simtel_path, telescope_model
     camera_efficiency_sst_prod5 = CameraEfficiency(
         telescope_model=telescope_model_sst_prod5,
         site_model=site_model_south,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         test=True,
     )
     simulator_camera_efficiency_prod5 = SimulatorCameraEfficiency(
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         telescope_model=telescope_model_sst_prod5,
         file_simtel=camera_efficiency_sst_prod5._file["simtel"],
         label="test-simtel-runner-camera-efficiency",

--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -69,7 +69,7 @@ def default_config_fixture():
 def mock_simulator(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
-    simtel_source_path = simtel_path
+    simtel_path = simtel_path
     telescope_model = TelescopeModel(
         site="North",
         telescope_name="LSTN-01",
@@ -94,7 +94,7 @@ def mock_simulator(
         site_model=site_model_north,
         default_le_config=default_config,
         le_application=le_application,
-        simtel_source_path=simtel_source_path,
+        simtel_path=simtel_path,
         light_source_type=light_source_type,
         label=label,
         config_data={},
@@ -105,7 +105,7 @@ def mock_simulator(
 def mock_simulator_variable(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
-    simtel_source_path = simtel_path
+    simtel_path = simtel_path
     telescope_model = TelescopeModel(
         site="North",
         telescope_name="LSTN-01",
@@ -130,7 +130,7 @@ def mock_simulator_variable(
         site_model=site_model_north,
         default_le_config=default_config,
         le_application=le_application,
-        simtel_source_path=simtel_source_path,
+        simtel_path=simtel_path,
         light_source_type=light_source_type,
         label=label,
         config_data={},
@@ -141,7 +141,7 @@ def mock_simulator_variable(
 def mock_simulator_laser(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
-    simtel_source_path = simtel_path
+    simtel_path = simtel_path
     telescope_model = TelescopeModel(
         site="North",
         telescope_name="LSTN-01",
@@ -166,7 +166,7 @@ def mock_simulator_laser(
         site_model=site_model_north,
         default_le_config=default_config,
         le_application=le_application,
-        simtel_source_path=simtel_source_path,
+        simtel_path=simtel_path,
         light_source_type=light_source_type,
         label=label,
         config_data={},
@@ -214,7 +214,7 @@ def test_from_kwargs_with_all_args(
         "default_le_config": default_config,
         "le_application": "xyzls",
         "label": "test_label",
-        "simtel_source_path": simtel_path,
+        "simtel_path": simtel_path,
         "light_source_type": "layout",
         # "config_data": {"some_param": "value"},
     }
@@ -225,7 +225,7 @@ def test_from_kwargs_with_all_args(
     assert simulator._calibration_model == calibration_model_illn
     assert simulator.le_application == "xyzls"
     assert simulator.label == "test_label"
-    assert simulator._simtel_source_path == simtel_path
+    assert simulator._simtel_path == simtel_path
     assert simulator.light_source_type == "layout"
 
 
@@ -238,7 +238,7 @@ def test_from_kwargs_with_minimal_args(
         "site_model": site_model_north,
         "default_le_config": default_config,
         "le_application": "xyzls",
-        "simtel_source_path": simtel_path,
+        "simtel_path": simtel_path,
         "light_source_type": "led",
     }
     simulator = SimulatorLightEmission.from_kwargs(**kwargs)
@@ -249,7 +249,7 @@ def test_from_kwargs_with_minimal_args(
     assert simulator.default_le_config == default_config
     assert simulator.le_application == "xyzls", "layout"
     assert simulator.label == telescope_model_lst.label
-    assert simulator._simtel_source_path is not None
+    assert simulator._simtel_path is not None
     assert simulator.light_source_type == "led"
 
 
@@ -432,11 +432,11 @@ def test_make_simtel_script(mock_simulator):
         mock_file.reset_mock()
 
         # Mock the necessary attributes and methods used within _make_simtel_script
-        mock_simulator._simtel_source_path = MagicMock()
+        mock_simulator._simtel_path = MagicMock()
         mock_simulator._telescope_model = MagicMock()
         mock_simulator._site_model = MagicMock()
 
-        mock_simulator._simtel_source_path.joinpath.return_value = (
+        mock_simulator._simtel_path.joinpath.return_value = (
             "/path/to/sim_telarray/bin/sim_telarray/"
         )
         mock_simulator._telescope_model.get_config_file.return_value = "/path/to/config.cfg"

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -25,7 +25,7 @@ def ray_tracing_sst(telescope_model_sst, simtel_path):
 
     return RayTracing(
         telescope_model=telescope_model_sst,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         config_data=config_data,
         label="test-simtel-runner-ray-tracing",
     )
@@ -34,7 +34,7 @@ def ray_tracing_sst(telescope_model_sst, simtel_path):
 @pytest.fixture()
 def simulator_ray_tracing(ray_tracing_sst, telescope_model_sst, simtel_path):
     return SimulatorRayTracing(
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         telescope_model=telescope_model_sst,
         config_data={
             "zenith_angle": ray_tracing_sst.config.zenith_angle * u.deg,

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -18,7 +18,7 @@ def camera_efficiency_lst(telescope_model_lst, site_model_north, simtel_path):
     return CameraEfficiency(
         telescope_model=telescope_model_lst,
         site_model=site_model_north,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         label="validate_camera_efficiency",
         test=True,
     )
@@ -29,7 +29,7 @@ def camera_efficiency_sst(telescope_model_sst, site_model_south, simtel_path):
     return CameraEfficiency(
         telescope_model=telescope_model_sst,
         site_model=site_model_south,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         label="validate_camera_efficiency",
         test=True,
     )
@@ -57,7 +57,7 @@ def test_from_kwargs(telescope_model_lst, site_model_north, simtel_path):
     ce = CameraEfficiency.from_kwargs(
         telescope_model=tel_model,
         site_model=site_model_north,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         label=label,
         zenith_angle=zenith_angle,
         test=True,
@@ -68,7 +68,7 @@ def test_from_kwargs(telescope_model_lst, site_model_north, simtel_path):
 def test_validate_telescope_model(simtel_path, site_model_north):
     with pytest.raises(ValueError):
         CameraEfficiency(
-            telescope_model="bla_bla", site_model=site_model_north, simtel_source_path=simtel_path
+            telescope_model="bla_bla", site_model=site_model_north, simtel_path=simtel_path
         )
 
 
@@ -134,7 +134,7 @@ def test_export_results(simtel_path, telescope_model_lst, site_model_north, capl
     camera_efficiency = CameraEfficiency(
         telescope_model=telescope_model_lst,
         site_model=site_model_north,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         label="export_results",
         config_data=config_data,
     )

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -21,7 +21,7 @@ def ray_tracing_lst(telescope_model_lst, simtel_path, io_handler):
 
     ray_tracing_lst = RayTracing(
         telescope_model=telescope_model_lst,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         config_data=config_data,
         label="validate_optics",
     )
@@ -50,7 +50,7 @@ def test_ray_tracing_from_dict(simtel_path, io_handler, telescope_model_mst, cap
     with caplog.at_level(logging.DEBUG):
         ray = RayTracing(
             telescope_model=telescope_model_mst,
-            simtel_source_path=simtel_path,
+            simtel_path=simtel_path,
             config_data=config_data,
         )
 
@@ -58,7 +58,7 @@ def test_ray_tracing_from_dict(simtel_path, io_handler, telescope_model_mst, cap
     assert len(ray.config.off_axis_angle) == 2
     assert "Initializing RayTracing class" in caplog.text
     assert "RayTracing contains a valid TelescopeModel" in caplog.text
-    assert ray._simtel_source_path == simtel_path
+    assert ray._simtel_path == simtel_path
     assert repr(ray) == f"RayTracing(label={telescope_model_mst.label})\n"
 
 
@@ -69,7 +69,7 @@ def test_ray_tracing_from_kwargs(io_handler, simtel_path, telescope_model_mst):
 
     ray = RayTracing.from_kwargs(
         telescope_model=telescope_model_mst,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         source_distance=source_distance,
         zenith_angle=zenith_angle,
         off_axis_angle=off_axis_angle,
@@ -91,7 +91,7 @@ def test_ray_tracing_single_mirror_mode(simtel_path, io_handler, telescope_model
     with caplog.at_level(logging.DEBUG):
         ray = RayTracing(
             telescope_model=telescope_model_mst,
-            simtel_source_path=simtel_path,
+            simtel_path=simtel_path,
             config_data=config_data,
         )
 
@@ -115,7 +115,7 @@ def test_ray_tracing_single_mirror_mode_mirror_numbers(
 
     ray = RayTracing(
         telescope_model=telescope_model_mst,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         config_data=config_data,
     )
 
@@ -132,7 +132,7 @@ def test_ray_tracing_invalid_telescope_model(simtel_path, io_handler, caplog):
     with pytest.raises(ValueError):
         RayTracing(
             telescope_model=None,
-            simtel_source_path=simtel_path,
+            simtel_path=simtel_path,
             config_data=config_data,
         )
         assert "Invalid TelescopeModel" in caplog.text
@@ -159,7 +159,7 @@ def test_export_results(simtel_path, telescope_model_lst, caplog):
 
     ray = RayTracing(
         telescope_model=telescope_model_lst,
-        simtel_source_path=simtel_path,
+        simtel_path=simtel_path,
         config_data=config_data,
         label="export_results",
     )


### PR DESCRIPTION
The variable for the simulation software source path is sometimes called `simtel_path` and sometimes `simtel_source_path`.

There are many statements like `simtel_source_path=simtel_path`.

This is confusing and this PR changes alle `simtel_source_path` to `simtel_path` with search and replace.

I would say that no line-be-line review is required as long as the test are successful. This is really just a search and replace effort.