### PR TITLE
Pre-commit update (and ruff update to 0.6.6)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         args: ["--line-length=100"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff
-    rev: v0.5.4
+    rev: v0.6.6
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -45,7 +45,7 @@ repos:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.1.4"
+    rev: "2.2.4"
     hooks:
       - id: pyproject-fmt
   # codespell

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def _set_matplotlib_backend():
     plt.switch_backend("Agg")
 
 
-@pytest.fixture()
+@pytest.fixture
 def tmp_test_directory(tmpdir_factory):
     """Sets temporary test directories. Some tests depend on this structure."""
 
@@ -42,12 +42,12 @@ def tmp_test_directory(tmpdir_factory):
     return tmp_test_dir
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_path():
     return "./data/"
 
 
-@pytest.fixture()
+@pytest.fixture
 def io_handler(tmp_test_directory, data_path):
     """Define io_handler fixture including output and model directories."""
     tmp_io_handler = simtools.io_operations.io_handler.IOHandler()
@@ -59,7 +59,7 @@ def io_handler(tmp_test_directory, data_path):
     return tmp_io_handler
 
 
-@pytest.fixture()
+@pytest.fixture
 def _mock_settings_env_vars(tmp_test_directory):
     """Removes all environment variable from the test system and explicitly sets those needed."""
     _url = (
@@ -83,13 +83,13 @@ def _mock_settings_env_vars(tmp_test_directory):
         yield
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_path():
     """Empty string used as placeholder for simtel_path."""
     return Path("")
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_path_no_mock():
     """Simtel path as set by the .env file."""
     load_dotenv(".env")
@@ -99,7 +99,7 @@ def simtel_path_no_mock():
     return ""
 
 
-@pytest.fixture()
+@pytest.fixture
 def args_dict(tmp_test_directory, simtel_path, data_path):
     """Minimal configuration from command line."""
     return Configurator().default_config(
@@ -114,7 +114,7 @@ def args_dict(tmp_test_directory, simtel_path, data_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def args_dict_site(tmp_test_directory, simtel_path, data_path):
     "Configuration include site and telescopes."
     return Configurator().default_config(
@@ -135,7 +135,7 @@ def args_dict_site(tmp_test_directory, simtel_path, data_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def db_config():
     """DB configuration from .env file."""
 
@@ -159,7 +159,7 @@ def db_config():
     return mongo_db_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulation_model_url(db_config):
     """Simulation model URL from .env file or default."""
     if (
@@ -173,7 +173,7 @@ def simulation_model_url(db_config):
     return db_config["db_simulation_model_url"]
 
 
-@pytest.fixture()
+@pytest.fixture
 def db(db_config):
     """Database object with configuration from .env file."""
     return db_handler.DatabaseHandler(mongo_db_config=db_config)
@@ -184,19 +184,19 @@ def pytest_addoption(parser):
     parser.addoption("--model_version", action="store", default=None)
 
 
-@pytest.fixture()
+@pytest.fixture
 def model_version():
     """Simulation model version used in tests."""
     return "6.0.0"
 
 
-@pytest.fixture()
+@pytest.fixture
 def model_version_prod5():
     """Simulation model version used in tests."""
     return "5.0.0"
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_model_north(io_handler, db_config, model_version):
     """Array model for North site."""
     return ArrayModel(
@@ -208,7 +208,7 @@ def array_model_north(io_handler, db_config, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_model_south(io_handler, db_config, model_version):
     """Array model for South site."""
     return ArrayModel(
@@ -220,7 +220,7 @@ def array_model_south(io_handler, db_config, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def site_model_south(db_config, model_version):
     """Site model for South site."""
     return SiteModel(
@@ -231,7 +231,7 @@ def site_model_south(db_config, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def site_model_north(db_config, model_version):
     """Site model for North site."""
     return SiteModel(
@@ -242,7 +242,7 @@ def site_model_north(db_config, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_model_lst(db_config, io_handler, model_version):
     """Telescope model LST North."""
     return TelescopeModel(
@@ -254,7 +254,7 @@ def telescope_model_lst(db_config, io_handler, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_model_mst(db_config, io_handler, model_version):
     """Telescope model MST South."""
     return TelescopeModel(
@@ -266,7 +266,7 @@ def telescope_model_mst(db_config, io_handler, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_model_sst(db_config, io_handler, model_version):
     """Telescope model SST South."""
     return TelescopeModel(
@@ -279,7 +279,7 @@ def telescope_model_sst(db_config, io_handler, model_version):
 
 
 # keep 5.0.0 model until a complete prod6 model is in the DB
-@pytest.fixture()
+@pytest.fixture
 def telescope_model_sst_prod5(db_config, io_handler, model_version_prod5):
     """Telescope model SST South (prod5/5.0.0)."""
     return TelescopeModel(
@@ -291,37 +291,37 @@ def telescope_model_sst_prod5(db_config, io_handler, model_version_prod5):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_north_with_calibration_devices_test_file():
     """Telescope positions North with calibration devices."""
     return "tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv"
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_north_test_file():
     """Telescope positions North."""
     return "tests/resources/telescope_positions-North-ground.ecsv"
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_north_utm_test_file():
     """Telescope positions North (UTM coordinates)."""
     return "tests/resources/telescope_positions-North-utm.ecsv"
 
 
-@pytest.fixture()
+@pytest.fixture
 def telescope_south_test_file():
     """Telescope positions South."""
     return "tests/resources/telescope_positions-South-ground.ecsv"
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_output_file_name():
     """CORSIKA output file name for testing."""
     return "tests/resources/tel_output_10GeV-2-gamma-20deg-CTAO-South.corsikaio"
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_histograms_instance(io_handler, corsika_output_file_name):
     """Corsika histogram instance."""
     from simtools.corsika.corsika_histograms import CorsikaHistograms
@@ -331,14 +331,14 @@ def corsika_histograms_instance(io_handler, corsika_output_file_name):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_histograms_instance_set_histograms(db, io_handler, corsika_histograms_instance):
     """Corsika histogram instance (fully configured)."""
     corsika_histograms_instance.set_histograms()
     return corsika_histograms_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_config_data(model_version):
     """Corsika configuration data (as given by CorsikaConfig)."""
     return {
@@ -359,7 +359,7 @@ def corsika_config_data(model_version):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_config(io_handler, db_config, corsika_config_data, array_model_south):
     """Corsika configuration object (using array model South)."""
     corsika_config = CorsikaConfig(
@@ -372,7 +372,7 @@ def corsika_config(io_handler, db_config, corsika_config_data, array_model_south
     return corsika_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_config_mock_array_model(io_handler, db_config, corsika_config_data):
     """Corsika configuration object (using array model South)."""
     array_model = mock.MagicMock()
@@ -390,7 +390,7 @@ def corsika_config_mock_array_model(io_handler, db_config, corsika_config_data):
     return corsika_config
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_runner(corsika_config, io_handler, simtel_path):
     return CorsikaRunner(
         corsika_config=corsika_config,
@@ -400,7 +400,7 @@ def corsika_runner(corsika_config, io_handler, simtel_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_runner_mock_array_model(corsika_config_mock_array_model, io_handler, simtel_path):
     return CorsikaRunner(
         corsika_config=corsika_config_mock_array_model,
@@ -410,7 +410,7 @@ def corsika_runner_mock_array_model(corsika_config_mock_array_model, io_handler,
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def file_has_text():
     """Check if a file contains a specific text."""
 
@@ -434,7 +434,7 @@ def file_has_text():
     return wrapper
 
 
-@pytest.fixture()
+@pytest.fixture
 def camera_efficiency_sst(io_handler, db_config, model_version, simtel_path):
     return CameraEfficiency(
         config_data={

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -19,7 +19,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def configurator(tmp_test_directory, _mock_settings_env_vars, simtel_path):
     config = Configurator()
     config.default_config(

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -13,19 +13,19 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_config_no_db(corsika_config_data):
     return CorsikaConfig(
         array_model=None, label="test-corsika-config", args_dict=corsika_config_data, db_config=None
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def gcm2():
     return "g/cm2"
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_configuration_parameters(gcm2):
     return {
         "corsika_iact_max_bunches": {"value": 1000000, "unit": None},
@@ -306,7 +306,7 @@ def test_write_seeds(corsika_config_no_db):
         assert _call.endswith(" 0 0\n")
 
 
-@pytest.mark.uses_model_database()
+@pytest.mark.uses_model_database
 def test_get_corsika_telescope_list(corsika_config):
     cc = corsika_config
     telescope_list_str = cc.get_corsika_telescope_list()

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -17,7 +17,7 @@ logger = logging.getLogger()
 JSON_TEST_FILE = "test_read_value_from_file_1.json"
 
 
-@pytest.fixture()
+@pytest.fixture
 def reference_point_altitude_file():
     return "tests/resources/reference_point_altitude.json"
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -23,7 +23,7 @@ mirror_file = "tests/resources/MLTdata-preproduction.ecsv"
 mirror_2f_schema_file = "tests/resources/MST_mirror_2f_measurements.schema.yml"
 
 
-@pytest.fixture()
+@pytest.fixture
 def reference_columns():
     """Return a test reference data column definition."""
     return [
@@ -79,7 +79,7 @@ def reference_columns():
     ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def reference_columns_name():
     """Test reference data column definition with columns named col0, col1, col3."""
     return [

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -13,18 +13,18 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def random_id():
     return uuid.uuid4().hex
 
 
-@pytest.fixture()
+@pytest.fixture
 def db_no_config_file():
     """Database object (without configuration)."""
     return db_handler.DatabaseHandler(mongo_db_config=None)
 
 
-@pytest.fixture()
+@pytest.fixture
 def _db_cleanup(db, random_id):
     yield
     # Cleanup
@@ -34,7 +34,7 @@ def _db_cleanup(db, random_id):
     db.db_client[f"sandbox_{random_id}"]["sites"].drop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def _db_cleanup_file_sandbox(db_no_config_file, random_id):
     yield
     # Cleanup

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -15,7 +15,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def job_submitter():
     submitter = jm.JobManager()
     submitter._logger = MagicMock()
@@ -24,25 +24,25 @@ def job_submitter():
     return submitter
 
 
-@pytest.fixture()
+@pytest.fixture
 def output_log():
     """Fixture for the output log file."""
     return Path("output.log")
 
 
-@pytest.fixture()
+@pytest.fixture
 def logfile_log():
     """Fixture for the general log file."""
     return Path("logfile.log")
 
 
-@pytest.fixture()
+@pytest.fixture
 def script_file():
     """Fixture for the script file."""
     return Path("script.sh")
 
 
-@pytest.fixture()
+@pytest.fixture
 def job_messages(script_file):
     """Fixture for the script message."""
     return {
@@ -178,7 +178,7 @@ def test_execute(mock_os_system, job_submitter, job_submitter_real):
     mock_os_system.assert_called_once_with(shell_command)
 
 
-@pytest.fixture()
+@pytest.fixture
 def job_submitter_real():
     submitter = jm.JobManager()
     submitter._logger = MagicMock()

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -14,21 +14,21 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_layout_north_instance(io_handler, db_config, model_version):
     return ArrayLayout(
         site="North", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_layout_south_instance(io_handler, db_config, model_version):
     return ArrayLayout(
         site="South", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def north_layout_center_data_dict():
     return {
         "center_lon": -17.8920302 * u.deg,
@@ -40,7 +40,7 @@ def north_layout_center_data_dict():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def south_layout_center_data_dict():
     return {
         "center_lon": -70.316345 * u.deg,
@@ -52,7 +52,7 @@ def south_layout_center_data_dict():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_layout_north_four_lst_instance(db_config, model_version):
     return ArrayLayout(
         site="North",
@@ -63,7 +63,7 @@ def array_layout_north_four_lst_instance(db_config, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_layout_south_four_lst_instance(db_config, model_version):
     return ArrayLayout(
         site="South",

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -17,12 +17,12 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def crs_wgs84():
     return pyproj.CRS("EPSG:4326")
 
 
-@pytest.fixture()
+@pytest.fixture
 def crs_local():
     center_lon = -17.8920302
     center_lat = 28.7621661
@@ -32,7 +32,7 @@ def crs_local():
     return pyproj.CRS.from_proj4(proj4_string)
 
 
-@pytest.fixture()
+@pytest.fixture
 def crs_utm():
     return pyproj.CRS.from_user_input(32628)
 

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_model(db_config, io_handler, model_version):
     return ArrayModel(
         label="test",
@@ -24,7 +24,7 @@ def array_model(db_config, io_handler, model_version):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_model_from_list(db_config, io_handler, model_version):
     return ArrayModel(
         label="test",

--- a/tests/unit_tests/model/test_mirrors.py
+++ b/tests/unit_tests/model/test_mirrors.py
@@ -10,7 +10,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mirror_template_ecsv(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated.ecsv",
@@ -20,7 +20,7 @@ def mirror_template_ecsv(io_handler):
     return Mirrors(mirror_list_file)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mirror_template_simtel(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated_simtel.dat",
@@ -30,7 +30,7 @@ def mirror_template_simtel(io_handler):
     return Mirrors(mirror_list_file)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mirror_table_template(io_handler):
     mirror_list_file = io_handler.get_input_data_file(
         file_name="mirror_list_CTA-N-LST1_v2019-03-31_rotated.ecsv",

--- a/tests/unit_tests/runners/test_corsika_runner.py
+++ b/tests/unit_tests/runners/test_corsika_runner.py
@@ -10,13 +10,13 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def bin_bash():
     """Path to bash."""
     return "/usr/bin/env bash"
 
 
-@pytest.fixture()
+@pytest.fixture
 def pfp_command():
     """Basic pfp command."""
     return "sim_telarray/bin/pfp"

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -16,25 +16,25 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_command():
     """Basic simtel command."""
     return "bin/sim_telarray"
 
 
-@pytest.fixture()
+@pytest.fixture
 def show_all():
     """Simtel show all options."""
     return "-C show=all"
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulation_file():
     """Base name for simulation test file."""
     return "run000001_proton_za20deg_azm000deg_South_test_layout_test-corsika-simtel-runner"
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_simtel_runner(io_handler, corsika_config_mock_array_model, simtel_path):
     """CorsikaSimtelRunner object."""
     return CorsikaSimtelRunner(

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -13,7 +13,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner_service(corsika_runner_mock_array_model):
     """Runner services object for corsika."""
     _runner_service = runner_services.RunnerServices(
@@ -23,7 +23,7 @@ def runner_service(corsika_runner_mock_array_model):
     return _runner_service
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner_service_mock_array_model(corsika_runner_mock_array_model):
     """Runner services object for corsika."""
     _runner_service = runner_services.RunnerServices(
@@ -33,7 +33,7 @@ def runner_service_mock_array_model(corsika_runner_mock_array_model):
     return _runner_service
 
 
-@pytest.fixture()
+@pytest.fixture
 def runner_service_config_only(corsika_config_mock_array_model):
     """Runner services object with simplified config."""
     return runner_services.RunnerServices(
@@ -42,7 +42,7 @@ def runner_service_config_only(corsika_config_mock_array_model):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def file_base_name():
     """Base name for simulation test file."""
     return "run000001_proton_za20deg_azm000deg_South_test_layout_test-corsika-runner"

--- a/tests/unit_tests/runners/test_simtel_runner.py
+++ b/tests/unit_tests/runners/test_simtel_runner.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_runner(simtel_path, corsika_config_mock_array_model):
     return SimtelRunner(
         simtel_path=simtel_path, label="test", corsika_config=corsika_config_mock_array_model

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -13,22 +13,22 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_config_file():
     return "tests/resources/simtel_config_test_la_palma.cfg"
 
 
-@pytest.fixture()
+@pytest.fixture
 def schema_num_gains():
     return "tests/resources/num_gains.schema.yml"
 
 
-@pytest.fixture()
+@pytest.fixture
 def schema_telescope_transmission():
     return "tests/resources/telescope_transmission.schema.yml"
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_reader_num_gains(simtel_config_file, schema_num_gains):
     return SimtelConfigReader(
         schema_file=schema_num_gains,
@@ -37,7 +37,7 @@ def config_reader_num_gains(simtel_config_file, schema_num_gains):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_reader_telescope_transmission(simtel_config_file, schema_telescope_transmission):
     return SimtelConfigReader(
         schema_file=schema_telescope_transmission,

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_config_writer(model_version):
     return SimtelConfigWriter(
         site="North",

--- a/tests/unit_tests/simtel/test_simtel_io_events.py
+++ b/tests/unit_tests/simtel/test_simtel_io_events.py
@@ -11,7 +11,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_files(io_handler):
     test_files = []
     test_files.append(

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -15,7 +15,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_io_file(io_handler):
     return io_handler.get_input_data_file(
         file_name="run201_proton_za20deg_azm0deg_North_test_layout_test-prod.simtel.zst",
@@ -23,7 +23,7 @@ def simtel_io_file(io_handler):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_io_file_hdata(io_handler):
     return io_handler.get_input_data_file(
         file_name="run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
@@ -31,12 +31,12 @@ def simtel_io_file_hdata(io_handler):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_hist_io_instance(simtel_io_file):
     return SimtelIOHistogram(histogram_file=simtel_io_file)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_hist_hdata_io_instance(simtel_io_file_hdata):
     return SimtelIOHistogram(
         histogram_file=simtel_io_file_hdata, view_cone=[0, 10], energy_range=[0.008, 300]

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -22,7 +22,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_io_file(io_handler):
     return io_handler.get_input_data_file(
         file_name="run201_proton_za20deg_azm0deg_North_test_layout_test-prod.simtel.zst",
@@ -30,7 +30,7 @@ def simtel_io_file(io_handler):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_io_file_hdata(io_handler):
     return io_handler.get_input_data_file(
         file_name="run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5.hdata.zst",
@@ -38,7 +38,7 @@ def simtel_io_file_hdata(io_handler):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_io_file_list(io_handler):
     return io_handler.get_input_data_file(
         file_name="simtel_output_files.txt",
@@ -46,19 +46,19 @@ def simtel_io_file_list(io_handler):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_hists_hdata_io_instance(simtel_io_file_hdata):
     return SimtelIOHistograms(
         histogram_files=simtel_io_file_hdata, view_cone=[0, 10], energy_range=[0.001, 300]
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_array_histograms_instance(simtel_io_file):
     return SimtelIOHistograms(histogram_files=[simtel_io_file, simtel_io_file], test=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_array_histograms_instance_file_list(simtel_io_file_list):
     return SimtelIOHistograms(histogram_files=simtel_io_file_list, test=True)
 

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simtel_runner(corsika_config_mock_array_model, simtel_path):
     return SimulatorArray(
         corsika_config=corsika_config_mock_array_model,

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulator_camera_efficiency(camera_efficiency_sst, simtel_path):
     camera_efficiency_sst.export_model_files()
     return SimulatorCameraEfficiency(

--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -48,7 +48,7 @@ def default_config_fixture():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simulator(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
@@ -82,7 +82,7 @@ def mock_simulator(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simulator_variable(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
@@ -116,7 +116,7 @@ def mock_simulator_variable(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_simulator_laser(
     db_config, default_config, label, model_version, simtel_path, site_model_north, io_handler
 ):
@@ -150,12 +150,12 @@ def mock_simulator_laser(
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_output_path(label, io_handler):
     return io_handler.get_output_directory(label)
 
 
-@pytest.fixture()
+@pytest.fixture
 def calibration_model_illn(db_config, io_handler, model_version):
     return CalibrationModel(
         site="North",

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -12,7 +12,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def ray_tracing_sst(telescope_model_sst, simtel_path):
     # telescope_model_sst.export_model_files()
 
@@ -31,7 +31,7 @@ def ray_tracing_sst(telescope_model_sst, simtel_path):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulator_ray_tracing(ray_tracing_sst, telescope_model_sst, simtel_path):
     return SimulatorRayTracing(
         simtel_path=simtel_path,

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -16,7 +16,7 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_data_lst(model_version_prod5):
     return {
         "telescope": "LSTN-01",
@@ -27,7 +27,7 @@ def config_data_lst(model_version_prod5):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def camera_efficiency_lst(io_handler, db_config, simtel_path, config_data_lst):
     return CameraEfficiency(
         config_data=config_data_lst,
@@ -38,7 +38,7 @@ def camera_efficiency_lst(io_handler, db_config, simtel_path, config_data_lst):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def prepare_results_file(io_handler):
     test_file_name = (
         "tests/resources/"

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -10,7 +10,7 @@ from simtools.ray_tracing import RayTracing
 from simtools.utils import names
 
 
-@pytest.fixture()
+@pytest.fixture
 def ray_tracing_lst(telescope_model_lst, simtel_path, io_handler):
     """A RayTracing instance with results read in that were simulated before"""
     config_data = {

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -19,22 +19,22 @@ logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def input_file_list():
     return ["run1", "abc_run22", "def_run02_and"]
 
 
-@pytest.fixture()
+@pytest.fixture
 def corsika_file():
     return "run1_proton_za20deg_azm0deg_North_1LST_test.corsika.zst"
 
 
-@pytest.fixture()
+@pytest.fixture
 def submit_engine():
     return "local"
 
 
-@pytest.fixture()
+@pytest.fixture
 def simulations_args_dict(corsika_config_data, model_version, simtel_path, submit_engine):
     """Return a dictionary with the simulation command line arguments."""
     args_dict = copy.deepcopy(corsika_config_data)
@@ -52,7 +52,7 @@ def simulations_args_dict(corsika_config_data, model_version, simtel_path, submi
     return args_dict
 
 
-@pytest.fixture()
+@pytest.fixture
 def array_simulator(io_handler, db_config, simulations_args_dict):
     args_dict = copy.deepcopy(simulations_args_dict)
     args_dict["simulation_software"] = "simtel"
@@ -64,7 +64,7 @@ def array_simulator(io_handler, db_config, simulations_args_dict):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def shower_simulator(io_handler, db_config, simulations_args_dict):
     args_dict = copy.deepcopy(simulations_args_dict)
     args_dict["simulation_software"] = "corsika"
@@ -77,7 +77,7 @@ def shower_simulator(io_handler, db_config, simulations_args_dict):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def shower_array_simulator(io_handler, db_config, simulations_args_dict):
     args_dict = copy.deepcopy(simulations_args_dict)
     args_dict["simulation_software"] = "corsika_simtel"

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -10,12 +10,12 @@ from simtools.testing import assertions
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_json_file():
     return Path("tests/resources/reference_point_altitude.json")
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_yaml_file():
     return Path("tests/resources/num_gains.schema.yml")
 

--- a/tests/unit_tests/testing/test_compare_output.py
+++ b/tests/unit_tests/testing/test_compare_output.py
@@ -12,7 +12,7 @@ from simtools.testing import compare_output
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_json_file(tmp_test_directory):
     def _create_json_file(file_name, content):
         file = tmp_test_directory / file_name
@@ -22,7 +22,7 @@ def create_json_file(tmp_test_directory):
     return _create_json_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_yaml_file(tmp_path):
     def _create_yaml_file(file_name, content):
         file = tmp_path / file_name
@@ -33,7 +33,7 @@ def create_yaml_file(tmp_path):
     return _create_yaml_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_ecsv_file(tmp_path):
     def _create_ecsv_file(file_name, content):
         table = Table(content)
@@ -44,7 +44,7 @@ def create_ecsv_file(tmp_path):
     return _create_ecsv_file
 
 
-@pytest.fixture()
+@pytest.fixture
 def file_name():
     def _file_name(counter, suffix):
         return f"file{counter}.{suffix}"

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -12,7 +12,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 ecsv_suffix = ".ecsv"
 
 
-@pytest.fixture()
+@pytest.fixture
 def invalid_name():
     return "Invalid name"
 


### PR DESCRIPTION
This updates the pre-commit tools to their newest version (using `pre-commit autoupdate`) and applies the new changes.

The only change is from ruff and related a rule change of [PT001](https://docs.astral.sh/ruff/rules/pytest-fixture-incorrect-parentheses-style/): meaning fixtures without arguments should not have parentheses.