### PR TITLE
Select latest version of model parameter databases

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -6,7 +6,7 @@ SIMTOOLS_DB_SERVER='cta-simpipe-protodb.zeuthen.desy.de' # MongoDB server
 SIMTOOLS_DB_API_USER=YOUR_USERNAME # username for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-Model-LATEST'
 # SIMTOOLS_DB_SIMULATION_MODEL_URL=''
 SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
 

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -7,7 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-3-0"
+  SIMTOOLS_DB_SIMULATION_MODEL: "CTAO-Simulation-Model-LATEST"
   SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -7,7 +7,7 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "Staging-CTA-Simulation-Model-v0-3-0"
+  SIMTOOLS_DB_SIMULATION_MODEL: "CTAO-Simulation-Model-LATEST"
   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
 on:

--- a/database_scripts/upload_dump_to_local_db.sh
+++ b/database_scripts/upload_dump_to_local_db.sh
@@ -6,7 +6,7 @@
 
 SIMTOOLS_NETWORK="simtools-mongo-network"
 CONTAINER_NAME="simtools-mongodb"
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'  # Name of the database to be created
 SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-Derived-Values'
 
 # Check if podman is available, if not use docker

--- a/database_scripts/upload_dump_to_local_db.sh
+++ b/database_scripts/upload_dump_to_local_db.sh
@@ -6,7 +6,7 @@
 
 SIMTOOLS_NETWORK="simtools-mongo-network"
 CONTAINER_NAME="simtools-mongodb"
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'  # Name of the database to be created
+SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-Model-v0-3-0'  # Name of the database to be created
 SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-Derived-Values'
 
 # Check if podman is available, if not use docker

--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -5,7 +5,7 @@
 # Requires configuration of local DB in .env file
 
 CONTAINER_NAME="simtools-mongodb"
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'  # Name of the database to be created
 SIMTOOLS_DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
 SIMTOOLS_DB_SIMULATION_MODEL_BRANCH="main"
 

--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -5,7 +5,7 @@
 # Requires configuration of local DB in .env file
 
 CONTAINER_NAME="simtools-mongodb"
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'  # Name of the database to be created
+SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-Model-v0-3-0'  # Name of the database to be created
 SIMTOOLS_DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
 SIMTOOLS_DB_SIMULATION_MODEL_BRANCH="main"
 

--- a/docs/source/user-guide/databases.md
+++ b/docs/source/user-guide/databases.md
@@ -16,7 +16,7 @@ This documentation is therefore incomplete.
 
 ### Model parameters DB
 
-The name of the model parameter database needs to be indicated by `$SIMTOOLS_DB_SIMULATION_MODEL` environmental variable and defined e.g., in the `.env` file.
+The name of the model parameter database needs to be indicated by `$SIMTOOLS_DB_SIMULATION_MODEL` environmental variable and defined e.g., in the `.env` file. Use `CTAO-Simulation-Model-LATEST` to use the latest version of the CTAO simulation model database (simtools will replace `LATEST` with the latest version number).
 
 Collections:
 
@@ -52,7 +52,7 @@ SIMTOOLS_DB_SERVER='cta-simpipe-protodb.zeuthen.desy.de' # MongoDB server
 SIMTOOLS_DB_API_USER=YOUR_USERNAME # username for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-Model-LATEST'
 # SIMTOOLS_DB_SIMULATION_MODEL_URL=''
 SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
 ```
@@ -133,10 +133,10 @@ SIMTOOLS_DB_SERVER='localhost'
 SIMTOOLS_DB_API_USER='api' # username for MongoDB
 SIMTOOLS_DB_API_PW='password' # Password for MongoDB
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
-SIMTOOLS_DB_SIMULATION_MODEL='Staging-CTA-Simulation-Model-v0-3-0'
+SIMTOOLS_DB_SIMULATION_MODEL='STAGING-CTA-Simulation-Model-LATEST'
 ```
 
-`SIMTOOLS_DB_SIMULATION_MODEL` is set as an example here to `Staging-CTA-Simulation-Model-v0-3-0` and should be changed accordingly.
+`SIMTOOLS_DB_SIMULATION_MODEL` is set as an example here to `STAGING-CTAO-Simulation-Model-LATEST` and should be changed accordingly.
 
 For using simtools inside a container:
 

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1,12 +1,14 @@
 """Module to handle interaction with DB."""
 
 import logging
+import re
 from pathlib import Path
 from threading import Lock
 
 import gridfs
 import pymongo
 from bson.objectid import ObjectId
+from packaging.version import Version
 from pymongo import MongoClient
 from pymongo.errors import BulkWriteError
 
@@ -70,6 +72,7 @@ class DatabaseHandler:
         self.list_of_collections = {}
 
         self._set_up_connection()
+        self._update_db_simulation_model()
 
     def _set_up_connection(self):
         """Open the connection to MongoDB."""
@@ -107,6 +110,43 @@ class DatabaseHandler:
             raise
 
         return _db_client
