### PR TITLE
Refactor validate_data_dict and improved testing

### DIFF
--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -183,10 +183,15 @@ class DataValidator:
             if isinstance(self.data_dict["unit"], list | np.ndarray)
             else [self.data_dict["unit"]]
         )
-        if isinstance(value_as_list, np.ndarray):
+        try:
             value_as_list = value_as_list.tolist()
-        if isinstance(unit_as_list, np.ndarray):
+        except AttributeError:
+            pass
+        try:
             unit_as_list = unit_as_list.tolist()
+        except AttributeError:
+            pass
+
         unit_as_list = [None if unit == "null" else unit for unit in unit_as_list]
 
         return value_as_list, unit_as_list

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -130,7 +130,49 @@ class DataValidator:
             raise KeyError("Data dict does not contain a 'name' or 'parameter' key.")
         self._data_description = self._read_validation_schema(self.schema_file_name, _name)
 
-        # validation assumes lists for values and units - convert to list if required
+        value_as_list, unit_as_list = self._get_value_and_units_as_lists()
+
+        for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
+            value_as_list[index], unit_as_list[index] = self._validate_value_and_unit(
+                value, unit, index
+            )
+
+        if len(value_as_list) == 1:
+            self.data_dict["value"], self.data_dict["unit"] = value_as_list[0], unit_as_list[0]
+
+        self._check_version_string(self.data_dict.get("version"))
+
+    def _validate_value_and_unit(self, value, unit, index):
+        """
+        Validate value, unit, and perform type checking and conversions.
+
+        Take into account different data types and allow to use json_schema for testing.
+        """
+        if self._get_data_description(index).get("type", None) == "dict":
+            self._validate_data_dict_using_json_schema(
+                self.data_dict["value"], self._get_data_description(index).get("json_schema")
+            )
+        else:
+            self._check_data_type(np.array(value).dtype, index)
+
+        if self.data_dict.get("type") not in ("string", "dict"):
+            self._check_for_not_a_number(value, index)
+            value, unit = self._check_and_convert_units(value, unit, index)
+            for range_type in ("allowed_range", "required_range"):
+                self._check_range(index, np.nanmin(value), np.nanmax(value), range_type)
+        return value, unit
+
+    def _get_value_and_units_as_lists(self):
+        """
+        Convert value and unit to lists if required.
+
+        Returns
+        -------
+        list
+            value as list
+        list
+            unit as list
+        """
         value_as_list = (
             self.data_dict.get("value")
             if isinstance(self.data_dict["value"], list | np.ndarray)
@@ -141,26 +183,13 @@ class DataValidator:
             if isinstance(self.data_dict["unit"], list | np.ndarray)
             else [self.data_dict["unit"]]
         )
+        if isinstance(value_as_list, np.ndarray):
+            value_as_list = value_as_list.tolist()
+        if isinstance(unit_as_list, np.ndarray):
+            unit_as_list = unit_as_list.tolist()
         unit_as_list = [None if unit == "null" else unit for unit in unit_as_list]
-        for index, (value, unit) in enumerate(zip(value_as_list, unit_as_list)):
-            if self._get_data_description(index).get("type", None) == "dict":
-                self._validate_data_dict_using_json_schema(
-                    self.data_dict["value"], self._get_data_description(index).get("json_schema")
-                )
-            else:
-                self._check_data_type(np.array(value).dtype, index)
-            if self.data_dict.get("type") not in ("string", "dict"):
-                self._check_for_not_a_number(value, index)
-                value_as_list[index], unit_as_list[index] = self._check_and_convert_units(
-                    value, unit, index
-                )
-                for range_type in ("allowed_range", "required_range"):
-                    self._check_range(index, np.nanmin(value), np.nanmax(value), range_type)
 
-        if len(value_as_list) == 1:
-            self.data_dict["value"], self.data_dict["unit"] = value_as_list[0], unit_as_list[0]
-
-        self._check_version_string(self.data_dict.get("version"))
+        return value_as_list, unit_as_list
 
     def _validate_data_dict_using_json_schema(self, data, json_schema):
         """

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -800,18 +800,12 @@ def test_get_value_and_units_as_lists():
     assert values == [100, 200]
     assert units == ["m", None]
 
-    # Test with mixed types
-    data_validator.data_dict = {"value": [100, 200], "unit": np.array(["m", "cm"])}
-    values, units = data_validator._get_value_and_units_as_lists()
-    assert values == [100, 200]
-    assert units == ["m", "cm"]
-
 
 def test_validate_value_and_unit_for_dict(reference_columns):
     data_validator = validate_data.DataValidator()
     data_validator._data_description = reference_columns
 
-    # Test case for dict type
+    # Test case for dict type with None
     data_validator.data_dict = {"value": {"key": "value"}, "unit": None, "type": "dict"}
     data_validator._data_description[0]["type"] = "dict"
     data_validator._data_description[0]["json_schema"] = {
@@ -824,3 +818,11 @@ def test_validate_value_and_unit_for_dict(reference_columns):
     )
     assert value == {"key": "value"}
     assert unit is None
+
+    # Test case for dict type with "null"
+    data_validator.data_dict = {"value": {"key": "value"}, "unit": "null", "type": "dict"}
+    value, unit = data_validator._validate_value_and_unit(
+        data_validator.data_dict["value"], data_validator.data_dict["unit"], 0
+    )
+    assert value == {"key": "value"}
+    assert unit == "null"


### PR DESCRIPTION
This is refactor PR with no change in functionality.

 `data_model.validate_data._validate_data_dict` is too complex and we split here the function into several. Also address the issue of a missing test for the call of `_validate_data_dict_using_json_schema`.

Closes #1193 