### PR TITLE
Improve robustness of database scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ simtools/_version.py
 # Coverage files
 coverage*
 .coverage*
+
+# Ignore temporary output of database scripts
+database_scripts/mongo-data

--- a/database_scripts/upload_from_model_repository_to_db.sh
+++ b/database_scripts/upload_from_model_repository_to_db.sh
@@ -2,8 +2,8 @@
 # Upload model parameter from repository to a local or remote mongoDB.
 #
 
-SIMTOOLS_DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
-SIMTOOLS_DB_SIMULATION_MODEL_BRANCH="main"
+DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
+DB_SIMULATION_MODEL_BRANCH="main"
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <DB simulation model name>"
@@ -12,15 +12,27 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-SIMTOOLS_DB_SIMULATION_MODEL="$1"
+DB_SIMULATION_MODEL="$1"
 
-echo "Cloning model parameters from $SIMTOOLS_DB_SIMULATION_MODEL_URL"
+echo "Cloning model parameters from $DB_SIMULATION_MODEL_URL"
 rm -rf ./tmp_model_parameters
-git clone --depth=1 -b $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH $SIMTOOLS_DB_SIMULATION_MODEL_URL ./tmp_model_parameters
+git clone --depth=1 -b $DB_SIMULATION_MODEL_BRANCH $DB_SIMULATION_MODEL_URL ./tmp_model_parameters
 
 CURRENTDIR=$(pwd)
 cd ./tmp_model_parameters/ || exit
 cp -f "$CURRENTDIR"/../.env .env
+
+# ask for confirmation before uploading to remote DB
+source .env
+regex='^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$'
+echo "DB_SERVER: $SIMTOOLS_DB_SERVER"
+if [[ $SIMTOOLS_DB_SERVER =~ $regex ]]; then
+  read -r -p "Do you really want to upload to remote DB $SIMTOOLS_DB_SERVER? Type 'yes' to confirm: " user_input
+  if [ "$user_input" != "yes" ]; then
+      echo "Operation aborted."
+      exit 1
+  fi
+fi
 
 # upload files to DB
 model_directory="./model_versions/"
@@ -28,7 +40,7 @@ for dir in "${model_directory}"*/; do
   simtools-db-add-model-parameters-from-repository-to-db \
   --model_version "$(basename "${dir}")" \
   --input_path "${dir}" \
-  --db_name "$SIMTOOLS_DB_SIMULATION_MODEL" \
+  --db_name "$DB_SIMULATION_MODEL" \
   --type "model_parameters"
 done
 

--- a/database_scripts/upload_from_model_repository_to_db.sh
+++ b/database_scripts/upload_from_model_repository_to_db.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Upload model parameter from repository to a local or remote mongoDB.
 #
+# Cover 'source .env': the script ensure that this file exists:
+# shellcheck disable=SC1091
 
 DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters.git"
 DB_SIMULATION_MODEL_BRANCH="main"

--- a/simtools/applications/db_add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_add_model_parameters_from_repository_to_db.py
@@ -42,7 +42,7 @@ import logging
 from pathlib import Path
 
 import simtools.utils.general as gen
-from simtools.configuration import configurator
+from simtools.configuration import commandline_parser, configurator
 from simtools.db import db_handler
 from simtools.utils import names
 
@@ -73,7 +73,7 @@ def _parse(label=None, description=None):
     config.parser.add_argument(
         "--db_name",
         help="Name of the new model parameter database to be created.",
-        type=str,
+        type=commandline_parser.CommandLineParser.strip_string,
         required=True,
     )
     config.parser.add_argument(

--- a/simtools/applications/db_add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_add_model_parameters_from_repository_to_db.py
@@ -42,7 +42,7 @@ import logging
 from pathlib import Path
 
 import simtools.utils.general as gen
-from simtools.configuration import commandline_parser, configurator
+from simtools.configuration import configurator
 from simtools.db import db_handler
 from simtools.utils import names
 
@@ -73,7 +73,7 @@ def _parse(label=None, description=None):
     config.parser.add_argument(
         "--db_name",
         help="Name of the new model parameter database to be created.",
-        type=commandline_parser.CommandLineParser.strip_string,
+        type=str.strip,
         required=True,
     )
     config.parser.add_argument(

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -194,7 +194,7 @@ class CommandLineParser(argparse.ArgumentParser):
         _job_group.add_argument(
             "--db_simulation_model",
             help="name of simulation model database",
-            type=self.strip_string,
+            type=str.strip,
             required=False,
             default=None,
         )
@@ -742,8 +742,3 @@ class CommandLineParser(argparse.ArgumentParser):
             raise ValueError("Input string does not contain an integer and a astropy quantity.")
 
         return (int(match.group(1)), u.Quantity(float(match.group(2)), match.group(3)))
-
-    @staticmethod
-    def strip_string(value):
-        """Remove leading and trailing whitespaces from a string."""
-        return value.strip()

--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -194,7 +194,7 @@ class CommandLineParser(argparse.ArgumentParser):
         _job_group.add_argument(
             "--db_simulation_model",
             help="name of simulation model database",
-            type=str,
+            type=self.strip_string,
             required=False,
             default=None,
         )
@@ -731,3 +731,8 @@ class CommandLineParser(argparse.ArgumentParser):
             raise ValueError("Input string does not contain an integer and a astropy quantity.")
 
         return (int(match.group(1)), u.Quantity(float(match.group(2)), match.group(3)))
+
+    @staticmethod
+    def strip_string(value):
+        """Remove leading and trailing whitespaces from a string."""
+        return value.strip()

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -257,7 +257,9 @@ def test_simulation_configuration():
     )
 
 
-def test_strip_string():
-    _parser_10 = parser.CommandLineParser()
+def test_initialize_db_config_arguments_strip_string():
+    parser_10 = parser.CommandLineParser()
+    parser_10.initialize_db_config_arguments()
     for test_string in ["test", " test", "test ", " test "]:
-        assert _parser_10.strip_string(test_string) == "test"
+        args = parser_10.parse_args(["--db_simulation_model", test_string])
+        assert args.db_simulation_model == "test"

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -255,3 +255,9 @@ def test_simulation_configuration():
     _parser_10.initialize_default_arguments(
         simulation_configuration={"software": None, "corsika_configuration": ["wrong_parameter"]}
     )
+
+
+def test_strip_string():
+    _parser_10 = parser.CommandLineParser()
+    for test_string in ["test", " test", "test ", " test "]:
+        assert _parser_10.strip_string(test_string) == "test"


### PR DESCRIPTION
Improve robustness of `simtools-db-add-model-parameters-from-repository-to-db` application and `upload_from_model_repository_to_db.sh` scripts. No functional changes.

This is triggered by:

- a leading space in the argument of `upload_from_model_repository_to_db.sh` for the database name is removed now (I have been puzzled quite a while why I can't read from a newly generated local database of name "CTAO-Simulation-Model-v0-0-1" (it was uploaded as " CTAO-Simulation-Model-v0-0-1")
- ask user for confirmation before `upload_from_model_repository_to_db.sh` is uploading to a remote DB (because I did this accidentally...). This requires `upload_from_model_repository_to_db.sh` to read the `.env` file and therefore the local DB variables in the script had to be renamed.

