### PR TITLE
Ignore pre-releases of the model parameter database

### DIFF
--- a/simtools/db/db_handler.py
+++ b/simtools/db/db_handler.py
@@ -108,10 +108,11 @@ class DatabaseHandler:
 
     def _update_db_simulation_model(self):
         """
-        Find the latest version (if requested) of the simulation model and update the DB config.
+        Find the latest released version of the simulation model and update the DB config.
 
         This is indicated by adding "LATEST" to the name of the simulation model database
         (field "db_simulation_model" in the database configuration dictionary).
+        Only release versions are considered, pre-releases are ignored.
 
         Raises
         ------
@@ -129,11 +130,14 @@ class DatabaseHandler:
         list_of_db_names = self.db_client.list_database_names()
         filtered_list_of_db_names = [s for s in list_of_db_names if s.startswith(prefix)]
         versioned_strings = []
-        version_pattern = re.compile(rf"{re.escape(prefix)}v(\d+)-(\d+)-(\d+)")
+        version_pattern = re.compile(
+            rf"{re.escape(prefix)}v(\d+)-(\d+)-(\d+)(?:-([a-zA-Z0-9_.]+))?"
+        )
 
         for s in filtered_list_of_db_names:
             match = version_pattern.search(s)
-            if match:
+            # A version is considered a pre-release if it contains a '-' character (re group 4)
+            if match and match.group(4) is None:
                 version_str = match.group(1) + "." + match.group(2) + "." + match.group(3)
                 version = Version(version_str)
                 versioned_strings.append((s, version))

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -68,6 +68,9 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker):
         "CTAO-Simulation-Model-v0-3-9",
         "CTAO-Simulation-Model-v0-3-19",
         "CTAO-Simulation-Model-v0-3-0",
+        "CTAO-Simulation-Model-v0-3-0-alpha-2",
+        "CTAO-Simulation-Model-v0-4-19-alpha-1",
+        "CTAO-Simulation-Model-v0-4-19-dev1",
     ]
     mocker.patch.object(db_copy.db_client, "list_database_names", return_value=db_names)
     db_copy.mongo_db_config["db_simulation_model"] = "CTAO-Simulation-Model-LATEST"


### PR DESCRIPTION
Minor changes to skip pre-releases when selecting the latest version of the model parameter database.

Using the definition from semantic versioning, where pre-releases are added as additional string (e.g., 5.0.0-alpha.1).

Closes #1115 