### PR TITLE
Add for the first-time a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Change log
+
+Notable changes relevant for the user of simtools are documented in this file. Please keep this file up to date and stick to the format.
+
+## v0.7.0 - 2024-07-11
+
+This is an intermediate development release with significant changes to the handling of model parameters and the reading of databases.
+Belows's release statements are incomplete.
+
+### Added
+
+- application `simulate_light_emission` to simulate the light emission from an artificial light source
+- application `calculate_trigger_rate` to derive the trigger rate for a given telescope type
+
+### Changed
+
+- interface to databases and model parameters
+- improved user and developer documentation
+
+### Removed
+
+- (removed files are not listed)
+
+### Fixed
+
+- (bug fixes are not listed)
+
+## Template for new release
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed

--- a/docs/source/developer-guide/maintainer_documentation.md
+++ b/docs/source/developer-guide/maintainer_documentation.md
@@ -8,7 +8,7 @@ Simtools releases are versioned following the [Semantic Versioning 2.0.0](https:
 
 To prepare a release, the following steps are required:
 
-1. Open a pull request to prepare a release. This should be the last pull request to be merged before making the actual release.
+1. Open a pull request to prepare a release.  Review the entries added to the `CHANGELOG.md` since the last release. This should be the last pull request to be merged before making the actual release.
 1. Prepare a GitHub release with the version number and a summary of the changes.
 1. Pypi deployment is done automatically by the CI/CD pipeline.
 1. Docker images are automatically built, tagged with the version number, and pushed to the [gammasim/simtools](https://github.com/orgs/gammasim/packages?repo_name=simtools).


### PR DESCRIPTION
This adds a CHANGELOG file to document for future release the changes relevant for users of simtools (and not for developers).

The file here is incomplete and should serve as a template for future documentation of the changelog.

See #1068 for additional details.