### PR TITLE
Add format checkers for astropy units of time and length

### DIFF
--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -21,6 +21,20 @@ def check_astropy_unit(unit_string):
     return True
 
 
+@format_checker.checks("astropy_unit_of_time", raises=ValueError)
+def check_astropy_unit_of_time(unit_string):
+    """Validate astropy units that this is an astropy unit of time."""
+    u.Unit(unit_string).to("s")
+    return True
+
+
+@format_checker.checks("astropy_unit_of_length", raises=ValueError)
+def check_astropy_unit_of_length(unit_string):
+    """Validate astropy units that this is an astropy unit of length."""
+    u.Unit(unit_string).to("m")
+    return True
+
+
 @format_checker.checks("array_element", raises=ValueError)
 def check_array_element(element):
     """Validate array elements for jsonschema."""

--- a/simtools/data_model/format_checkers.py
+++ b/simtools/data_model/format_checkers.py
@@ -10,7 +10,7 @@ from simtools.utils import names
 format_checker = jsonschema.FormatChecker()
 
 
-@format_checker.checks("astropy_unit", raises=ValueError)
+@format_checker.checks("astropy_unit")
 def check_astropy_unit(unit_string):
     """Validate astropy units (including dimensionless) for jsonschema."""
     try:
@@ -21,28 +21,28 @@ def check_astropy_unit(unit_string):
     return True
 
 
-@format_checker.checks("astropy_unit_of_time", raises=ValueError)
+@format_checker.checks("astropy_unit_of_time")
 def check_astropy_unit_of_time(unit_string):
     """Validate astropy units that this is an astropy unit of time."""
     u.Unit(unit_string).to("s")
     return True
 
 
-@format_checker.checks("astropy_unit_of_length", raises=ValueError)
+@format_checker.checks("astropy_unit_of_length)")
 def check_astropy_unit_of_length(unit_string):
     """Validate astropy units that this is an astropy unit of length."""
     u.Unit(unit_string).to("m")
     return True
 
 
-@format_checker.checks("array_element", raises=ValueError)
+@format_checker.checks("array_element")
 def check_array_element(element):
     """Validate array elements for jsonschema."""
     names.validate_array_element_name(element)
     return True
 
 
-@format_checker.checks("array_triggers_name", raises=ValueError)
+@format_checker.checks("array_triggers_name")
 def check_array_triggers_name(name):
     """Validate array trigger names for jsonschema."""
     pattern = r"(.*)(?=_single_telescope|_array)"

--- a/simtools/schemas/model_parameters/array_triggers.schema.yml
+++ b/simtools/schemas/model_parameters/array_triggers.schema.yml
@@ -46,7 +46,7 @@ data:
               unit:
                 anyOf:
                   - type: string
-                    format: astropy_unit
+                    format: astropy_unit_of_time
             required: [value, unit]
           hard_stereo:
             type: object
@@ -71,7 +71,7 @@ data:
                   - type: "null"
               unit:
                 type: string
-                format: astropy_unit
+                format: astropy_unit_of_length
             required: [value, unit]
         required: [name, multiplicity, width, hard_stereo, min_separation]
 instrument:

--- a/tests/unit_tests/data_model/test_format_checkers.py
+++ b/tests/unit_tests/data_model/test_format_checkers.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python3
 
+import re
+
 import pytest
+from astropy.units.core import UnitConversionError
 
 from simtools.data_model import format_checkers
 
@@ -14,6 +17,28 @@ def test_check_astropy_unit():
 
     with pytest.raises(ValueError, match="'not a unit!' is not a valid Unit"):
         format_checkers.check_astropy_unit("not a unit!")
+
+
+def test_check_astropy_unit_of_time():
+    assert format_checkers.check_astropy_unit_of_time("ns")
+    with pytest.raises(
+        UnitConversionError, match=re.escape("'km' (length) and 's' (time) are not convertible")
+    ):
+        format_checkers.check_astropy_unit_of_time("km")
+
+    with pytest.raises(TypeError, match=re.escape("None is not a valid Unit")):
+        format_checkers.check_astropy_unit_of_time(None)
+
+
+def test_check_astropy_unit_of_length():
+    assert format_checkers.check_astropy_unit_of_length("km")
+    with pytest.raises(
+        UnitConversionError, match=re.escape("'ns' (time) and 'm' (length) are not convertible")
+    ):
+        format_checkers.check_astropy_unit_of_length("ns")
+
+    with pytest.raises(TypeError, match=re.escape("None is not a valid Unit")):
+        format_checkers.check_astropy_unit_of_length(None)
 
 
 def test_check_array_elements():

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -94,9 +94,8 @@ def test_validate_schema_astropy_units(caplog):
 
     # not good
     _dict_1["data"][0]["unit"] = "not_a_unit"
-    with caplog.at_level(logging.DEBUG):
-        with pytest.raises(jsonschema.exceptions.ValidationError):
-            metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with pytest.raises(ValueError, match="'not_a_unit' is not a valid Unit"):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
 
 
 def test_resolve_references():


### PR DESCRIPTION
This pull request introduces new format checkers for astropy units of time and length, updates the schema to use these new format checkers, and adds corresponding unit tests.

Closes #1200 

### New Format Checkers:
* Added `check_astropy_unit_of_time` to validate astropy units of time. (`simtools/data_model/format_checkers.py`)
* Added `check_astropy_unit_of_length` to validate astropy units of length. (`simtools/data_model/format_checkers.py`)

### Schema Updates:
* Updated the schema to use `astropy_unit_of_time` for time units. (`simtools/schemas/model_parameters/array_triggers.schema.yml`)
* Updated the schema to use `astropy_unit_of_length` for length units. (`simtools/schemas/model_parameters/array_triggers.schema.yml`)

### Unit Tests:
* Added tests for `check_astropy_unit_of_time` and `check_astropy_unit_of_length` to ensure proper validation and error handling. (`tests/unit_tests/data_model/test_format_checkers.py`)
* Imported `re` and `UnitConversionError` to support the new tests. (`tests/unit_tests/data_model/test_format_checkers.py`)