### PR TITLE
Warnings for plt.plot(); connection to display server

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from unittest import mock
 
+import matplotlib.pyplot as plt
 import pytest
 from astropy import units as u
 from dotenv import dotenv_values, load_dotenv
@@ -19,6 +20,12 @@ from simtools.model.telescope_model import TelescopeModel
 from simtools.runners.corsika_runner import CorsikaRunner
 
 logger = logging.getLogger()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _set_matplotlib_backend():
+    """Set matplotlib backend to Agg for testing (plotting without display server)."""
+    plt.switch_backend("Agg")
 
 
 @pytest.fixture()

--- a/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
@@ -20,7 +20,7 @@ def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, capl
             corsika_histograms_instance_set_histograms, property_name
         )
         assert np.size(all_figs) == 1
-        assert isinstance(all_figs[0], type(plt.figure()))
+        assert isinstance(all_figs[0], plt.Figure)
 
     corsika_histograms_instance_set_histograms.set_histograms(
         individual_telescopes=True, telescope_indices=[0, 1, 2]


### PR DESCRIPTION
Fix two (minor issues):

- matplotlib tries to connect to a display server during unit tests; this slows tests down and is not necessary. Add a fixture which sets the matplotlib backend to Agg 
- one test executed an unnecessary `plt.figure()` in an instance check

Closes #1072 

To see the impact of the changes:

- when running local unit tests, no python plot windows are opened anymore
- when running `pytest --count 10 --no-cov tests/unit_tests/corsika/test_corsika_histograms_visualize.py::test_kernel_plot_2d_photons`, no warnings are issued anymore