+
+    def _update_db_simulation_model(self):
+        """
+        Find the latest version (if requested) of the simulation model and update the DB config.
+
+        This is indicated by adding "LATEST" to the name of the simulation model database
+        (field "db_simulation_model" in the database configuration dictionary).
+
+        """
+        try:
+            if not self.mongo_db_config["db_simulation_model"].endswith("LATEST"):
+                return
+        except TypeError:
+            return
+
+        prefix = self.mongo_db_config["db_simulation_model"].replace("LATEST", "")
+        list_of_db_names = self.db_client.list_database_names()
+        filtered_list_of_db_names = [s for s in list_of_db_names if s.startswith(prefix)]
+        versioned_strings = []
+        version_pattern = re.compile(rf"{re.escape(prefix)}v(\d+)-(\d+)-(\d+)")
+
+        for s in filtered_list_of_db_names:
+            match = version_pattern.search(s)
+            if match:
+                version_str = match.group(1) + "." + match.group(2) + "." + match.group(3)
+                version = Version(version_str)
+                versioned_strings.append((s, version))
+
+        if versioned_strings:
+            latest_string, _ = max(versioned_strings, key=lambda x: x[1])
+            self.mongo_db_config["db_simulation_model"] = latest_string
+            self._logger.info(
+                f"Updated the DB simulation model to the latest version {latest_string}"
+            )
+        else:
+            self._logger.error("Found LATEST in the DB name but no matching versions found in DB.")
+            raise ValueError
 
     def get_model_parameters(
         self,

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -45,6 +45,36 @@ def _db_cleanup_file_sandbox(db_no_config_file, random_id):
     db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.files"].drop()
 
 
+def test_update_db_simulation_model(db, db_no_config_file, mocker, caplog):
+
+    db_no_config_file._update_db_simulation_model()
+    assert db_no_config_file.mongo_db_config is None
+
+    db_name = db.mongo_db_config["db_simulation_model"]
+    db._update_db_simulation_model()
+    assert db_name == db.mongo_db_config["db_simulation_model"]
+
+    db_copy = copy.deepcopy(db)
+    db_copy.mongo_db_config["db_simulation_model"] = "DB_NAME-LATEST"
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError):
+            db_copy._update_db_simulation_model()
+        assert "Found LATEST in the DB name but no matching versions found in DB." in caplog.text
+
+    db_names = [
+        "Staging-CTA-Simulation-Model-v0-3-0",
+        "Staging-CTA-Simulation-Model-v0-2-0",
+        "Staging-CTA-Simulation-Model-v0-1-19",
+        "Staging-CTA-Simulation-Model-v0-3-9",
+        "Staging-CTA-Simulation-Model-v0-3-19",
+        "Staging-CTA-Simulation-Model-v0-3-0",
+    ]
+    mocker.patch.object(db_copy.db_client, "list_database_names", return_value=db_names)
+    db_copy.mongo_db_config["db_simulation_model"] = "Staging-CTA-Simulation-Model-LATEST"
+    db_copy._update_db_simulation_model()
+    assert db_copy.mongo_db_config["db_simulation_model"] == "Staging-CTA-Simulation-Model-v0-3-19"
+
+
 def test_reading_db_lst_without_simulation_repo(db, model_version):
 
     db_copy = copy.deepcopy(db)

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -62,17 +62,17 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker, caplog):
         assert "Found LATEST in the DB name but no matching versions found in DB." in caplog.text
 
     db_names = [
-        "Staging-CTA-Simulation-Model-v0-3-0",
-        "Staging-CTA-Simulation-Model-v0-2-0",
-        "Staging-CTA-Simulation-Model-v0-1-19",
-        "Staging-CTA-Simulation-Model-v0-3-9",
-        "Staging-CTA-Simulation-Model-v0-3-19",
-        "Staging-CTA-Simulation-Model-v0-3-0",
+        "CTAO-Simulation-Model-v0-3-0",
+        "CTAO-Simulation-Model-v0-2-0",
+        "CTAO-Simulation-Model-v0-1-19",
+        "CTAO-Simulation-Model-v0-3-9",
+        "CTAO-Simulation-Model-v0-3-19",
+        "CTAO-Simulation-Model-v0-3-0",
     ]
     mocker.patch.object(db_copy.db_client, "list_database_names", return_value=db_names)
-    db_copy.mongo_db_config["db_simulation_model"] = "Staging-CTA-Simulation-Model-LATEST"
+    db_copy.mongo_db_config["db_simulation_model"] = "CTAO-Simulation-Model-LATEST"
     db_copy._update_db_simulation_model()
-    assert db_copy.mongo_db_config["db_simulation_model"] == "Staging-CTA-Simulation-Model-v0-3-19"
+    assert db_copy.mongo_db_config["db_simulation_model"] == "CTAO-Simulation-Model-v0-3-19"
 
 
 def test_reading_db_lst_without_simulation_repo(db, model_version):


### PR DESCRIPTION
There are several versions of the model database available. We do not want to change the version number hardwired at several places in simtools (e.g., the unit / integration tests) frequently.

This PR adds functionality to select the LATEST model parameter DB version:

- relies on semantic versioning for the model data base (we do that)
- key is a `LATEST` in the DB name for the simulation model
- set e.g., SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-Model-LATEST' and the algorithm in db_handler will look for the maximum version number