### PR TITLE
Sync sonar properties with python project template

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,6 @@
 sonar.projectKey=gammasim_simtools_AY_ssha9WiFxsX-2oy_w
+sonar.host.url=https://sonar-cta-dpps.zeuthen.desy.de
+sonar.qualitygate.wait=true
 sonar.language=python
 sonar.python.coverage.reportPaths=coverage.xml
 sonar.python.version=3.11


### PR DESCRIPTION
Synchronize sonar properties with ctao python template project (see [here](https://gitlab.cta-observatory.org/cta-computing/documentation/python-project-template/-/blob/main/sonar-project.properties?ref_type=heads)).

Added `sonar.qualitygate.wait=true` (see https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/ci-integration/jenkins-integration/pipeline-pause/) to `sonar-project.properties`.

Closes #912 