### PR TITLE
Remove 3x duplication of string fs.files (reported as code smell by sonar)

### DIFF
--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -35,12 +35,17 @@ def _db_cleanup(db, random_id):
 
 
 @pytest.fixture
-def _db_cleanup_file_sandbox(db_no_config_file, random_id):
+def fs_files():
+    return "fs.files"
+
+
+@pytest.fixture
+def _db_cleanup_file_sandbox(db_no_config_file, random_id, fs_files):
     yield
     # Cleanup
     logger.info("Dropping the temporary files in the sandbox")
     db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.chunks"].drop()
-    db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.files"].drop()
+    db_no_config_file.db_client[f"sandbox_{random_id}"][fs_files].drop()
 
 
 def test_find_latest_simulation_model_db(db, db_no_config_file, mocker):
@@ -589,7 +594,7 @@ def test_model_version(db):
         db.model_version(version="0.0.9876")
 
 
-def test_get_collections(db, db_config):
+def test_get_collections(db, db_config, fs_files):
 
     collections = db.get_collections()
     assert isinstance(collections, list)
@@ -598,12 +603,12 @@ def test_get_collections(db, db_config):
     collections_from_name = db.get_collections(db_config["db_simulation_model"])
     assert isinstance(collections_from_name, list)
     assert "telescopes" in collections_from_name
-    assert "fs.files" in collections_from_name
+    assert fs_files in collections_from_name
 
     collections_no_model = db.get_collections(db_config["db_simulation_model"], True)
     assert isinstance(collections_no_model, list)
     assert "telescopes" in collections_no_model
-    assert "fs.files" not in collections_no_model
+    assert fs_files not in collections_no_model
     assert "metadata" not in collections_no_model
 
 


### PR DESCRIPTION
Fixes the code smell reported by sonarq [here](https://sonar-cta-dpps.zeuthen.desy.de/project/issues?resolved=false&types=CODE_SMELL&id=gammasim_simtools_AY_ssha9WiFxsX-2oy_w&open=AZG6fmByGE3VkZNQHi9L).

This is actually a bit annoying, but quick to fix.