### PR TITLE
Introduce simtools testing modules; move tests from integration tests into this module

### DIFF
--- a/simtools/testing/assertions.py
+++ b/simtools/testing/assertions.py
@@ -32,7 +32,6 @@ def assert_file_type(file_type, file_name):
         try:
             with open(file_name, encoding="utf-8") as file:
                 yaml.safe_load(file)
-            print("FFFF safe load", file_name)
             return True
         except (yaml.YAMLError, FileNotFoundError):
             return False

--- a/simtools/testing/assertions.py
+++ b/simtools/testing/assertions.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 
 import yaml
 
@@ -31,13 +32,11 @@ def assert_file_type(file_type, file_name):
         try:
             with open(file_name, encoding="utf-8") as file:
                 yaml.safe_load(file)
+            print("FFFF safe load", file_name)
             return True
         except (yaml.YAMLError, FileNotFoundError):
             return False
 
     # no dedicated tests for other file types, checking suffix only
     _logger.info(f"File type test is checking suffix only for {file_name} (suffix: {file_type}))")
-    if file_name.suffix[1:] == file_type:
-        return True
-
-    return False
+    return Path(file_name).suffix[1:] == file_type

--- a/simtools/testing/assertions.py
+++ b/simtools/testing/assertions.py
@@ -1,0 +1,43 @@
+"""Functions asserting certain conditions are met (used e.g., in integration tests)."""
+
+import json
+import logging
+
+import yaml
+
+_logger = logging.getLogger(__name__)
+
+
+def assert_file_type(file_type, file_name):
+    """
+    Assert that the file is of the given type.
+
+    Parameters
+    ----------
+    file_type: str
+        File type (json, yaml).
+    file_name: str
+        File name.
+
+    """
+    if file_type == "json":
+        try:
+            with open(file_name, encoding="utf-8") as file:
+                json.load(file)
+            return True
+        except (json.JSONDecodeError, FileNotFoundError):
+            return False
+    if file_type in ("yaml", "yml"):
+        try:
+            with open(file_name, encoding="utf-8") as file:
+                yaml.safe_load(file)
+            return True
+        except (yaml.YAMLError, FileNotFoundError):
+            return False
+
+    # no dedicated tests for other file types, checking suffix only
+    _logger.info(f"File type test is checking suffix only for {file_name} (suffix: {file_type}))")
+    if file_name.suffix[1:] == file_type:
+        return True
+
+    return False

--- a/simtools/testing/assertions.py
+++ b/simtools/testing/assertions.py
@@ -29,6 +29,8 @@ def assert_file_type(file_type, file_name):
         except (json.JSONDecodeError, FileNotFoundError):
             return False
     if file_type in ("yaml", "yml"):
+        if Path(file_name).suffix[1:] not in ("yaml", "yml"):
+            return False
         try:
             with open(file_name, encoding="utf-8") as file:
                 yaml.safe_load(file)

--- a/simtools/testing/compare_output.py
+++ b/simtools/testing/compare_output.py
@@ -13,7 +13,7 @@ _logger = logging.getLogger(__name__)
 
 def compare_files(file1, file2, tolerance=1.0e-5):
     """
-    Compare two files of file type ecsv or json.
+    Compare two files of file type ecsv, json or yaml.
 
     Parameters
     ----------

--- a/simtools/testing/compare_output.py
+++ b/simtools/testing/compare_output.py
@@ -1,6 +1,7 @@
 """Compare application output to reference output."""
 
 import logging
+from pathlib import Path
 
 import numpy as np
 from astropy.table import Table
@@ -29,18 +30,22 @@ def compare_files(file1, file2, tolerance=1.0e-5):
         True if the files are equal, False otherwise.
 
     """
-    if str(file1).endswith(".ecsv") and str(file2).endswith(".ecsv"):
+    _file1_suffix = Path(file1).suffix
+    _file2_suffix = Path(file2).suffix
+    if _file1_suffix != _file2_suffix:
+        raise ValueError(f"File suffixes do not match: {file1} and {file2}")
+    if _file1_suffix == ".ecsv":
         return compare_ecsv_files(file1, file2, tolerance)
