### PR TITLE
Data field in schema file should be a list

### DIFF
--- a/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
+++ b/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Step size for recording of longitudinal shower development.
   Any value >=1. for the step size enables the recording of the shower development.
 data:
-    type: float64
+  - type: float64
     unit: g/cm2
     default: 20.0
     allowed_range:


### PR DESCRIPTION
This fixes a bug in the schema file definition.

Absolutely puzzling that the CI ([here](https://github.com/gammasim/simtools/actions/runs/9890868431/job/27320057258)) did run successful. 

I tried to reproduce this locally, without success. Very very weird. 