### PR TITLE
Simplify code to get simtel_configuration parameters from DB and improve call efficiency

### DIFF
--- a/simtools/applications/db_get_parameter_from_db.py
+++ b/simtools/applications/db_get_parameter_from_db.py
@@ -85,8 +85,11 @@ def main():  # noqa: D103
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
 
     if args_dict["db_collection"] == "configuration_sim_telarray":
-        pars = db.get_sim_telarray_configuration_parameters(
-            args_dict["site"], args_dict["telescope"], args_dict["model_version"]
+        pars = db.get_model_parameters(
+            args_dict["site"],
+            args_dict["telescope"],
+            args_dict["model_version"],
+            collection="configuration_sim_telarray",
         )
     elif args_dict["db_collection"] == "configuration_corsika":
         pars = db.get_corsika_configuration_parameters(args_dict["model_version"])

--- a/simtools/db/db_array_elements.py
+++ b/simtools/db/db_array_elements.py
@@ -1,14 +1,14 @@
 """Retrieval of array elements from the database."""
 
-from functools import cache
+from functools import lru_cache
 
 from pymongo import ASCENDING
 
 from simtools.utils import names
 
 
-@cache
-def get_array_elements(db, model_version, collection):
+@lru_cache
+def get_array_elements(db_collection, model_version):
     """
     Get all array element names and their design model for a given DB collection.
 
@@ -17,12 +17,10 @@ def get_array_elements(db, model_version, collection):
 
     Parameters
     ----------
-    db: DBHandler
-        Instance of the database handler
+    db_collection:
+        pymongo.collection.Collection
     model_version: str
        Model version.
-    collection: str
-        Database collection (e.g., telescopes, calibration_devices)
 
     Returns
     -------
@@ -37,9 +35,7 @@ def get_array_elements(db, model_version, collection):
         If array element entry in the database is incomplete.
 
     """
-    db_collection = db.get_collection(db_name=None, collection_name=collection)
-
-    query = {"version": db.model_version(model_version)}
+    query = {"version": model_version}
     results = db_collection.find(query, {"instrument": 1, "value": 1, "parameter": 1}).sort(
         "instrument", ASCENDING
     )
@@ -53,7 +49,7 @@ def get_array_elements(db, model_version, collection):
             raise KeyError("Incomplete array element entry in the database.") from exc
 
     if len(_all_available_array_elements) == 0:
-        raise ValueError(f"No array elements found in DB collection {collection}.")
+        raise ValueError(f"No array elements found in DB collection {db_collection}.")
 
     return _all_available_array_elements
 
@@ -84,7 +80,10 @@ def get_array_element_list_for_db_query(array_element_name, db, model_version, c
 
     """
     try:
-        _available_array_elements = get_array_elements(db, model_version, collection)
+        _available_array_elements = get_array_elements(
+            db.get_collection(db_name=None, collection_name=collection),
+            db.model_version(model_version),
+        )
     except ValueError:
         return [names.get_array_element_type_from_name(array_element_name) + "-design"]
     try:
@@ -122,7 +121,10 @@ def get_array_elements_of_type(array_element_type, db, model_version, collection
         Sorted list of all array element names found in collection
 
     """
-    _available_array_elements = get_array_elements(db, model_version, collection)
+    _available_array_elements = get_array_elements(
+        db.get_collection(db_name=None, collection_name=collection),
+        db.model_version(model_version),
+    )
     return sorted(
         [entry for entry in _available_array_elements if entry.startswith(array_element_type)]
     )

--- a/simtools/db/db_array_elements.py
+++ b/simtools/db/db_array_elements.py
@@ -4,6 +4,8 @@ from functools import cache
 
 from pymongo import ASCENDING
 
+from simtools.utils import names
+
 
 @cache
 def get_array_elements(db, model_version, collection):
@@ -62,6 +64,7 @@ def get_array_element_list_for_db_query(array_element_name, db, model_version, c
 
     Return a list of array element names to be used for querying the database for a given array
     element. This is in most cases the array element itself and its design model.
+    In cases of no design model available, the design model of the array element is returned.
 
     Parameters
     ----------
@@ -80,7 +83,10 @@ def get_array_element_list_for_db_query(array_element_name, db, model_version, c
         List of array element model names as used in the DB.
 
     """
-    _available_array_elements = get_array_elements(db, model_version, collection)
+    try:
+        _available_array_elements = get_array_elements(db, model_version, collection)
+    except ValueError:
+        return [names.get_array_element_type_from_name(array_element_name) + "-design"]
     try:
         return [array_element_name, _available_array_elements[array_element_name]]
     except KeyError:

--- a/tests/unit_tests/db/test_db_array_elements.py
+++ b/tests/unit_tests/db/test_db_array_elements.py
@@ -10,7 +10,7 @@ from simtools.db import db_array_elements
 def test_get_array_elements(db, model_version):
 
     time_1 = time.time()
-    available_telescopes = db_array_elements.get_array_elements(
+    db_array_elements.get_array_elements(
         db.get_collection(db_name=None, collection_name="telescopes"),
         db.model_version(model_version),
     )

--- a/tests/unit_tests/db/test_db_array_elements.py
+++ b/tests/unit_tests/db/test_db_array_elements.py
@@ -65,6 +65,10 @@ def test_get_array_element_list_for_db_query(db, model_version):
             "MSTS-301", db=db, model_version=model_version, collection="calibration_devices"
         )
 
+    assert db_array_elements.get_array_element_list_for_db_query(
+        "LSTN-02", db=db, model_version=model_version, collection="configuration_sim_telarray"
+    ) == ["LSTN-design"]
+
 
 def test_get_array_elements_of_type(db, model_version):
     available_telescopes = db_array_elements.get_array_elements_of_type(

--- a/tests/unit_tests/db/test_db_array_elements.py
+++ b/tests/unit_tests/db/test_db_array_elements.py
@@ -1,14 +1,28 @@
 #!/usr/bin/python3
 
+import time
+
 import pytest
 
 from simtools.db import db_array_elements
 
 
 def test_get_array_elements(db, model_version):
+
+    time_1 = time.time()
     available_telescopes = db_array_elements.get_array_elements(
-        db=db, model_version=model_version, collection="telescopes"
+        db.get_collection(db_name=None, collection_name="telescopes"),
+        db.model_version(model_version),
     )
+    time_2 = time.time()
+    available_telescopes = db_array_elements.get_array_elements(
+        db.get_collection(db_name=None, collection_name="telescopes"),
+        db.model_version(model_version),
+    )
+    time_3 = time.time()
+
+    # check that the second call is much faster than the first one
+    assert (time_2 - time_1) > 0.1 * (time_3 - time_2)
 
     expected_telescope_names = {
         "LSTN-01": "LSTN-design",
@@ -24,7 +38,8 @@ def test_get_array_elements(db, model_version):
         assert expected_telescope_names[_t] in available_telescopes[_t]
 
     available_calibration_devices = db_array_elements.get_array_elements(
-        db=db, model_version=model_version, collection="calibration_devices"
+        db.get_collection(db_name=None, collection_name="calibration_devices"),
+        db.model_version(model_version),
     )
     expected_calibration_devices = {
         "ILLN-01": "ILLN-design",
@@ -34,11 +49,10 @@ def test_get_array_elements(db, model_version):
         assert _d in available_calibration_devices
         assert expected_calibration_devices[_d] in available_calibration_devices[_d]
 
-    with pytest.raises(
-        ValueError, match=r"^No array elements found in DB collection wrong_collection."
-    ):
+    with pytest.raises(ValueError, match=r"^No array elements found in DB collection"):
         db_array_elements.get_array_elements(
-            db=db, model_version=model_version, collection="wrong_collection"
+            db.get_collection(db_name=None, collection_name="wrong_collection"),
+            db.model_version(model_version),
         )
 
 

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -142,10 +142,14 @@ def test_get_derived_values(db, model_version_prod5):
 
 def test_get_sim_telarray_configuration_parameters(db, model_version):
 
-    _pars = db.get_sim_telarray_configuration_parameters("North", "LSTN-01", model_version)
+    _pars = db.get_model_parameters(
+        "North", "LSTN-01", model_version, collection="configuration_sim_telarray"
+    )
     assert "min_photoelectrons" in _pars
 
-    _pars = db.get_sim_telarray_configuration_parameters("North", "LSTN-design", model_version)
+    _pars = db.get_model_parameters(
+        "North", "LSTN-design", model_version, collection="configuration_sim_telarray"
+    )
     assert "min_photoelectrons" in _pars
 
 

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -146,11 +146,11 @@ def test_load_parameters_from_db(telescope_model_lst, mocker):
     telescope_copy = copy.deepcopy(telescope_model_lst)
     mock_db = mocker.patch.object(DatabaseHandler, "get_model_parameters")
     telescope_copy._load_parameters_from_db()
-    mock_db.assert_called_once()
+    assert mock_db.call_count == 2
 
     telescope_copy.db = None
     telescope_copy._load_parameters_from_db()
-    not mock_db.assert_called_once()
+    assert mock_db.call_count == 2
 
 
 def test_extra_labels(telescope_model_lst):


### PR DESCRIPTION
This PR reduces the number of DB calls significantly without major refactoring by:

- fixes a bug in reading configuration_simtelarray: this was actually not working using the caching mechanism in `db_handler` (solved now by explicitly adding the `collection` to the `db.get_model_parameters` call.
- improved API to db_array_elements.get_array_elements() for much better call efficiency (is called now only once per database collection). The caching before was syntax correct, but not very efficient. This is improved by passing on directly the pymongo.collection.Collection object. 
- replacement of db_handler.get_sim_telarray_configuration_parameters by db_handler.get_model_parameter (as it does actually the same thing). This implementation allows as well to have in future non-design entries for the simtel_configuration

Tested this with the unit test `tests/unit_tests/corsika/test_corsika_config.py::test_get_corsika_telescope_list`. The execution time is reduced by a factor >2 with the changes proposed here (from 17-22s to 7-9s). I've done an extensive printout of where time is spend:

- loop over all telescopes and for each telescopes we query for telescope and simtel_configuratino parameters for the actual telescope (e.g. MSTS-13) and the design telescope (MSTS-design)
- with this PR, we query MSTS-design only once

For future improvements, this requires probably a refactoring to get parameters from multiple telescopes at the same time.

For reference, the unit test duration (sorted) is now:

```
7.89s setup    tests/unit_tests/corsika/test_corsika_config.py::test_get_corsika_telescope_list
4.32s call     tests/unit_tests/model/test_array_model.py::test_exporting_config_files
3.99s setup    tests/unit_tests/simtel/test_simulator_camera_efficiency.py::test_make_run_command
3.87s call     tests/unit_tests/model/test_array_model.py::test_get_config_file
3.67s call     tests/unit_tests/test_simulator.py::test_simulate_array_simulator
3.65s setup    tests/unit_tests/simtel/test_simulator_camera_efficiency.py::test_make_run_command_with_nsb_spectrum
```

All tests done with remote DB from home office (outside of DESY).

This is a significant improvement to what has been reported in #1130 (I had similar execution times on my development machine).

@orelgueta - for you to note (not to review).

Closes #1130 (I think so).