### PR TITLE
Allow for class Telescope in model parameters

### DIFF
--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -77,7 +77,7 @@ def site_parameters():
 
 
 def telescope_parameters():
-    return load_model_parameters(class_key_list=("Structure", "Camera"))
+    return load_model_parameters(class_key_list=("Structure", "Camera", "Telescope"))
 
 
 def validate_array_element_id_name(name):


### PR DESCRIPTION
This is for parameters which are not of class "Camera" or "Structure" but describe something relevant for the complete telescope.