### PR TITLE
Use array_element instead of telescope in names, model_parameter, db_handler

### DIFF
--- a/docs/source/developer-guide/coding_guidelines.md
+++ b/docs/source/developer-guide/coding_guidelines.md
@@ -113,7 +113,7 @@ For example:
 - "North-LST-1" is the first LST commissioned at the La Palma site, while "North-LST-D234" is the current design of the further 3 LSTs.
 - "North-MST-FlashCam-D" and "North-MST-NectarCam-D" are the two MST designs containing different cameras.
 
-Any input telescope names can (and should) be validated by the function validate_telescope_name
+Any input telescope names can (and should) be validated by the function validate_array_element_name
 (see module {ref}`utils.names <utilsnames>`).
 For the Site field, any different capitalization (e.g "south") or site names like "paranal" and
 "lapalma" will be accepted

--- a/docs/source/user-guide/model_parameters.md
+++ b/docs/source/user-guide/model_parameters.md
@@ -40,7 +40,7 @@ These files describe the simulation model parameters including (among others fie
 They include information about setting and validation activities, data sources, and simulation software.
 The schema files and especially the model parameter descriptions are derived from (and planned to be synchronized with) the [sim_telarray manual](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/).
 
-The schema files are in human readable yaml format and follow a fixed meta metaschema (see [model_parameter_and_data_schema.metaschema.yml](https://github.com/gammasim/simtools/blob/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml); found in simtools schema directory).
+The schema files are in human readable YAML format and follow a fixed meta metaschema (see [model_parameter_and_data_schema.metaschema.yml](https://github.com/gammasim/simtools/blob/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml); found in simtools schema directory).
 
 ### Example
 

--- a/docs/source/user-guide/model_parameters.md
+++ b/docs/source/user-guide/model_parameters.md
@@ -230,7 +230,7 @@ simtools-add_model-parameters-from-repository-to-db \
 This application loops over all subdirectories in `input_path` and uploads all json files to the database `new_db_name` (or updates an existing database with the same name):
 
 - subdirectories starting with `OBS` are uploaded to the `sites` collection
-- json files from the subdirectory `configuration_sim_telarray` are uploaded to the `configuration_sim_telarray` collection
+- json files from the subdirectory `configuration_sim_telarray/configuration_corsika` are uploaded to the `configuration_sim_telarray/configuration_corsika` collection
 - `Files` are added to the `files` collection
 - all other json files are uploaded to collection defined in the array element description in [simtools/schemas/array_elements.yml](https://github.com/gammasim/simtools/blob/main/simtools/schemas/array_elements.yml). Allowed values are e.g., `telescopes`, `calibration_devices`.
 

--- a/simtools/applications/db_add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_add_model_parameters_from_repository_to_db.py
@@ -116,7 +116,7 @@ def add_values_from_json_to_db(file, collection, db, db_name, file_prefix, logge
     )
     db.add_new_parameter(
         db_name=db_name,
-        telescope=par_dict["instrument"],
+        array_element_name=par_dict["instrument"],
         parameter=par_dict["parameter"],
         version=par_dict["version"],
         value=par_dict["value"],

--- a/simtools/applications/db_add_value_from_json_to_db.py
+++ b/simtools/applications/db_add_value_from_json_to_db.py
@@ -83,7 +83,7 @@ def main():  # noqa: D103
             logger.info(f"Adding the following parameter to the DB: {par_dict['parameter']}")
             db.add_new_parameter(
                 db_name=db_config["db_simulation_model"],
-                telescope=par_dict["instrument"],
+                array_element_name=par_dict["instrument"],
                 parameter=par_dict["parameter"],
                 version=par_dict["version"],
                 value=par_dict["value"],

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -45,7 +45,7 @@ def main():  # noqa: D103
     for telescope_now in telescopes:
         for par_now, par_value in parameter.items():
             all_versions = db.get_all_versions(
-                telescope_model_name="-".join(telescope_now.split("-")[1:]),
+                array_element_name="-".join(telescope_now.split("-")[1:]),
                 site=names.get_site_from_array_element_name(telescope_now),
                 parameter="camera_config_file",  # Just a random parameter to get the versions
                 collection="telescopes",
@@ -64,7 +64,7 @@ def main():  # noqa: D103
                 )
                 pars = db.read_mongo_db(
                     db_name=db_config["db_simulation_model"],
-                    telescope_model_name=telescope_now,
+                    array_element_name=telescope_now,
                     model_version=version_now,
                     run_location="./",
                     collection_name="telescopes",

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -46,7 +46,7 @@ def main():  # noqa: D103
         for par_now, par_value in parameter.items():
             all_versions = db.get_all_versions(
                 telescope_model_name="-".join(telescope_now.split("-")[1:]),
-                site=names.get_site_from_telescope_name(telescope_now),
+                site=names.get_site_from_array_element_name(telescope_now),
                 parameter="camera_config_file",  # Just a random parameter to get the versions
                 collection="telescopes",
             )

--- a/simtools/applications/db_development_tools/add_new_parameter_to_db.py
+++ b/simtools/applications/db_development_tools/add_new_parameter_to_db.py
@@ -53,7 +53,7 @@ def main():  # noqa: D103
             for version_now in all_versions:
                 db.add_new_parameter(
                     db_name=db_config["db_simulation_model"],
-                    telescope=telescope_now,
+                    array_element_name=telescope_now,
                     parameter=par_now,
                     version=version_now,
                     value=par_value,

--- a/simtools/applications/generate_regular_arrays.py
+++ b/simtools/applications/generate_regular_arrays.py
@@ -76,7 +76,7 @@ def main():
         # Single telescope at the center
         if array_name[0] == "1":
             tel_name.append(
-                names.get_telescope_name_from_type_site_id(tel_size, args_dict["site"], "01")
+                names.get_array_element_name_from_type_site_id(tel_size, args_dict["site"], "01")
             )
             pos_x.append(0 * u.m)
             pos_y.append(0 * u.m)
@@ -85,7 +85,9 @@ def main():
         else:
             for i in range(1, 5):
                 tel_name.append(
-                    names.get_telescope_name_from_type_site_id(tel_size, args_dict["site"], f"0{i}")
+                    names.get_array_element_name_from_type_site_id(
+                        tel_size, args_dict["site"], f"0{i}"
+                    )
                 )
                 pos_x.append(telescope_distance[tel_size] * (-1) ** (i // 2))
                 pos_y.append(telescope_distance[tel_size] * (-1) ** (i % 2))

--- a/simtools/applications/plot_array_layout.py
+++ b/simtools/applications/plot_array_layout.py
@@ -299,7 +299,7 @@ def _layouts_from_list(args_dict, db_config, rotate_angle):
         List of array layouts.
     """
     site = (
-        names.get_site_from_telescope_name(args_dict["array_element_list"][0])
+        names.get_site_from_array_element_name(args_dict["array_element_list"][0])
         if args_dict["site"] is None
         else args_dict["site"]
     )

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -536,7 +536,7 @@ class CommandLineParser(argparse.ArgumentParser):
         argparse.ArgumentTypeError
             for invalid telescope
         """
-        names.validate_telescope_name(str(value))
+        names.validate_array_element_name(str(value))
         return str(value)
 
     @staticmethod

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -208,9 +208,9 @@ class MetadataCollector:
             if self.args_dict and self.args_dict.get("site", None):
                 _association["site"] = names.validate_site_name(self.args_dict["site"])
             if "telescope" in self.args_dict:
-                _telescope_name = names.validate_telescope_name(self.args_dict["telescope"])
+                _telescope_name = names.validate_array_element_name(self.args_dict["telescope"])
                 _association["class"] = "telescope"
-                _association["type"] = names.get_telescope_type_from_telescope_name(_telescope_name)
+                _association["type"] = names.get_array_element_type_from_name(_telescope_name)
                 _association["subtype"] = ""
         except (TypeError, KeyError):
             self._logger.error("Error reading association metadata from args")

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def update_model_parameters_from_repo(
     parameters,
     site,
-    telescope_name,
+    array_element_name,
     parameter_collection,
     model_version,
     db_simulation_model_url,
@@ -33,8 +33,8 @@ def update_model_parameters_from_repo(
         Existing dictionary with parameters to be updated.
     site: str
         Observatory site (e.g., South or North)
-    telescope_name: str
-        Telescope name (e.g., MSTN-01, MSTN-DESIGN)
+    array_element_name: str
+        Array element name (e.g., MSTN-01, MSTN-design)
     parameter_collection: str
         Collection of parameters to be queried (e.g., telescope or site)
     model_version: str
@@ -51,7 +51,7 @@ def update_model_parameters_from_repo(
     logger.info(
         "Updating model parameters from repository for site: %s, telescope: %s",
         site,
-        telescope_name,
+        array_element_name,
     )
 
     if db_simulation_model_url is None:
@@ -64,11 +64,11 @@ def update_model_parameters_from_repo(
             "model_versions",
             model_version,
             db_simulation_model,
-            telescope_name,
+            array_element_name,
         )
-        # use design telescope model in case there is no model defined for this telescope ID
-        _design_model = names.get_telescope_type_from_telescope_name(telescope_name) + "-design"
-        if _design_model == telescope_name:
+        # use design array element model in case there is no model defined for this telescope ID
+        _design_model = names.get_array_element_type_from_name(array_element_name) + "-design"
+        if _design_model == array_element_name:
             _design_model = None
     elif parameter_collection == "site":
         _file_path = gen.join_url_or_path(

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -49,7 +49,7 @@ def update_model_parameters_from_repo(
 
     """
     logger.info(
-        "Updating model parameters from repository for site: %s, telescope: %s",
+        "Updating model parameters from repository for site: %s, array element: %s",
         site,
         array_element_name,
     )
@@ -66,7 +66,7 @@ def update_model_parameters_from_repo(
             db_simulation_model,
             array_element_name,
         )
-        # use design array element model in case there is no model defined for this telescope ID
+        # use design array element model in case there is no model defined for this array element ID
         _design_model = names.get_array_element_type_from_name(array_element_name) + "-design"
         if _design_model == array_element_name:
             _design_model = None
@@ -88,8 +88,8 @@ def update_model_parameters_from_repo(
         try:
             _tmp_par = gen.collect_data_from_file_or_dict(file_name=_parameter_file, in_dict=None)
         except (FileNotFoundError, gen.InvalidConfigDataError):
-            # use design telescope model in case there is no model defined for this telescope ID
-            # accept errors, as not all parameters are defined in the repository
+            # use design array element model in case there is no model defined for this
+            #  array element ID. Accept errors, as not all parameters are defined in the repository
             try:
                 _file_path = gen.join_url_or_path(
                     db_simulation_model_url,

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -182,11 +182,11 @@ class DatabaseHandler:
         dict containing the parameters
 
         """
-        _site, array_element_name, _model_version = self._validate_model_input(
+        _site, _array_element_name, _model_version = self._validate_model_input(
             site, array_element_name, model_version
         )
         array_element_list = self.get_array_element_list_for_db_query(
-            array_element_name, model_version
+            _array_element_name, model_version
         )
         pars = {}
         for array_element in array_element_list:

--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -404,7 +404,7 @@ class DatabaseHandler:
 
     def _get_site_parameters_mongo_db(self, db_name, site, model_version, only_applicable=False):
         """
-        Get parameters from MongoDB for a specific telescope.
+        Get parameters from MongoDB for a specific site.
 
         Parameters
         ----------

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -98,8 +98,7 @@ class ArrayLayout:
         """Initialize site parameters required for transformations using the database."""
         self._logger.debug("Initialize parameters from DB")
         if self.mongo_db_config is None:
-            self._logger.error("No database configuration provided")
-            raise ValueError
+            raise ValueError("No database configuration provided")
 
         self.site_model = SiteModel(
             site=self.site,

--- a/simtools/layout/array_layout.py
+++ b/simtools/layout/array_layout.py
@@ -233,7 +233,7 @@ class ArrayLayout:
             tel.name = row["telescope_name"]
             if "asset_code" not in row:
                 try:
-                    tel.asset_code = names.get_telescope_type_from_telescope_name(tel.name)
+                    tel.asset_code = names.get_array_element_type_from_name(tel.name)
                 # asset code is not a valid telescope name; possibly a calibration device
                 except ValueError:
                     tel.asset_code = tel.name.split("-")[0]
@@ -671,7 +671,7 @@ class ArrayLayout:
                 _telescope_list_from_type = [
                     tel
                     for tel in self._telescope_list
-                    if names.get_telescope_type_from_telescope_name(tel.asset_code) in asset_list
+                    if names.get_array_element_type_from_name(tel.asset_code) in asset_list
                 ]
                 self._telescope_list = list(
                     set(_telescope_list_from_name + _telescope_list_from_type)

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -339,7 +339,7 @@ class ArrayModel:
         array_elements_dict = {}
         for name in array_elements_list:
             try:
-                array_elements_dict[names.validate_telescope_name(name)] = None
+                array_elements_dict[names.validate_array_element_name(name)] = None
             except ValueError:
                 array_elements_dict.update(self._get_all_array_elements_of_type(name))
         return array_elements_dict

--- a/simtools/model/calibration_model.py
+++ b/simtools/model/calibration_model.py
@@ -41,7 +41,7 @@ class CalibrationModel(ModelParameter):
         ModelParameter.__init__(
             self,
             site=site,
-            telescope_name=calibration_device_model_name,
+            array_element_name=calibration_device_model_name,
             collection="calibration_devices",
             mongo_db_config=mongo_db_config,
             model_version=model_version,

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -34,8 +34,8 @@ class ModelParameter:
         Version of the model (ex. prod5).
     site: str
         Site name (e.g., South or North).
-    telescope_name: str
-        Telescope name (e.g., LSTN-01, LSTN-design).
+    array_element_name: str
+        Name of array element (e.g., LSTN-01, LSTN-design).
     collection: str
         instrument class (e.g. telescopes, calibration_devices)
         as stored under collection in the DB.
@@ -51,7 +51,7 @@ class ModelParameter:
         mongo_db_config,
         model_version,
         site=None,
-        telescope_name=None,
+        array_element_name=None,
         collection="telescopes",
         db=None,
         label=None,
@@ -71,14 +71,14 @@ class ModelParameter:
         self.model_version = self.db.model_version(model_version)
         self.site = names.validate_site_name(site) if site is not None else None
         self.name = (
-            names.validate_telescope_name(
-                self.db.get_telescope_db_name(
-                    telescope_name=telescope_name,
+            names.validate_array_element_name(
+                self.db.get_array_element_db_name(
+                    array_element_name=array_element_name,
                     model_version=self.model_version,
                     collection=self.collection,
                 )
             )
-            if telescope_name is not None
+            if array_element_name is not None
             else None
         )
         self._config_file_directory = None
@@ -310,7 +310,7 @@ class ModelParameter:
                 self._simulation_config_parameters[simulation_software] = (
                     self.db.get_simulation_configuration_parameters(
                         site=self.site,
-                        telescope_model_name=self.name,
+                        array_element_name=self.name,
                         model_version=self.model_version,
                         simulation_software=simulation_software,
                     )

--- a/simtools/model/model_utils.py
+++ b/simtools/model/model_utils.py
@@ -51,7 +51,7 @@ def is_two_mirror_telescope(telescope_model_name):
     bool
         True if the telescope is a two mirror one.
     """
-    tel_type = names.get_telescope_type_from_telescope_name(telescope_model_name)
+    tel_type = names.get_array_element_type_from_name(telescope_model_name)
     if "SST" in tel_type or "SCT" in tel_type:
         return True
     return False

--- a/simtools/model/telescope_model.py
+++ b/simtools/model/telescope_model.py
@@ -49,7 +49,7 @@ class TelescopeModel(ModelParameter):
         ModelParameter.__init__(
             self,
             site=site,
-            telescope_name=telescope_name,
+            array_element_name=telescope_name,
             mongo_db_config=mongo_db_config,
             model_version=model_version,
             db=None,

--- a/simtools/simtel/simtel_config_reader.py
+++ b/simtools/simtel/simtel_config_reader.py
@@ -98,7 +98,7 @@ class SimtelConfigReader:
         _json_dict = {
             "parameter": self.parameter_name,
             "instrument": telescope_name,
-            "site": names.get_site_from_telescope_name(telescope_name),
+            "site": names.get_site_from_array_element_name(telescope_name),
             "version": model_version,
             "value": self.parameter_dict.get(self.simtel_telescope_name),
             "unit": self._get_unit_from_schema(),
@@ -442,7 +442,7 @@ class SimtelConfigReader:
             raise exc
 
         return (
-            names.get_telescope_type_from_telescope_name(telescope_name)
+            names.get_array_element_type_from_name(telescope_name)
             in self.schema_dict["instrument"]["type"]
         )
 

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -11,16 +11,16 @@ import yaml
 _logger = logging.getLogger(__name__)
 
 __all__ = [
-    "get_site_from_telescope_name",
-    "get_telescope_type_from_telescope_name",
+    "get_site_from_array_element_name",
+    "get_array_element_type_from_name",
     "generate_file_name",
     "layout_telescope_list_file_name",
     "sanitize_name",
     "simtel_single_mirror_list_file_name",
     "simtel_config_file_name",
     "validate_site_name",
-    "validate_telescope_id_name",
-    "validate_telescope_name",
+    "validate_array_element_id_name",
+    "validate_array_element_name",
 ]
 
 
@@ -80,24 +80,24 @@ def telescope_parameters():
     return load_model_parameters(class_key_list=("Structure", "Camera"))
 
 
-def validate_telescope_id_name(name):
+def validate_array_element_id_name(name):
     """
-    Validate telescope ID.
+    Validate array element ID.
 
     Allowed IDs are
-    - design (for design telescopes or testing)
-    - telescope ID (e.g., 1, 5, 15)
+    - design (for design array elements or testing)
+    - array element ID (e.g., 1, 5, 15)
     - test (for testing)
 
     Parameters
     ----------
     name: str or int
-        Telescope ID name.
+        Array element ID name.
 
     Returns
     -------
     str
-        Validated telescope ID (added leading zeros, e.g., 1 is converted to 01).
+        Validated array element ID (added leading zeros, e.g., 1 is converted to 01).
 
     Raises
     ------
@@ -109,7 +109,7 @@ def validate_telescope_id_name(name):
     if name.lower() in ("design", "test"):
         return str(name).lower()
 
-    msg = f"Invalid telescope ID name {name}"
+    msg = f"Invalid array element ID name {name}"
     _logger.error(msg)
     raise ValueError(msg)
 
@@ -167,14 +167,14 @@ def _validate_name(name, all_names):
     raise ValueError(msg)
 
 
-def validate_telescope_name(name):
+def validate_array_element_name(name):
     """
-    Validate telescope name (e.g., MSTN-design, MSTN-01).
+    Validate array element name (e.g., MSTN-design, MSTN-01).
 
     Parameters
     ----------
     name: str
-        Telescope name.
+        array element name.
 
     Returns
     -------
@@ -186,52 +186,56 @@ def validate_telescope_name(name):
     except ValueError as exc:
         msg = f"Invalid name {name}"
         raise ValueError(msg) from exc
-    return _validate_name(_tel_type, array_elements()) + "-" + validate_telescope_id_name(_tel_id)
+    return (
+        _validate_name(_tel_type, array_elements()) + "-" + validate_array_element_id_name(_tel_id)
+    )
 
 
-def get_telescope_name_from_type_site_id(telescope_type, site, telescope_id):
+def get_array_element_name_from_type_site_id(array_element_type, site, array_element_id):
     """
-    Get telescope name from type, site and ID.
+    Get array element name from type, site and ID.
 
     Parameters
     ----------
-    telescope_type: str
-        Telescope type.
+    array_element_type: str
+        Array element type.
     site: str
         Site name.
-    telescope_id: str
-        Telescope ID.
+    array_element_id: str
+        Array element ID.
 
     Returns
     -------
     str
-        Telescope name.
+        Array element name.
     """
     _short_site = validate_site_name(site)[0]
-    _val_id = validate_telescope_id_name(telescope_id)
-    return f"{telescope_type}{_short_site}-{_val_id}"
+    _val_id = validate_array_element_id_name(array_element_id)
+    return f"{array_element_type}{_short_site}-{_val_id}"
 
 
-def get_telescope_type_from_telescope_name(name):
+def get_array_element_type_from_name(name):
     """
-    Get telescope type from name, e.g. "LSTN", "MSTN".
+    Get array element type from name, e.g. "LSTN", "MSTN".
 
     Parameters
     ----------
-    telescope_name: str
-        Telescope name
+    name: str
+        Array element name
 
     Returns
     -------
     str
-        Telescope type.
+        Array element type.
     """
     return _validate_name(name.split("-")[0], array_elements())
 
 
-def get_list_of_telescope_types(array_element_class="telescopes", site=None, observatory="CTAO"):
+def get_list_of_array_element_types(
+    array_element_class="telescopes", site=None, observatory="CTAO"
+):
     """
-    Get list of telescope types.
+    Get list of array element types.
 
     Parameters
     ----------
@@ -243,7 +247,7 @@ def get_list_of_telescope_types(array_element_class="telescopes", site=None, obs
     Returns
     -------
     list
-        List of telescope types.
+        List of array element types.
     """
     return [
         key
@@ -254,21 +258,21 @@ def get_list_of_telescope_types(array_element_class="telescopes", site=None, obs
     ]
 
 
-def get_site_from_telescope_name(name):
+def get_site_from_array_element_name(name):
     """
-    Get site name from telescope name.
+    Get site name from array element name.
 
     Parameters
     ----------
     name: str
-        Telescope name.
+        Array element name.
 
     Returns
     -------
     str
         Site name (South or North).
     """
-    return array_elements()[get_telescope_type_from_telescope_name(name)]["site"]
+    return array_elements()[get_array_element_type_from_name(name)]["site"]
 
 
 def get_collection_name_from_array_element_name(name):
@@ -285,7 +289,7 @@ def get_collection_name_from_array_element_name(name):
     str
         Collection name .
     """
-    return array_elements()[get_telescope_type_from_telescope_name(name)]["collection"]
+    return array_elements()[get_array_element_type_from_name(name)]["collection"]
 
 
 def get_simulation_software_name_from_parameter_name(

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -174,7 +174,7 @@ def validate_array_element_name(name):
     Parameters
     ----------
     name: str
-        array element name.
+        Array element name.
 
     Returns
     -------

--- a/simtools/visualization/plot_camera.py
+++ b/simtools/visualization/plot_camera.py
@@ -48,8 +48,7 @@ def plot_pixel_layout(camera, camera_in_sky_coor=False, pixels_id_to_print=50):
         if camera.pixels["pix_id"][i_pix] < pixels_id_to_print + 1:
             font_size = (
                 4
-                if "SCT"
-                in names.get_telescope_type_from_telescope_name(camera.telescope_model_name)
+                if "SCT" in names.get_array_element_type_from_name(camera.telescope_model_name)
                 else 2
             )
             plt.text(

--- a/simtools/visualization/visualize.py
+++ b/simtools/visualization/visualize.py
@@ -594,7 +594,7 @@ def get_telescope_patch(name, x, y, radius):
         Instance of mpatches.Circle.
     """
     tel_obj = leg_h.TelescopeHandler()
-    valid_name = names.get_telescope_type_from_telescope_name(name)
+    valid_name = names.get_array_element_type_from_name(name)
     fill_flag = False
 
     x = x.to(u.m)
@@ -677,7 +677,7 @@ def plot_array(
 
 
 def initialize_tel_counters():
-    return {one_telescope: 0 for one_telescope in names.get_list_of_telescope_types()}
+    return {one_telescope: 0 for one_telescope in names.get_list_of_array_element_types()}
 
 
 def get_rotated_positions(telescopes, rotate_angle):
@@ -709,7 +709,7 @@ def create_patches(telescopes, scale, marker_scaling, show_tel_label, ax, fontsi
         telescope_name = get_telescope_name(tel_now)
         update_tel_counters(tel_counters, telescope_name)
         sphere_radius = get_sphere_radius(tel_now)
-        i_tel_name = names.get_telescope_type_from_telescope_name(telescope_name)
+        i_tel_name = names.get_array_element_type_from_name(telescope_name)
         patches.append(
             get_telescope_patch(
                 i_tel_name,
@@ -752,7 +752,7 @@ def get_sphere_radius(tel_now):
 
 def update_legend(ax, tel_counters, legend_objects, legend_labels):
     """Update the legend with the telescope counts."""
-    for one_telescope in names.get_list_of_telescope_types():
+    for one_telescope in names.get_list_of_array_element_types():
         if tel_counters[one_telescope] > 0:
             legend_objects.append(leg_h.all_telescope_objects[one_telescope]())
             legend_labels.append(f"{one_telescope} ({tel_counters[one_telescope]})")

--- a/tests/unit_tests/db/test_db_from_repo_handler.py
+++ b/tests/unit_tests/db/test_db_from_repo_handler.py
@@ -16,7 +16,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
             db_from_repo_handler.update_model_parameters_from_repo(
                 parameters={},
                 site="North",
-                telescope_name="MSTN-01",
+                array_element_name="MSTN-01",
                 model_version="2024-02-01",
                 parameter_collection="telescopes",
                 db_simulation_model_url=None,
@@ -32,7 +32,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
         _pars_mstn = db_from_repo_handler.update_model_parameters_from_repo(
             parameters=dict.fromkeys(_pars_telescope_model, None),
             site="North",
-            telescope_name=_tel,
+            array_element_name=_tel,
             model_version="2024-02-01",
             parameter_collection="telescopes",
             db_simulation_model_url=simulation_model_url,
@@ -52,7 +52,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
     _pars_south = db_from_repo_handler.update_model_parameters_from_repo(
         parameters=dict.fromkeys(_pars_site_model, None),
         site="South",
-        telescope_name=None,
+        array_element_name=None,
         model_version="2024-02-01",
         parameter_collection="site",
         db_simulation_model_url=simulation_model_url,
@@ -65,7 +65,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
             db_from_repo_handler.update_model_parameters_from_repo(
                 parameters=dict.fromkeys(_pars_telescope_model, None),
                 site="North",
-                telescope_name="MSTN-01",
+                array_element_name="MSTN-01",
                 model_version="2024-02-01",
                 parameter_collection="not_a_collection",
                 db_simulation_model_url=simulation_model_url,
@@ -77,7 +77,7 @@ def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):
     db_from_repo_handler.update_model_parameters_from_repo(
         parameters=dict.fromkeys(_pars_site_model, None),
         site="South",
-        telescope_name=None,
+        array_element_name=None,
         model_version="2024-02-01",
         parameter_collection="site",
         db_simulation_model_url=simulation_model_url,
@@ -90,7 +90,7 @@ def test_update_telescope_parameters_from_repo(db_config, simulation_model_url):
     _pars = db_from_repo_handler.update_model_parameters_from_repo(
         parameters=dict.fromkeys(_pars_telescope_model, None),
         site="North",
-        telescope_name="MSTN-01",
+        array_element_name="MSTN-01",
         parameter_collection="telescopes",
         model_version="2024-02-01",
         db_simulation_model_url=simulation_model_url,
@@ -100,7 +100,7 @@ def test_update_telescope_parameters_from_repo(db_config, simulation_model_url):
     _pars_design = db_from_repo_handler.update_model_parameters_from_repo(
         parameters=dict.fromkeys(_pars_telescope_model, None),
         site="North",
-        telescope_name="MSTN-design",
+        array_element_name="MSTN-design",
         parameter_collection="telescopes",
         model_version="2024-02-01",
         db_simulation_model_url=simulation_model_url,
@@ -117,7 +117,7 @@ def test_update_site_parameters_from_repo(db_config):
     _pars = db_from_repo_handler.update_model_parameters_from_repo(
         parameters=dict.fromkeys(_pars_site_model, None),
         site="South",
-        telescope_name=None,
+        array_element_name=None,
         parameter_collection="site",
         model_version="2024-02-01",
         db_simulation_model_url=db_config["db_simulation_model_url"],

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -45,7 +45,7 @@ def _db_cleanup_file_sandbox(db_no_config_file, random_id):
     db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.files"].drop()
 
 
-def test_update_db_simulation_model(db, db_no_config_file, mocker, caplog):
+def test_update_db_simulation_model(db, db_no_config_file, mocker):
 
     db_no_config_file._update_db_simulation_model()
     assert db_no_config_file.mongo_db_config is None
@@ -56,10 +56,10 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker, caplog):
 
     db_copy = copy.deepcopy(db)
     db_copy.mongo_db_config["db_simulation_model"] = "DB_NAME-LATEST"
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa PT011
-            db_copy._update_db_simulation_model()
-        assert "Found LATEST in the DB name but no matching versions found in DB." in caplog.text
+    with pytest.raises(
+        ValueError, match=r"Found LATEST in the DB name but no matching versions found in DB."
+    ):
+        db_copy._update_db_simulation_model()
 
     db_names = [
         "CTAO-Simulation-Model-v0-3-0",
@@ -555,12 +555,12 @@ def test_get_all_available_array_elements(db, model_version, caplog):
     ]
     assert all(_t in available_telescopes for _t in expected_telescope_names)
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa PT011
-            db.get_all_available_array_elements(
-                model_version=model_version, collection="wrong_collection"
-            )
-        assert "Query for collection name wrong_collection not implemented." in caplog.text
+    with pytest.raises(
+        ValueError, match=r"^Query for collection name wrong_collection not implemented."
+    ):
+        db.get_all_available_array_elements(
+            model_version=model_version, collection="wrong_collection"
+        )
 
 
 def test_get_available_array_elements_of_type(db, model_version, caplog):
@@ -594,7 +594,7 @@ def test_parameter_cache_key(db):
     assert db._parameter_cache_key(None, None, "Prod5") == "2020-06-28"
 
 
-def test_model_version(db, caplog):
+def test_model_version(db):
 
     assert db.model_version(version="Released") == "2020-06-28"
     assert db.model_version(version="Latest") == "2020-06-28"
@@ -602,10 +602,8 @@ def test_model_version(db, caplog):
     assert db.model_version(version="Prod6") == "2024-02-01"
     assert db.model_version(version="prod6") == "2024-02-01"
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa PT011
-            db.model_version(version="test")
-        assert "Invalid model version test" in caplog.text
+    with pytest.raises(ValueError, match=r"Invalid model version test"):
+        db.model_version(version="test")
 
 
 def test_get_collections(db, db_config):

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -148,13 +148,13 @@ def test_get_sim_telarray_configuration_parameters(db, model_version):
 
 
 @pytest.mark.usefixtures("_db_cleanup")
-def test_copy_telescope_db(db, random_id, io_handler, model_version):
+def test_copy_array_element_db(db, random_id, io_handler, model_version):
     logger.info("----Testing copying a whole telescope-----")
-    db.copy_telescope(
+    db.copy_array_element(
         db_name=None,
-        tel_to_copy="LSTN-01",
+        element_to_copy="LSTN-01",
         version_to_copy=model_version,
-        new_tel_name="LSTN-test",
+        new_array_element_name="LSTN-test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
         collection_to_copy_to="telescopes_" + random_id,
@@ -168,7 +168,7 @@ def test_copy_telescope_db(db, random_id, io_handler, model_version):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name="LSTN-test",
+        array_element_name="LSTN-test",
         model_version=model_version,
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
@@ -187,7 +187,7 @@ def test_copy_telescope_db(db, random_id, io_handler, model_version):
     with pytest.raises(ValueError, match=r"The following query returned zero results"):
         db.read_mongo_db(
             db_name=f"sandbox_{random_id}",
-            telescope_model_name="LSTN-test",
+            array_element_name="LSTN-test",
             model_version=model_version,
             run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
             collection_name="telescopes_" + random_id,
@@ -217,11 +217,11 @@ def test_add_tagged_version(db, random_id, io_handler, model_version):
 @pytest.mark.usefixtures("_db_cleanup")
 def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     logger.info("----Testing adding a new parameter-----")
-    db.copy_telescope(
+    db.copy_array_element(
         db_name=None,
-        tel_to_copy="LSTN-01",
+        element_to_copy="LSTN-01",
         version_to_copy=model_version,
-        new_tel_name="LSTN-test",
+        new_array_element_name="LSTN-test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
         collection_to_copy_to="telescopes_" + random_id,
@@ -232,7 +232,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_str",
         value="hello",
@@ -240,7 +240,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_int",
         value=999,
@@ -248,7 +248,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_float",
         value=999.9,
@@ -256,7 +256,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_quantity",
         value=999.9 * u.m,
@@ -264,7 +264,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_quantity_str",
         value="999.9 cm",
@@ -272,7 +272,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         version="test",
         parameter="new_test_parameter_simtel_list",
         value="0.969 0.0 0.0 0.0 0.0 0.0",
@@ -281,7 +281,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name="LSTN-test",
+        array_element_name="LSTN-test",
         model_version="test",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
@@ -316,7 +316,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name="North",
+        array_element_name="North",
         model_version="test",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="sites_" + random_id,
@@ -328,7 +328,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     # calibration_devices parameters
     db.add_new_parameter(
         db_name=f"sandbox_{random_id}",
-        telescope="ILLN-design",
+        array_element_name="ILLN-design",
         version="test",
         parameter="led_pulse_offset",
         value="0 ns",
@@ -336,7 +336,7 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name="ILLN-design",
+        array_element_name="ILLN-design",
         model_version="test",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="calibration_devices_" + random_id,
@@ -360,11 +360,11 @@ def test_adding_new_parameter_db(db, random_id, io_handler, model_version):
 @pytest.mark.usefixtures("_db_cleanup")
 def test_update_parameter_field_db(db, random_id, io_handler):
     logger.info("----Testing modifying a field of a parameter-----")
-    db.copy_telescope(
+    db.copy_array_element(
         db_name=None,
-        tel_to_copy="LSTN-01",
+        element_to_copy="LSTN-01",
         version_to_copy="Released",
-        new_tel_name="LSTN-test",
+        new_array_element_name="LSTN-test",
         collection_name="telescopes",
         db_to_copy_to=f"sandbox_{random_id}",
         collection_to_copy_to="telescopes_" + random_id,
@@ -382,7 +382,7 @@ def test_update_parameter_field_db(db, random_id, io_handler):
     )
     db.update_parameter_field(
         db_name=f"sandbox_{random_id}",
-        telescope="LSTN-test",
+        array_element_name="LSTN-test",
         model_version="Released",
         parameter="camera_pixels",
         field="applicable",
@@ -391,7 +391,7 @@ def test_update_parameter_field_db(db, random_id, io_handler):
     )
     pars = db.read_mongo_db(
         db_name=f"sandbox_{random_id}",
-        telescope_model_name="LSTN-test",
+        array_element_name="LSTN-test",
         model_version="Released",
         run_location=io_handler.get_output_directory(sub_dir="model", dir_type="test"),
         collection_name="telescopes_" + random_id,
@@ -399,12 +399,10 @@ def test_update_parameter_field_db(db, random_id, io_handler):
     )
     assert pars["camera_pixels"]["applicable"] is False
 
-    with pytest.raises(
-        ValueError, match=r"You need to specify if to update a telescope or a site."
-    ):
+    with pytest.raises(ValueError, match=r"You need to specify an array element or a site."):
         db.update_parameter_field(
             db_name=f"sandbox_{random_id}",
-            telescope=None,
+            array_element_name=None,
             site=None,
             model_version="2024-02-01",
             parameter="not_important",
@@ -504,7 +502,7 @@ def test_insert_files_db(db, io_handler, random_id, caplog):
 def test_get_all_versions(db, mocker, caplog):
     # not specifying a telescope model name and parameter
     all_versions = db.get_all_versions(
-        telescope_model_name=None,
+        array_element_name=None,
         site="North",
         parameter=None,
         collection="telescopes",
@@ -513,7 +511,7 @@ def test_get_all_versions(db, mocker, caplog):
 
     # using a specific parameter
     all_versions = db.get_all_versions(
-        telescope_model_name="LSTN-01",
+        array_element_name="LSTN-01",
         site="North",
         parameter="camera_config_file",
         collection="telescopes",
@@ -573,18 +571,18 @@ def test_get_available_array_elements_of_type(db, model_version, caplog):
     assert all("design" not in tel_type for tel_type in available_types)
 
 
-def test_get_telescope_db_name(db):
-    assert db.get_telescope_db_name("LSTN-01", model_version="Prod5") == "LSTN-01"
-    assert db.get_telescope_db_name("LSTS-20", model_version="Prod5") == "LSTS-design"
-    assert db.get_telescope_db_name("LSTN-design", model_version="Prod5") == "LSTN-design"
-    assert db.get_telescope_db_name("LSTS-design", model_version="Prod5") == "LSTS-design"
-    assert db.get_telescope_db_name("SSTS-91", model_version="Prod5") == "SSTS-design"
-    assert db.get_telescope_db_name("SSTS-design", model_version="Prod5") == "SSTS-design"
+def test_get_array_element_db_name(db):
+    assert db.get_array_element_db_name("LSTN-01", model_version="Prod5") == "LSTN-01"
+    assert db.get_array_element_db_name("LSTS-20", model_version="Prod5") == "LSTS-design"
+    assert db.get_array_element_db_name("LSTN-design", model_version="Prod5") == "LSTN-design"
+    assert db.get_array_element_db_name("LSTS-design", model_version="Prod5") == "LSTS-design"
+    assert db.get_array_element_db_name("SSTS-91", model_version="Prod5") == "SSTS-design"
+    assert db.get_array_element_db_name("SSTS-design", model_version="Prod5") == "SSTS-design"
     with pytest.raises(ValueError, match=r"Invalid name SSTN"):
-        db.get_telescope_db_name("SSTN-05", model_version="Prod5", collection="telescopes")
+        db.get_array_element_db_name("SSTN-05", model_version="Prod5", collection="telescopes")
 
     with pytest.raises(ValueError, match=r"Invalid database name."):
-        db.get_telescope_db_name("ILLN-01", model_version="Prod5", collection="telescopes")
+        db.get_array_element_db_name("ILLN-01", model_version="Prod5", collection="telescopes")
 
 
 def test_parameter_cache_key(db):

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -74,12 +74,10 @@ def array_layout_south_four_lst_instance(db_config, model_version):
     )
 
 
-def test_initialize_site_parameters_from_db(caplog):
+def test_initialize_site_parameters_from_db():
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError):  # noqa PT011
-            ArrayLayout(site="North", mongo_db_config=None, model_version="test_model_version")
-    assert "No database configuration provided" in caplog.text
+    with pytest.raises(ValueError, match="No database configuration provided"):
+        ArrayLayout(site="North", mongo_db_config=None, model_version="test_model_version")
 
 
 def test_initialize_coordinate_systems(

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -17,8 +17,8 @@ def invalid_name():
     return "Invalid name"
 
 
-def test_get_list_of_telescope_types():
-    assert names.get_list_of_telescope_types(array_element_class="telescopes", site=None) == [
+def test_get_list_of_array_element_types():
+    assert names.get_list_of_array_element_types(array_element_class="telescopes", site=None) == [
         "LSTN",
         "MSTN",
         "LSTS",
@@ -27,19 +27,23 @@ def test_get_list_of_telescope_types():
         "SCTS",
     ]
 
-    assert names.get_list_of_telescope_types(array_element_class="telescopes", site="North") == [
+    assert names.get_list_of_array_element_types(
+        array_element_class="telescopes", site="North"
+    ) == [
         "LSTN",
         "MSTN",
     ]
 
-    assert names.get_list_of_telescope_types(array_element_class="telescopes", site="South") == [
+    assert names.get_list_of_array_element_types(
+        array_element_class="telescopes", site="South"
+    ) == [
         "LSTS",
         "MSTS",
         "SSTS",
         "SCTS",
     ]
 
-    assert "ILLN" in names.get_list_of_telescope_types(
+    assert "ILLN" in names.get_list_of_array_element_types(
         array_element_class="calibration_devices", site="North"
     )
 
@@ -66,7 +70,7 @@ def test_validate_name():
             assert key == names._validate_name(_tel, with_lists_in_dicts)
 
 
-def test_validate_telescope_id_name(caplog):
+def test_validate_array_element_id_name(caplog):
     _test_ids = {
         "1": "01",
         "01": "01",
@@ -77,16 +81,14 @@ def test_validate_telescope_id_name(caplog):
         "TEST": "test",
     }
     for key, value in _test_ids.items():
-        assert value == names.validate_telescope_id_name(key)
+        assert value == names.validate_array_element_id_name(key)
 
-    assert "01" == names.validate_telescope_id_name(1)
-    assert "11" == names.validate_telescope_id_name(11)
+    assert "01" == names.validate_array_element_id_name(1)
+    assert "11" == names.validate_array_element_id_name(11)
 
     for _id in ["no_id", "D2345"]:
-        with caplog.at_level(logging.ERROR):
-            with pytest.raises(ValueError, match=r"^Invalid telescope ID name"):
-                names.validate_telescope_id_name(_id)
-            assert f"Invalid telescope ID name {_id}" in caplog.text
+        with pytest.raises(ValueError, match=r"^Invalid array element ID name"):
+            names.validate_array_element_id_name(_id)
 
 
 def test_validate_site_name(invalid_name):
@@ -97,7 +99,7 @@ def test_validate_site_name(invalid_name):
         names.validate_site_name("Not a site")
 
 
-def test_validate_telescope_name(invalid_name):
+def test_validate_array_element_name(invalid_name):
     telescopes = {
         "LSTN-Design": "LSTN-design",
         "LSTN-TEST": "LSTN-test",
@@ -107,35 +109,35 @@ def test_validate_telescope_name(invalid_name):
 
     for key, value in telescopes.items():
         logging.getLogger().info(f"Validating {key}")
-        new_name = names.validate_telescope_name(key)
+        new_name = names.validate_array_element_name(key)
         logging.getLogger().info(f"New name {new_name}")
         assert value == new_name
 
     with pytest.raises(ValueError, match=rf"^{invalid_name}"):
-        names.validate_telescope_name("South-MST-FlashCam-D")
+        names.validate_array_element_name("South-MST-FlashCam-D")
     with pytest.raises(ValueError, match=rf"^{invalid_name}"):
-        names.validate_telescope_name("LSTN")
+        names.validate_array_element_name("LSTN")
 
 
-def test_get_telescope_name_from_type_site_id():
-    assert "LSTN-01" == names.get_telescope_name_from_type_site_id("LST", "North", "01")
-    assert "LSTN-01" == names.get_telescope_name_from_type_site_id("LST", "North", "1")
-    assert "LSTS-01" == names.get_telescope_name_from_type_site_id("LST", "South", "01")
+def test_get_array_element_name_from_type_site_id():
+    assert "LSTN-01" == names.get_array_element_name_from_type_site_id("LST", "North", "01")
+    assert "LSTN-01" == names.get_array_element_name_from_type_site_id("LST", "North", "1")
+    assert "LSTS-01" == names.get_array_element_name_from_type_site_id("LST", "South", "01")
 
 
-def test_get_site_from_telescope_name(invalid_name):
-    assert "North" == names.get_site_from_telescope_name("MSTN")
-    assert "North" == names.get_site_from_telescope_name("MSTN-05")
-    assert "South" == names.get_site_from_telescope_name("MSTS-05")
+def test_get_site_from_array_element_name(invalid_name):
+    assert "North" == names.get_site_from_array_element_name("MSTN")
+    assert "North" == names.get_site_from_array_element_name("MSTN-05")
+    assert "South" == names.get_site_from_array_element_name("MSTS-05")
     with pytest.raises(ValueError, match=rf"^{invalid_name}"):
-        names.get_site_from_telescope_name("LSTW")
+        names.get_site_from_array_element_name("LSTW")
 
 
 def test_get_class_from_telescope_name(invalid_name):
     assert "telescopes" == names.get_collection_name_from_array_element_name("LSTN-01")
     assert "calibration_devices" == names.get_collection_name_from_array_element_name("ILLS-01")
     with pytest.raises(ValueError, match=rf"^{invalid_name}"):
-        names.get_site_from_telescope_name("SATW")
+        names.get_site_from_array_element_name("SATW")
 
 
 def test_sanitize_name(caplog):
@@ -149,16 +151,16 @@ def test_sanitize_name(caplog):
         names.sanitize_name("")
 
 
-def test_get_telescope_type_from_telescope_name(invalid_name):
-    assert names.get_telescope_type_from_telescope_name("LSTN-01") == "LSTN"
-    assert names.get_telescope_type_from_telescope_name("MSTN-02") == "MSTN"
-    assert names.get_telescope_type_from_telescope_name("SSTS-27") == "SSTS"
-    assert names.get_telescope_type_from_telescope_name("SCTS-27") == "SCTS"
-    assert names.get_telescope_type_from_telescope_name("MAGIC-2") == "MAGIC"
-    assert names.get_telescope_type_from_telescope_name("VERITAS-4") == "VERITAS"
+def test_get_array_element_type_from_name(invalid_name):
+    assert names.get_array_element_type_from_name("LSTN-01") == "LSTN"
+    assert names.get_array_element_type_from_name("MSTN-02") == "MSTN"
+    assert names.get_array_element_type_from_name("SSTS-27") == "SSTS"
+    assert names.get_array_element_type_from_name("SCTS-27") == "SCTS"
+    assert names.get_array_element_type_from_name("MAGIC-2") == "MAGIC"
+    assert names.get_array_element_type_from_name("VERITAS-4") == "VERITAS"
     for _name in ["", "01", "Not_a_telescope", "LST", "MST"]:
         with pytest.raises(ValueError, match=rf"^{invalid_name}"):
-            names.get_telescope_type_from_telescope_name(_name)
+            names.get_array_element_type_from_name(_name)
 
 
 def test_generate_file_name_camera_efficiency():

--- a/tests/unit_tests/visualization/test_legend_handlers.py
+++ b/tests/unit_tests/visualization/test_legend_handlers.py
@@ -41,7 +41,7 @@ def test_handlers(io_handler):
 
     tel_handler = leg_h.TelescopeHandler()
     assert len(tel_handler.colors_dict) == len(
-        names.get_list_of_telescope_types(
+        names.get_list_of_array_element_types(
             array_element_class="telescopes", site=None, observatory=None
         )
     )

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -93,7 +93,7 @@ def test_add_unit():
 def test_get_telescope_patch(io_handler):
     def test_one_site(x, y):
         _test_radius = 15.0
-        for tel_type in names.get_list_of_telescope_types():
+        for tel_type in names.get_list_of_array_element_types():
             patch = visualize.get_telescope_patch(tel_type, x, y, _test_radius * u.m)
             if mpatches.Circle == type(patch):
                 assert patch.radius == _test_radius


### PR DESCRIPTION
Mostly a scripted name change from telescope to array_element in the modules mention above. This generalizes the functions and names to take into account the we simulate telescopes and calibration devices.

Closes #871 