### PR TITLE
Add format_checkers module for json schema; explicit checking of array elements

### DIFF
--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -14,11 +14,10 @@ def check_astropy_unit(unit_string):
     try:
         u.Unit(unit_string)
         return True
-    except (ValueError, TypeError):
-        pass
-    if unit_string == "dimensionless":
-        return True
-    raise ValueError(f"'{unit_string}' is not a valid Unit")
+    except (ValueError, TypeError) as exc:
+        if unit_string == "dimensionless":
+            return True
+        raise ValueError(f"'{unit_string}' is not a valid Unit") from exc
 
 
 @format_checker.checks("array_element", raises=ValueError)

--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -14,8 +14,11 @@ def check_astropy_unit(unit_string):
     try:
         u.Unit(unit_string)
         return True
-    except ValueError:
-        return unit_string == "dimensionless"
+    except (ValueError, TypeError):
+        pass
+    if unit_string == "dimensionless":
+        return True
+    raise ValueError(f"'{unit_string}' is not a valid Unit")
 
 
 @format_checker.checks("array_element", raises=ValueError)

--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -13,11 +13,10 @@ def check_astropy_unit(unit_string):
     """Validate astropy units (including dimensionless) for jsonschema."""
     try:
         u.Unit(unit_string)
-        return True
     except (ValueError, TypeError) as exc:
-        if unit_string == "dimensionless":
-            return True
-        raise ValueError(f"'{unit_string}' is not a valid Unit") from exc
+        if unit_string != "dimensionless":
+            raise ValueError(f"'{unit_string}' is not a valid Unit") from exc
+    return True
 
 
 @format_checker.checks("array_element", raises=ValueError)

--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -1,0 +1,25 @@
+"""Custom format checkers for jsonschema validation."""
+
+import astropy.units as u
+import jsonschema
+
+from simtools.utils import names
+
+format_checker = jsonschema.FormatChecker()
+
+
+@format_checker.checks("astropy_unit", raises=ValueError)
+def check_astropy_unit(unit_string):
+    """Validate astropy units (including dimensionless) for jsonschema."""
+    try:
+        u.Unit(unit_string)
+        return True
+    except ValueError:
+        return unit_string == "dimensionless"
+
+
+@format_checker.checks("array_element", raises=ValueError)
+def check_array_element(element):
+    """Validate array elements for jsonschema."""
+    names.validate_array_element_name(element)
+    return True

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -11,24 +11,14 @@ Follows CTAO top-level data model definition.
 import logging
 from importlib.resources import files
 
-import astropy.units as u
 import jsonschema
 
 import simtools.constants
 import simtools.utils.general as gen
+from simtools.data_model import format_checkers
 from simtools.utils import names
 
 _logger = logging.getLogger(__name__)
-
-
-@jsonschema.Draft7Validator.FORMAT_CHECKER.checks("astropy_unit", ValueError)
-def check_astropy_unit(unit_string):
-    """Validate astropy units (including dimensionless) for jsonschema."""
-    try:
-        u.Unit(unit_string)
-        return True
-    except ValueError:
-        return unit_string == "dimensionless"
 
 
 def validate_schema(data, schema_file):
@@ -51,9 +41,7 @@ def validate_schema(data, schema_file):
     schema, schema_file = _load_schema(schema_file)
 
     try:
-        jsonschema.validate(
-            data, schema=schema, format_checker=jsonschema.Draft7Validator.FORMAT_CHECKER
-        )
+        jsonschema.validate(data, schema=schema, format_checker=format_checkers.format_checker)
     except jsonschema.exceptions.ValidationError:
         _logger.error(f"Failed using {schema}")
         raise

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -12,6 +12,7 @@ from astropy.table import Column, Table, unique
 from astropy.utils.diff import report_diff_values
 
 import simtools.utils.general as gen
+from simtools.data_model import format_checkers
 
 __all__ = ["DataValidator"]
 
@@ -177,7 +178,7 @@ class DataValidator:
             return
         self._logger.debug("Validation of dict type using JSON schema")
         try:
-            jsonschema.validate(data, json_schema)
+            jsonschema.validate(data, json_schema, format_checker=format_checkers.format_checker)
         except jsonschema.exceptions.ValidationError as exc:
             self._logger.error(f"Validation error: {exc}")
             raise exc

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -5,6 +5,7 @@ import os
 import re
 from pathlib import Path
 
