### PR TITLE
Missing API documentation; add check that this is not missed in future

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -41,14 +41,14 @@ jobs:
             ! -name "__init__.py" \
             ! -path "simtools/_*" -prune)
           FULLY_DOCUMENTED="TRUE"
-          for M in $MODULES; do
-              module=$(basename $M .py)
+          for M in "$MODULES"; do
+              module=$(basename "$M" .py)
               if ! grep -q "$module" docs/source/api-reference/*.md; then
                 echo "Undocumented module: $module"
                 FULLY_DOCUMENTED="FALSE"
               fi
           done
-          if [[ $FULLY_DOCUMENTED = "FALSE" ]]; then
+          if [[ "$FULLY_DOCUMENTED" = "FALSE" ]]; then
               exit 1
           fi
 

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -41,7 +41,7 @@ jobs:
             ! -name "__init__.py" \
             ! -path "simtools/_*" -prune)
           FULLY_DOCUMENTED="TRUE"
-          for M in "$MODULES"; do
+          for M in "${MODULES[@]}"; do
               module=$(basename "$M" .py)
               if ! grep -q "$module" docs/source/api-reference/*.md; then
                 echo "Undocumented module: $module"

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: |-
           MODULES=$(find simtools -type f -name "*.py" \
             ! -path "simtools/applications/*" \
-            ! -name "__init__.py" \
+            ! -name "__init__.py" ! -name "version.y" \
             ! -path "simtools/_*" -prune)
           FULLY_DOCUMENTED="TRUE"
           for M in "${MODULES[@]}"; do

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -34,6 +34,24 @@ jobs:
             exit 1
           fi
 
+      - name: Check for complete API documentation
+        run: |-
+          MODULES=$(find simtools -type f -name "*.py" \
+            ! -path "simtools/applications/*" \
+            ! -name "__init__.py" \
+            ! -path "simtools/_*" -prune)
+          FULLY_DOCUMENTED="TRUE"
+          for M in $MODULES; do
+              module=$(basename $M .py)
+              if ! grep -q "$module" docs/source/api-reference/*.md; then
+                echo "Undocumented module: $module"
+                FULLY_DOCUMENTED="FALSE"
+              fi
+          done
+          if [[ $FULLY_DOCUMENTED = "FALSE" ]]; then
+              exit 1
+          fi
+
       - name: Build docs
         shell: bash -l {0}
         run: |

--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -38,7 +38,7 @@ jobs:
         run: |-
           MODULES=$(find simtools -type f -name "*.py" \
             ! -path "simtools/applications/*" \
-            ! -name "__init__.py" ! -name "version.y" \
+            ! -name "__init__.py" ! -name "version.py" \
             ! -path "simtools/_*" -prune)
           FULLY_DOCUMENTED="TRUE"
           for M in "${MODULES[@]}"; do

--- a/docs/source/api-reference/data_model.md
+++ b/docs/source/api-reference/data_model.md
@@ -14,6 +14,15 @@ Data products ingested or produced by simtools generally follows the CTAO data m
    :members:
 ```
 
+(format_checkers)=
+
+## format_checkers
+
+```{eval-rst}
+.. automodule:: data_model.format_checkers
+   :members:
+```
+
 (datamodelmetadatacollector)=
 
 ## metadata_collector

--- a/docs/source/api-reference/db_handler.md
+++ b/docs/source/api-reference/db_handler.md
@@ -13,6 +13,15 @@ Modules for database access. See the databases sections for details.
    :members:
 ```
 
+## db_array_elements
+
+(db-array-elements)=
+
+```{eval-rst}
+.. automodule:: db.db_array_elements
+   :members:
+```
+
 ## db_from_repo_handler
 
 (db-from-repo-handler)=

--- a/docs/source/api-reference/sim_telarray.md
+++ b/docs/source/api-reference/sim_telarray.md
@@ -67,6 +67,15 @@ Support modules for running sim_telarray.
    :members:
 ```
 
+## simulator_light_emission
+
+(simulate-light-1)=
+
+```{eval-rst}
+.. automodule:: simtel.simulator_light_emission
+   :members:
+```
+
 ## simulator_ray_tracing
 
 (simulate-ray-tracing-1)=

--- a/docs/source/api-reference/utils.md
+++ b/docs/source/api-reference/utils.md
@@ -49,10 +49,3 @@ the util module.
 .. automodule:: constants
    :members:
 ```
-
-## version
-
-```{eval-rst}
-.. automodule:: version
-   :members:
-```

--- a/docs/source/api-reference/utils.md
+++ b/docs/source/api-reference/utils.md
@@ -35,3 +35,24 @@ the util module.
 .. automodule:: utils.names
    :members:
 ```
+
+## value_conversion
+
+```{eval-rst}
+.. automodule:: utils.value_conversion
+   :members:
+```
+
+## constants
+
+```{eval-rst}
+.. automodule:: constants
+   :members:
+```
+
+## version
+
+```{eval-rst}
+.. automodule:: version
+   :members:
+```

--- a/docs/source/api-reference/visualization.md
+++ b/docs/source/api-reference/visualization.md
@@ -25,3 +25,9 @@ the visualization module.
 .. automodule:: visualization.legend_handlers
    :members:
 ```
+
+## plot_camera
+
+```{eval-rst}
+.. automodule:: visualization.plot_camera
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,7 +170,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/", None),
     "astropy": ("https://docs.astropy.org/en/latest/", None),
-    "matplotlib": ("https://matplotlib.org/stable", None),
+    "matplotlib": ("https://matplotlib.org/", None),
 }
 
 # myst (markdown options)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,7 +170,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "astropy": ("https://docs.astropy.org/en/latest", None),
-    "matplotlib": ("https://matplotlib.org/stable", None),
+    #    "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
 # local dir

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,9 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
+# local dir
+locale_dirs = []
+
 # myst (markdown options)
 myst_heading_anchors = 3
 myst_enable_extensions = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -167,10 +167,10 @@ htmlhelp_basename = "simtoolsdoc"
 # -- Options for intersphinx extension ---------------------------------------
 intersphinx_mapping = {
     "python": (f"https://docs.python.org/{python_requires}", None),
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
-    "astropy": ("https://docs.astropy.org/en/latest/", None),
-    "matplotlib": ("https://matplotlib.org/", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "astropy": ("https://docs.astropy.org/en/latest", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
 # myst (markdown options)


### PR DESCRIPTION
The documentation generated with sphinx requires each modules to be explicitly listed in one of the files in docs/source/api-reference/ . This will result in the documentation [here](https://gammasim.github.io/simtools/api-reference/index.html).

We often forget to update these files when introducing new modules and classes (I always forget). 

This PR:

1. adds a test to .github/workflows/CI-docs.yml to make sure that every module appears somewhere in the apidoc (unfortunately a bit complicated; let me know if this can be written simpler)
2. adds missing API docs revealed by this test
3. removes intersphinx connection to matplotlib, as this seems to be broken (intersphinx allows to click in the webpages on matplotlib commands we are using; this links directly to the matplotlib documentation; nice to have, but not essential)
4. checked for any other warnings from sphinx (added therefore the localdir addition)

To test that 1. is working, see the 'Check for complete API documentation' [here](https://github.com/gammasim/simtools/actions/runs/11268361543/job/31334985739).

To test that 2. added all missing APIs, see the [test here](https://github.com/gammasim/simtools/actions/runs/11268394007/job/31335074844)

Closes #1196
