### PR TITLE
Bug fixes related to  pytest-raises-with-multiple-statements (PT012)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,6 @@ lint.ignore = [
   "G004",   # Logging statement uses f-string
   "ISC001", # incompatible with ruff format
   "PT011",  # TODO - fix
-  "PT012",  # TODO - fix
   "RUF012", #  Mutable class attributes should be annotated
 ]
 lint.per-file-ignores."**/tests/**" = [

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -940,9 +940,9 @@ def change_dict_keys_case(data_dict, lower_case=True):
 
     try:
         return _process_dict_keys(data_dict, case_func)
-    except AttributeError:
+    except AttributeError as exc:
         _logger.error(f"Input is not a proper dictionary: {data_dict}")
-        raise
+        raise AttributeError from exc
 
 
 def remove_substring_recursively_from_dict(data_dict, substring="\n"):

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -192,7 +192,7 @@ def test_process_rx(
         assert Path(empty_file).is_file()
     with pytest.raises(IndexError):
         ray._process_rx(empty_file)
-        assert "Invalid output from rx" in caplog.text
+    assert "Invalid output from rx" in caplog.text
     with pytest.raises(FileNotFoundError):
         ray._process_rx(file=tmp_test_directory / "non_existing_file.gz")
-        assert "Photon list file not found" in caplog.text
+    assert "Photon list file not found" in caplog.text

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -71,7 +71,7 @@ def test_zenith_angle(caplog):
 
     with pytest.raises(TypeError):
         parser.CommandLineParser.zenith_angle("North")
-        assert "The zenith angle provided is not a valid numeric value" in caplog.text
+    assert "The zenith angle provided is not a valid numeric" in caplog.text
 
 
 def test_parse_quantity_pair(caplog):
@@ -131,12 +131,15 @@ def test_azimuth_angle(caplog):
         match=r"The provided azimuth angle, 370.0, is outside of the allowed \[0, 360\] interval",
     ):
         parser.CommandLineParser.azimuth_angle(370)
-    with pytest.raises(argparse.ArgumentTypeError):
+    caplog.clear()
+    with pytest.raises(
+        argparse.ArgumentTypeError, match=r"^The azimuth angle given as string can only be one of"
+    ):
         parser.CommandLineParser.azimuth_angle("TEST")
-        assert "The azimuth angle can only be a number or one of" in caplog.text
+
     with pytest.raises(TypeError):
         parser.CommandLineParser.azimuth_angle([0, 10])
-        assert "The azimuth angle provided is not a valid numerical or string value." in caplog.text
+    assert "The azimuth angle provided is not a valid numerical or string value." in caplog.text
 
 
 def test_initialize_default_arguments():

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -194,7 +194,7 @@ def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
 def test_get_hist_1d_projection(corsika_histograms_instance_set_histograms, caplog):
     with pytest.raises(ValueError):
         corsika_histograms_instance_set_histograms._get_hist_1d_projection("label_not_valid")
-        assert "label_not_valid is not valid." in caplog.text
+    assert "label_not_valid is not valid." in caplog.text
 
     labels = ["wavelength", "time", "altitude"]
     expected_shape_of_bin_edges = [(1, 81), (1, 101), (1, 101)]
@@ -289,7 +289,7 @@ def test_raise_if_no_histogram(corsika_output_file_name, caplog, io_handler):
     corsika_histograms_instance_not_hist = CorsikaHistograms(corsika_output_file_name)
     with pytest.raises(HistogramNotCreatedError):
         corsika_histograms_instance_not_hist._raise_if_no_histogram()
-        assert "The histograms were not created." in caplog
+    assert "The histograms were not created." in caplog.text
 
 
 def test_get_hist_2d_projection(corsika_histograms_instance, caplog):
@@ -298,7 +298,7 @@ def test_get_hist_2d_projection(corsika_histograms_instance, caplog):
     label = "hist_non_existent"
     with pytest.raises(ValueError):
         corsika_histograms_instance._get_hist_2d_projection(label)
-        assert "label is not valid." in caplog.text
+    assert "label is not valid." in caplog.text
 
     labels = ["counts", "density", "direction", "time_altitude"]
     hist_sums = [11633, 29.1, 11634, 11634]  # sum of photons are approximately the same
@@ -709,10 +709,10 @@ def test_get_event_parameter_info(corsika_histograms_instance_set_histograms, ca
         corsika_histograms_instance_set_histograms.get_event_parameter_info(
             "non_existent_parameter"
         )
-        assert (
-            f"`key` is not valid. Valid entries are "
-            f"{corsika_histograms_instance_set_histograms.all_event_keys}" in caplog.text
-        )
+    assert (
+        f"key is not valid. Valid entries are "
+        f"{corsika_histograms_instance_set_histograms.all_event_keys}" in caplog.text
+    )
 
 
 def test_get_run_info(corsika_histograms_instance_set_histograms, caplog):
@@ -724,10 +724,10 @@ def test_get_run_info(corsika_histograms_instance_set_histograms, caplog):
 
     with pytest.raises(KeyError):
         corsika_histograms_instance_set_histograms.get_run_info("non_existent_parameter")
-        assert (
-            f"`key` is not valid. Valid entries are "
-            f"{corsika_histograms_instance_set_histograms.all_run_keys}" in caplog.text
-        )
+    assert (
+        f"key is not valid. Valid entries are "
+        f"{corsika_histograms_instance_set_histograms.all_run_keys}" in caplog.text
+    )
 
 
 def test_event_1d_histogram(corsika_histograms_instance_set_histograms):

--- a/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
@@ -42,8 +42,7 @@ def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, capl
         corsika_histograms_visualize._kernel_plot_2d_photons(
             corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
         )
-        msg = "This property does not exist. "
-        assert msg in caplog.text
+    assert "This property does not exist. " in caplog.text
 
 
 def test_plot_2ds(corsika_histograms_instance_set_histograms):
@@ -97,8 +96,7 @@ def test_kernel_plot_1d_photons(corsika_histograms_instance_set_histograms, capl
         corsika_histograms_visualize._kernel_plot_1d_photons(
             corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
         )
-        msg = "This property does not exist. "
-        assert msg in caplog.text
+    assert "This property does not exist. " in caplog.text
 
 
 def test_plot_1ds(corsika_histograms_instance_set_histograms):

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -147,7 +147,7 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
     metadata_1.args_dict["input_meta"] = tmp_test_directory / "test_read_input_metadata_file.json"
     with pytest.raises(gen.InvalidConfigDataError):
         metadata_1._read_input_metadata_from_file()
-        assert "More than one metadata entry" in caplog.text
+    assert "More than one metadata entry" in caplog.text
 
     metadata_1.args_dict["input_meta"] = "tests/resources/telescope_positions-North-utm.ecsv"
     assert len(metadata_1._read_input_metadata_from_file()) > 0

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -50,8 +50,8 @@ def test_validate_schema(tmp_test_directory):
 
     metadata_model.validate_schema(data, schema_file)
 
+    invalid_data = {"name": "Alice", "age": "Thirty"}
     with pytest.raises(jsonschema.exceptions.ValidationError):
-        invalid_data = {"name": "Alice", "age": "Thirty"}
         metadata_model.validate_schema(invalid_data, schema_file)
 
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -371,14 +371,15 @@ def test_check_and_convert_units_with_errors(reference_columns):
     table_2["wrong_column"] = Column([0.1, 0.5], dtype="float32")
 
     with pytest.raises(IndexError):
-        for col_name in table_2.colnames:
-            data_validator._check_and_convert_units(table_2[col_name], unit=None, col_name=col_name)
+        data_validator._check_and_convert_units(
+            table_2["wrong_column"], unit=None, col_name="wrong_column"
+        )
 
     table_3 = Table()
     table_3["wavelength"] = Column([300.0, 350.0], unit="kg", dtype="float32")
 
-    with pytest.raises(u.core.UnitConversionError):
-        for col_name in table_3.colnames:
+    for col_name in table_3.colnames:
+        with pytest.raises(u.core.UnitConversionError):
             data_validator._check_and_convert_units(table_3[col_name], unit=None, col_name=col_name)
 
 

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -174,12 +174,12 @@ def test_change_parameter(telescope_model_lst):
     tel_model.change_parameter("camera_pixels", 9999)
     assert tel_model.get_parameter_value("camera_pixels") == 9999
 
+    logger.info("Testing changing camera_pixels to a float (now allowed)")
     with pytest.raises(ValueError):
-        logger.info("Testing changing camera_pixels to a float (now allowed)")
         tel_model.change_parameter("camera_pixels", 9999.9)
 
+    logger.info("Testing changing camera_pixels to a nonsense string")
     with pytest.raises(ValueError):
-        logger.info("Testing changing camera_pixels to a nonsense string")
         tel_model.change_parameter("camera_pixels", "bla_bla")
 
     logger.info(f"Old camera_pixels:{tel_model.get_parameter_value('mirror_focal_length')}")
@@ -191,8 +191,8 @@ def test_change_parameter(telescope_model_lst):
     tel_model.change_parameter("mirror_focal_length", "9999.9 0.")
     assert pytest.approx(9999.9) == tel_model.get_parameter_value("mirror_focal_length")[0]
 
+    logger.info("Testing changing mirror_focal_length to a nonsense string")
     with pytest.raises(ValueError):
-        logger.info("Testing changing mirror_focal_length to a nonsense string")
         tel_model.change_parameter("mirror_focal_length", "bla_bla")
 
     with pytest.raises(InvalidModelParameterError, match="Parameter bla_bla not in the model"):

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -219,11 +219,11 @@ def test_combine_histogram_files(simtel_io_file, caplog):
 
     # Test inconsistency
     instance_all.combined_hists[0]["lower_x"] = instance_all.combined_hists[0]["lower_x"] + 1
+    instance_all._combined_hists = None
+    assert instance_all._combined_hists is None
     with pytest.raises(InconsistentHistogramFormatError):
-        instance_all._combined_hists = None
-        assert instance_all._combined_hists is None
         _ = instance_all.combined_hists
-        assert "Trying to add histograms with inconsistent dimensions" in caplog.text
+    assert "Trying to add histograms with inconsistent dimensions" in caplog.text
 
 
 def test_plot_one_histogram(simtel_array_histograms_instance):

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -135,7 +135,7 @@ def test_ray_tracing_invalid_telescope_model(simtel_path, io_handler, caplog):
             simtel_path=simtel_path,
             config_data=config_data,
         )
-        assert "Invalid TelescopeModel" in caplog.text
+    assert "Invalid TelescopeModel" in caplog.text
 
 
 def test_ray_tracing_read_results(ray_tracing_lst):
@@ -176,7 +176,7 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog):
     # First test a wrong key
     with pytest.raises(KeyError):
         ray_tracing_lst.plot(key="invalid_key")
-        assert "Invalid key" in caplog.text
+    assert "Invalid key" in caplog.text
 
     # Now test a valid key
     with caplog.at_level(logging.INFO):
@@ -204,15 +204,15 @@ def test_ray_tracing_invalid_key(ray_tracing_lst, caplog):
     invalid_key = "Invalid key"
     with pytest.raises(KeyError):
         ray_tracing_lst.plot_histogram(key="invalid_key")
-        assert invalid_key in caplog.text
+    assert invalid_key in caplog.text
 
     with pytest.raises(KeyError):
         ray_tracing_lst.get_mean(key="invalid_key")
-        assert invalid_key in caplog.text
+    assert invalid_key in caplog.text
 
     with pytest.raises(KeyError):
         ray_tracing_lst.get_std_dev(key="invalid_key")
-        assert invalid_key in caplog.text
+    assert invalid_key in caplog.text
 
 
 def test_ray_tracing_get_std_dev(ray_tracing_lst):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -109,7 +109,7 @@ def test_simulation_software(array_simulator, shower_simulator, shower_array_sim
     with pytest.raises(gen.InvalidConfigDataError):
         with caplog.at_level(logging.ERROR):
             test_array_simulator.simulation_software = "this_simulator_is_not_there"
-        assert "Invalid simulation software" in caplog.text
+    assert "Invalid simulation software" in caplog.text
 
 
 def test_initialize_array_model(shower_simulator, db_config):
@@ -126,10 +126,10 @@ def test_initialize_run_list(shower_simulator, caplog):
     with pytest.raises(KeyError):
         with caplog.at_level(logging.ERROR):
             test_shower_simulator._initialize_run_list()
-        assert (
-            "Error in initializing run list (missing 'run_number_start' or 'number_of_runs')"
-            in caplog.text
-        )
+    assert (
+        "Error in initializing run list (missing 'run_number_start' or 'number_of_runs')"
+        in caplog.text
+    )
 
 
 def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):
@@ -309,8 +309,8 @@ def test_make_resources_report(shower_simulator):
     _resources_1 = test_shower_simulator._make_resources_report(input_file_list=log_file_name)
     assert _resources_1["Wall time/run [sec]"] == 6
 
+    test_shower_simulator.runs = [4]
     with pytest.raises(FileNotFoundError):
-        test_shower_simulator.runs = [4]
         test_shower_simulator._make_resources_report(input_file_list)
 
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -56,7 +56,7 @@ def test_collect_dict_data(args_dict, io_handler, tmp_test_directory, caplog) ->
 
     with pytest.raises(InvalidConfigDataError):
         gen.collect_data_from_file_or_dict(None, None, allow_empty=False)
-        assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
+    assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
 
     _lines = gen.collect_data_from_file_or_dict("tests/resources/test_file.list", None)
     assert len(_lines) == 2
@@ -124,7 +124,7 @@ def test_validate_config_data(args_dict, io_handler, caplog) -> None:
     }
     with pytest.raises(MissingRequiredConfigEntryError):
         gen.validate_config_data(config_data=config_data, parameters=parameters)
