### PR TITLE
Run integration tests for indicated model version when no `model_vers…

### DIFF
--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -260,7 +260,10 @@ def test_applications_from_config(tmp_test_directory, config, monkeypatch, reque
         model_version_requested = request.config.getoption("--model_version")
         if "MODEL_VERSION_USE_CURRENT" in config:
             model_version_config = config["CONFIGURATION"]["MODEL_VERSION"]
-            if model_version_requested != model_version_config:
+            if (
+                model_version_requested != model_version_config
+                and model_version_requested is not None
+            ):
                 pytest.skip(
                     "Model version requested {model_version_requested} not supported for this test"
                 )


### PR DESCRIPTION
…ion` command line is given