### PR TITLE
Improve tests for building and command line applications

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -19,7 +19,50 @@ on:
 
 jobs:
 
+  testbuilding:
+    # Build the package and check if it is installable
+    # (tests among others that all components are there)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Build the package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
+          python -m build
+
+  test_commandline_tools:
+    # Test the command line tools defined in pyproject.toml
+    # (tests if they are correctly defined and can be executed)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gammasim/simtools-prod:latest
+      options: --user 0
+
+    steps:
+
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Test command line tools
+        run: |
+          # read list of scripts from pyproject.toml and execute them
+          scripts=$(grep 'scripts.simtools-' pyproject.toml | sed -e 's/^scripts\.//' -e 's/ =.*$//')
+          for script in $scripts; do
+            echo "Running $script"
+            $script --help
+          done
+
   integrationtests:
+    # Run integration tests
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gammasim/simtools-dev:latest

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Test command line tools
         run: |
+          set -e
           # read list of scripts from pyproject.toml and execute them
           scripts=$(grep 'scripts.simtools-' pyproject.toml | sed -e 's/^scripts\.//' -e 's/ =.*$//')
           for script in $scripts; do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ scripts.simtools-generate-simtel-array-histograms = "simtools.applications.gener
 scripts.simtools-plot-array-layout = "simtools.applications.plot_array_layout:main"
 scripts.simtools-simulate-light-emission = "simtools.applications.simulate_light_emission:main"
 scripts.simtools-simulate-prod = "simtools.applications.simulate_prod:main"
-scripts.simtools-simulate-showers-for-trigger-rates = "simtools.applications.simulate_showers_for_trigger_rates:main"
 scripts.simtools-submit-data-from-external = "simtools.applications.submit_data_from_external:main"
 scripts.simtools-validate-camera-efficiency = "simtools.applications.validate_camera_efficiency:main"
 scripts.simtools-validate-camera-fov = "simtools.applications.validate_camera_fov:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ scripts.simtools-generate-default-metadata = "simtools.applications.generate_def
 scripts.simtools-generate-regular-arrays = "simtools.applications.generate_regular_arrays:main"
 scripts.simtools-generate-simtel-array-histograms = "simtools.applications.generate_simtel_array_histograms:main"
 scripts.simtools-plot-array-layout = "simtools.applications.plot_array_layout:main"
-scripts.simtools-production = "simtools.applications.production:main"
 scripts.simtools-simulate-light-emission = "simtools.applications.simulate_light_emission:main"
 scripts.simtools-simulate-prod = "simtools.applications.simulate_prod:main"
 scripts.simtools-simulate-showers-for-trigger-rates = "simtools.applications.simulate_showers_for_trigger_rates:main"


### PR DESCRIPTION
Add tests to prevent bugs encountered while working on deploy:

- run a python build to ensure that a simtools package can be build (this would have caught an error of listing the readme in pyproject.toml as README.rst, while we actually have a README.md)
- run each application / command line tool defined in pyproject.toml (this would have caught an error that an application name included a typo)