+import jsonschema
 import numpy as np
 from astropy import units as u
 from astropy.table import Column, Table, unique
@@ -142,7 +143,9 @@ class DataValidator:
         unit_as_list = [None if unit == "null" else unit for unit in unit_as_list]
         for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
             if self._get_data_description(index).get("type", None) == "dict":
-                self._logger.debug(f"Skipping validation of dict type for entry {index}")
+                self._validate_data_dict_using_json_schema(
+                    self.data_dict["value"], self._get_data_description(index).get("json_schema")
+                )
             else:
                 self._check_data_type(np.array(value).dtype, index)
             if self.data_dict.get("type") != "string":
@@ -157,6 +160,27 @@ class DataValidator:
             self.data_dict["value"], self.data_dict["unit"] = value_as_list[0], unit_as_list[0]
 
         self._check_version_string(self.data_dict.get("version"))
+
+    def _validate_data_dict_using_json_schema(self, data, json_schema):
+        """
+        Validate a dictionary using a json schema.
+
+        Parameters
+        ----------
+        data: dict
+            Data dictionary
+        json_schema: dict
+            JSON schema
+        """
+        if json_schema is None:
+            self._logger.debug("Skipping validation of dict type")
+            return
+        self._logger.debug("Validation of dict type using JSON schema")
+        try:
+            jsonschema.validate(data, json_schema)
+        except jsonschema.exceptions.ValidationError as exc:
+            self._logger.error(f"Validation error: {exc}")
+            raise exc
 
     def _validate_data_table(self):
         """Validate tabulated data."""

--- a/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -1,5 +1,5 @@
 ---
-$schema: http://json-schema.org/draft-06/schema#
+$schema: http://json-schema.org/draft-07/schema#
 $ref: '#/definitions/SimtoolsDataAndModelParameters'
 title: SimPipe Data and Model Parameter Metaschema
 description: YAML representation of data and model parameter metaschema
@@ -98,6 +98,11 @@ definitions:
           Use `file` if the parameter describes a file name.
           Use `data_table` if the parameter describes a data table
           (requires TABLE_COLUMNS description)"
+      json_schema:
+        $ref: "http://json-schema.org/draft-07/schema#"
+        description: |-
+          "json schema describing the parameter"
+        additionalProperties: true
       unit:
         $ref: '#/definitions/Unit'
       allowed_range:

--- a/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -1,5 +1,5 @@
 ---
-$schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsDataAndModelParameters'
 title: SimPipe Data and Model Parameter Metaschema
 description: YAML representation of data and model parameter metaschema
@@ -99,7 +99,7 @@ definitions:
           Use `data_table` if the parameter describes a data table
           (requires TABLE_COLUMNS description)"
       json_schema:
-        $ref: "http://json-schema.org/draft-07/schema#"
+        $ref: "http://json-schema.org/draft-06/schema#"
         description: |-
           "json schema describing the parameter"
         additionalProperties: true

--- a/simtools/schemas/model_parameters/array_layouts.schema.yml
+++ b/simtools/schemas/model_parameters/array_layouts.schema.yml
@@ -21,6 +21,7 @@ data:
             type: array
             items:
               type: string
+              format: array_element
         required:
           - name
           - elements

--- a/simtools/schemas/model_parameters/array_layouts.schema.yml
+++ b/simtools/schemas/model_parameters/array_layouts.schema.yml
@@ -10,6 +10,21 @@ description: |-
   Array layout definitions.
 data:
   - type: dict
+    json_schema:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          elements:
+            type: array
+            items:
+              type: string
+        required:
+          - name
+          - elements
+        additionalProperties: false
 instrument:
   class: Site
   type:

--- a/tests/unit_tests/data_model/test_format_checkers.py
+++ b/tests/unit_tests/data_model/test_format_checkers.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+import pytest
+
+from simtools.data_model import format_checkers
+
+
+def test_check_astropy_unit():
+    assert format_checkers.check_astropy_unit("dimensionless")
+    assert format_checkers.check_astropy_unit("m")
+
+
+def test_check_array_elements():
+    assert format_checkers.check_array_element("MSTN-15")
+
+    with pytest.raises(ValueError, match=r"^Invalid name"):
+        format_checkers.check_array_element("not_an_array_element")

