### PR TITLE
Limit git clone to depth 1

### DIFF
--- a/database_scripts/upload_from_model_repository_to_local_db.sh
+++ b/database_scripts/upload_from_model_repository_to_local_db.sh
@@ -35,7 +35,7 @@ db.createUser({
 
 echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
 rm -rf ./tmp_model_parameters
-git clone -b $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
+git clone --depth=1 -b $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
 
 CURRENTDIR=$(pwd)
 cd ./tmp_model_parameters/ || exit


### PR DESCRIPTION
No need to clone the full history of the model parameter repository - limit the clone to depth 1 before uploading it to the model parameter database.