### PR TITLE
Add unix find to production image

### DIFF
--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_BRANCH=main
 
 RUN microdnf update -y && microdnf install -y \
+    findutils \
     gcc-c++ \
     git \
     python3.11-pip \


### PR DESCRIPTION
Add 'find' to the production image.

Main motivation is that several gitlab CI's require find and we don't want to install it for each workflow (see e.g. [here](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/blob/main/.gitlab-ci.yml?ref_type=heads)

