### PR TITLE
Simplify db definition

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,14 +1,14 @@
 # Template file for environment variables settings
-# Copy this file to '.env' and add the required
-# credentials for simulation model database access
+# Copy this file to '.env' and add the required # credentials for simulation model database access
+# Important! These are also the default values used in the github CI
 SIMTOOLS_DB_API_PORT=27017 #Port on the MongoDB server
 SIMTOOLS_DB_SERVER='cta-simpipe-protodb.zeuthen.desy.de' # MongoDB server
 SIMTOOLS_DB_API_USER=YOUR_USERNAME # username for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible person
-SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
-# SIMTOOLS_DB_SIMULATION_MODEL_URL=''
-SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
+SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin' # DB authentication
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0' # simulation DB name
+# SIMTOOLS_DB_SIMULATION_MODEL_URL='' # for testing only
+SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray' # path to sim_telarray and corsika installation
 
 # The dashboards to monitor the MongoDB instance are in (accessible only from within DESY)
 # https://statspub.zeuthen.desy.de/d/4vXnWwMGz/mongodb?orgId=1&refresh=30s

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -3,12 +3,8 @@ name: CI-integrationtests
 # Integration tests for applications
 
 env:
-  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
-  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-3-0"
-  SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:
   workflow_dispatch:
@@ -37,6 +33,14 @@ jobs:
 
       - name: checkout
         uses: actions/checkout@v4
+
+      - name: Read .env_template file
+        id: read-env
+        run: |
+          # Read .env_template and export variables except SIMTOOLS_DB_API_PW and SIMTOOLS_DB_API_USER
+          grep -v '^SIMTOOLS_DB_API_PW\|^SIMTOOLS_DB_API_USER$' .env_template | while read line; do
+            export "$line"
+          done
 
       - name: Set PATH
         run: |


### PR DESCRIPTION
The DB parameters are defined in several places:

- [.env_template](.env_template)
- Github Action secrets
- CI-integrationtests.yml and CI-unittests.yml
- (additional listed in the [documentation of the datbases](https://gammasim.github.io/simtools/user-guide/databases.html#using-the-remote-database-located-at-desy), but there we don't need to most recent values)

This PR tries to simplify this at least a bit:

- CI-integrationtests.yml and CI-unittests.yml are reading the available values from  [.env_template](.env_template)
- only `SIMTOOLS_DB_API_USER` and `SIMTOOLS_DB_API_PW` are read from secrets

This means we have the only variable parameter `SIMTOOLS_DB_SIMULATION_MODEL` fixed at one single place.

