### PR TITLE
Pre commit autoupdate - add simtools installation

### DIFF
--- a/.github/workflows/CI-software-update.yml
+++ b/.github/workflows/CI-software-update.yml
@@ -13,12 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install pylint # pre-commit uses local pylint
+      - name: Install packages (as pre-commit is running on all files after autoupdate)
         run: |
+          pip install -e '.[tests,dev,doc]'
           pip install pylint
 
       - uses: browniebroke/pre-commit-autoupdate-action@main

--- a/.github/workflows/CI-software-update.yml
+++ b/.github/workflows/CI-software-update.yml
@@ -14,6 +14,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pylint # pre-commit uses local pylint
+        run: |
+          pip install pylint
 
       - uses: browniebroke/pre-commit-autoupdate-action@main
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
         args: ["--line-length=100"]
@@ -45,7 +45,7 @@ repos:
       - id: actionlint
   # https://pyproject-fmt.readthedocs.io/en/latest/
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "2.2.4"
+    rev: "2.3.0"
     hooks:
       - id: pyproject-fmt
   # codespell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dynamic = [


### PR DESCRIPTION
Pre-commit autoupdate (see PR #1195) run a `pre-commit --all-files` after updating the pre-commit software.

This is good (as we can see if simtools passes any updated pre-commit tools), but requires an installation of the simtools environment. This PR adds a simple pip install to do this.

