### PR TITLE
Bug fix in reading model versions

### DIFF
--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -542,7 +542,7 @@ def test_get_all_versions(db, mocker, caplog):
     mocker.patch.object(db, "_get_db_name", return_value=None)
     with caplog.at_level(logging.WARNING):
         assert db.get_all_versions() == []
-    assert "did not return any results. No versions found" in caplog.text
+    assert "No database name defined to determine" in caplog.text
 
 
 def test_get_all_available_array_elements(db, model_version, caplog):
@@ -628,6 +628,7 @@ def test_get_collections(db, db_config):
     assert isinstance(collections_no_model, list)
     assert "telescopes" in collections_no_model
     assert "fs.files" not in collections_no_model
+    assert "metadata" not in collections_no_model
 
 
 def test_model_version_empty(db, mocker):

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -45,13 +45,13 @@ def _db_cleanup_file_sandbox(db_no_config_file, random_id):
     db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.files"].drop()
 
 
-def test_update_db_simulation_model(db, db_no_config_file, mocker):
+def test_find_latest_simulation_model_db(db, db_no_config_file, mocker):
 
-    db_no_config_file._update_db_simulation_model()
+    db_no_config_file._find_latest_simulation_model_db()
     assert db_no_config_file.mongo_db_config is None
 
     db_name = db.mongo_db_config["db_simulation_model"]
-    db._update_db_simulation_model()
+    db._find_latest_simulation_model_db()
     assert db_name == db.mongo_db_config["db_simulation_model"]
 
     db_copy = copy.deepcopy(db)
@@ -59,7 +59,7 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker):
     with pytest.raises(
         ValueError, match=r"Found LATEST in the DB name but no matching versions found in DB."
     ):
-        db_copy._update_db_simulation_model()
+        db_copy._find_latest_simulation_model_db()
 
     db_names = [
         "CTAO-Simulation-Model-v0-3-0",
@@ -71,7 +71,7 @@ def test_update_db_simulation_model(db, db_no_config_file, mocker):
     ]
     mocker.patch.object(db_copy.db_client, "list_database_names", return_value=db_names)
     db_copy.mongo_db_config["db_simulation_model"] = "CTAO-Simulation-Model-LATEST"
-    db_copy._update_db_simulation_model()
+    db_copy._find_latest_simulation_model_db()
     assert db_copy.mongo_db_config["db_simulation_model"] == "CTAO-Simulation-Model-v0-3-19"
 
 


### PR DESCRIPTION
Fix a bug noticed while running `simtools-db-add-model-parameters-from-repository-to-db` in the CI of the gitlab model_parameter repository (see [here](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/jobs/218577)).

Issue:

- `db_handler::_get_all_versions()` requires the existence of no collections or at least the telescope collection to be available when reading the model versions from the DB
- gitlab CI run starts by adding a file to the collection `calibration_devices`. This leads to a failure when trying to add a second file.

Solution:

`db_handler::_get_all_versions()` default collection is now 'None', in which case we query all collections to get the list of available model parameter versions.

This is a solution for now and probably works only as long as we have all model parameters for each model parameter version in the repository / DB (in future, we probably have only changes relative to a baseline model).

Unrelated minor change: improved naming by renaming `update_db_simulation_model`. to `_find_latest_simulation_model_db`.


