### PR TITLE
Update corsika/sim_telarray version to 240927

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         production: ['prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc']
-        version: ['240913']
+        version: ['240927']
         hadronic_model: ['qgs2']
 
     steps:

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,6 +1,6 @@
 ARG BUILD_OPT="prod6-baseline"
 ARG HADRONIC_MODEL="qgs2"
-ARG VERSION="240318"
+ARG VERSION="240927"
 FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${HADRONIC_MODEL}-${BUILD_OPT}-${VERSION}
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -1,6 +1,6 @@
 ARG BUILD_OPT="prod6-sc"
 ARG HADRONIC_MODEL="qgs2"
-ARG VERSION="240318"
+ARG VERSION="240927"
 FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${HADRONIC_MODEL}-${BUILD_OPT}-${VERSION}
 WORKDIR /workdir
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Uploaded the most recent corsika/simtel tar ball from

https://www.mpi-hd.mpg.de/hfm/CTA/MC/Software/Testing/corsika7.7_simtelarray.tar.gz

to the cloud space with the date ID 20240927. Changed the github CI accordingly.

Note: this CI is manually triggered.