### PR TITLE
Integration test telescope position

### DIFF
--- a/simtools/applications/db_get_parameter_from_db.py
+++ b/simtools/applications/db_get_parameter_from_db.py
@@ -49,12 +49,15 @@ r"""
 
 """
 
+import json
 import logging
+from pathlib import Path
 from pprint import pprint
 
 import simtools.utils.general as gen
 from simtools.configuration import configurator
 from simtools.db import db_handler
+from simtools.io_operations import io_handler
 
 
 def _parse():
@@ -73,6 +76,13 @@ def _parse():
         default="telescopes",
         required=False,
     )
+    config.parser.add_argument(
+        "--output_file",
+        help="output file name (if not given: print to stdout)",
+        type=str,
+        required=False,
+    )
+
     return config.initialize(db_config=True, simulation_model="telescope")
 
 
@@ -101,9 +111,17 @@ def main():  # noqa: D103
         pars = db.get_site_parameters(args_dict["site"], args_dict["model_version"])
     if args_dict["parameter"] not in pars:
         raise KeyError(f"The requested parameter, {args_dict['parameter']}, does not exist.")
-    print()
-    pprint(pars[args_dict["parameter"]])
-    print()
+    if args_dict["output_file"] is not None:
+        _io_handler = io_handler.IOHandler()
+        pars[args_dict["parameter"]].pop("_id")
+        pars[args_dict["parameter"]].pop("entry_date")
+        _output_file = Path(_io_handler.get_output_directory()) / args_dict["output_file"]
+        with open(_output_file, "w", encoding="utf-8") as json_file:
+            json.dump(pars[args_dict["parameter"]], json_file, indent=4)
+    else:
+        print()
+        pprint(pars[args_dict["parameter"]])
+        print()
 
 
 if __name__ == "__main__":

--- a/tests/integration_tests/config/db_get_parameter_from_db_array_element_position_ground.yml
+++ b/tests/integration_tests/config/db_get_parameter_from_db_array_element_position_ground.yml
@@ -1,0 +1,14 @@
+CTA_SIMPIPE:
+  APPLICATION: simtools-db-get-parameter-from-db
+  TEST_NAME: telescope_parameter_array_element_position_ground
+  CONFIGURATION:
+    SITE: North
+    TELESCOPE: MSTN-09
+    PARAMETER: array_element_position_ground
+    MODEL_VERSION: 6.0.0
+    OUTPUT_FILE: test.json
+    OUTPUT_PATH: simtools-output
+  INTEGRATION_TESTS:
+    - REFERENCE_OUTPUT_FILE: |
+        ./tests/resources/array_element_position_ground.json
+      TOLERANCE: 1.e-2

--- a/tests/resources/array_element_position_ground.json
+++ b/tests/resources/array_element_position_ground.json
@@ -1,0 +1,9 @@
+{
+    "version": "6.0.0",
+    "site": "North",
+    "value": "221.68 -355.66 49.0",
+    "unit": "m",
+    "type": "float64",
+    "file": false,
+    "applicable": true
+}


### PR DESCRIPTION
Triggered by issue #1187 , where a major issue in reading parameter from the db has been not detected by any tests.

This PR adds:

- an integration test which reads the telescope position for MSTN-09 and compares it with a file in test/resources
- functionality to db_get_parameter_from_db to write json to a file (until now: print json dict to screen only)

This pull request includes several changes to enhance the functionality of the `db_get_parameter_from_db.py` script, fix a bug in the `get_array_element_list_for_db_query` function, and add new integration tests to ensure the correctness of the modifications.
