### PR TITLE
Fix testeff again

### DIFF
--- a/simtools/applications/validate_camera_efficiency.py
+++ b/simtools/applications/validate_camera_efficiency.py
@@ -74,16 +74,15 @@ def _parse(label):
         required=False,
     )
     config.parser.add_argument(
-        "--apply_correction_to_nsb_spectrum",
+        "--skip_correction_to_nsb_spectrum",
         help=(
             "Apply a correction to the NSB spectrum to account for the "
             "difference between the altitude used in the reference B&E spectrum and "
             "the observation level at the CTAO sites."
             "This correction is done internally in sim_telarray and is on by default."
         ),
-        type=bool,
-        default=True,
         required=False,
+        action="store_true",
     )
     _args_dict, _db_config = config.initialize(
         db_config=True,

--- a/simtools/camera_efficiency.py
+++ b/simtools/camera_efficiency.py
@@ -170,8 +170,8 @@ class CameraEfficiency:
             file_log=self._file["log"],
             label=self.label,
             nsb_spectrum=self.config["nsb_spectrum"],
-            apply_correction_to_nsb_spectrum=self.config.get(
-                "apply_correction_to_nsb_spectrum", True
+            skip_correction_to_nsb_spectrum=self.config.get(
+                "skip_correction_to_nsb_spectrum", False
             ),
         )
         simtel.run(test=self.test)
@@ -180,6 +180,10 @@ class CameraEfficiency:
         """Export model and config files to the output directory."""
         self.telescope_model.export_config_file()
         self.telescope_model.export_model_files()
+        if not self.config.get("skip_correction_to_nsb_spectrum", False):
+            self.telescope_model.export_nsb_spectrum_to_telescope_altitude_correction_file(
+                model_directory=self.telescope_model.config_file_directory
+            )
 
     def analyze(self, export=True, force=False):
         """

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -570,3 +570,29 @@ class ModelParameter:
                 model_version=self.model_version,
                 label=self.label,
             )
+
+    def export_nsb_spectrum_to_telescope_altitude_correction_file(self, model_directory):
+        """
+        Export the NSB spectrum to the telescope altitude correction file.
+
+        This method is needed because testeff corrects the NSB spectrum from the original altitude
+        used in the Benn & Ellison model to the telescope altitude.
+        This is done internally in testeff, but the NSB spectrum is not written out to the model
+        directory. This method allows to export it explicitly.
+
+        Parameters
+        ----------
+        model_directory: Path
+            Model directory to export the file to.
+        """
+        self.db.export_model_files(
+            {
+                "nsb_spectrum_at_2200m": {
+                    "value": self._simulation_config_parameters["simtel"][
+                        "correct_nsb_spectrum_to_telescope_altitude"
+                    ]["value"],
+                    "file": True,
+                }
+            },
+            model_directory,
+        )

--- a/simtools/simtel/simulator_camera_efficiency.py
+++ b/simtools/simtel/simulator_camera_efficiency.py
@@ -39,7 +39,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         file_log=None,
         zenith_angle=None,
         nsb_spectrum=None,
-        apply_correction_to_nsb_spectrum=True,
+        skip_correction_to_nsb_spectrum=False,
     ):
         """Initialize SimtelRunner."""
         self._logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
         self._file_log = file_log
         self.zenith_angle = zenith_angle
         self.nsb_spectrum = nsb_spectrum
-        self.apply_correction_to_nsb_spectrum = apply_correction_to_nsb_spectrum
+        self.skip_correction_to_nsb_spectrum = skip_correction_to_nsb_spectrum
 
     @property
     def nsb_spectrum(self):
@@ -122,7 +122,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
             )
 
         command = str(self._simtel_path.joinpath("sim_telarray/testeff"))
-        if not self.apply_correction_to_nsb_spectrum:
+        if self.skip_correction_to_nsb_spectrum:
             command += " -nc"  # Do not apply correction to original altitude where B&E was derived
         command += " -I"  # Clear the fall-back configuration directories
         command += f" -I{self._telescope_model.config_file_directory}"

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -370,6 +370,12 @@ def skip_camera_efficiency(config):
                 "due to a limitation of the old testeff not allowing to specify "
                 "the include directory. Please update your sim_telarray tarball."
             )
+        full_test_name = f"{config['APPLICATION']}_{config['TEST_NAME']}"
+        if "simtools-validate-camera-efficiency_SSTS" == full_test_name:
+            pytest.skip(
+                "The test simtools-validate-camera-efficiency_SSTS is skipped "
+                "since the fake SST mirrors are not yet implemented (#1155)"
+            )
 
 
 def new_testeff_version():

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -340,3 +340,26 @@ def test_get_config_file(telescope_model_lst, mocker):
     telescope_copy._is_config_file_up_to_date = False
     telescope_copy.get_config_file(no_export=True)
     not mock_export.assert_called_once()
+
+
+def test_export_nsb_spectrum_to_telescope_altitude_correction_file(telescope_model_lst, mocker):
+    model_directory = Path("test_model_directory")
+    telescope_copy = copy.deepcopy(telescope_model_lst)
+
+    mock_db_export = mocker.patch.object(DatabaseHandler, "export_model_files")
+    mock_simulation_config_parameters = {
+        "simtel": {"correct_nsb_spectrum_to_telescope_altitude": {"value": "test_value"}}
+    }
+    telescope_copy._simulation_config_parameters = mock_simulation_config_parameters
+
+    telescope_copy.export_nsb_spectrum_to_telescope_altitude_correction_file(model_directory)
+
+    mock_db_export.assert_called_once_with(
+        {
+            "nsb_spectrum_at_2200m": {
+                "value": "test_value",
+                "file": True,
+            }
+        },
+        model_directory,
+    )

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -70,7 +70,7 @@ def test_make_run_command_with_nsb_spectrum(simulator_camera_efficiency, expecte
 def test_make_run_command_without_altitude_correction(
     simulator_camera_efficiency, expected_command, benn_ellison_spectrum_file_name
 ):
-    simulator_camera_efficiency.apply_correction_to_nsb_spectrum = False
+    simulator_camera_efficiency.skip_correction_to_nsb_spectrum = True
     command = simulator_camera_efficiency._make_run_command()
 
     for item in expected_command:


### PR DESCRIPTION
The summary below was written by copilot. The gist is that 
- the necessary file is now exported to the model directory, though the function in `model_parameters.py` is a bit ugly. 
- I switched around the option from apply the correction to skip the correction which makes more sense.
- An expected failing test is skipped and will be fixed as part of a separate issue that is already open (#1155)


This pull request includes several changes to the `simtools` package to update the handling of the NSB spectrum correction and add new functionality for exporting model files. The key changes involve renaming a parameter, updating method calls, and adding new methods and tests to support these updates.

### Parameter Renaming and Method Updates:

* [`simtools/applications/validate_camera_efficiency.py`](diffhunk://#diff-2913884023b204e85818728662db87e178bd88577aebc711f71d1d06516d020cL77-R85): Renamed the `--apply_correction_to_nsb_spectrum` argument to `--skip_correction_to_nsb_spectrum` and changed its type to a boolean flag.
* [`simtools/camera_efficiency.py`](diffhunk://#diff-bc5417f38c587bd9cfb704dd4629b94cad12c922d31b5db57fcef1bfc723d115L173-R174): Updated method calls to use the new `skip_correction_to_nsb_spectrum` parameter instead of `apply_correction_to_nsb_spectrum`. [[1]](diffhunk://#diff-bc5417f38c587bd9cfb704dd4629b94cad12c922d31b5db57fcef1bfc723d115L173-R174) [[2]](diffhunk://#diff-bc5417f38c587bd9cfb704dd4629b94cad12c922d31b5db57fcef1bfc723d115R183-R186)
* [`simtools/simtel/simulator_camera_efficiency.py`](diffhunk://#diff-9b284b4a4dceb07e38e06c1eedcbd9ed3a5d8507469267750a399d74d68a5ed8L42-R42): Updated the constructor and `_make_run_command` method to use `skip_correction_to_nsb_spectrum`. [[1]](diffhunk://#diff-9b284b4a4dceb07e38e06c1eedcbd9ed3a5d8507469267750a399d74d68a5ed8L42-R42) [[2]](diffhunk://#diff-9b284b4a4dceb07e38e06c1eedcbd9ed3a5d8507469267750a399d74d68a5ed8L57-R57) [[3]](diffhunk://#diff-9b284b4a4dceb07e38e06c1eedcbd9ed3a5d8507469267750a399d74d68a5ed8L125-R125)

### New Functionality:

* [`simtools/model/model_parameter.py`](diffhunk://#diff-18c743e051dbc9138833b175744087202a64dd20839636f6e7cf18810af020f1R573-R598): Added a new method `export_nsb_spectrum_to_telescope_altitude_correction_file` to export the NSB spectrum correction file.

### Tests:

* [`tests/integration_tests/test_applications_from_config.py`](diffhunk://#diff-9d1c10b9b317d4376926be73e2dd71f43b69f927bfb3640168acec79b3904e06R373-R378): Added a condition to skip a specific test due to unimplemented features.
* [`tests/unit_tests/model/test_model_parameter.py`](diffhunk://#diff-f6af9b31cd5f7e65e2aaf67f59155bf19590b3ec19d7b226a2bcbefc5e5d058dR343-R365): Added a new unit test for the `export_nsb_spectrum_to_telescope_altitude_correction_file` method.
* [`tests/unit_tests/simtel/test_simulator_camera_efficiency.py`](diffhunk://#diff-5d1b632876be448532eb356ea500e5f81f9e40b02598f9373e77fe69138eea58L73-R73): Updated the test to use `skip_correction_to_nsb_spectrum`.