### PR TITLE
Bug fix for reading telescope model for design and telescope ID.

### DIFF
--- a/simtools/db/db_array_elements.py
+++ b/simtools/db/db_array_elements.py
@@ -82,7 +82,7 @@ def get_array_element_list_for_db_query(array_element_name, db, model_version, c
     """
     _available_array_elements = get_array_elements(db, model_version, collection)
     try:
-        return [array_element_name, _available_array_elements[array_element_name]]
+        return [_available_array_elements[array_element_name], array_element_name]
     except KeyError:
         pass
 

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
@@ -35,5 +35,5 @@ CTA_SIMPIPE:
         # should be between 20 and 1000 (very loose requirement)
         pe_sum: [20, 1000]
         # The mean number of photons per telescope after atmospheric absorption and QE
-        # should be between 70 and 1000 (very loose requirement)
-        photons: [70, 1000]
+        # should be between 90 and 1000 (very loose requirement)
+        photons: [90, 1000]

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
@@ -35,5 +35,5 @@ CTA_SIMPIPE:
         # should be between 20 and 1000 (very loose requirement)
         pe_sum: [20, 1000]
         # The mean number of photons per telescope after atmospheric absorption and QE
-        # should be between 70 and 1000 (very loose requirement)
-        photons: [70, 1000]
+        # should be between 75 and 1000 (very loose requirement)
+        photons: [75, 1000]

--- a/tests/unit_tests/db/test_db_array_elements.py
+++ b/tests/unit_tests/db/test_db_array_elements.py
@@ -46,15 +46,15 @@ def test_get_array_element_list_for_db_query(db, model_version):
 
     assert db_array_elements.get_array_element_list_for_db_query(
         "LSTN-01", db=db, model_version=model_version, collection="telescopes"
-    ) == ["LSTN-01", "LSTN-design"]
+    ) == ["LSTN-design", "LSTN-01"]
 
     assert db_array_elements.get_array_element_list_for_db_query(
         "MSTS-10", db=db, model_version=model_version, collection="telescopes"
-    ) == ["MSTS-10", "MSTS-design"]
+    ) == ["MSTS-design", "MSTS-10"]
 
     assert db_array_elements.get_array_element_list_for_db_query(
         "MSTS-301", db=db, model_version=model_version, collection="telescopes"
-    ) == ["MSTS-301", "MSTN-design"]
+    ) == ["MSTN-design", "MSTS-301"]
 
     assert db_array_elements.get_array_element_list_for_db_query(
         "MSTS-design", db=db, model_version=model_version, collection="telescopes"


### PR DESCRIPTION
Apply an important bug fix to read correctly the model parameters for a given array element.

The sequence should be:

1. read the design model (e.g. MSTN-design)
2. update the design model with the telescope specific values (e.g. from MSTN-04)

This sequence is reverted in the current main and this PR fixes the issue.

More details:

in db_handel.get_model_parameter we get a list of array elements for the database query. This should be in the example above `["MSTN-design", "MSTN-04"]`, but is in the main `["MSTN-04", "MSTN-design"]`, meaning the design model value overwrite the telescope specific ones. This bug has been introduced with PR #1181 and the introduction of the `design_model` model parameter.

Will add a test to prevent this in future in a separate pull request.

Closes #1186 