### PR TITLE
Remove sim telarray native configuration files

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -102,7 +102,7 @@ jobs:
             --cov --cov-report=xml
 
       # CTAO-DPPS-SonarQube
-      - uses: SonarSource/sonarqube-scan-action@v3
+      - uses: SonarSource/sonarqube-scan-action@v2.3
         if: contains(matrix.extra-args, 'codecov')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -102,7 +102,7 @@ jobs:
             --cov --cov-report=xml
 
       # CTAO-DPPS-SonarQube
-      - uses: SonarSource/sonarqube-scan-action@v2.3
+      - uses: SonarSource/sonarqube-scan-action@v2.3.0
         if: contains(matrix.extra-args, 'codecov')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -9,7 +9,6 @@ RUN microdnf update -y && microdnf install -y \
     findutils \
     gcc-c++ \
     git \
-    procps \
     python3.11-pip \
     python3.11-devel \
     wget && \

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -10,7 +10,6 @@ RUN microdnf update -y && microdnf install -y \
     findutils \
     gcc-c++ \
     git \
-    procps \
     python3.11-pip \
     python3.11-devel && \
     microdnf clean all

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -18,6 +18,8 @@ RUN mkdir sim_telarray
 COPY corsika7.7_simtelarray.tar.gz sim_telarray
 RUN cd sim_telarray && \
     tar -xvf corsika7.7_simtelarray.tar.gz && \
+    rm -f examples-with-data.tar.gz && \
+    rm -f sim_telarray_config.tar.gz && \
     ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
 RUN find sim_telarray/ -name "*.tar.gz" -exec rm -f {} \;
@@ -25,8 +27,8 @@ RUN find sim_telarray/ -name "*.tar.gz" -exec rm -f {} \;
 # corsika source code is removed to follow
 # the corsika non-distribution policy.
 RUN rm -f sim_telarray/corsika-run && \
-   mv sim_telarray/corsika-77*/run sim_telarray/corsika-run && \
-   rm -rf sim_telarray/corsika-77*
+    mv sim_telarray/corsika-77*/run sim_telarray/corsika-run && \
+    rm -rf sim_telarray/corsika-77*
 
 FROM almalinux/9-minimal
 WORKDIR /workdir
@@ -38,8 +40,13 @@ RUN microdnf update -y && microdnf install -y \
     zstd \
     gsl-devel \
     gcc-fortran \
+    procps \
     && \
     microdnf clean all
+
+# create a symbolic link to the corsika executable
+RUN cprog=$(/bin/ls /workdir/sim_telarray/corsika-run/corsika*$(uname)_* 2>/dev/null | tail -1) && \
+    ln -sf $cprog /workdir/sim_telarray/corsika-run/corsika
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 

--- a/simtools/corsika/corsika_config.py
+++ b/simtools/corsika/corsika_config.py
@@ -496,6 +496,13 @@ class CorsikaConfig:
             file.write(text_iact)
             file.write("\nEXIT")
 
+        # Write out the atmospheric transmission file to the model directory.
+        # This is done explicitly because it is not done "automatically" when CORSIKA is not piped
+        # to sim_telarray.
+        self.array_model.site_model.export_atmospheric_transmission_file(
+            model_directory=self.array_model.get_config_directory()
+        )
+
         self._is_file_updated = True
         return self.config_file_path
 

--- a/simtools/model/array_model.py
+++ b/simtools/model/array_model.py
@@ -92,6 +92,7 @@ class ArrayModel:
             mongo_db_config=self.mongo_db_config,
             model_version=self.model_version,
             label=self.label,
+            array_model=self,
         )
 
         array_elements = {}

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -2,6 +2,7 @@
 """Definition of site model."""
 
 import logging
+from pathlib import Path
 
 from simtools.model.model_parameter import ModelParameter
 
@@ -30,6 +31,7 @@ class SiteModel(ModelParameter):
         mongo_db_config,
         model_version,
         label=None,
+        array_model=None,
     ):
         """Initialize SiteModel."""
         self._logger = logging.getLogger(__name__)
@@ -42,6 +44,7 @@ class SiteModel(ModelParameter):
             db=None,
             label=label,
         )
+        self.array_model = array_model
 
     def get_reference_point(self):
         """
@@ -77,13 +80,18 @@ class SiteModel(ModelParameter):
 
         """
         if config_file_style:
+            model_directory = Path("")
+            if self.array_model:
+                model_directory = self.array_model.get_config_directory()
             return {
                 "OBSLEV": [
                     self.get_parameter_value_with_unit("corsika_observation_level").to_value("cm")
                 ],
                 # We always use a custom profile by filename, so this has to be set to 99
                 "ATMOSPHERE": [99, "Y"],
-                "IACT ATMOFILE": [self.get_parameter_value("atmospheric_profile")],
+                "IACT ATMOFILE": [
+                    model_directory / self.get_parameter_value("atmospheric_profile")
+                ],
                 "MAGNET": [
                     self.get_parameter_value("geomag_horizontal"),
                     self.get_parameter_value("geomag_vertical"),
@@ -130,3 +138,26 @@ class SiteModel(ModelParameter):
             List of available array layouts
         """
         return [layout["name"] for layout in self.get_parameter_value("array_layouts")]
+
+    def export_atmospheric_transmission_file(self, model_directory):
+        """
+        Export atmospheric transmission file.
+
+        This method is needed because when CORSIKA is not piped to sim_telarray,
+        the atmospheric transmission file is not written out to the model directory.
+        This method allows to export it explicitly.
+
+        Parameters
+        ----------
+        model_directory: Path
+            Model directory to export the file to.
+        """
+        self.db.export_model_files(
+            {
+                "atmospheric_transmission_file": {
+                    "value": self.get_parameter_value("atmospheric_profile"),
+                    "file": True,
+                }
+            },
+            model_directory,
+        )

--- a/simtools/model/site_model.py
+++ b/simtools/model/site_model.py
@@ -23,6 +23,8 @@ class SiteModel(ModelParameter):
         Model version.
     label: str
         Instance label. Important for output file naming.
+    array_model : ArrayModel
+        Array model.
     """
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,6 +421,17 @@ def corsika_runner_mock_array_model(corsika_config_mock_array_model, io_handler,
 
 
 @pytest.fixture
+def array_model(db_config, io_handler, model_version):
+    return ArrayModel(
+        label="test",
+        site="North",
+        layout_name="test_layout",
+        mongo_db_config=db_config,
+        model_version=model_version,
+    )
+
+
+@pytest.fixture
 def file_has_text():
     """Check if a file contains a specific text."""
 

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -234,6 +234,12 @@ def test_applications_from_config(tmp_test_directory, config, monkeypatch, reque
 
     """
 
+    if "camera-efficiency" in config["APPLICATION"]:
+        pytest.skip(
+            "Any applications calling testeff are skipped for now "
+            "due to a limitation of testeff not allowing to specify the include directory."
+        )
+
     # The db_add_file_to_db.py application requires a user confirmation.
     # With this line we mock the user confirmation to be y for the test
     # Notice this is done for all tests, so keep in mind if in the future we add tests with input.

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -14,17 +14,6 @@ logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
-def array_model(db_config, io_handler, model_version):
-    return ArrayModel(
-        label="test",
-        site="North",
-        layout_name="test_layout",
-        mongo_db_config=db_config,
-        model_version=model_version,
-    )
-
-
-@pytest.fixture
 def array_model_from_list(db_config, io_handler, model_version):
     return ArrayModel(
         label="test",

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -101,3 +101,31 @@ def test_is_photon_list_file_ok(simulator_ray_tracing):
         file.writelines(150 * [f"{1}\n"])
 
     assert simulator_ray_tracing._is_photon_list_file_ok()
+
+
+def test_write_out_single_pixel_camera_file(simulator_ray_tracing):
+    simulator_ray_tracing._write_out_single_pixel_camera_file()
+
+    single_pixel_camera_file = simulator_ray_tracing.telescope_model.config_file_directory.joinpath(
+        "single_pixel_camera.dat"
+    )
+    funnel_perfect_file = simulator_ray_tracing.telescope_model.config_file_directory.joinpath(
+        "funnel_perfect.dat"
+    )
+
+    assert single_pixel_camera_file.exists()
+    assert funnel_perfect_file.exists()
+
+    with single_pixel_camera_file.open("r") as file:
+        lines = file.readlines()
+        assert lines[0].strip() == "# Single pixel camera"
+        assert lines[1].strip() == 'PixType 1   0  0 300   1 300 0.00   "funnel_perfect.dat"'
+        assert lines[2].strip() == "Pixel 0 1 0. 0.  0  0  0 0x00 1"
+        assert lines[3].strip() == "Trigger 1 of 0"
+
+    with funnel_perfect_file.open("r") as file:
+        lines = file.readlines()
+        assert lines[1].strip() == "0    1.0"
+        assert lines[2].strip() == "30   1.0"
+        assert lines[3].strip() == "60   1.0"
+        assert lines[4].strip() == "90   1.0"

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -48,6 +48,44 @@ def simulator_ray_tracing(ray_tracing_sst, telescope_model_sst, simtel_path):
     )
 
 
+@pytest.fixture
+def simulator_ray_tracing_single_mirror(ray_tracing_sst, telescope_model_sst, simtel_path):
+    return SimulatorRayTracing(
+        simtel_path=simtel_path,
+        telescope_model=telescope_model_sst,
+        config_data={
+            "zenith_angle": ray_tracing_sst.config.zenith_angle * u.deg,
+            "source_distance": ray_tracing_sst._source_distance * u.km,
+            "off_axis_angle": 0 * u.deg,
+            "mirror_numbers": 0,
+            "use_random_focal_length": ray_tracing_sst.config.use_random_focal_length,
+            "single_mirror_mode": True,
+        },
+        label="test-simtel-runner-ray-tracing",
+    )
+
+
+@pytest.fixture
+def single_pixel_camera_file_content():
+    return [
+        "# Single pixel camera",
+        'PixType 1   0  0 300   1 300 0.00   "funnel_perfect.dat"',
+        "Pixel 0 1 0. 0.  0  0  0 0x00 1",
+        "Trigger 1 of 0",
+    ]
+
+
+@pytest.fixture
+def funnel_perfect_file_content():
+    return [
+        "# Perfect light collection where the angular efficiency of funnels is needed",
+        "0    1.0",
+        "30   1.0",
+        "60   1.0",
+        "90   1.0",
+    ]
+
+
 def test_load_required_files(simulator_ray_tracing):
     simulator_ray_tracing._load_required_files(force_simulate=False)
 
@@ -57,6 +95,55 @@ def test_load_required_files(simulator_ray_tracing):
     assert not simulator_ray_tracing._corsika_file.exists()
     assert simulator_ray_tracing._photons_file.exists()
     assert simulator_ray_tracing._stars_file.exists()
+    assert not simulator_ray_tracing.telescope_model.config_file_directory.joinpath(
+        "single_pixel_camera.dat"
+    ).exists()
+
+
+def assert_single_pixel_and_perfect_funnel_files(
+    simulator_ray_tracing_to_test, single_pixel_camera_file_content, funnel_perfect_file_content
+):
+    single_pixel_camera_file = (
+        simulator_ray_tracing_to_test.telescope_model.config_file_directory.joinpath(
+            "single_pixel_camera.dat"
+        )
+    )
+    funnel_perfect_file = (
+        simulator_ray_tracing_to_test.telescope_model.config_file_directory.joinpath(
+            "funnel_perfect.dat"
+        )
+    )
+
+    for created_file, content in zip(
+        [single_pixel_camera_file, funnel_perfect_file],
+        [single_pixel_camera_file_content, funnel_perfect_file_content],
+    ):
+        assert created_file.exists()
+        with created_file.open("r") as file:
+            lines = file.readlines()
+            for i_line, line in enumerate(lines):
+                assert line.strip() == content[i_line]
+
+
+def test_load_required_files_single_mirror(
+    simulator_ray_tracing_single_mirror,
+    single_pixel_camera_file_content,
+    funnel_perfect_file_content,
+):
+    simulator_ray_tracing_single_mirror._load_required_files(force_simulate=False)
+
+    # This file is not actually needed and does not exist in simtools.
+    # However, its name is needed too provide the name of a CORSIKA input file to sim_telarray
+    # so here we check the it does not actually exist.
+    assert not simulator_ray_tracing_single_mirror._corsika_file.exists()
+    assert simulator_ray_tracing_single_mirror._photons_file.exists()
+    assert simulator_ray_tracing_single_mirror._stars_file.exists()
+
+    assert_single_pixel_and_perfect_funnel_files(
+        simulator_ray_tracing_single_mirror,
+        single_pixel_camera_file_content,
+        funnel_perfect_file_content,
+    )
 
 
 def test_make_run_command(simulator_ray_tracing, model_version):
@@ -103,29 +190,11 @@ def test_is_photon_list_file_ok(simulator_ray_tracing):
     assert simulator_ray_tracing._is_photon_list_file_ok()
 
 
-def test_write_out_single_pixel_camera_file(simulator_ray_tracing):
+def test_write_out_single_pixel_camera_file(
+    simulator_ray_tracing, single_pixel_camera_file_content, funnel_perfect_file_content
+):
     simulator_ray_tracing._write_out_single_pixel_camera_file()
 
-    single_pixel_camera_file = simulator_ray_tracing.telescope_model.config_file_directory.joinpath(
-        "single_pixel_camera.dat"
+    assert_single_pixel_and_perfect_funnel_files(
+        simulator_ray_tracing, single_pixel_camera_file_content, funnel_perfect_file_content
     )
-    funnel_perfect_file = simulator_ray_tracing.telescope_model.config_file_directory.joinpath(
-        "funnel_perfect.dat"
-    )
-
-    assert single_pixel_camera_file.exists()
-    assert funnel_perfect_file.exists()
-
-    with single_pixel_camera_file.open("r") as file:
-        lines = file.readlines()
-        assert lines[0].strip() == "# Single pixel camera"
-        assert lines[1].strip() == 'PixType 1   0  0 300   1 300 0.00   "funnel_perfect.dat"'
-        assert lines[2].strip() == "Pixel 0 1 0. 0.  0  0  0 0x00 1"
-        assert lines[3].strip() == "Trigger 1 of 0"
-
-    with funnel_perfect_file.open("r") as file:
-        lines = file.readlines()
-        assert lines[1].strip() == "0    1.0"
-        assert lines[2].strip() == "30   1.0"
-        assert lines[3].strip() == "60   1.0"
-        assert lines[4].strip() == "90   1.0"


### PR DESCRIPTION
This PR removes our dependence on sim_telarray configuration files entirely. We only use simtools created configuration files from now on.

I had to skip the `testeff` tests because of this change since in the current version, `testeff` does not allow to provide a different configuration directory. A fix for that is already available. In addition, testeff requires a file which is currently unavailable in the DB (MR on gitlab is open). 

A couple of explicit additions were necessary because CORSIKA config does not write out configuration files. However, the atmospheric profile is necessary for all CORSIKA simulations, so now it is written out explicitly in the `corsika_config` step.