### PR TITLE
Update version number for corsika/sim_telarray package (20240913)

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         production: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
-        version: ['240923']
+        version: ['240913']
         hadronic_model: ['qgs2']
 
     steps:

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         production: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
-        version: ['240318']
+        version: ['240923']
         hadronic_model: ['qgs2']
 
     steps:

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,4 +1,4 @@
-FROM almalinux as build_image
+FROM almalinux AS build_image
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive
 ARG BUILD_OPT="prod6-sc"
@@ -10,6 +10,7 @@ RUN yum update -y && yum install -y \
     which \
     gcc-fortran \
     gsl-devel \
+    patch \
     && \
     yum clean all
 


### PR DESCRIPTION
This PR required the following steps:

- download most recent CORSIKA/sim-telarray package from KB's testing website (date 2024/09/13)
- upload the package to sync and share
- define a new github secret for the actions CLOUD_SIMTEL_230913
- update the workflow for building the docker for CORSIKA/sim-telarray