-    if str(file1).endswith(".json") and str(file2).endswith(".json"):
-        return compare_json_files(file1, file2)
+    if _file1_suffix in (".json", ".yaml", ".yml"):
+        return compare_json_or_yaml_files(file1, file2)
 
     _logger.warning(f"Unknown file type for files: {file1} and {file2}")
     return False
 
 
-def compare_json_files(file1, file2, tolerance=1.0e-2):
+def compare_json_or_yaml_files(file1, file2, tolerance=1.0e-2):
     """
-    Compare two json files.
+    Compare two json or yaml files.
 
     Take into account float comparison for sim_telarray string-embedded floats.
 
@@ -62,7 +67,7 @@ def compare_json_files(file1, file2, tolerance=1.0e-2):
     data1 = gen.collect_data_from_file_or_dict(file1, in_dict=None)
     data2 = gen.collect_data_from_file_or_dict(file2, in_dict=None)
 
-    _logger.debug(f"Comparing json files: {file1} and {file2}")
+    _logger.debug(f"Comparing json/yaml files: {file1} and {file2}")
 
     if data1 == data2:
         return True

--- a/simtools/testing/compare_output.py
+++ b/simtools/testing/compare_output.py
@@ -1,0 +1,108 @@
+"""Compare application output to reference output."""
+
+import logging
+
+import numpy as np
+from astropy.table import Table
+
+import simtools.utils.general as gen
+
+_logger = logging.getLogger(__name__)
+
+
+def compare_files(file1, file2, tolerance=1.0e-5):
+    """
+    Compare two files of file type ecsv or json.
+
+    Parameters
+    ----------
+    file1: str
+        First file to compare
+    file2: str
+        Second file to compare
+    tolerance: float
+        Tolerance for comparing numerical values.
+
+    Returns
+    -------
+    bool
+        True if the files are equal, False otherwise.
+
+    """
+    if str(file1).endswith(".ecsv") and str(file2).endswith(".ecsv"):
+        return compare_ecsv_files(file1, file2, tolerance)
+    if str(file1).endswith(".json") and str(file2).endswith(".json"):
+        return compare_json_files(file1, file2)
+
+    _logger.warning(f"Unknown file type for files: {file1} and {file2}")
+    return False
+
+
+def compare_json_files(file1, file2, tolerance=1.0e-2):
+    """
+    Compare two json files.
+
+    Take into account float comparison for sim_telarray string-embedded floats.
+
+    Parameters
+    ----------
+    file1: str
+        First file to compare
+    file2: str
+        Second file to compare
+    tolerance: float
+        Tolerance for comparing numerical values.
+
+    Returns
+    -------
+    bool
+        True if the files are equal, False otherwise.
+
+    """
+    data1 = gen.collect_data_from_file_or_dict(file1, in_dict=None)
+    data2 = gen.collect_data_from_file_or_dict(file2, in_dict=None)
+
+    _logger.debug(f"Comparing json files: {file1} and {file2}")
+
+    if data1 == data2:
+        return True
+
+    if "value" in data1 and isinstance(data1["value"], str):
+        value_list_1 = gen.convert_string_to_list(data1.pop("value"))
+        value_list_2 = gen.convert_string_to_list(data2.pop("value"))
+        return np.allclose(value_list_1, value_list_2, rtol=tolerance)
+    return data1 == data2
+
+
+def compare_ecsv_files(file1, file2, tolerance=1.0e-5):
+    """
+    Compare two ecsv files.
+
+    The comparison is successful if:
+
+    - same number of rows
+    - numerical values in columns are close
+
+    Parameters
+    ----------
+    file1: str
+        First file to compare
+    file2: str
+        Second file to compare
+    tolerance: float
+        Tolerance for comparing numerical values.
+
+    """
+    _logger.info(f"Comparing files: {file1} and {file2}")
+    table1 = Table.read(file1, format="ascii.ecsv")
+    table2 = Table.read(file2, format="ascii.ecsv")
+
+    comparison_result = len(table1) == len(table2)
+
+    for col_name in table1.colnames:
+        if np.issubdtype(table1[col_name].dtype, np.floating):
+            comparison_result = comparison_result and np.allclose(
+                table1[col_name], table2[col_name], rtol=tolerance
+            )
+
+    return comparison_result

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -36,7 +36,6 @@ def test_assert_file_type_yaml(test_json_file, test_yaml_file):
     assert not assertions.assert_file_type("yml", "tests/resources/does_not_exit.schema.yml")
     assert not assertions.assert_file_type("yml", "tests/resources/simtel_config_test_la_palma.cfg")
 
-    # TODO - discuss if we want to accept this
     assert assertions.assert_file_type("yml", test_json_file)
 
 

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -50,3 +50,7 @@ def test_assert_file_type_others(caplog):
         "File type test is checking suffix only for tests/resources/"
         "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
     )
+
+
+def test_assert_no_suffix():
+    assert not assertions.assert_file_type("yml", "tests/resources/does_not_exit_yml")

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -42,13 +42,11 @@ def test_assert_file_type_yaml(test_json_file, test_yaml_file, caplog):
 
 def test_assert_file_type_others(caplog):
 
-    # with caplog.at_level(logging.INFO):
-    #     assert assertions.assert_file_type(
-    #         "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
-    #     )
-    # assert (
-    #     "File type test is checking suffix only for tests/resources/"
-    #     "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
-    # )
-
-    assert assertions.assert_file_type("ecsv", "telescope_positions-South-groundecsv")
+    with caplog.at_level(logging.INFO):
+        assert assertions.assert_file_type(
+            "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
+        )
+    assert (
+        "File type test is checking suffix only for tests/resources/"
+        "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
+    )

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -29,14 +29,15 @@ def test_assert_file_type_json(test_json_file, test_yaml_file):
     assert assertions.assert_file_type("json", Path(test_json_file))
 
 
-def test_assert_file_type_yaml(test_json_file, test_yaml_file):
+def test_assert_file_type_yaml(test_json_file, test_yaml_file, caplog):
 
     assert assertions.assert_file_type("yaml", test_yaml_file)
     assert assertions.assert_file_type("yml", test_yaml_file)
     assert not assertions.assert_file_type("yml", "tests/resources/does_not_exit.schema.yml")
-    assert not assertions.assert_file_type("yml", "tests/resources/simtel_config_test_la_palma.cfg")
 
-    assert assertions.assert_file_type("yml", test_json_file)
+    assert not assertions.assert_file_type(
+        "yaml", "tests/resources/telescope_positions-South-ground.ecsv"
+    )
 
 
 def test_assert_file_type_others(caplog):

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python3
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from simtools.testing import assertions
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+@pytest.fixture()
+def test_json_file():
+    return Path("tests/resources/reference_point_altitude.json")
+
+
+@pytest.fixture()
+def test_yaml_file():
+    return Path("tests/resources/num_gains.schema.yml")
+
+
+def test_assert_file_type_json(test_json_file, test_yaml_file):
+
+    assert assertions.assert_file_type("json", test_json_file)
+    assert not assertions.assert_file_type("json", "tests/resources/does_not_exist.json")
+    assert not assertions.assert_file_type("json", test_yaml_file)
+
+    assert assertions.assert_file_type("json", Path(test_json_file))
+
+
+def test_assert_file_type_yaml(test_json_file, test_yaml_file):
+
+    assert assertions.assert_file_type("yaml", test_yaml_file)
+    assert assertions.assert_file_type("yml", test_yaml_file)
+    assert not assertions.assert_file_type("yml", "tests/resources/does_not_exit.schema.yml")
+    assert not assertions.assert_file_type("yml", "tests/resources/simtel_config_test_la_palma.cfg")
+
+    # TODO - discuss if we want to accept this
+    assert assertions.assert_file_type("yml", test_json_file)
+
+
+def test_assert_file_type_others(caplog):
+
+    with caplog.at_level(logging.INFO):
+        assert assertions.assert_file_type(
+            "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
+        )
+    assert (
+        "File type test is checking suffix only for tests/resources/telescope_positions-South-ground.ecsv (suffix: ecsv)"
+        in caplog.text
+    )

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -42,11 +42,13 @@ def test_assert_file_type_yaml(test_json_file, test_yaml_file, caplog):
 
 def test_assert_file_type_others(caplog):
 
-    with caplog.at_level(logging.INFO):
-        assert assertions.assert_file_type(
-            "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
-        )
-    assert (
-        "File type test is checking suffix only for tests/resources/"
-        "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
-    )
+    # with caplog.at_level(logging.INFO):
+    #     assert assertions.assert_file_type(
+    #         "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
+    #     )
+    # assert (
+    #     "File type test is checking suffix only for tests/resources/"
+    #     "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
+    # )
+
+    assert assertions.assert_file_type("ecsv", "telescope_positions-South-groundecsv")

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -47,6 +47,6 @@ def test_assert_file_type_others(caplog):
             "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"
         )
     assert (
-        "File type test is checking suffix only for tests/resources/telescope_positions-South-ground.ecsv (suffix: ecsv)"
-        in caplog.text
+        "File type test is checking suffix only for tests/resources/"
+        "telescope_positions-South-ground.ecsv (suffix: ecsv)" in caplog.text
     )

--- a/tests/unit_tests/testing/test_compare_output.py
+++ b/tests/unit_tests/testing/test_compare_output.py
@@ -44,125 +44,133 @@ def create_ecsv_file(tmp_path):
     return _create_ecsv_file
 
 
-def test_compare_json_files_float_strings(create_json_file):
+@pytest.fixture()
+def file_name():
+    def _file_name(counter, suffix):
+        return f"file{counter}.{suffix}"
+
+    return _file_name
+
+
+def test_compare_json_files_float_strings(create_json_file, file_name):
     content = {"key": 1, "value": "1.23 4.56 7.89"}
-    file1 = create_json_file("file1.json", content)
-    file2 = create_json_file("file2.json", content)
+    file1 = create_json_file(file_name(1, "json"), content)
+    file2 = create_json_file(file_name(2, "json"), content)
 
     assert compare_output.compare_json_or_yaml_files(file1, file2)
 
     content3 = {"key": 2, "value": "1.23 4.56 7.80"}
-    file3 = create_json_file("file3.json", content3)
+    file3 = create_json_file(file_name(3, "json"), content3)
     assert not compare_output.compare_json_or_yaml_files(file1, file3)
 
 
-def test_compare_json_files_equal_integers(create_json_file):
+def test_compare_json_files_equal_integers(create_json_file, file_name):
     content = {"key": 1, "value": 5}
-    file1 = create_json_file("file1.json", content)
-    file2 = create_json_file("file2.json", content)
+    file1 = create_json_file(file_name(1, "json"), content)
+    file2 = create_json_file(file_name(2, "json"), content)
 
     assert compare_output.compare_json_or_yaml_files(file1, file2)
 
     content3 = {"key": 2, "value": 7}
-    file3 = create_json_file("file3.json", content3)
+    file3 = create_json_file(file_name(3, "json"), content3)
     assert not compare_output.compare_json_or_yaml_files(file1, file3)
 
 
-def test_compare_yaml_files_float_strings(create_yaml_file):
+def test_compare_yaml_files_float_strings(create_yaml_file, file_name):
     content = {"key": 1, "value": "1.23 4.56 7.89"}
-    file1 = create_yaml_file("file1.yaml", content)
-    file2 = create_yaml_file("file2.yaml", content)
+    file1 = create_yaml_file(file_name(1, "yaml"), content)
+    file2 = create_yaml_file(file_name(2, "yaml"), content)
 
     assert compare_output.compare_json_or_yaml_files(file1, file2)
 
     content3 = {"key": 2, "value": "1.23 4.56 7.80"}
-    file3 = create_yaml_file("file3.yaml", content3)
+    file3 = create_yaml_file(file_name(3, "yaml"), content3)
     assert not compare_output.compare_json_or_yaml_files(file1, file3)
 
 
-def test_compare_yaml_files_equal_integers(create_yaml_file):
+def test_compare_yaml_files_equal_integers(create_yaml_file, file_name):
     content = {"key": 1, "value": 5}
-    file1 = create_yaml_file("file1.yaml", content)
-    file2 = create_yaml_file("file2.yaml", content)
+    file1 = create_yaml_file(file_name(1, "yaml"), content)
+    file2 = create_yaml_file(file_name(2, "yaml"), content)
 
     assert compare_output.compare_json_or_yaml_files(file1, file2)
 
     content3 = {"key": 2, "value": 7}
-    file3 = create_yaml_file("file3.yaml", content3)
+    file3 = create_yaml_file(file_name(3, "yaml"), content3)
     assert not compare_output.compare_json_or_yaml_files(file1, file3)
 
 
-def test_compare_ecsv_files_equal(create_ecsv_file):
+def test_compare_ecsv_files_equal(create_ecsv_file, file_name):
     content = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
-    file1 = create_ecsv_file("file1.ecsv", content)
-    file2 = create_ecsv_file("file2.ecsv", content)
+    file1 = create_ecsv_file(file_name(1, "ecsv"), content)
+    file2 = create_ecsv_file(file_name(2, "ecsv"), content)
 
     assert compare_output.compare_ecsv_files(file1, file2)
 
 
-def test_compare_ecsv_files_different_lengths(create_ecsv_file):
+def test_compare_ecsv_files_different_lengths(create_ecsv_file, file_name):
     content1 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
     content2 = {"col1": [1.1, 2.2], "col2": [4.4, 5.5]}
-    file1 = create_ecsv_file("file1.ecsv", content1)
-    file2 = create_ecsv_file("file2.ecsv", content2)
+    file1 = create_ecsv_file(file_name(1, "yaml"), content1)
+    file2 = create_ecsv_file(file_name(2, "ecsv"), content2)
 
     assert not compare_output.compare_ecsv_files(file1, file2)
 
 
-def test_compare_ecsv_files_close_values(create_ecsv_file):
+def test_compare_ecsv_files_close_values(create_ecsv_file, file_name):
     content1 = {"col1": [1.1001, 2.2001, 3.3001], "col2": [4.4001, 5.5001, 6.6001]}
     content2 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
-    file1 = create_ecsv_file("file1.ecsv", content1)
-    file2 = create_ecsv_file("file2.ecsv", content2)
+    file1 = create_ecsv_file(file_name(1, "ecsv"), content1)
+    file2 = create_ecsv_file(file_name(2, "ecsv"), content2)
 
     assert compare_output.compare_ecsv_files(file1, file2, tolerance=1.0e-3)
 
 
-def test_compare_ecsv_files_large_difference(create_ecsv_file):
+def test_compare_ecsv_files_large_difference(create_ecsv_file, file_name):
     content1 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
     content2 = {"col1": [10.1, 20.2, 30.3], "col2": [40.4, 50.5, 60.6]}
-    file1 = create_ecsv_file("file1.ecsv", content1)
-    file2 = create_ecsv_file("file2.ecsv", content2)
+    file1 = create_ecsv_file(file_name(1, "ecsv"), content1)
+    file2 = create_ecsv_file(file_name(2, "ecsv"), content2)
 
     assert not compare_output.compare_ecsv_files(file1, file2)
 
 
-def test_compare_files_ecsv(create_ecsv_file):
+def test_compare_files_ecsv(create_ecsv_file, file_name):
     content = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
-    file1 = create_ecsv_file("file1.ecsv", content)
-    file2 = create_ecsv_file("file2.ecsv", content)
+    file1 = create_ecsv_file(file_name(1, "ecsv"), content)
+    file2 = create_ecsv_file(file_name(2, "ecsv"), content)
 
     assert compare_output.compare_files(file1, file2)
 
 
-def test_compare_files_json(create_json_file):
+def test_compare_files_json(create_json_file, file_name):
     content = {"key": 1, "value": "1.23 4.56 7.89"}
-    file1 = create_json_file("file1.json", content)
-    file2 = create_json_file("file2.json", content)
+    file1 = create_json_file(file_name(1, "json"), content)
+    file2 = create_json_file(file_name(2, "json"), content)
 
     assert compare_output.compare_files(file1, file2)
 
 
-def test_compare_files_yaml(create_yaml_file):
+def test_compare_files_yaml(create_yaml_file, file_name):
     content = {"key": 1, "value": "1.23 4.56 7.89"}
-    file1 = create_yaml_file("file1.yaml", content)
-    file2 = create_yaml_file("file2.yaml", content)
+    file1 = create_yaml_file(file_name(1, "yaml"), content)
+    file2 = create_yaml_file(file_name(2, "yaml"), content)
 
     assert compare_output.compare_files(file1, file2)
 
 
-def test_compare_files_different_suffixes(create_json_file, create_yaml_file):
+def test_compare_files_different_suffixes(create_json_file, create_yaml_file, file_name):
     content = {"key": 1, "value": "1.23 4.56 7.89"}
-    file1 = create_json_file("file1.json", content)
-    file2 = create_yaml_file("file2.yaml", content)
+    file1 = create_json_file(file_name(1, "json"), content)
+    file2 = create_yaml_file(file_name(2, "yaml"), content)
 
     with pytest.raises(ValueError, match="File suffixes do not match"):
         compare_output.compare_files(file1, file2)
 
 
-def test_compare_files_unknown_type(tmp_test_directory):
-    file1 = tmp_test_directory / "file1.txt"
-    file2 = tmp_test_directory / "file2.txt"
+def test_compare_files_unknown_type(tmp_test_directory, file_name):
+    file1 = tmp_test_directory / file_name(1, "txt")
+    file2 = tmp_test_directory / file_name(2, "txt")
     file1.write_text("dummy content", encoding="utf-8")
     file2.write_text("dummy content", encoding="utf-8")
 

--- a/tests/unit_tests/testing/test_compare_output.py
+++ b/tests/unit_tests/testing/test_compare_output.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3
+
+import json
+import logging
+
+import pytest
+import yaml
+from astropy.table import Table
+
+from simtools.testing import compare_output
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+
+@pytest.fixture()
+def create_json_file(tmp_test_directory):
+    def _create_json_file(file_name, content):
+        file = tmp_test_directory / file_name
+        file.write_text(json.dumps(content), encoding="utf-8")
+        return file
+
+    return _create_json_file
+
+
+@pytest.fixture()
+def create_yaml_file(tmp_path):
+    def _create_yaml_file(file_name, content):
+        file = tmp_path / file_name
+        with open(file, "w", encoding="utf-8") as f:
+            yaml.dump(content, f)
+        return file
+
+    return _create_yaml_file
+
+
+@pytest.fixture()
+def create_ecsv_file(tmp_path):
+    def _create_ecsv_file(file_name, content):
+        table = Table(content)
+        file_path = tmp_path / file_name
+        table.write(file_path, format="ascii.ecsv")
+        return file_path
+
+    return _create_ecsv_file
+
+
+def test_compare_json_files_float_strings(create_json_file):
+    content = {"key": 1, "value": "1.23 4.56 7.89"}
+    file1 = create_json_file("file1.json", content)
+    file2 = create_json_file("file2.json", content)
+
+    assert compare_output.compare_json_or_yaml_files(file1, file2)
+
+    content3 = {"key": 2, "value": "1.23 4.56 7.80"}
+    file3 = create_json_file("file3.json", content3)
+    assert not compare_output.compare_json_or_yaml_files(file1, file3)
+
+
+def test_compare_json_files_equal_integers(create_json_file):
+    content = {"key": 1, "value": 5}
+    file1 = create_json_file("file1.json", content)
+    file2 = create_json_file("file2.json", content)
+
+    assert compare_output.compare_json_or_yaml_files(file1, file2)
+
+    content3 = {"key": 2, "value": 7}
+    file3 = create_json_file("file3.json", content3)
+    assert not compare_output.compare_json_or_yaml_files(file1, file3)
+
+
+def test_compare_yaml_files_float_strings(create_yaml_file):
+    content = {"key": 1, "value": "1.23 4.56 7.89"}
+    file1 = create_yaml_file("file1.yaml", content)
+    file2 = create_yaml_file("file2.yaml", content)
+
+    assert compare_output.compare_json_or_yaml_files(file1, file2)
+
+    content3 = {"key": 2, "value": "1.23 4.56 7.80"}
+    file3 = create_yaml_file("file3.yaml", content3)
+    assert not compare_output.compare_json_or_yaml_files(file1, file3)
+
+
+def test_compare_yaml_files_equal_integers(create_yaml_file):
+    content = {"key": 1, "value": 5}
+    file1 = create_yaml_file("file1.yaml", content)
+    file2 = create_yaml_file("file2.yaml", content)
+
+    assert compare_output.compare_json_or_yaml_files(file1, file2)
+
+    content3 = {"key": 2, "value": 7}
+    file3 = create_yaml_file("file3.yaml", content3)
+    assert not compare_output.compare_json_or_yaml_files(file1, file3)
+
+
+def test_compare_ecsv_files_equal(create_ecsv_file):
+    content = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
+    file1 = create_ecsv_file("file1.ecsv", content)
+    file2 = create_ecsv_file("file2.ecsv", content)
+
+    assert compare_output.compare_ecsv_files(file1, file2)
+
+
+def test_compare_ecsv_files_different_lengths(create_ecsv_file):
+    content1 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
+    content2 = {"col1": [1.1, 2.2], "col2": [4.4, 5.5]}
+    file1 = create_ecsv_file("file1.ecsv", content1)
+    file2 = create_ecsv_file("file2.ecsv", content2)
+
+    assert not compare_output.compare_ecsv_files(file1, file2)
+
+
+def test_compare_ecsv_files_close_values(create_ecsv_file):
+    content1 = {"col1": [1.1001, 2.2001, 3.3001], "col2": [4.4001, 5.5001, 6.6001]}
+    content2 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
+    file1 = create_ecsv_file("file1.ecsv", content1)
+    file2 = create_ecsv_file("file2.ecsv", content2)
+
+    assert compare_output.compare_ecsv_files(file1, file2, tolerance=1.0e-3)
+
+
+def test_compare_ecsv_files_large_difference(create_ecsv_file):
+    content1 = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
+    content2 = {"col1": [10.1, 20.2, 30.3], "col2": [40.4, 50.5, 60.6]}
+    file1 = create_ecsv_file("file1.ecsv", content1)
+    file2 = create_ecsv_file("file2.ecsv", content2)
+
+    assert not compare_output.compare_ecsv_files(file1, file2)
+
+
+def test_compare_files_ecsv(create_ecsv_file):
+    content = {"col1": [1.1, 2.2, 3.3], "col2": [4.4, 5.5, 6.6]}
+    file1 = create_ecsv_file("file1.ecsv", content)
+    file2 = create_ecsv_file("file2.ecsv", content)
+
+    assert compare_output.compare_files(file1, file2)
+
+
+def test_compare_files_json(create_json_file):
+    content = {"key": 1, "value": "1.23 4.56 7.89"}
+    file1 = create_json_file("file1.json", content)
+    file2 = create_json_file("file2.json", content)
+
+    assert compare_output.compare_files(file1, file2)
+
+
+def test_compare_files_yaml(create_yaml_file):
+    content = {"key": 1, "value": "1.23 4.56 7.89"}
+    file1 = create_yaml_file("file1.yaml", content)
+    file2 = create_yaml_file("file2.yaml", content)
+
+    assert compare_output.compare_files(file1, file2)
+
+
+def test_compare_files_different_suffixes(create_json_file, create_yaml_file):
+    content = {"key": 1, "value": "1.23 4.56 7.89"}
+    file1 = create_json_file("file1.json", content)
+    file2 = create_yaml_file("file2.yaml", content)
+
+    with pytest.raises(ValueError, match="File suffixes do not match"):
+        compare_output.compare_files(file1, file2)
+
+
+def test_compare_files_unknown_type(tmp_test_directory):
+    file1 = tmp_test_directory / "file1.txt"
+    file2 = tmp_test_directory / "file2.txt"
+    file1.write_text("dummy content", encoding="utf-8")
+    file2.write_text("dummy content", encoding="utf-8")
+
+    assert not compare_output.compare_files(file1, file2)


### PR DESCRIPTION
Move the functions to compare files and assert file types from `tests/integration_tests/test_applications_from_config.py` into separate modules in `simtools/testing`:

- allows to reuse those functions and have them unit tested
- expected to be extended significantly in future (it looks a bit empty right now)

There is no change in functionality, I've moved simply the code into the modules and:

- added unit tests
- improved the code itself (as a result of the unit tests)

Please have a look at the naming of the modules and provide feedback if this is good. Naming new modules is often difficult.

Closes #970 