### PR TITLE
Re-introduce writing of file lists to simulate_prod

### DIFF
--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -11,6 +11,7 @@ Command line arguments
 ----------------------
 simtel_file_names (str or list):
     Path to the simtel_array file or a list of simtel_array output files.
+    Files can be generated in `simulate_prod` using the `--save_file_lists` option.
 save_tables (bool):
     If true, save the tables with the energy-dependent trigger rate to a ecsv file.
 area_from_distribution (bool):

--- a/simtools/applications/calculate_trigger_rate.py
+++ b/simtools/applications/calculate_trigger_rate.py
@@ -11,7 +11,7 @@ Command line arguments
 ----------------------
 simtel_file_names (str or list):
     Path to the simtel_array file or a list of simtel_array output files.
-    Files can be generated in `simulate_prod` using the `--save_file_lists` option.
+    Files can be generated in `simulate_prod` using the ``--save_file_lists`` option.
 save_tables (bool):
     If true, save the tables with the energy-dependent trigger rate to a ecsv file.
 area_from_distribution (bool):

--- a/simtools/applications/simulate_prod.py
+++ b/simtools/applications/simulate_prod.py
@@ -114,6 +114,13 @@ def _parse(description=None):
         required=False,
         default=False,
     )
+    config.parser.add_argument(
+        "--save_file_lists",
+        help="Save lists of output and log files.",
+        action="store_true",
+        required=False,
+        default=False,
+    )
     return config.initialize(
         db_config=True,
         simulation_model=["site", "layout", "telescope"],
@@ -182,6 +189,8 @@ def main():  # noqa: D103
 
     if args_dict["pack_for_grid_register"]:
         pack_for_register(logger, simulator, args_dict)
+    if args_dict["save_file_lists"]:
+        simulator.save_file_lists()
 
 
 if __name__ == "__main__":

--- a/simtools/simulator.py
+++ b/simtools/simulator.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import simtools.utils.general as gen
 from simtools.corsika.corsika_config import CorsikaConfig
+from simtools.io_operations import io_handler
 from simtools.job_execution.job_manager import JobManager
 from simtools.model.array_model import ArrayModel
 from simtools.runners.corsika_runner import CorsikaRunner
@@ -67,6 +68,8 @@ class Simulator:
         self.simulation_software = self.args_dict["simulation_software"]
         self._logger.debug(f"Init Simulator {self.simulation_software}")
         self.label = label
+
+        self.io_handler = io_handler.IOHandler()
 
         self.runs = self._initialize_run_list()
         self._results = defaultdict(list)
@@ -531,3 +534,18 @@ class Simulator:
         if run_list is None and run_range is None:
             return [] if self.runs is None else self.runs
         return self._validate_run_list_and_range(run_list, run_range)
+
+    def save_file_lists(self):
+        """Save files lists for output and log files."""
+        for file_type in ["output", "log", "hist"]:
+            file_name = self.io_handler.get_output_directory(label=self.label).joinpath(
+                f"{file_type}_files.txt"
+            )
+            file_list = self.get_file_list(file_type=file_type)
+            if all(element is not None for element in file_list) and len(file_list) > 0:
+                self._logger.info(f"Saving list of {file_type} files to {file_name}")
+                with open(file_name, "w", encoding="utf-8") as f:
+                    for line in self.get_file_list(file_type=file_type):
+                        f.write(f"{line}\n")
+            else:
+                self._logger.debug(f"No files to save for {file_type} files.")

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
@@ -19,6 +19,7 @@ CTA_SIMPIPE:
     CORE_SCATTER: "10 500 m"
     DATA_DIRECTORY: simtools-output
     OUTPUT_PATH: simtools-output
+    SAVE_FILE_LISTS: True
     LOG_LEVEL: DEBUG
   INTEGRATION_TESTS:
     - OUTPUT_FILE: |

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_corsika.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_corsika.yml
@@ -19,6 +19,7 @@ CTA_SIMPIPE:
     CORE_SCATTER: "10 1400 m"
     DATA_DIRECTORY: simtools-output
     OUTPUT_PATH: simtools-output
+    SAVE_FILE_LISTS: True
     LOG_LEVEL: DEBUG
   INTEGRATION_TESTS:
     - OUTPUT_FILE: |

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -321,3 +321,21 @@ def test_get_runs_to_simulate(shower_simulator):
 
     shower_simulator.runs = None
     assert isinstance(shower_simulator._get_runs_to_simulate(), list)
+
+
+def test_save_file_lists(shower_simulator, mocker, caplog):
+    with caplog.at_level(logging.DEBUG):
+        shower_simulator.save_file_lists()
+        assert "No files to save for output files." in caplog.text
+
+    mock_shower_simulator = copy.deepcopy(shower_simulator)
+    mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=["file1", "file2"])
+
+    with caplog.at_level(logging.INFO):
+        mock_shower_simulator.save_file_lists()
+        assert "Saving list of output files to" in caplog.text
+
+    mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=[None, None])
+    with caplog.at_level(logging.DEBUG):
+        mock_shower_simulator.save_file_lists()
+        assert "No files to save for output files." in caplog.text


### PR DESCRIPTION
PR #989 removed `simulate_showers_for_trigger_rates`, as simulation of corsika is covered by `simulate_prod`. We "lost" in this pull request the writing of lists of output files, which is used as input in e.g., `calculate_trigger_rate`.

This PR adds a command line option to `simulate_prod` called `--save_file_lists` which introduces this functionality again.