### PR TITLE
Missing documentation for new testing module

### DIFF
--- a/docs/source/api-reference/index.md
+++ b/docs/source/api-reference/index.md
@@ -22,6 +22,7 @@ ray_tracing
 runners
 sim_telarray
 simulators
+testing
 utils
 visualization
 ```

--- a/docs/source/api-reference/testing.md
+++ b/docs/source/api-reference/testing.md
@@ -1,0 +1,24 @@
+(testing)=
+
+# Testing
+
+The Testing module provides tools for testing the code. This might be part of the integration tests or unit tests.
+
+(assertionsmodule)=
+
+## assertions
+
+```{eval-rst}
+.. automodule:: testing.assertions
+   :members:
+
+```
+
+(compare_outputmodule)=
+
+## compare_output
+
+```{eval-rst}
+.. automodule:: testing.compare_output
+   :members:
+```


### PR DESCRIPTION
Pull request #1138 introduces a simtools testing module.

This PR fixes that new modules requires additions to our API documentation.

As the documentation is not available in the github review setup, best is to

- checkout this branch locally
- `cd docs` and run `make html`
- open the file `build/html/index.html` in a browser and check in the API section for the testing module.