### PR TITLE
Improve simulation configuration for corsika and simtel simulations.

### DIFF
--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -369,14 +369,14 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         shower_config.add_argument(
             "--erange",
-            help="Energy range of the primary particle (min/max value).",
+            help="Energy range of the primary particle (min/max value, e'g', '10 GeV 5 TeV').",
             type=CommandLineParser.parse_quantity_pair,
             required=False,
             default=["3 GeV 330 TeV"],
         )
         shower_config.add_argument(
             "--viewcone",
-            help="Viewcone for primary arrival directions (min/max value in degrees).",
+            help="Viewcone for primary arrival directions (min/max value, e.g. '0 deg 5 deg').",
             type=CommandLineParser.parse_quantity_pair,
             required=False,
             default=["0 deg 0 deg"],

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -331,7 +331,7 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         _configuration_group.add_argument(
             "--nshow",
-            help="Number of showers to simulate.",
+            help="Number of showers per run to simulate.",
             type=int,
             required=False,
         )

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -383,7 +383,7 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         shower_config.add_argument(
             "--core_scatter",
-            help="Scatter area for shower cores (number of use; scatter radius).",
+            help="Scatter radiusfor shower cores (number of use; scatter radius).",
             type=CommandLineParser.parse_integer_and_quantity,
             required=False,
             default=["10 1400 m"],

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -656,7 +656,7 @@ class CommandLineParser(argparse.ArgumentParser):
         """
         Parse a string representing an integer and a quantity with units.
 
-        This si e.g., used for the 'core_scatter" argument.
+        This is e.g., used for the 'core_scatter' argument.
 
         Parameters
         ----------

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -383,7 +383,7 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         shower_config.add_argument(
             "--core_scatter",
-            help="Scatter radiusfor shower cores (number of use; scatter radius).",
+            help="Scatter radius for shower cores (number of use; scatter radius).",
             type=CommandLineParser.parse_integer_and_quantity,
             required=False,
             default=["10 1400 m"],

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import re
 from pathlib import Path
 
 import astropy.units as u
@@ -34,6 +35,7 @@ class CommandLineParser(argparse.ArgumentParser):
         paths=True,
         output=False,
         simulation_model=None,
+        simulation_configuration=None,
         db_config=False,
         job_submission=False,
     ):
@@ -49,12 +51,15 @@ class CommandLineParser(argparse.ArgumentParser):
         simulation_model: list
             List of simulation model configuration parameters to add to list of args
             (use: 'version', 'telescope', 'site')
+        simulation_configuration: list
+            List of simulation software configuration parameters to add to list of args.
         db_config: bool
             Add database configuration parameters to list of args.
         job_submission: bool
             Add job submission configuration parameters to list of args.
         """
         self.initialize_simulation_model_arguments(simulation_model)
+        self.initialize_simulation_configuration_arguments(simulation_configuration)
         if job_submission:
             self.initialize_job_submission_arguments()
         if db_config:
@@ -172,7 +177,7 @@ class CommandLineParser(argparse.ArgumentParser):
 
     def initialize_db_config_arguments(self):
         """Initialize DB configuration parameters."""
-        _job_group = self.add_argument_group("MongoDB configuration")
+        _job_group = self.add_argument_group("database configuration")
         _job_group.add_argument("--db_api_user", help="database user", type=str, required=False)
         _job_group.add_argument("--db_api_pw", help="database password", type=str, required=False)
         _job_group.add_argument("--db_api_port", help="database port", type=int, required=False)
@@ -231,26 +236,218 @@ class CommandLineParser(argparse.ArgumentParser):
         Parameters
         ----------
         model_options: list
-            Options to be set: "telescope", "site"
+            Options to be set: "telescope", "site", "layout", "layout_file"
         """
-        if model_options is not None:
-            _job_group = self.add_argument_group("simulation model")
-            if "site" in model_options or "telescope" in model_options:
-                _job_group.add_argument(
-                    "--site", help="site (e.g., North, South)", type=self.site, required=False
-                )
-            if "telescope" in model_options:
-                _job_group.add_argument(
-                    "--telescope",
-                    help="telescope model name (e.g., LSTN-01, SSTS-design, ...)",
-                    type=self.telescope,
-                )
+        if model_options is None:
+            return
+
+        _job_group = self.add_argument_group("simulation model")
+        _job_group.add_argument(
+            "--model_version",
+            help="model version",
+            type=str,
+            default="Released",
+        )
+        if any(
+            option in model_options for option in ["site", "telescope", "layout", "layout_file"]
+        ):
+            self._add_model_option_site(_job_group)
+
+        if "telescope" in model_options:
             _job_group.add_argument(
-                "--model_version",
-                help="model version",
-                type=str,
-                default="Released",
+                "--telescope",
+                help="telescope model name (e.g., LSTN-01, SSTS-design, ...)",
+                type=self.telescope,
             )
+
+        if "layout" in model_options or "layout_file" in model_options:
+            _job_group = self._add_model_option_layout(_job_group, "layout_file" in model_options)
+
+    def initialize_simulation_configuration_arguments(self, simulation_configuration):
+        """
+        Initialize default arguments for simulation configuration and simulation software.
+
+        Parameters
+        ----------
+        simulation_configuration: list
+            List of simulation software configuration parameters.
+        """
+        if simulation_configuration is None:
+            return
+
+        if "software" in simulation_configuration:
+            self._initialize_simulation_software()
+        if "corsika_configuration" in simulation_configuration:
+            self._initialize_simulation_configuration()
+            self._initialize_shower_configuration()
+
+    def _initialize_simulation_software(self):
+        """Initialize simulation software arguments."""
+        _software_group = self.add_argument_group("simulation software")
+        _software_group.add_argument(
+            "--simulation_software",
+            help="Simulation software steps.",
+            type=str,
+            choices=["corsika", "simtel", "corsika_simtel"],
+            required=True,
+            default="corsika_simtel",
+        )
+
+    def _initialize_simulation_configuration(self):
+        """Initialize simulation configuration arguments."""
+        _configuration_group = self.add_argument_group("simulation configuration")
+        _configuration_group.add_argument(
+            "--primary",
+            help="Primary particle to simulate.",
+            type=str.lower,
+            required=True,
+            choices=[
+                "gamma",
+                "gamma_diffuse",
+                "electron",
+                "proton",
+                "muon",
+                "helium",
+                "nitrogen",
+                "silicon",
+                "iron",
+            ],
+        )
+        _configuration_group.add_argument(
+            "--azimuth_angle",
+            help=(
+                "Telescope pointing direction in azimuth. "
+                "It can be in degrees between 0 and 360 or one of north, south, east or west "
+                "North is 0 degrees and the azimuth grows clockwise (East is 90 degrees)."
+            ),
+            type=CommandLineParser.azimuth_angle,
+            required=True,
+        )
+        _configuration_group.add_argument(
+            "--zenith_angle",
+            help="Zenith angle in degrees (between 0 and 180).",
+            type=CommandLineParser.zenith_angle,
+            required=True,
+        )
+        _configuration_group.add_argument(
+            "--nshow",
+            help="Number of showers to simulate.",
+            type=int,
+            required=False,
+        )
+        _configuration_group.add_argument(
+            "--run_number_start",
+            help="Run number for the first run.",
+            type=int,
+            required=True,
+            default=1,
+        )
+        _configuration_group.add_argument(
+            "--number_of_runs",
+            help="Number of runs to be simulated.",
+            type=int,
+            required=True,
+            default=1,
+        )
+        _configuration_group.add_argument(
+            "--event_number_first_shower",
+            help="Event number of first shower",
+            type=int,
+            required=False,
+            default=1,
+        )
+
+    def _initialize_shower_configuration(self):
+        """Initialize shower configuration arguments."""
+        shower_config = self.add_argument_group("shower parameters")
+        shower_config.add_argument(
+            "--eslope",
+            help="Slope of the energy spectrum.",
+            type=float,
+            required=False,
+            default=-2.0,
+        )
+        shower_config.add_argument(
+            "--erange",
+            help="Energy range of the primary particle (min/max value).",
+            type=CommandLineParser.parse_quantity_pair,
+            required=False,
+            default=["3 GeV 330 TeV"],
+        )
+        shower_config.add_argument(
+            "--viewcone",
+            help="Viewcone for primary arrival directions (min/max value in degrees).",
+            type=CommandLineParser.parse_quantity_pair,
+            required=False,
+            default=["0 deg 0 deg"],
+        )
+        shower_config.add_argument(
+            "--core_scatter",
+            help="Scatter area for shower cores (number of use; scatter radius).",
+            type=CommandLineParser.parse_integer_and_quantity,
+            required=False,
+            default=["10 1400 m"],
+        )
+
+    @staticmethod
+    def _add_model_option_layout(job_group, add_layout_file):
+        """
+        Add layout option to the job group.
+
+        Parameters
+        ----------
+        job_group: argparse.ArgumentParser
+            Job group
+        add_layout_file: bool
+            Add layout file option
+
+        Returns
+        -------
+        argparse.ArgumentParser
+        """
+        _layout_group = job_group.add_mutually_exclusive_group(required=False)
+        _layout_group.add_argument(
+            "--array_layout_name",
+            help="array layout name (e.g., alpha, subsystem_msts)",
+            type=str,
+            required=False,
+        )
+        _layout_group.add_argument(
+            "--array_element_list",
+            help="list of array elements (e.g., LSTN-01, LSTN-02, MSTN).",
+            nargs="+",
+            type=str,
+            required=False,
+            default=None,
+        )
+        if add_layout_file:
+            _layout_group.add_argument(
+                "--array_layout_file",
+                help="file(s) with the list of array elements (astropy table format).",
+                nargs="+",
+                type=str,
+                required=False,
+                default=None,
+            )
+        return job_group
+
+    def _add_model_option_site(self, job_group):
+        """
+        Add site option to the job group.
+
+        Parameters
+        ----------
+        job_group: argparse.ArgumentParser
+            Job group
+
+        Returns
+        -------
+        argparse.ArgumentParser
+        """
+        job_group.add_argument(
+            "--site", help="site (e.g., North, South)", type=self.site, required=False
+        )
+        return job_group
 
     @staticmethod
     def site(value):
@@ -271,7 +468,6 @@ class CommandLineParser(argparse.ArgumentParser):
         ------
         argparse.ArgumentTypeError
             for invalid sites
-
         """
         names.validate_site_name(str(value))
         return str(value)
@@ -295,7 +491,6 @@ class CommandLineParser(argparse.ArgumentParser):
         ------
         argparse.ArgumentTypeError
             for invalid telescope
-
         """
         names.validate_telescope_name(str(value))
         return str(value)
@@ -319,8 +514,6 @@ class CommandLineParser(argparse.ArgumentParser):
         ------
         argparse.ArgumentTypeError
             When value is outside of the interval [0,1]
-
-
         """
         fvalue = float(value)
         if fvalue < 0.0 or fvalue > 1.0:
@@ -351,8 +544,6 @@ class CommandLineParser(argparse.ArgumentParser):
         ------
         argparse.ArgumentTypeError
             When angle is outside of the interval [0, 180]
-
-
         """
         logger = logging.getLogger(__name__)
 
@@ -371,7 +562,6 @@ class CommandLineParser(argparse.ArgumentParser):
                 f"The provided zenith angle, {angle:.1f}, "
                 "is outside of the allowed [0, 180] interval"
             )
-
         return fangle
 
     @staticmethod
@@ -396,8 +586,6 @@ class CommandLineParser(argparse.ArgumentParser):
         ------
         argparse.ArgumentTypeError
             When angle is outside of the interval [0, 360] or not in (north, south, east, west)
-
-
         """
         logger = logging.getLogger(__name__)
         try:
@@ -414,6 +602,9 @@ class CommandLineParser(argparse.ArgumentParser):
                 "The azimuth angle provided is not a valid numeric value. "
                 "Will check if it is an astropy.Quantity instead"
             )
+        except TypeError as exc:
+            logger.error("The azimuth angle provided is not a valid numerical or string value.")
+            raise exc
         try:
             return u.Quantity(angle).to("deg")
         except TypeError:
@@ -421,22 +612,69 @@ class CommandLineParser(argparse.ArgumentParser):
                 "The azimuth angle provided is not a valid astropy.Quantity. "
                 "Will check if it is (north, south, east, west) instead"
             )
