### PR TITLE
Add corsika DB parameter schema

### DIFF
--- a/simtools/schemas/model_parameters/corsika_cherenkov_photon_bunch_size.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_cherenkov_photon_bunch_size.schema.yml
@@ -1,0 +1,27 @@
+%YAML 1.2
+---
+title: Schema for corsika_cherenkov_photon_bunch_size model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: |-
+  Different default than sim_telarray. No use of having HEGRA defaults.
+name: corsika_cherenkov_photon_bunch_size
+description: |-
+  Cherenkov bunch size definition.
+data:
+  - type: float64
+    unit: dimensionless
+    default: 1.
+    allowed_range:
+      min: 0.
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_cherenkov_photon_wavelength_range.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_cherenkov_photon_wavelength_range.schema.yml
@@ -1,0 +1,38 @@
+%YAML 1.2
+---
+title: Schema for corsika_cherenkov_photon_wavelength_range model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_cherenkov_photon_wavelength_range
+description: |-
+  Cherenkov photon wavelength band.
+data:
+  - name: wavlgl
+    type: float64
+    description: Lower limit of the Cherenkov photon wavelength band.
+    unit: nm
+    default: 240.
+    allowed_range:
+      min: 100.
+      max: 700.
+    required: true
+  - name: wavlgu
+    type: float64
+    description: Upper limit of the Cherenkov photon wavelength band.
+    unit: nm
+    default: 700.
+    allowed_range:
+      min: 100.
+      max: 700.
+    required: true
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
@@ -16,7 +16,7 @@ data:
     default: 0.
     allowed_range:
       min: 0.
-      max: 112.8e5
+      max: 11280000.0
 activity:
   setting:
     - SetParameterFromExternal

--- a/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
@@ -1,0 +1,28 @@
+%YAML 1.2
+---
+title: Schema for corsika_first_interaction_height model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_first_interaction_height
+description: |-
+  Starting altitude of primary particles in altitude above observation level.
+  This parameter should be set to values other than '0.' for specialized studies
+  only. See CORSIKA manual for details.
+data:
+  - type: float64
+    unit: cm
+    default: 0.
+    allowed_range:
+      min: 0.
+      max: 112.8e5
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+title: Schema for corsika_iact_io_buffer model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_iact_io_buffer
+description: |-
+  Maximum size of data blocks written by the CORSIKA IACT module.
+data:
+  - type: int
+    unit: byte
+    default: 100000000
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
@@ -1,0 +1,27 @@
+%YAML 1.2
+---
+title: Schema for corsika_iact_max_bunches model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_iact_max_bunches
+short_description: |-
+  Maximum number of bunches that can be kept per telescope, including in temporary files.
+description: |-
+  Maximum number of bunches that can be kept per telescope, including in temporary files.
+  Telescopes for which this limit is exceeded will have the number of bunches reduced in
+  increasing powers of two (by discarding every second bunch and adding its bunch size to the bunch kept).
+data:
+  - type: int
+    unit: dimensionless
+    default: 1000000
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
@@ -1,0 +1,28 @@
+%YAML 1.2
+---
+title: Schema for corsika_iact_split_auto model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_iact_split_auto
+short_description: |-
+  Maximum number of bunches before splitting into several blocks (per telescope).
+description: |-
+  Maximum number of bunches before splitting into several blocks (per telescope).
+  If the full data block for the entire array would exceed the given number of bunches,
+  it gets split up into separate blocks per individual telescope, in order to avoid
+  exceeding the hard I/O buffer size limit.
+data:
+  - type: int
+    unit: dimensionless
+    default: 15000000
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
@@ -1,0 +1,27 @@
+%YAML 1.2
+---
+title: Schema for corsika_longitudinal_shower_development model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_longitudinal_shower_development
+description: |-
+  Step size for recording of longitudinal shower development.
+  Any value >=1. for the step size enables the recording of the shower development.
+data:
+    type: float64
+    unit: g/cm2
+    default: 20.0
+    allowed_range:
+      min: 0.
+      max: 14998.
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
@@ -1,0 +1,52 @@
+%YAML 1.2
+---
+title: Schema for corsika_particle_kinetic_energy_cutoff model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_particle_kinetic_energy_cutoff
+description: |-
+  Kinetic energy cutoffs for different particle types.
+data:
+  - name: hadrons
+    type: float64
+    description: Kinetic energy cutoffs for hadrons.
+    unit: GeV
+    default: 0.3
+    allowed_range:
+      min: 0.05
+    required: true
+  - name: muons
+    type: float64
+    description: Kinetic energy cutoffs for muons.
+    unit: GeV
+    default: 0.1
+    allowed_range:
+      min: 0.05
+    required: true
+  - name: electrons
+    type: float64
+    description: Kinetic energy cutoffs for electrons.
+    unit: GeV
+    default: 0.020
+    allowed_range:
+      min: 0.05
+    required: true
+  - name: gammas
+    type: float64
+    description: Kinetic energy cutoffs for gammas.
+    unit: GeV
+    default: 0.020
+    allowed_range:
+      min: 0.05
+    required: true
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika

--- a/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
@@ -23,7 +23,7 @@ data:
     unit: GeV
     default: 0.1
     allowed_range:
-      min: 0.05
+      min: 0.01
     required: true
   - name: electrons
     type: float64
@@ -31,7 +31,7 @@ data:
     unit: GeV
     default: 0.020
     allowed_range:
-      min: 0.05
+      min: 0.00005
     required: true
   - name: gammas
     type: float64
@@ -39,7 +39,7 @@ data:
     unit: GeV
     default: 0.020
     allowed_range:
-      min: 0.05
+      min: 0.00005
     required: true
 activity:
   setting:

--- a/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
@@ -1,0 +1,27 @@
+%YAML 1.2
+---
+title: Schema for corsika_starting_grammage model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_starting_grammage
+description: |-
+  Starting altitude of the primary particle in mass overburden for all showers.
+  This parameter should be set to values other than '0.' for specialized studies
+  only. See CORSIKA manual for details.
+data:
+  - type: float64
+    unit: g/cm2
+    default: 0.
+    allowed_range:
+      min: 0.
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika


### PR DESCRIPTION
This PR adds schema files for those CORSIKA parameters which have been added to the model parameter repository with [this merge request](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/merge_requests/43).

See also #1056 for some additional information.