### PR TITLE
Addresses errors of type "pytest-raises-too-broad" from ruff

### DIFF
--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -35,7 +35,7 @@ db.createUser({
 
 echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
 rm -rf ./tmp_model_parameters
-git clone -b $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
+git clone --depth=1 -b $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
 
 CURRENTDIR=$(pwd)
 cd ./tmp_model_parameters/ || exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ lint.ignore = [
   "D215",   # section-underline-not-over-indented
   "G004",   # Logging statement uses f-string
   "ISC001", # incompatible with ruff format
-  "PT011",  # TODO - fix
   "RUF012", #  Mutable class attributes should be annotated
 ]
 lint.per-file-ignores."**/tests/**" = [

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -468,7 +468,7 @@ class CorsikaHistograms:
         if label not in self._allowed_histograms:
             msg = f"allowed labels must be one of the following: {self._allowed_histograms}"
             self._logger.error(msg)
-            raise ValueError
+            raise ValueError(msg)
 
         all_axes = [X_AXIS_STRING, Y_AXIS_STRING]
         if label == "hist_position":
@@ -731,7 +731,7 @@ class CorsikaHistograms:
         if label not in self._allowed_2d_labels:
             msg = f"label is not valid. Valid entries are {self._allowed_2d_labels}"
             self._logger.error(msg)
-            raise ValueError
+            raise ValueError(msg)
         self._raise_if_no_histogram()
 
         num_telescopes_to_fill = (
@@ -871,7 +871,7 @@ class CorsikaHistograms:
         if label not in self._allowed_1d_labels:
             msg = f"{label} is not valid. Valid entries are {self._allowed_1d_labels}"
             self._logger.error(msg)
-            raise ValueError
+            raise ValueError(msg)
         self._raise_if_no_histogram()
 
         x_bin_edges_list, hist_1d_list = [], []

--- a/simtools/corsika/corsika_histograms_visualize.py
+++ b/simtools/corsika/corsika_histograms_visualize.py
@@ -45,7 +45,7 @@ def _kernel_plot_2d_photons(histograms_instance, property_name, log_z=False):
             f"{histograms_instance.dict_2d_distributions}"
         )
         _logger.error(msg)
-        raise ValueError
+        raise ValueError(msg)
     _function = getattr(
         histograms_instance,
         histograms_instance.dict_2d_distributions[property_name]["function"],
@@ -245,7 +245,7 @@ def _kernel_plot_1d_photons(histograms_instance, property_name, log_y=True):
             f"{histograms_instance.dict_1d_distributions}"
         )
         _logger.error(msg)
-        raise ValueError
+        raise ValueError(msg)
 
     _function = getattr(
         histograms_instance,

--- a/simtools/corsika/primary_particle.py
+++ b/simtools/corsika/primary_particle.py
@@ -56,8 +56,7 @@ class PrimaryParticle:
                 self._pdg_id = ids["pdg_id"]
                 self._pdg_name = ids["pdg_name"]
                 return
-        self._logger.error("Invalid CORSIKA7 ID: %s", value)
-        raise ValueError
+        raise ValueError(f"Invalid CORSIKA7 ID: {value}")
 
     @property
     def name(self):
@@ -83,11 +82,9 @@ class PrimaryParticle:
             self._name = Corsika7ID.from_pdgid(self._pdg_id).name()
             return
         if len(pdg_list) > 1:
-            self._logger.error(f"Found more than one particle with name {value}: {pdg_list}")
-            raise ValueError
+            raise ValueError(f"Found more than one particle with name {value}: {pdg_list}")
 
-        self._logger.error("Invalid particle name: %s", value)
-        raise ValueError
+        raise ValueError(f"Invalid particle name: {value}")
 
     @property
     def pdg_id(self):
@@ -110,8 +107,7 @@ class PrimaryParticle:
             self._pdg_id = Particle.findall(pdgid=value)[0].pdgid.numerator
             self._pdg_name = Particle.findall(pdgid=value)[0].name
         except IndexError as exc:
-            self._logger.error("Invalid DPG ID: %s", value)
-            raise ValueError from exc
+            raise ValueError(f"Invalid DPG ID: {value}") from exc
         self._corsika7_id = Corsika7ID.from_pdgid(self._pdg_id).numerator
         self._name = Corsika7ID.from_pdgid(self._pdg_id).name()
 

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -553,21 +553,17 @@ class DataValidator:
         if range_type not in _entry:
             return
 
-        try:
-            if not self._interval_check(
-                (col_min, col_max),
-                (_entry[range_type].get("min", -np.inf), _entry[range_type].get("max", np.inf)),
-                range_type,
-            ):
-                raise ValueError
-        except ValueError:
-            self._logger.error(
+        if not self._interval_check(
+            (col_min, col_max),
+            (_entry[range_type].get("min", -np.inf), _entry[range_type].get("max", np.inf)),
+            range_type,
+        ):
+            raise ValueError(
                 f"Value for column '{col_name}' out of range. "
                 f"([{col_min}, {col_max}], {range_type}: "
                 f"[{_entry[range_type].get('min', -np.inf)}, "
                 f"{_entry[range_type].get('max', np.inf)}])"
             )
-            raise
 
     @staticmethod
     def _interval_check(data, axis_range, range_type):

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -106,11 +106,10 @@ class DataValidator:
     def validate_parameter_and_file_name(self):
         """Validate that file name and key 'parameter_name' in data dict are the same."""
         if self.data_dict.get("parameter") != Path(self.data_file_name).stem:
-            self._logger.error(
+            raise ValueError(
                 f"Parameter name in data dict {self.data_dict.get('parameter')} and "
                 f"file name {Path(self.data_file_name).stem} do not match."
             )
-            raise ValueError
 
     def _validate_data_dict(self):
         """
@@ -277,11 +276,10 @@ class DataValidator:
             ):
                 self.data_table = unique(self.data_table)
             else:
-                self._logger.error(
+                raise ValueError(
                     "Failed removal of duplication for column "
                     f"{_column_with_unique_requirement}, values are not unique"
                 )
-                raise ValueError
 
     def _get_unique_column_requirement(self):
         """
@@ -397,8 +395,7 @@ class DataValidator:
             return np.isnan(data).any() or np.isinf(data).any()
 
         if np.isnan(data).any() or np.isinf(data).any():
-            self._logger.error("NaN or Inf values found in data")
-            raise ValueError
+            raise ValueError("NaN or Inf values found in data")
 
         return False
 
@@ -542,12 +539,8 @@ class DataValidator:
         """
         self._logger.debug(f"Checking data in column '{col_name}' for '{range_type}' ")
 
-        try:
-            if range_type not in ("allowed_range", "required_range"):
-                raise KeyError
-        except KeyError:
-            self._logger.error("Allowed range types are 'allowed_range', 'required_range'")
-            raise
+        if range_type not in ("allowed_range", "required_range"):
+            raise KeyError("Allowed range types are 'allowed_range', 'required_range'")
 
         _entry = self._get_data_description(col_name)
         if range_type not in _entry:

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -80,8 +80,7 @@ def update_model_parameters_from_repo(
         )
         _design_model = None
     else:
-        logger.error(f"Unknown parameter collection {parameter_collection}")
-        raise ValueError
+        raise ValueError(f"Unknown parameter collection {parameter_collection}")
 
     for key in parameters:
         _tmp_par = {}

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -1356,7 +1356,7 @@ class DatabaseHandler:
         if _design_name in self._available_array_elements:
             return _design_name
 
-        raise ValueError
+        raise ValueError("Invalid database name.")
 
     def _parameter_cache_key(self, site, telescope, model_version, db_name=None):
         """

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -428,11 +428,10 @@ class ModelParameter:
             dtype=None,
             allow_subtypes=True,
         ):
-            self._logger.error(
+            raise ValueError(
                 f"Could not cast {value} of type {type(value)} "
                 f"to {self.get_parameter_type(par_name)}."
             )
-            raise ValueError
 
         self._logger.debug(
             f"Changing parameter {par_name} "

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -116,10 +116,7 @@ class SiteModel(ModelParameter):
         for layout in layouts:
             if layout["name"] == layout_name.lower():
                 return layout["elements"]
-        self._logger.error(
-            "Array layout '%s' not found in '%s' site model.", layout_name, self.site
-        )
-        raise ValueError
+        raise ValueError(f"Array layout '{layout_name}' not found in '{self.site}' site model.")
 
     def get_list_of_array_layouts(self):
         """

--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -137,8 +137,7 @@ class SimtelConfigWriter:
             parameters["array_config_variant"] = ""
             parameters["array_config_version"] = self._model_version
         else:
-            self._logger.error(f"Unknown metadata type {config_type}")
-            raise ValueError
+            raise ValueError(f"Unknown metadata type {config_type}")
         return parameters
 
     def write_array_config_file(self, config_file_path, telescope_model, site_model):

--- a/simtools/simtel/simtel_io_histogram.py
+++ b/simtools/simtel/simtel_io_histogram.py
@@ -546,7 +546,7 @@ class SimtelIOHistogram:
         else:
             msg = f"label {label} is not valid. Please use either 'reference' or 'simulation'."
             self._logger.error(msg)
-            raise ValueError
+            raise ValueError(msg)
         return particle_distribution_function
 
     def _get_simulation_spectral_distribution_function(self):
@@ -572,7 +572,7 @@ class SimtelIOHistogram:
                 "Consider using a .simtel file instead."
             )
             self._logger.error(msg)
-            raise ValueError from exc
+            raise ValueError(msg) from exc
         return spectral_distribution
 
     def estimate_observation_time(self, stacked_num_simulated_events=None):

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -703,7 +703,10 @@ def get_log_level_from_user(log_level):
         "error": logging.ERROR,
         "critical": logging.CRITICAL,
     }
-    log_level_lower = log_level.lower()
+    try:
+        log_level_lower = log_level.lower()
+    except AttributeError:
+        log_level_lower = log_level
     if log_level_lower not in possible_levels:
         raise ValueError(
             f"'{log_level}' is not a logging level, "

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -556,5 +556,5 @@ def sanitize_name(name):
     if not sanitized.isidentifier():
         msg = f"The string {name} could not be sanitized."
         _logger.error(msg)
-        raise ValueError
+        raise ValueError(msg)
     return sanitized

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -256,7 +256,9 @@ def test_get_corsika_config_file_name(corsika_config_mock_array_model, io_handle
         corsika_config_mock_array_model.get_corsika_config_file_name("config_tmp", run_number=1)
         == f"corsika_config_run000001_{file_name}.txt"
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Must provide a run number for a temporary CORSIKA config file"
+    ):
         assert (
             corsika_config_mock_array_model.get_corsika_config_file_name("config_tmp")
             == f"corsika_config_run000001_{file_name}.txt"
@@ -276,7 +278,7 @@ def test_get_corsika_config_file_name(corsika_config_mock_array_model, io_handle
         corsika_config_mock_array_model.get_corsika_config_file_name("multipipe")
         == "multi_cta-South-test_layout.cfg"
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^The requested file type"):
         corsika_config_mock_array_model.get_corsika_config_file_name("foobar")
 
 

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -131,7 +131,7 @@ def test_create_regular_axes_valid_label(corsika_histograms_instance):
 
 def test_create_regular_axes_invalid_label(corsika_histograms_instance):
     label = "invalid_label"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"allowed labels must be one of the following"):
         corsika_histograms_instance._create_regular_axes(label)
 
 
@@ -192,7 +192,7 @@ def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
 
 
 def test_get_hist_1d_projection(corsika_histograms_instance_set_histograms, caplog):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="label_not_valid is not valid."):
         corsika_histograms_instance_set_histograms._get_hist_1d_projection("label_not_valid")
     assert "label_not_valid is not valid." in caplog.text
 
@@ -296,7 +296,7 @@ def test_get_hist_2d_projection(corsika_histograms_instance, caplog):
     corsika_histograms_instance.set_histograms()
 
     label = "hist_non_existent"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^label is not valid. Valid entries are"):
         corsika_histograms_instance._get_hist_2d_projection(label)
     assert "label is not valid." in caplog.text
 

--- a/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
@@ -38,7 +38,7 @@ def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, capl
         for _, _ in enumerate(corsika_histograms_instance_set_histograms.telescope_indices):
             assert isinstance(all_figs[0], plt.Figure)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"This property does not exist. The valid entries"):
         corsika_histograms_visualize._kernel_plot_2d_photons(
             corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
         )
@@ -92,7 +92,7 @@ def test_kernel_plot_1d_photons(corsika_histograms_instance_set_histograms, capl
             else:
                 assert isinstance(all_figs[i_hist], plt.Figure)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"This property does not"):
         corsika_histograms_visualize._kernel_plot_1d_photons(
             corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
         )

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -38,7 +38,7 @@ def test_corsika7_id(caplog):
     assert si.pdg_id == 1000140280
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             PrimaryParticle(corsika7_id=9999)
         assert "Invalid CORSIKA7 ID: 9999" in caplog.text
 
@@ -56,12 +56,12 @@ def test_common_name(caplog):
     assert pi0.pdg_id == 111
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             PrimaryParticle(name="pi")
         assert "Found more than one particle with name pi" in caplog.text
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             PrimaryParticle(name="the_particle_which_explains_nothing")
         assert "Invalid particle name: the_particle_which_explains_nothing" in caplog.text
 
@@ -83,7 +83,7 @@ def test_pdg_id(caplog):
     assert pi0.name == "pi0"
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             PrimaryParticle(pdg_id=9999)
         assert "Invalid DPG ID: 9999" in caplog.text
 

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -25,7 +25,7 @@ def test_str():
     assert str(fe) == "iron (5626, 1000260560, Fe56)"
 
 
-def test_corsika7_id(caplog):
+def test_corsika7_id():
     p = PrimaryParticle(corsika7_id=14)
 
     assert p.corsika7_id == 14
@@ -37,13 +37,11 @@ def test_corsika7_id(caplog):
     assert si.name == "silicon"
     assert si.pdg_id == 1000140280
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            PrimaryParticle(corsika7_id=9999)
-        assert "Invalid CORSIKA7 ID: 9999" in caplog.text
+    with pytest.raises(ValueError, match="Invalid CORSIKA7 ID: 9999"):
+        PrimaryParticle(corsika7_id=9999)
 
 
-def test_common_name(caplog):
+def test_common_name():
     p = PrimaryParticle(name="proton")
 
     assert p.corsika7_id == 14
@@ -55,15 +53,13 @@ def test_common_name(caplog):
     assert pi0.name == "pi0"
     assert pi0.pdg_id == 111
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            PrimaryParticle(name="pi")
-        assert "Found more than one particle with name pi" in caplog.text
+    with pytest.raises(ValueError, match=r"Found more than one particle with name pi"):
+        PrimaryParticle(name="pi")
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            PrimaryParticle(name="the_particle_which_explains_nothing")
-        assert "Invalid particle name: the_particle_which_explains_nothing" in caplog.text
+    with pytest.raises(
+        ValueError, match="Invalid particle name: the_particle_which_explains_nothing"
+    ):
+        PrimaryParticle(name="the_particle_which_explains_nothing")
 
 
 def test_pdg_id(caplog):
@@ -82,10 +78,8 @@ def test_pdg_id(caplog):
     assert pi0.corsika7_id == 7
     assert pi0.name == "pi0"
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            PrimaryParticle(pdg_id=9999)
-        assert "Invalid DPG ID: 9999" in caplog.text
+    with pytest.raises(ValueError, match="Invalid DPG ID: 9999"):
+        PrimaryParticle(pdg_id=9999)
 
 
 def test_particle_names():

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -141,7 +141,10 @@ def test_validate_parameter_and_file_name():
     data_validator.validate_and_transform()
 
     data_validator.data_dict["parameter"] = "incorrect_name"
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(
+        ValueError,
+        match="Parameter name in data dict incorrect_name and file name num_gains do not match.",
+    ):
         data_validator.validate_parameter_and_file_name()
 
 
@@ -271,7 +274,7 @@ def test_check_data_for_duplicates(reference_columns):
     table_3["qe"] = Column([0.1, 0.5, 0.8], dtype="float32")
 
     data_validator.data_table = table_3
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"^Failed removal of duplication for column"):
         data_validator._check_data_for_duplicates()
 
 
@@ -314,19 +317,14 @@ def test_check_range(reference_columns, caplog):
         data_validator._check_range(col_w.name, col_w.min(), col_w.max(), "failed_range")
 
     col_3 = Column(name="qe", data=[0.1, 5.00], dtype="float32")
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
-        assert "Value for column 'qe' out of range" in caplog.text
+    with pytest.raises(ValueError, match=r"Value for column 'qe' out of range"):
+        data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
     col_3 = Column(name="qe", data=[-0.1, 0.5], dtype="float32")
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
-        assert "Value for column 'qe' out of range" in caplog.text
+    with pytest.raises(ValueError, match=r"^Value for column 'qe' out of range"):
+        data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(KeyError):
-            data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "invalid_range")
+    with pytest.raises(KeyError, match=r"Allowed range types are"):
+        data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "invalid_range")
 
 
 def test_is_dimensionless():
@@ -556,11 +554,11 @@ def test_check_for_not_a_number(reference_columns):
     assert data_validator._check_for_not_a_number("string", "wavelength")
 
     # wavelength does not allow for nan
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
         data_validator._check_for_not_a_number([np.nan, 350.0, 315.0], "wavelength")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
         data_validator._check_for_not_a_number([np.nan, 350.0, np.inf], "wavelength")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
         data_validator._check_for_not_a_number([300.0, 350.0, np.inf], "wavelength")
 
     # position_x allows for nan
@@ -569,9 +567,9 @@ def test_check_for_not_a_number(reference_columns):
     assert data_validator._check_for_not_a_number([333.0, np.inf, 315.0], "position_x")
 
     assert not data_validator._check_for_not_a_number(333.0, "wavelength")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
         data_validator._check_for_not_a_number(np.inf, "wavelength")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
         data_validator._check_for_not_a_number(np.nan, "wavelength")
 
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -553,12 +553,13 @@ def test_check_for_not_a_number(reference_columns):
 
     assert data_validator._check_for_not_a_number("string", "wavelength")
 
+    error_message = "NaN or Inf values found in data"
     # wavelength does not allow for nan
-    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
+    with pytest.raises(ValueError, match=rf"{error_message}"):
         data_validator._check_for_not_a_number([np.nan, 350.0, 315.0], "wavelength")
-    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
+    with pytest.raises(ValueError, match=rf"{error_message}"):
         data_validator._check_for_not_a_number([np.nan, 350.0, np.inf], "wavelength")
-    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
+    with pytest.raises(ValueError, match=rf"{error_message}"):
         data_validator._check_for_not_a_number([300.0, 350.0, np.inf], "wavelength")
 
     # position_x allows for nan
@@ -567,9 +568,9 @@ def test_check_for_not_a_number(reference_columns):
     assert data_validator._check_for_not_a_number([333.0, np.inf, 315.0], "position_x")
 
     assert not data_validator._check_for_not_a_number(333.0, "wavelength")
-    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
+    with pytest.raises(ValueError, match=rf"{error_message}"):
         data_validator._check_for_not_a_number(np.inf, "wavelength")
-    with pytest.raises(ValueError, match=r"NaN or Inf values found in data"):
+    with pytest.raises(ValueError, match=rf"{error_message}"):
         data_validator._check_for_not_a_number(np.nan, "wavelength")
 
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -141,7 +141,7 @@ def test_validate_parameter_and_file_name():
     data_validator.validate_and_transform()
 
     data_validator.data_dict["parameter"] = "incorrect_name"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator.validate_parameter_and_file_name()
 
 
@@ -271,7 +271,7 @@ def test_check_data_for_duplicates(reference_columns):
     table_3["qe"] = Column([0.1, 0.5, 0.8], dtype="float32")
 
     data_validator.data_table = table_3
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_data_for_duplicates()
 
 
@@ -315,14 +315,14 @@ def test_check_range(reference_columns, caplog):
 
     col_3 = Column(name="qe", data=[0.1, 5.00], dtype="float32")
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
-    assert "Value for column 'qe' out of range" in caplog.text
+        assert "Value for column 'qe' out of range" in caplog.text
     col_3 = Column(name="qe", data=[-0.1, 0.5], dtype="float32")
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             data_validator._check_range(col_3.name, col_3.min(), col_3.max(), "allowed_range")
-    assert "Value for column 'qe' out of range" in caplog.text
+        assert "Value for column 'qe' out of range" in caplog.text
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
@@ -556,11 +556,11 @@ def test_check_for_not_a_number(reference_columns):
     assert data_validator._check_for_not_a_number("string", "wavelength")
 
     # wavelength does not allow for nan
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_for_not_a_number([np.nan, 350.0, 315.0], "wavelength")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_for_not_a_number([np.nan, 350.0, np.inf], "wavelength")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_for_not_a_number([300.0, 350.0, np.inf], "wavelength")
 
     # position_x allows for nan
@@ -569,9 +569,9 @@ def test_check_for_not_a_number(reference_columns):
     assert data_validator._check_for_not_a_number([333.0, np.inf, 315.0], "position_x")
 
     assert not data_validator._check_for_not_a_number(333.0, "wavelength")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_for_not_a_number(np.inf, "wavelength")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         data_validator._check_for_not_a_number(np.nan, "wavelength")
 
 

--- a/tests/unit_tests/db/test_db_from_repo_handler.py
+++ b/tests/unit_tests/db/test_db_from_repo_handler.py
@@ -61,7 +61,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
     assert len(_pars_south) > 0
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             db_from_repo_handler.update_model_parameters_from_repo(
                 parameters=dict.fromkeys(_pars_telescope_model, None),
                 site="North",

--- a/tests/unit_tests/db/test_db_from_repo_handler.py
+++ b/tests/unit_tests/db/test_db_from_repo_handler.py
@@ -61,7 +61,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
     assert len(_pars_south) > 0
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
+        with pytest.raises(ValueError, match=r"^Unknown parameter collection"):
             db_from_repo_handler.update_model_parameters_from_repo(
                 parameters=dict.fromkeys(_pars_telescope_model, None),
                 site="North",
@@ -71,7 +71,6 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
                 db_simulation_model_url=simulation_model_url,
                 db_simulation_model="verified_model",
             )
-        assert "Unknown parameter collection" in caplog.text
 
     # Test with a parameter that is not in the repository (no error should be raised)
     _pars_site_model.append("not_a_parameter")

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -57,7 +57,7 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker, caplog):
     db_copy = copy.deepcopy(db)
     db_copy.mongo_db_config["db_simulation_model"] = "DB_NAME-LATEST"
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa PT011
             db_copy._update_db_simulation_model()
         assert "Found LATEST in the DB name but no matching versions found in DB." in caplog.text
 
@@ -134,7 +134,7 @@ def test_get_derived_values(db, model_version):
         logger.error("Derived DB not updated for new telescope names. Expect failure")
         raise AssertionError
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^abc"):
         pars = db.get_derived_values("North", None, "Prod5")
 
 
@@ -184,7 +184,7 @@ def test_copy_telescope_db(db, random_id, io_handler, model_version):
 
     # After deleting the copied telescope
     # we always expect to get a ValueError (query returning zero results)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"The following query returned zero results"):
         db.read_mongo_db(
             db_name=f"sandbox_{random_id}",
             telescope_model_name="LSTN-test",
@@ -346,7 +346,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     assert pars["led_pulse_offset"]["unit"] == "ns"
 
     # wrong collection
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Cannot add parameter to collection "):
         db.add_new_parameter(
             db_name=f"sandbox_{random_id}",
             site="North",
@@ -399,7 +399,9 @@ def test_update_parameter_field_db(db, random_id, io_handler):
     )
     assert pars["camera_pixels"]["applicable"] is False
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match=r"You need to specify if to update a telescope or a site."
+    ):
         db.update_parameter_field(
             db_name=f"sandbox_{random_id}",
             telescope=None,
@@ -554,7 +556,7 @@ def test_get_all_available_array_elements(db, model_version, caplog):
     assert all(_t in available_telescopes for _t in expected_telescope_names)
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa PT011
             db.get_all_available_array_elements(
                 model_version=model_version, collection="wrong_collection"
             )
@@ -578,10 +580,10 @@ def test_get_telescope_db_name(db):
     assert db.get_telescope_db_name("LSTS-design", model_version="Prod5") == "LSTS-design"
     assert db.get_telescope_db_name("SSTS-91", model_version="Prod5") == "SSTS-design"
     assert db.get_telescope_db_name("SSTS-design", model_version="Prod5") == "SSTS-design"
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid name SSTN"):
         db.get_telescope_db_name("SSTN-05", model_version="Prod5", collection="telescopes")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"Invalid database name."):
         db.get_telescope_db_name("ILLN-01", model_version="Prod5", collection="telescopes")
 
 
@@ -601,7 +603,7 @@ def test_model_version(db, caplog):
     assert db.model_version(version="prod6") == "2024-02-01"
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa PT011
             db.model_version(version="test")
         assert "Invalid model version test" in caplog.text
 

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -77,7 +77,7 @@ def array_layout_south_four_lst_instance(db_config, model_version):
 def test_initialize_site_parameters_from_db(caplog):
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa PT011
             ArrayLayout(site="North", mongo_db_config=None, model_version="test_model_version")
     assert "No database configuration provided" in caplog.text
 

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -175,11 +175,11 @@ def test_change_parameter(telescope_model_lst):
     assert tel_model.get_parameter_value("camera_pixels") == 9999
 
     logger.info("Testing changing camera_pixels to a float (now allowed)")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"^Could not cast 9999.9 of type"):
         tel_model.change_parameter("camera_pixels", 9999.9)
 
     logger.info("Testing changing camera_pixels to a nonsense string")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"^Could not cast bla_bla of type"):
         tel_model.change_parameter("camera_pixels", "bla_bla")
 
     logger.info(f"Old camera_pixels:{tel_model.get_parameter_value('mirror_focal_length')}")
@@ -192,7 +192,7 @@ def test_change_parameter(telescope_model_lst):
     assert pytest.approx(9999.9) == tel_model.get_parameter_value("mirror_focal_length")[0]
 
     logger.info("Testing changing mirror_focal_length to a nonsense string")
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"^Could not cast bla_bla of type"):
         tel_model.change_parameter("mirror_focal_length", "bla_bla")
 
     with pytest.raises(InvalidModelParameterError, match="Parameter bla_bla not in the model"):

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -175,11 +175,11 @@ def test_change_parameter(telescope_model_lst):
     assert tel_model.get_parameter_value("camera_pixels") == 9999
 
     logger.info("Testing changing camera_pixels to a float (now allowed)")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         tel_model.change_parameter("camera_pixels", 9999.9)
 
     logger.info("Testing changing camera_pixels to a nonsense string")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         tel_model.change_parameter("camera_pixels", "bla_bla")
 
     logger.info(f"Old camera_pixels:{tel_model.get_parameter_value('mirror_focal_length')}")
@@ -192,7 +192,7 @@ def test_change_parameter(telescope_model_lst):
     assert pytest.approx(9999.9) == tel_model.get_parameter_value("mirror_focal_length")[0]
 
     logger.info("Testing changing mirror_focal_length to a nonsense string")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         tel_model.change_parameter("mirror_focal_length", "bla_bla")
 
     with pytest.raises(InvalidModelParameterError, match="Parameter bla_bla not in the model"):

--- a/tests/unit_tests/model/test_site_model.py
+++ b/tests/unit_tests/model/test_site_model.py
@@ -53,7 +53,7 @@ def test_get_array_elements_for_layout(db_config, model_version, caplog):
     assert "LSTN-01" in _north.get_array_elements_for_layout("test_layout")
 
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             _north.get_array_elements_for_layout("not_a_layout")
         assert "Array layout 'not_a_layout' not found in 'North' site model." in caplog.text
 

--- a/tests/unit_tests/model/test_site_model.py
+++ b/tests/unit_tests/model/test_site_model.py
@@ -40,7 +40,7 @@ def test_get_corsika_site_parameters(db_config, model_version):
     assert "ARRANG" in _north.get_corsika_site_parameters(config_file_style=True)
 
 
-def test_get_array_elements_for_layout(db_config, model_version, caplog):
+def test_get_array_elements_for_layout(db_config, model_version):
     _north = SiteModel(
         site="North",
         mongo_db_config=db_config,
@@ -52,10 +52,10 @@ def test_get_array_elements_for_layout(db_config, model_version, caplog):
     assert len(_north.get_array_elements_for_layout("test_layout")) == 13
     assert "LSTN-01" in _north.get_array_elements_for_layout("test_layout")
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            _north.get_array_elements_for_layout("not_a_layout")
-        assert "Array layout 'not_a_layout' not found in 'North' site model." in caplog.text
+    with pytest.raises(
+        ValueError, match="Array layout 'not_a_layout' not found in 'North' site model."
+    ):
+        _north.get_array_elements_for_layout("not_a_layout")
 
 
 def test_get_list_of_array_layouts(db_config, model_version):

--- a/tests/unit_tests/runners/test_corsika_runner.py
+++ b/tests/unit_tests/runners/test_corsika_runner.py
@@ -62,9 +62,10 @@ def test_prepare_run_script_with_input_file(corsika_runner_mock_array_model, cap
 
 
 def test_prepare_run_script_with_invalid_run(corsika_runner_mock_array_model):
-    for run in [-2, "test"]:
-        with pytest.raises(ValueError):
-            _ = corsika_runner_mock_array_model.prepare_run_script(run_number=run)
+    with pytest.raises(ValueError, match="^Invalid type of run number"):
+        _ = corsika_runner_mock_array_model.prepare_run_script(run_number=-2)
+    with pytest.raises(ValueError, match="^could not convert string to float"):
+        _ = corsika_runner_mock_array_model.prepare_run_script(run_number="test")
 
 
 def test_prepare_run_script_with_extra(

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -77,9 +77,10 @@ def test_prepare_run_script(corsika_simtel_runner):
 
 
 def test_prepare_run_script_with_invalid_run(corsika_simtel_runner):
-    for run_number in [-2, "test"]:
-        with pytest.raises(ValueError):
-            _ = corsika_simtel_runner.prepare_run_script(run_number=run_number)
+    with pytest.raises(ValueError, match=r"^Invalid type of run number"):
+        _ = corsika_simtel_runner.prepare_run_script(run_number=-2)
+    with pytest.raises(ValueError, match=r"^could not convert string to float"):
+        _ = corsika_simtel_runner.prepare_run_script(run_number="test")
 
 
 def test_export_multipipe_script(corsika_simtel_runner, simtel_command, show_all):

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -182,7 +182,7 @@ def test_get_file_name(runner_service):
     assert isinstance(runner_service.get_file_name("output", run_number=1), pathlib.Path)
     assert isinstance(runner_service.get_file_name("sub_log", run_number=1), pathlib.Path)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^The requested file type"):
         runner_service.get_file_name("foobar", run_number=1, mode="out")
 
 

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -340,6 +340,6 @@ def test_validate_parameter_dict(config_reader_num_gains, caplog):
     _config._validate_parameter_dict(_temp_dict)
     _temp_dict["value"] = 25
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             _config._validate_parameter_dict(_temp_dict)
         assert "out of range" in caplog.text

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -322,7 +322,7 @@ def test_get_unit_from_schema(schema_num_gains, simtel_config_file):
     assert _config._get_unit_from_schema() is None
 
 
-def test_validate_parameter_dict(config_reader_num_gains, caplog):
+def test_validate_parameter_dict(config_reader_num_gains):
 
     _config = config_reader_num_gains
 
@@ -339,7 +339,5 @@ def test_validate_parameter_dict(config_reader_num_gains, caplog):
     }
     _config._validate_parameter_dict(_temp_dict)
     _temp_dict["value"] = 25
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa: PT011
-            _config._validate_parameter_dict(_temp_dict)
-        assert "out of range" in caplog.text
+    with pytest.raises(ValueError, match=r"out of range"):
+        _config._validate_parameter_dict(_temp_dict)

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -49,7 +49,7 @@ def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
     assert file_has_text(file, "num_gains = 1")
 
 
-def test_get_simtel_metadata(simtel_config_writer, caplog):
+def test_get_simtel_metadata(simtel_config_writer):
 
     _tel = simtel_config_writer._get_simtel_metadata("telescope")
     assert len(_tel) == 8
@@ -61,9 +61,8 @@ def test_get_simtel_metadata(simtel_config_writer, caplog):
     assert _site["site_config_name"] == simtel_config_writer._site
     assert _site["array_config_name"] == simtel_config_writer._layout_name
 
-    with pytest.raises(ValueError):  # noqa: PT011
+    with pytest.raises(ValueError, match=r"^Unknown metadata type"):
         simtel_config_writer._get_simtel_metadata("unknown")
-    assert "Unknown metadata type" in caplog.text
 
 
 def test_get_value_string_for_simtel(simtel_config_writer):

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -49,7 +49,7 @@ def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
     assert file_has_text(file, "num_gains = 1")
 
 
-def test_get_simtel_metadata(simtel_config_writer):
+def test_get_simtel_metadata(simtel_config_writer, caplog):
 
     _tel = simtel_config_writer._get_simtel_metadata("telescope")
     assert len(_tel) == 8
@@ -61,8 +61,9 @@ def test_get_simtel_metadata(simtel_config_writer):
     assert _site["site_config_name"] == simtel_config_writer._site
     assert _site["array_config_name"] == simtel_config_writer._layout_name
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         simtel_config_writer._get_simtel_metadata("unknown")
+    assert "Unknown metadata type" in caplog.text
 
 
 def test_get_value_string_for_simtel(simtel_config_writer):

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -162,10 +162,11 @@ def test_get_particle_distribution_function(
     with caplog.at_level(logging.ERROR):
         with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
             simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
-    assert (
-        "spectral_index not found in the configuration of the file. Consider using a .simtel file instead."
-        in caplog.text
+    assert_string = (
+        "spectral_index not found in the configuration of the file. "
+        "Consider using a .simtel file instead."
     )
+    assert assert_string in caplog.text
 
     # Test invalid label
     with caplog.at_level(logging.ERROR):

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -45,11 +45,11 @@ def simtel_hist_hdata_io_instance(simtel_io_file_hdata):
 
 def test_init_errors(simtel_io_file_hdata, caplog):
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"view_cone needs to be passed as argument"):
             _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
     assert "view_cone needs to be passed as argument" in caplog.text
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"energy_range needs to be passed as argument"):
             _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
     assert "energy_range needs to be passed as argument" in caplog.text
 
@@ -160,7 +160,7 @@ def test_get_particle_distribution_function(
     )
     assert simulation_function.index == -2.0
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
             simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
     assert (
         "spectral_index not found in the configuration of the file. Consider using a .simtel file instead."
@@ -169,7 +169,7 @@ def test_get_particle_distribution_function(
 
     # Test invalid label
     with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Please use either"):
             simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
     assert "Please use either 'reference' or 'simulation'" in caplog.text
 

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -122,20 +122,19 @@ def test_ray_tracing_single_mirror_mode_mirror_numbers(
     assert ray._mirror_numbers == [1, 2, 3]
 
 
-def test_ray_tracing_invalid_telescope_model(simtel_path, io_handler, caplog):
+def test_ray_tracing_invalid_telescope_model(simtel_path, io_handler):
     config_data = {
         "source_distance": 10 * u.km,
         "zenith_angle": 30 * u.deg,
         "off_axis_angle": [0, 2] * u.deg,
     }
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid TelescopeModel"):
         RayTracing(
             telescope_model=None,
             simtel_path=simtel_path,
             config_data=config_data,
         )
-    assert "Invalid TelescopeModel" in caplog.text
 
 
 def test_ray_tracing_read_results(ray_tracing_lst):

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -440,13 +440,13 @@ def test_log_level_from_user() -> None:
     assert gen.get_log_level_from_user("error") == logging.ERROR
     assert gen.get_log_level_from_user("critical") == logging.CRITICAL
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^'invalid' is not a logging level"):
         gen.get_log_level_from_user("invalid")
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match=r"^'1' is not a logging level"):
         gen.get_log_level_from_user(1)
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match=r"^'None' is not a logging level"):
         gen.get_log_level_from_user(None)
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError, match=r"^'True' is not a logging level"):
         gen.get_log_level_from_user(True)
 
 
@@ -824,7 +824,7 @@ def test_validate_data_type():
             is expected_result
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Either value or dtype must be given"):
         gen.validate_data_type("int", None, None, False)
 
 

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -79,7 +79,7 @@ def test_validate_telescope_id_name(caplog):
 
     for _id in ["no_id", "D2345"]:
         with caplog.at_level(logging.ERROR):
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match=r"^Invalid telescope ID name"):
                 names.validate_telescope_id_name(_id)
             assert f"Invalid telescope ID name {_id}" in caplog.text
 
@@ -88,7 +88,7 @@ def test_validate_site_name():
     for key, value in names.site_names().items():
         for test_name in value:
             assert key == names.validate_site_name(test_name)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Invalid name"):
         names.validate_site_name("Not a site")
 
 
@@ -106,9 +106,9 @@ def test_validate_telescope_name():
         logging.getLogger().info(f"New name {new_name}")
         assert value == new_name
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Invalid name"):
         names.validate_telescope_name("South-MST-FlashCam-D")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Invalid name"):
         names.validate_telescope_name("LSTN")
 
 
@@ -122,25 +122,25 @@ def test_get_site_from_telescope_name():
     assert "North" == names.get_site_from_telescope_name("MSTN")
     assert "North" == names.get_site_from_telescope_name("MSTN-05")
     assert "South" == names.get_site_from_telescope_name("MSTS-05")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Invalid name"):
         names.get_site_from_telescope_name("LSTW")
 
 
 def test_get_class_from_telescope_name():
     assert "telescopes" == names.get_collection_name_from_array_element_name("LSTN-01")
     assert "calibration_devices" == names.get_collection_name_from_array_element_name("ILLS-01")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^Invalid name"):
         names.get_site_from_telescope_name("SATW")
 
 
-def test_sanitize_name():
+def test_sanitize_name(caplog):
     assert names.sanitize_name("y_edges unit") == "y_edges_unit"
     assert names.sanitize_name("Y_EDGES UNIT") == "y_edges_unit"
     assert names.sanitize_name("123name") == "_123name"
     assert names.sanitize_name("na!@#$%^&*()me") == "na__________me"
     assert names.sanitize_name("!validName") == "_validname"
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r"^The string  could not be sanitized."):
         names.sanitize_name("")
 
 
@@ -152,7 +152,7 @@ def test_get_telescope_type_from_telescope_name():
     assert names.get_telescope_type_from_telescope_name("MAGIC-2") == "MAGIC"
     assert names.get_telescope_type_from_telescope_name("VERITAS-4") == "VERITAS"
     for _name in ["", "01", "Not_a_telescope", "LST", "MST"]:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"^Invalid name"):
             names.get_telescope_type_from_telescope_name(_name)
 
 

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -12,6 +12,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 ecsv_suffix = ".ecsv"
 
 
+@pytest.fixture()
+def invalid_name():
+    return "Invalid name"
+
+
 def test_get_list_of_telescope_types():
     assert names.get_list_of_telescope_types(array_element_class="telescopes", site=None) == [
         "LSTN",
@@ -84,15 +89,15 @@ def test_validate_telescope_id_name(caplog):
             assert f"Invalid telescope ID name {_id}" in caplog.text
 
 
-def test_validate_site_name():
+def test_validate_site_name(invalid_name):
     for key, value in names.site_names().items():
         for test_name in value:
             assert key == names.validate_site_name(test_name)
-    with pytest.raises(ValueError, match=r"^Invalid name"):
+    with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.validate_site_name("Not a site")
 
 
-def test_validate_telescope_name():
+def test_validate_telescope_name(invalid_name):
     telescopes = {
         "LSTN-Design": "LSTN-design",
         "LSTN-TEST": "LSTN-test",
@@ -106,9 +111,9 @@ def test_validate_telescope_name():
         logging.getLogger().info(f"New name {new_name}")
         assert value == new_name
 
-    with pytest.raises(ValueError, match=r"^Invalid name"):
+    with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.validate_telescope_name("South-MST-FlashCam-D")
-    with pytest.raises(ValueError, match=r"^Invalid name"):
+    with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.validate_telescope_name("LSTN")
 
 
@@ -118,18 +123,18 @@ def test_get_telescope_name_from_type_site_id():
     assert "LSTS-01" == names.get_telescope_name_from_type_site_id("LST", "South", "01")
 
 
-def test_get_site_from_telescope_name():
+def test_get_site_from_telescope_name(invalid_name):
     assert "North" == names.get_site_from_telescope_name("MSTN")
     assert "North" == names.get_site_from_telescope_name("MSTN-05")
     assert "South" == names.get_site_from_telescope_name("MSTS-05")
-    with pytest.raises(ValueError, match=r"^Invalid name"):
+    with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.get_site_from_telescope_name("LSTW")
 
 
-def test_get_class_from_telescope_name():
+def test_get_class_from_telescope_name(invalid_name):
     assert "telescopes" == names.get_collection_name_from_array_element_name("LSTN-01")
     assert "calibration_devices" == names.get_collection_name_from_array_element_name("ILLS-01")
-    with pytest.raises(ValueError, match=r"^Invalid name"):
+    with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.get_site_from_telescope_name("SATW")
 
 
@@ -144,7 +149,7 @@ def test_sanitize_name(caplog):
         names.sanitize_name("")
 
 
-def test_get_telescope_type_from_telescope_name():
+def test_get_telescope_type_from_telescope_name(invalid_name):
     assert names.get_telescope_type_from_telescope_name("LSTN-01") == "LSTN"
     assert names.get_telescope_type_from_telescope_name("MSTN-02") == "MSTN"
     assert names.get_telescope_type_from_telescope_name("SSTS-27") == "SSTS"
@@ -152,7 +157,7 @@ def test_get_telescope_type_from_telescope_name():
     assert names.get_telescope_type_from_telescope_name("MAGIC-2") == "MAGIC"
     assert names.get_telescope_type_from_telescope_name("VERITAS-4") == "VERITAS"
     for _name in ["", "01", "Not_a_telescope", "LST", "MST"]:
-        with pytest.raises(ValueError, match=r"^Invalid name"):
+        with pytest.raises(ValueError, match=rf"^{invalid_name}"):
             names.get_telescope_type_from_telescope_name(_name)
 
 


### PR DESCRIPTION
Addresses "pytest-raises-too-broad" (PT011) error from ruff, see https://docs.astral.sh/ruff/rules/pytest-raises-too-broad/

Some smaller bug fixes are included learned from switching this on: in some cases the same error was thrown at a different then expected place in the code.

Note the discussion in issue #1087 : this PR implements the common way of issuing error messages (e.g. ValueError(msg)).