-        if isinstance(angle, str):
-            azimuth_angle = angle.lower()
-            if azimuth_angle == "north":
-                return 0 * u.deg
-            if azimuth_angle == "south":
-                return 180 * u.deg
-            if azimuth_angle == "east":
-                return 90 * u.deg
-            if azimuth_angle == "west":
-                return 270 * u.deg
-            raise argparse.ArgumentTypeError(
-                "The azimuth angle can only be a number or one of "
-                f"(north, south, east, west), not {angle}"
-            )
-        logger.error(
-            f"The azimuth value provided, {angle}, is not a valid number "
-            "nor one of (north, south, east, west)."
+        azimuth_map = {
+            "north": 0 * u.deg,
+            "south": 180 * u.deg,
+            "east": 90 * u.deg,
+            "west": 270 * u.deg,
+        }
+        azimuth_angle = angle.lower()
+        if azimuth_angle in azimuth_map:
+            return azimuth_map[azimuth_angle]
+        raise argparse.ArgumentTypeError(
+            "The azimuth angle can only be one of " f"(north, south, east, west), not {angle}"
         )
-        raise TypeError
+
+    @staticmethod
+    def parse_quantity_pair(string):
+        """
+        Parse a string representing a pair of astropy quantities separated by a space.
+
+        Args:
+            string: The input string (e.g., "0 deg 1.5 deg").
+
+        Returns
+        -------
+            tuple: A tuple containing two astropy.units.Quantity objects.
+
+        Raises
+        ------
+            ValueError: If the string is not formatted correctly (e.g., missing space).
+        """
+        pattern = r"(\d+\.?\d*)\s*([a-zA-Z]+)"
+        matches = re.findall(pattern, string)
+        if len(matches) != 2:
+            raise ValueError("Input string does not contain exactly two quantities.")
+
+        return (
+            u.Quantity(float(matches[0][0]), matches[0][1]),
+            u.Quantity(float(matches[1][0]), matches[1][1]),
+        )
+
+    @staticmethod
+    def parse_integer_and_quantity(input_string):
+        """
+        Parse a string representing an integer and a quantity with units.
+
+        This si e.g., used for the 'core_scatter" argument.
+
+        Parameters
+        ----------
+        input_string: str
+            The input string (e.g., "5 1500 m").
+
+        Returns
+        -------
+        tuple: A tuple containing an integer and an astropy.units.Quantity object.
+
+        Raises
+        ------
+        ValueError: If the input string does not match the required format.
+        """
+        pattern = r"(\d+)\s+(\d+\.?\d*)\s*([a-zA-Z]+)"
+        match = re.match(pattern, input_string.strip())
+
+        if not match:
+            raise ValueError("Input string does not contain an integer and a astropy quantity.")
+
+        return (int(match.group(1)), u.Quantity(float(match.group(2)), match.group(3)))

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -1,4 +1,4 @@
-"""Configuration of applications."""
+"""Application configuration."""
 
 import argparse
 import logging
@@ -103,6 +103,7 @@ class Configurator:
         paths=True,
         output=False,
         simulation_model=None,
+        simulation_configuration=None,
         db_config=False,
         job_submission=False,
     ):