--- a/tests/unit_tests/data_model/test_format_checkers.py
+++ b/tests/unit_tests/data_model/test_format_checkers.py
@@ -8,6 +8,12 @@ from simtools.data_model import format_checkers
 def test_check_astropy_unit():
     assert format_checkers.check_astropy_unit("dimensionless")
     assert format_checkers.check_astropy_unit("m")
+    assert format_checkers.check_astropy_unit("")
+    with pytest.raises(ValueError, match="'None' is not a valid Unit"):
+        format_checkers.check_astropy_unit(None)
+
+    with pytest.raises(ValueError, match="'not a unit!' is not a valid Unit"):
+        format_checkers.check_astropy_unit("not a unit!")
 
 
 def test_check_array_elements():

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -9,11 +9,6 @@ from simtools.data_model import metadata_model
 from simtools.utils import general as gen
 
 
-def test_check_astropy_unit():
-    assert metadata_model.check_astropy_unit("dimensionless")
-    assert metadata_model.check_astropy_unit("m")
-
-
 def test_get_default_metadata_dict():
     _top_meta = metadata_model.get_default_metadata_dict()
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 from importlib.resources import files
 
+import jsonschema
 import numpy as np
 import pytest
 import yaml
@@ -737,3 +738,32 @@ def test_check_version_string(caplog):
             data_validator._check_version_string(version)
 
     assert data_validator._check_version_string(None) is None
+
+
+def test_validate_data_dict_using_json_schema(caplog):
+    data_validator = validate_data.DataValidator()
+
+    valid_json_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "value": {"type": "number"},
+        },
+        "required": ["name", "value"],
+    }
+    valid_data = {"name": "test", "value": 123}
+
+    with caplog.at_level(logging.DEBUG):
+        data_validator._validate_data_dict_using_json_schema(valid_data, valid_json_schema)
+    assert "Validation of dict type using JSON schema" in caplog.text
+
+    invalid_data = {"name": "test", "value": "not_a_number"}
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(jsonschema.exceptions.ValidationError):
+            data_validator._validate_data_dict_using_json_schema(invalid_data, valid_json_schema)
+    assert "Validation error:" in caplog.text
+
+    with caplog.at_level(logging.DEBUG):
+        data_validator._validate_data_dict_using_json_schema(valid_data, None)
+    assert "Skipping validation of dict type" in caplog.text

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -120,7 +120,7 @@ def test_validate_and_transform(caplog, mocker):
         _dict = data_validator.validate_and_transform(True)
         assert isinstance(_dict, dict)
     assert "Validating data from:" in caplog.text
-    assert mock_prepare_model_parameter.called_once
+    mock_prepare_model_parameter.assert_called_once()
 
 
 def test_validate_data_file(caplog):

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -96,7 +96,7 @@ def reference_columns_name():
     ]
 
 
-def test_validate_and_transform(caplog):
+def test_validate_and_transform(caplog, mocker):
     data_validator = validate_data.DataValidator()
     # no input file defined
     with caplog.at_level(logging.ERROR):
@@ -113,10 +113,14 @@ def test_validate_and_transform(caplog):
 
     data_validator.data_file_name = "tests/resources/model_parameters/num_gains.json"
     data_validator.schema_file_name = "tests/resources/num_gains.schema.yml"
+    mock_prepare_model_parameter = mocker.patch(
+        "simtools.data_model.validate_data.DataValidator._prepare_model_parameter"
+    )
     with caplog.at_level(logging.INFO):
-        _dict = data_validator.validate_and_transform()
+        _dict = data_validator.validate_and_transform(True)
         assert isinstance(_dict, dict)
     assert "Validating data from:" in caplog.text
+    assert mock_prepare_model_parameter.called_once
 
 
 def test_validate_data_file(caplog):


### PR DESCRIPTION
**Review after #PR 1190 is merged to main**

The usage of jsonschema ensures that formats and values have the correct format.

Introduce here a custom format checker module to simplify the usages for simtools-related custom formats:

- moved simtools.data_model.metadata_model.astropy_unit into simtools.data_model.format_checkers (this allows to test that a unit is consistent with an astropy unit in a model parameter json / db entry).
- added `simtools.data_model.format_checkers.array_element`, which allows to check that an entry is consistent with the simtools array element naming (using `names.validate_array_element_name`)

