### PR TITLE
Improve primary particle API

### DIFF
--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -328,7 +328,6 @@ class CorsikaConfig:
         """
         if not args_dict or args_dict.get("primary_id_type") is None:
             return PrimaryParticle()
-        print("FFFF", args_dict.get("primary_id_type"), args_dict["primary"])
         return PrimaryParticle(
             particle_id_type=args_dict.get("primary_id_type"), particle_id=args_dict.get("primary")
         )

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -326,15 +326,12 @@ class CorsikaConfig:
             Primary particle.
 
         """
-        if not args_dict:
+        if not args_dict or args_dict.get("primary_id_type") is None:
             return PrimaryParticle()
-        if args_dict.get("primary_id_type") == "common_name":
-            return PrimaryParticle(name=args_dict.get("primary"))
-        if args_dict.get("primary_id_type") == "corsika7_id":
-            return PrimaryParticle(corsika7_id=int(args_dict.get("primary")))
-        if args_dict.get("primary_id_type") == "pdg_id":
-            return PrimaryParticle(pdg_id=int(args_dict.get("primary")))
-        return PrimaryParticle()
+        print("FFFF", args_dict.get("primary_id_type"), args_dict["primary"])
+        return PrimaryParticle(
+            particle_id_type=args_dict.get("primary_id_type"), particle_id=args_dict.get("primary")
+        )
 
     def get_config_parameter(self, par_name):
         """

--- a/simtools/corsika/primary_particle.py
+++ b/simtools/corsika/primary_particle.py
@@ -30,10 +30,11 @@ class PrimaryParticle:
 
         valid_id_types = {"corsika7_id", "common_name", "pdg_id"}
 
-        if (particle_id_type is None) != (particle_id is None):
-            raise ValueError("Both 'particle_id_type' and 'particle_id' must be provided.")
-        if particle_id_type is not None and particle_id_type not in valid_id_types:
+        if bool(particle_id_type) != bool(particle_id):
+            raise ValueError("Both 'particle_id_type' and 'particle_id' must be provided together.")
+        if particle_id_type and particle_id_type not in valid_id_types:
             raise ValueError(f"Particle ID type must be one of {valid_id_types}")
+
         if particle_id_type == "corsika7_id":
             self.corsika7_id = particle_id
         elif particle_id_type == "common_name":

--- a/simtools/corsika/primary_particle.py
+++ b/simtools/corsika/primary_particle.py
@@ -28,10 +28,10 @@ class PrimaryParticle:
         self._pdg_id = None
         self._pdg_name = None
 
-        valid_id_types = {"corsika7_id", "common_name", "pdg_id"}
-
         if bool(particle_id_type) != bool(particle_id):
             raise ValueError("Both 'particle_id_type' and 'particle_id' must be provided together.")
+
+        valid_id_types = {"corsika7_id", "common_name", "pdg_id"}
         if particle_id_type and particle_id_type not in valid_id_types:
             raise ValueError(f"Particle ID type must be one of {valid_id_types}")
 
@@ -142,8 +142,8 @@ class PrimaryParticle:
             "gamma": {"corsika7_id": 1},
             "electron": {"corsika7_id": 3},
             "positron": {"corsika7_id": 2},
-            "muon-": {"corsika7_id": 5},
-            "muon+": {"corsika7_id": 6},
+            "muon+": {"corsika7_id": 5},
+            "muon-": {"corsika7_id": 6},
             "proton": {"corsika7_id": 14},
             "neutron": {"corsika7_id": 13},
             "helium": {"corsika7_id": 402},

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -51,6 +51,11 @@ def test_corsika7_id():
     with pytest.raises(ValueError, match="Invalid CORSIKA7 ID: 9999"):
         PrimaryParticle(particle_id_type="corsika7_id", particle_id=9999)
 
+    eta = PrimaryParticle(particle_id_type="corsika7_id", particle_id=17)
+    assert eta.corsika7_id == 17
+    assert eta.name == "eta"
+    assert eta.pdg_id == 221
+
 
 def test_common_name():
     p = PrimaryParticle(particle_id_type="common_name", particle_id="proton")

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -16,70 +16,83 @@ def test_init():
 
     assert p.corsika7_id is None
 
+    with pytest.raises(
+        ValueError, match="Both 'particle_id_type' and 'particle_id' must be provided."
+    ):
+        PrimaryParticle(particle_id_type="corsika7_id")
+    with pytest.raises(
+        ValueError, match="Both 'particle_id_type' and 'particle_id' must be provided."
+    ):
+        PrimaryParticle(particle_id_type="common_name")
+    with pytest.raises(ValueError, match="Particle ID type must be one of"):
+        PrimaryParticle(particle_id_type="invalid_type", particle_id=14)
+
 
 def test_str():
-    p = PrimaryParticle(corsika7_id=14)
+    p = PrimaryParticle(particle_id_type="corsika7_id", particle_id=14)
     assert str(p) == "proton (14, 2212, p)"
 
-    fe = PrimaryParticle(corsika7_id=5626)
+    fe = PrimaryParticle(particle_id_type="corsika7_id", particle_id=5626)
     assert str(fe) == "iron (5626, 1000260560, Fe56)"
 
 
 def test_corsika7_id():
-    p = PrimaryParticle(corsika7_id=14)
+    p = PrimaryParticle(particle_id_type="corsika7_id", particle_id=14)
 
     assert p.corsika7_id == 14
     assert p.name == "proton"
     assert p.pdg_id == 2212
 
-    si = PrimaryParticle(corsika7_id=2814)
+    si = PrimaryParticle(particle_id_type="corsika7_id", particle_id=2814)
     assert si.corsika7_id == 2814
     assert si.name == "silicon"
     assert si.pdg_id == 1000140280
 
     with pytest.raises(ValueError, match="Invalid CORSIKA7 ID: 9999"):
-        PrimaryParticle(corsika7_id=9999)
+        PrimaryParticle(particle_id_type="corsika7_id", particle_id=9999)
 
 
 def test_common_name():
-    p = PrimaryParticle(name="proton")
+    p = PrimaryParticle(particle_id_type="common_name", particle_id="proton")
 
     assert p.corsika7_id == 14
     assert p.name == "proton"
     assert p.pdg_id == 2212
 
-    pi0 = PrimaryParticle(name="pi0")
+    pi0 = PrimaryParticle(particle_id_type="common_name", particle_id="pi0")
     assert pi0.corsika7_id == 7
     assert pi0.name == "pi0"
     assert pi0.pdg_id == 111
 
     with pytest.raises(ValueError, match=r"Found more than one particle with name pi"):
-        PrimaryParticle(name="pi")
+        PrimaryParticle(particle_id_type="common_name", particle_id="pi")
 
     with pytest.raises(
         ValueError, match="Invalid particle name: the_particle_which_explains_nothing"
     ):
-        PrimaryParticle(name="the_particle_which_explains_nothing")
+        PrimaryParticle(
+            particle_id_type="common_name", particle_id="the_particle_which_explains_nothing"
+        )
 
 
 def test_pdg_id(caplog):
-    p = PrimaryParticle(pdg_id=2212)
+    p = PrimaryParticle(particle_id_type="pdg_id", particle_id=2212)
 
     assert p.corsika7_id == 14
     assert p.name == "proton"
     assert p.pdg_id == 2212
 
-    fe = PrimaryParticle(pdg_id=1000260560)
+    fe = PrimaryParticle(particle_id_type="pdg_id", particle_id=1000260560)
     assert fe.corsika7_id == 5626
     assert fe.name == "iron"
     assert fe.pdg_id == 1000260560
 
-    pi0 = PrimaryParticle(pdg_id=111)
+    pi0 = PrimaryParticle(particle_id_type="pdg_id", particle_id=111)
     assert pi0.corsika7_id == 7
     assert pi0.name == "pi0"
 
     with pytest.raises(ValueError, match="Invalid DPG ID: 9999"):
-        PrimaryParticle(pdg_id=9999)
+        PrimaryParticle(particle_id_type="pdg_id", particle_id=9999)
 
 
 def test_particle_names():


### PR DESCRIPTION
Address two issues regarding the PrimaryParticle class:

1. PrimaryParticle should be declared with either the corsika_id or the pdg_id or the name. This is the intended use case, but the constructor allowed to define mismatching particle IDs (see #1126 ).
2. PrimaryParticle relies the the particle actually appears in a dict (`particle_names`). This is required as we want to allow for the somewhat different naming in CTA compared to PDG (e.g., a proton is a `proton` in the CTA simulation language but a `p` in PDG). Changed the functionality now that particles which are not in the dict use the name provided from PDG.
3. Fixed issue #1125 and allow to create `muon-` and `muon+`.

@maxnoe suggested a slightly different implementation of 1. The reason for choosing `PrimaryParticle(particle_id_type, particle_id)` is that this allows a clean configuration of this class with no if statements in corsika_config.