@@ -128,7 +129,8 @@ class Configurator:
             Add output file configuration to list of args.
         simulation_model: list
             List of simulation model configuration parameters to add to list of args
-            (use: 'version', 'telescope', 'site')
+        simulation_configuration: list
+            List of simulation software configuration parameters to add to list of args.
         db_config: bool
             Add database configuration parameters to list of args.
         job_submission: bool
@@ -146,6 +148,7 @@ class Configurator:
             paths=paths,
             output=output,
             simulation_model=simulation_model,
+            simulation_configuration=simulation_configuration,
             db_config=db_config,
             job_submission=job_submission,
         )
@@ -199,7 +202,6 @@ class Configurator:
         Reset required parser arguments (i.e., arguments added with "required=True").
 
         Includes also mutually exclusive groups.
-
         Access protected attributes of parser (no public method available).
 
         """
@@ -249,8 +251,6 @@ class Configurator:
         ------
         InvalidConfigurationParameterError
            if parameter has already been defined with a different value.
-
-
         """
         # parameter not changed or None
         if self.parser.get_default(key) == self.config[key] or self.config[key] is None:
@@ -401,7 +401,7 @@ class Configurator:
             return []
 
     @staticmethod
-    def _convert_stringnone_to_none(input_dict):
+    def _convert_string_none_to_none(input_dict):
         """
         Convert string type 'None' to type None (argparse returns None as str).
 
@@ -424,9 +424,8 @@ class Configurator:
         ----------
         input_container
             List or dictionary with configuration updates.
-
         """
