### PR TITLE
Bug fix on warning issued in get_version in db_handler

### DIFF
--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1104,10 +1104,10 @@ class DatabaseHandler:
                 )
             else:
                 DatabaseHandler.model_versions_cached[_cache_key] = []
-            if len(DatabaseHandler.model_versions_cached[_cache_key]) == 0:
-                self._logger.warning(
-                    f"The query {query} did not return any results. No versions found"
-                )
+        if len(DatabaseHandler.model_versions_cached[_cache_key]) == 0:
+            self._logger.warning(
+                f"The query {query} did not return any results. No versions found"
+            )
 
         return DatabaseHandler.model_versions_cached[_cache_key]
 

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1105,9 +1105,7 @@ class DatabaseHandler:
             else:
                 DatabaseHandler.model_versions_cached[_cache_key] = []
         if len(DatabaseHandler.model_versions_cached[_cache_key]) == 0:
-            self._logger.warning(
-                f"The query {query} did not return any results. No versions found"
-            )
+            self._logger.warning(f"The query {query} did not return any results. No versions found")
 
         return DatabaseHandler.model_versions_cached[_cache_key]
 


### PR DESCRIPTION
Fix reasons for failing unit tests (e.g., see [here](https://github.com/gammasim/simtools/actions/runs/9900460634/job/27351280417)) when running using pytest-random and pytest-xdist (this is what we do at night for the scheduled unit test: run them 10 times in random order).

The bug was that the warning was issued at the wrong level. 

Tested this locally with 

```
pytest -n auto --count 1000 --no-cov tests/unit_tests/db/test_db_handler.py::test_get_all_versions
```
