### PR TITLE
Incidence angle, not incident angle

### DIFF
--- a/simtools/schemas/model_parameters/camera_filter.schema.yml
+++ b/simtools/schemas/model_parameters/camera_filter.schema.yml
@@ -10,9 +10,9 @@ name: camera_filter
 description: |-
   Wavelength dependence of the camera filter transmission, independent
   of the pixel type.  The transmission may be given for the average or
-  various incident angles.  In the latter case, the transmission is
+  various incidence angles.  In the latter case, the transmission is
   applied for each photon as a function of both its wavelength and its
-  incident angle.  The efficiency factors will be applied on top of the
+  incidence angle.  The efficiency factors will be applied on top of the
   global par:camera-transmission factor, and on top of any pixel-type
   dependent efficiency (both angular and by wavelength), according to
   the what is listed in par:camera_config_pixel_type.

--- a/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
+++ b/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
@@ -1,11 +1,11 @@
 %YAML 1.2
 ---
-title: Schema for lightguide_efficiency_vs_incident_angle model parameter
+title: Schema for lightguide_efficiency_vs_incidence_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
 meta_schema_version: 0.1.0
-name: lightguide_efficiency_vs_incident_angle
+name: lightguide_efficiency_vs_incidence_angle
 developer_note: |-
   Part of sim_telarray camera_config_file (parameter PixType).
   To be replaced by a data table.


### PR DESCRIPTION
Noticed that we have

secondary_mirror_incidence_angle, primary_mirror_incidence_angle, camera_filter_incidence_angle

but

lightguide_efficiency_vs_incident_angle.json

Correct this so that all is 'incidence'.

Related to https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/merge_requests/47