-        self.config = self._convert_stringnone_to_none(
+        self.config = self._convert_string_none_to_none(
             vars(
                 self.parser.parse_args(
                     self._arglist_from_config(self.config)
@@ -443,8 +442,6 @@ class Configurator:
         ----------
         dict
             Dictionary with DB parameters
-
-
         """
         _db_dict = {}
         _db_para = (

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -71,6 +71,39 @@ def test_zenith_angle(caplog):
         assert "The zenith angle provided is not a valid numeric value" in caplog.text
 
 
+def test_parse_quantity_pair(caplog):
+    for test_string in ["100 GeV 5 TeV", "100GeV 5TeV", "100GeV 5 TeV"]:
+        e_pair = parser.CommandLineParser.parse_quantity_pair(test_string)
+        assert pytest.approx(e_pair[0].value) == 100.0
+        assert e_pair[0].unit == u.GeV
+        assert pytest.approx(e_pair[1].value) == 5.0
+        assert e_pair[1].unit == u.TeV
+
+    with pytest.raises(ValueError, match=r"Input string does not contain exactly two quantities."):
+        parser.CommandLineParser.parse_quantity_pair("100 GeV 5 TeV 20 PeV")
+
+    with pytest.raises(ValueError, match=r"^'abc' did not parse as unit:"):
+        parser.CommandLineParser.parse_quantity_pair("100 GeV 5 abc")
+
+    with pytest.raises(ValueError, match=r"Input string does not contain exactly two quantities."):
+        parser.CommandLineParser.parse_quantity_pair("a GeV 5 TeV")
+
+
+def test_parse_integer_and_quantity(caplog):
+    for test_string in ["5 1500 m", "5 1500m", "5 1500.0 m"]:
+        c_pair = parser.CommandLineParser.parse_integer_and_quantity(test_string)
+        assert c_pair[0] == 5
+        assert pytest.approx(c_pair[1].value) == 1500.0
+        assert c_pair[1].unit == u.m
+
+    with pytest.raises(ValueError, match=r"^'abc' did not parse as unit:"):
+        parser.CommandLineParser.parse_integer_and_quantity("5 5 abc")
+    with pytest.raises(
+        ValueError, match=r"Input string does not contain an integer and a astropy quantity."
+    ):
+        parser.CommandLineParser.parse_integer_and_quantity("0 m 5 m")
+
+
 def test_azimuth_angle(caplog):
     assert parser.CommandLineParser.azimuth_angle(0).value == pytest.approx(0.0)
     assert parser.CommandLineParser.azimuth_angle(45).value == pytest.approx(45.0)
@@ -100,7 +133,7 @@ def test_azimuth_angle(caplog):
         assert "The azimuth angle can only be a number or one of" in caplog.text
     with pytest.raises(TypeError):
         parser.CommandLineParser.azimuth_angle([0, 10])
-        assert "is not a valid number nor one of (north, south, east, west)" in caplog.text
+        assert "The azimuth angle provided is not a valid numerical or string value." in caplog.text
 
 
 def test_initialize_default_arguments():
@@ -169,4 +202,37 @@ def test_initialize_default_arguments():
     _parser_6 = parser.CommandLineParser()
     _parser_6.initialize_default_arguments(db_config=True)
     job_groups = _parser_6._action_groups
-    assert "MongoDB configuration" in [str(group.title) for group in job_groups]
+    assert "database configuration" in [str(group.title) for group in job_groups]
+
+    # layout parsers
+    _parser_7 = parser.CommandLineParser()
+    _parser_7.initialize_default_arguments(simulation_model=["layout"])
+    job_groups = _parser_7._action_groups
+    for group in job_groups:
+        if str(group.title) == "simulation model":
+            assert any(action.dest == "array_layout_name" for action in group._group_actions)
+            assert any(action.dest == "array_element_list" for action in group._group_actions)
+
+    # layout parsers
+    _parser_8 = parser.CommandLineParser()
+    _parser_8.initialize_default_arguments(simulation_model=["layout", "layout_file"])
+    job_groups = _parser_8._action_groups
+    for group in job_groups:
+        if str(group.title) == "simulation model":
+            assert any(action.dest == "array_layout_name" for action in group._group_actions)
+            assert any(action.dest == "array_element_list" for action in group._group_actions)
+            assert any(action.dest == "array_layout_file" for action in group._group_actions)
+
+    # simulation configuration
+    _parser_9 = parser.CommandLineParser()
+    _parser_9.initialize_default_arguments(
+        simulation_configuration=["software", "corsika_configuration"]
+    )
+    job_groups = _parser_9._action_groups
+    for group in job_groups:
+        if str(group.title) == "simulation software":
+            assert any(action.dest == "simulation_software" for action in group._group_actions)
+        if str(group.title) == "simulation configuration":
+            assert any(action.dest == "primary" for action in group._group_actions)
+        if str(group.title) == "shower parameters":
+            assert any(action.dest == "viewcone" for action in group._group_actions)

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -184,8 +184,8 @@ def test_arglist_from_config():
     )
 
 
-def test_convert_stringnone_to_none():
-    assert {} == Configurator._convert_stringnone_to_none({})
+def test_convert_string_none_to_none():
+    assert {} == Configurator._convert_string_none_to_none({})
 
     _tmp_dict = {
         "a": 1.0,
@@ -196,7 +196,7 @@ def test_convert_stringnone_to_none():
     _tmp_none = copy(_tmp_dict)
     _tmp_none["d"] = None
 
-    assert _tmp_none == Configurator._convert_stringnone_to_none(_tmp_dict)
+    assert _tmp_none == Configurator._convert_string_none_to_none(_tmp_dict)
 
 
 def test_get_db_parameters_from_env(configurator, args_dict):
@@ -308,6 +308,20 @@ def test_fill_from_environmental_variables_with_dotenv_file(configurator, tmp_te
 
     assert configurator.config["label"] == "test_label"
     assert configurator.config["config"] == "test_config_file_env"
+
+
+def test_default_config_with_site():
+    configurator = Configurator(config={})
+    configurator.default_config(arg_list=["--site", "North"])
+    assert "site" in configurator.config
+    assert "telescope" not in configurator.config
+
+
+def test_default_config_with_telescope():
+    configurator = Configurator(config={})
+    configurator.default_config(arg_list=["--telescope", "LSTN-01"])
+    assert "telescope" in configurator.config
+    assert "site" in configurator.config
 
 
 def test_get_db_parameters():


### PR DESCRIPTION
Improve simulation configuration for corsika and simtel simulations.

Added `simulation_configuration=["software", "corsika_configuration"]` to allow for the configuration of simulation software (e.g., corsika/simtel) or corsika configuration parameters (e.g. number of showers to be simulated).

Added `array_layout` model option to add especially `array_layout_name` to command line configuration.

Added functionality to the configuration model required to configure corsika parameters like `erange`, `viewcone`, `cscatter`:

1. for `erange`, `viewcone`: CommandLineParser.parse_quantity_pair requires a single string with a pair of quantities, e.g., "10 GeV 50 PeV" or "10GeV 50PeV" or "0deg 1.55deg"
2. for `cscatter`: CommandLineParser.parse_integer_and_quantity requires a single with with a pair consisting of an integer and a astropy.quantity (as needed for the core scatter keyword). This mean e.g., "5 1500m" or "5 1500 m".

Minor changes:

- simplified handling of azimuth angle configuration
- improved unit testing

Closes #1005 