Maintenance updates:

- decouple format checker from jsonschema draft `Draft7Validator` (not sure why we have used it from the beginning)

## Copilot summary (generated automatically)

This pull request introduces custom format checkers for JSON schema validation, refactors existing validation logic to use these new checkers, and updates relevant tests and schemas to accommodate these changes.

### Custom Format Checkers for JSON Schema Validation:
* [`simtools/data_model/format_checkers.py`](diffhunk://#diff-abfa9dc7adb421e96a3ae076286df886f293d97e372abce176bb80ed2624a770R1-R25): Added custom format checkers for `astropy_unit` and `array_element` to validate astropy units and array elements, respectively.

### Refactoring Code to Use New Format Checkers:
* [`simtools/data_model/metadata_model.py`](diffhunk://#diff-e29c478f2ac735868adcfbe13c79f350fae5123576a533180569bf407d6fee52L14-L33): Removed existing format checker functions and updated the `validate_schema` function to use the new format checkers from `format_checkers`. [[1]](diffhunk://#diff-e29c478f2ac735868adcfbe13c79f350fae5123576a533180569bf407d6fee52L14-L33) [[2]](diffhunk://#diff-e29c478f2ac735868adcfbe13c79f350fae5123576a533180569bf407d6fee52L54-R44)
* [`simtools/data_model/validate_data.py`](diffhunk://#diff-eecb8454a9066ab719b15e61c0de45617d89f765b7c97caf7c5cb9fa5f15c8e2R8-R15): Added a new method `_validate_data_dict_using_json_schema` to validate data dictionaries using JSON schemas and the new format checkers. Updated `_validate_data_dict` to use this new method. [[1]](diffhunk://#diff-eecb8454a9066ab719b15e61c0de45617d89f765b7c97caf7c5cb9fa5f15c8e2R8-R15) [[2]](diffhunk://#diff-eecb8454a9066ab719b15e61c0de45617d89f765b7c97caf7c5cb9fa5f15c8e2L145-R149) [[3]](diffhunk://#diff-eecb8454a9066ab719b15e61c0de45617d89f765b7c97caf7c5cb9fa5f15c8e2R165-R185)

### Schema Updates:
* [`simtools/schemas/model_parameter_and_data_schema.metaschema.yml`](diffhunk://#diff-be3cf0fa965ee04a73de99ddf922c3313f7800fbaf76497b2c5e5e71e5e05832R101-R105): Added a `json_schema` property to the schema definitions.
* [`simtools/schemas/model_parameters/array_layouts.schema.yml`](diffhunk://#diff-f1c8a0bd3084f045e93a77202c32c6ba70593f36c6090dcd0dc2c73cacd3a377R13-R28): Updated the schema to include a `json_schema` for array layout definitions.

### Test Updates:
* [`tests/unit_tests/data_model/test_format_checkers.py`](diffhunk://#diff-c10e3f5cebac591f500342720bc1bbcfec1391600b355243546b1da18a02faf5R1-R17): Added new tests for the custom format checkers.
* [`tests/unit_tests/data_model/test_metadata_model.py`](diffhunk://#diff-61d8a0df29affe4790476b8ba9da60255b4b9a62ecd8239c195facb56403f53dL12-L16): Removed tests for the old format checker functions.
* [`tests/unit_tests/data_model/test_validate_data.py`](diffhunk://#diff-c1c68a857731db82f8d071d52024afdc53f85476788c9fe711f3979d97abd3a3R9): Updated tests to mock the `_prepare_model_parameter` method and added new tests for `_validate_data_dict_using_json_schema`. [[1]](diffhunk://#diff-c1c68a857731db82f8d071d52024afdc53f85476788c9fe711f3979d97abd3a3R9) [[2]](diffhunk://#diff-c1c68a857731db82f8d071d52024afdc53f85476788c9fe711f3979d97abd3a3L98-R99) [[3]](diffhunk://#diff-c1c68a857731db82f8d071d52024afdc53f85476788c9fe711f3979d97abd3a3R116-R123) [[4]](diffhunk://#diff-c1c68a857731db82f8d071d52024afdc53f85476788c9fe711f3979d97abd3a3R745-R773)