### PR TITLE
Test for two new lines at end of sim_telarray configuration file writing

### DIFF
--- a/simtools/simtel/simtel_config_writer.py
+++ b/simtools/simtel/simtel_config_writer.py
@@ -186,7 +186,7 @@ class SimtelConfigWriter:
                 file.write(f"%{tel_name}\n")
                 file.write(f"#elif TELESCOPE == {count + 1}\n\n")
                 file.write(f"# include <{tel_config_file}>\n\n")
-            file.write("#endif \n\n")
+            file.write("#endif \n\n")  # configuration files need to end with \n\n
 
     def write_single_mirror_list_file(
         self, mirror_number, mirrors, single_mirror_list_file, set_focal_length_to_zero=False

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -41,7 +41,7 @@ def test_write_array_config_file(
     # simtel configuration files need to end with two new lines
     with open(file) as f:
         lines = f.readlines()
-        assert lines[-2].endswith("#endif \n")
+        assert lines[-2].endswith("\n")
         assert lines[-1] == "\n"
 
 

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -38,6 +38,12 @@ def test_write_array_config_file(
     )
     assert file_has_text(file, "TELESCOPE == 1")
 
+    # simtel configuration files need to end with two new lines
+    with open(file) as f:
+        lines = f.readlines()
+        assert lines[-2].endswith("#endif \n")
+        assert lines[-1] == "\n"
+
 
 def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
     file = io_handler.get_output_file(


### PR DESCRIPTION
Addresses #455 :

- added a comment into to code that this is required at the end of a configuration file
- added unittest to test that the written simtel configuration file ends with `\n\n`  

Closes #455 