-        assert "Required entry in config_data" in caplog.text
+    assert "Required entry in config_data" in caplog.text
 
     # Test that a default value is set for a missing parameter.
     config_data["offaxis"] = [0 * u.deg, 0.2 * u.rad, 3 * u.deg]
@@ -219,7 +219,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
     }
     with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
-        assert "Config entry given with wrong unit" in caplog.text
+    assert "Config entry with undefined length should have a single unit:" in caplog.text
     _parinfo = {
         "len": 5,
         "unit": [None, u.Unit("kg"), u.Unit("m"), u.Unit("m"), None],
@@ -227,7 +227,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
     }
     with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
-        assert "Config entry given with wrong unit" in caplog.text
+    assert "Config entry given with wrong unit" in caplog.text
     _parinfo = {
         "len": 5,
         "unit": [None, u.Unit("m"), u.Unit("m"), u.Unit("m"), None],
@@ -236,7 +236,7 @@ def test_validate_and_convert_value_with_units(caplog) -> None:
     _value = [0, 10 * u.m, 3 * u.km, 4, None]
     with pytest.raises(InvalidConfigEntryError):
         gen._validate_and_convert_value_with_units(_value, None, _parname, _parinfo)
-        assert "Config entry given without unit" in caplog.text
+    assert "Config entry given without unit" in caplog.text
 
 
 def test_validate_and_convert_value_without_units() -> None:
@@ -612,7 +612,7 @@ def test_change_dict_keys_case(caplog) -> None:
 
     with pytest.raises(AttributeError):
         gen.change_dict_keys_case([2], False)
-        assert "Input is not a proper dictionary" in caplog.text
+    assert "Input is not a proper dictionary" in caplog.text
 
 
 def test_sort_arrays() -> None:

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -46,9 +46,10 @@ def test_rotate_telescope_position(caplog) -> None:
 
     with pytest.raises(TypeError):
         transf.rotate(x, y[0], angle_deg)
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError, match="x and y types are not valid! Cannot perform transformation."
+    ):
         transf.rotate("1", "2", angle_deg)
-        assert "x and y types are not valid! Cannot perform transformation" in caplog.text
     with pytest.raises(TypeError):
         transf.rotate(str(x[0]), y[0], angle_deg)
     with pytest.raises(TypeError):


### PR DESCRIPTION
This is actually interesting...every correction in the PR is a bug fix of a unit test!

We did very often:

```
with pytest.raises(some error):
    call_a_a_function_raising_some_error()
    assert statement
```

This is wrong - the assert is never called when doing this, it should be:

```
with pytest.raises(some error):
    call_a_a_function_raising_some_error()
assert statement
```

 So flake8-pytest-style/ruff [PT012](https://docs.astral.sh/ruff/rules/pytest-raises-with-multiple-statements/) is actually a very useful test.

This PR corrects all PT012 and fixed 2-3 unit tests (mostly wrong tests on the error messages). PT012 is now also switched on in pyproject.toml.


