### PR TITLE
Change null string to None for unit validation

### DIFF
--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -139,6 +139,7 @@ class DataValidator:
             if isinstance(self.data_dict["unit"], list | np.ndarray)
             else [self.data_dict["unit"]]
         )
+        unit_as_list = [None if unit == 'null' else unit for unit in unit_as_list]
         for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
             if self._get_data_description(index).get("type", None) == "dict":
                 self._logger.debug(f"Skipping validation of dict type for entry {index}")

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -139,7 +139,7 @@ class DataValidator:
             if isinstance(self.data_dict["unit"], list | np.ndarray)
             else [self.data_dict["unit"]]
         )
-        unit_as_list = [None if unit == 'null' else unit for unit in unit_as_list]
+        unit_as_list = [None if unit == "null" else unit for unit in unit_as_list]
         for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
             if self._get_data_description(index).get("type", None) == "dict":
                 self._logger.debug(f"Skipping validation of dict type for entry {index}")

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -654,6 +654,9 @@ def test_validate_data_dict():
     data_validator_2.data_dict = {"name": "num_gains", "value": [2], "unit": [None]}
     data_validator_2._validate_data_dict()
 
+    data_validator_2.data_dict = {"name": "num_gains", "value": [2], "unit": ["null"]}
+    data_validator_2._validate_data_dict()
+
 
 def test_prepare_model_parameter():
     data_validator = validate_data.DataValidator()


### PR DESCRIPTION
This is a small bug fix in the unit validation check in case the units is given as list (indicated by a string) in the model parameter json files.

e.g. the unit string in:

```
{
    "parameter": "nsb_autoscale_airmass",
    "instrument": "LSTN-02",
    "site": "North",
    "version": "6.0.0",
    "value": "0.84 0.29",
    "unit": "null, null",
    "type": "float64",
    "applicable": true,
    "file": false
}
```

should be interpreted as `[None, None]` and not as `["null", "null"]`. This PR fixes this issue (and adds a test).