### PR TITLE
Introduce selective log levels via fixture

### DIFF
--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -75,7 +75,7 @@ class RayTracing:
     ):
         """Initialize RayTracing class."""
         self._logger = logging.getLogger(__name__)
-        self._logger.debug("Initializing RayTracing class")
+        self._logger.info("Initializing RayTracing class")
 
         self.simtel_path = Path(simtel_path)
         self._io_handler = io_handler.IOHandler()
@@ -155,7 +155,7 @@ class RayTracing:
         tuple
             Tuple containing source distance and mirror numbers.
         """
-        self._logger.debug(
+        self._logger.info(
             "Single mirror mode is activated - "
             "source distance is being recalculated to 2 * focal length "
             " (this is not correct for dual-mirror telescopes)."

--- a/simtools/ray_tracing.py
+++ b/simtools/ray_tracing.py
@@ -75,7 +75,7 @@ class RayTracing:
     ):
         """Initialize RayTracing class."""
         self._logger = logging.getLogger(__name__)
-        self._logger.info("Initializing RayTracing class")
+        self._logger.debug("Initializing RayTracing class")
 
         self.simtel_path = Path(simtel_path)
         self._io_handler = io_handler.IOHandler()
@@ -155,7 +155,7 @@ class RayTracing:
         tuple
             Tuple containing source distance and mirror numbers.
         """
-        self._logger.info(
+        self._logger.debug(
             "Single mirror mode is activated - "
             "source distance is being recalculated to 2 * focal length "
             " (this is not correct for dual-mirror telescopes)."

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -165,7 +165,7 @@ def collect_data_from_file_or_dict(file_name, in_dict, allow_empty=False):
         return dict(in_dict)
 
     if allow_empty:
-        _logger.debug("Input has not been provided (neither by file, nor by dict)")
+        _logger.warning("Input has not been provided (neither by file, nor by dict)")
         return None
 
     msg = "Input has not been provided (neither by file, nor by dict)"
@@ -816,7 +816,7 @@ def read_file_encoded_in_utf_or_latin(file_name):
         with open(file_name, encoding="utf-8") as file:
             lines = file.readlines()
     except UnicodeDecodeError:
-        logging.debug("Unable to decode file using UTF-8. Trying Latin-1.")
+        logging.error("Unable to decode file using UTF-8. Trying Latin-1.")
         try:
             with open(file_name, encoding="latin-1") as file:
                 lines = file.readlines()

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -165,7 +165,7 @@ def collect_data_from_file_or_dict(file_name, in_dict, allow_empty=False):
         return dict(in_dict)
 
     if allow_empty:
-        _logger.warning("Input has not been provided (neither by file, nor by dict)")
+        _logger.debug("Input has not been provided (neither by file, nor by dict)")
         return None
 
     msg = "Input has not been provided (neither by file, nor by dict)"
@@ -816,7 +816,7 @@ def read_file_encoded_in_utf_or_latin(file_name):
         with open(file_name, encoding="utf-8") as file:
             lines = file.readlines()
     except UnicodeDecodeError:
-        logging.error("Unable to decode file using UTF-8. Trying Latin-1.")
+        logging.debug("Unable to decode file using UTF-8. Trying Latin-1.")
         try:
             with open(file_name, encoding="latin-1") as file:
                 lines = file.readlines()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,15 @@ def _set_matplotlib_backend():
 
 
 @pytest.fixture
+def _log_level(request):
+    original_level = logger.level
+    level = request.param if hasattr(request, "param") else logging.DEBUG
+    logger.setLevel(level)
+    yield
+    logger.setLevel(original_level)
+
+
+@pytest.fixture
 def tmp_test_directory(tmpdir_factory):
     """Sets temporary test directories. Some tests depend on this structure."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,15 +30,6 @@ def _set_matplotlib_backend():
 
 
 @pytest.fixture
-def _log_level(request):
-    original_level = logger.level
-    level = request.param if hasattr(request, "param") else logging.DEBUG
-    logger.setLevel(level)
-    yield
-    logger.setLevel(original_level)
-
-
-@pytest.fixture
 def tmp_test_directory(tmpdir_factory):
     """Sets temporary test directories. Some tests depend on this structure."""
 

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -15,7 +15,6 @@ import simtools.utils.general as gen
 from simtools.testing import assertions, compare_output
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def get_application_command(app, config_file=None, config_string=None):

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -11,7 +11,6 @@ from simtools.model.telescope_model import TelescopeModel
 from simtools.ray_tracing import RayTracing
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.mark.parametrize("telescope_model_name", ["SSTS-design"])

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -46,8 +46,6 @@ def test_efficiency_interval():
         parser.CommandLineParser.efficiency_interval(-8.5)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_zenith_angle(caplog):
     assert parser.CommandLineParser.zenith_angle(0).value == pytest.approx(0.0)
     assert parser.CommandLineParser.zenith_angle(45).value == pytest.approx(45.0)
@@ -68,8 +66,9 @@ def test_zenith_angle(caplog):
     ):
         parser.CommandLineParser.zenith_angle(190)
 
-    with pytest.raises(TypeError):
-        parser.CommandLineParser.zenith_angle("North")
+    with caplog.at_level("WARNING"):
+        with pytest.raises(TypeError):
+            parser.CommandLineParser.zenith_angle("North")
     assert "The zenith angle provided is not a valid numeric" in caplog.text
 
 
@@ -106,8 +105,6 @@ def test_parse_integer_and_quantity(caplog):
         parser.CommandLineParser.parse_integer_and_quantity("0 m 5 m")
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_azimuth_angle(caplog):
     assert parser.CommandLineParser.azimuth_angle(0).value == pytest.approx(0.0)
     assert parser.CommandLineParser.azimuth_angle(45).value == pytest.approx(45.0)
@@ -137,9 +134,9 @@ def test_azimuth_angle(caplog):
         argparse.ArgumentTypeError, match=r"^The azimuth angle given as string can only be one of"
     ):
         parser.CommandLineParser.azimuth_angle("TEST")
-
-    with pytest.raises(TypeError):
-        parser.CommandLineParser.azimuth_angle([0, 10])
+    with caplog.at_level("ERROR"):
+        with pytest.raises(TypeError):
+            parser.CommandLineParser.azimuth_angle([0, 10])
     assert "The azimuth angle provided is not a valid numerical or string value." in caplog.text
 
 

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -178,7 +178,7 @@ def test_simulation_model():
 
     assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
-        if str(group.title) == "simulation model":
+        if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "model_version" for action in group._group_actions)
             assert all(action.dest != "site" for action in group._group_actions)
             assert all(action.dest != "telescope" for action in group._group_actions)
@@ -189,7 +189,7 @@ def test_simulation_model():
     job_groups = _parser_s._action_groups
     assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
-        if str(group.title) == "simulation model":
+        if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "model_version" for action in group._group_actions)
             assert any(action.dest == "site" for action in group._group_actions)
             assert all(action.dest != "telescope" for action in group._group_actions)

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -9,7 +9,6 @@ import pytest
 import simtools.configuration.commandline_parser as parser
 
 logger = logging.getLogger()
-
 SIMULATION_MODEL_STRING = "simulation model"
 
 

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -9,8 +9,6 @@ import pytest
 import simtools.configuration.commandline_parser as parser
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
-
 
 simulation_model_string = "simulation model"
 
@@ -49,6 +47,8 @@ def test_efficiency_interval():
         parser.CommandLineParser.efficiency_interval(-8.5)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_zenith_angle(caplog):
     assert parser.CommandLineParser.zenith_angle(0).value == pytest.approx(0.0)
     assert parser.CommandLineParser.zenith_angle(45).value == pytest.approx(45.0)
@@ -107,6 +107,8 @@ def test_parse_integer_and_quantity(caplog):
         parser.CommandLineParser.parse_integer_and_quantity("0 m 5 m")
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_azimuth_angle(caplog):
     assert parser.CommandLineParser.azimuth_angle(0).value == pytest.approx(0.0)
     assert parser.CommandLineParser.azimuth_angle(45).value == pytest.approx(45.0)
@@ -169,30 +171,30 @@ def test_simulation_model():
     _parser_n = parser.CommandLineParser()
     _parser_n.initialize_default_arguments(simulation_model=None)
 
-    # model version only, no site or telescope
+    # Model version only, no site or telescope
     _parser_v = parser.CommandLineParser()
     _parser_v.initialize_default_arguments(simulation_model=["version"])
     job_groups = _parser_v._action_groups
 
     assert simulation_model_string in [str(group.title) for group in job_groups]
     for group in job_groups:
-        if str(group.title) == simulation_model_string:
+        if str(group.title) == "simulation model":
             assert any(action.dest == "model_version" for action in group._group_actions)
             assert all(action.dest != "site" for action in group._group_actions)
             assert all(action.dest != "telescope" for action in group._group_actions)
 
-    # site model can exist without a telescope model
+    # Site model can exist without a telescope model
     _parser_s = parser.CommandLineParser()
     _parser_s.initialize_default_arguments(simulation_model=["site"])
     job_groups = _parser_s._action_groups
     assert simulation_model_string in [str(group.title) for group in job_groups]
     for group in job_groups:
-        if str(group.title) == simulation_model_string:
+        if str(group.title) == "simulation model":
             assert any(action.dest == "model_version" for action in group._group_actions)
             assert any(action.dest == "site" for action in group._group_actions)
             assert all(action.dest != "telescope" for action in group._group_actions)
 
-    # no telescope model without site model
+    # No telescope model without site model
     _parser_t = parser.CommandLineParser()
     _parser_t.initialize_default_arguments(simulation_model=["telescope", "site"])
     job_groups = _parser_t._action_groups

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -10,7 +10,7 @@ import simtools.configuration.commandline_parser as parser
 
 logger = logging.getLogger()
 
-simulation_model_string = "simulation model"
+SIMULATION_MODEL_STRING = "simulation model"
 
 
 def test_site():
@@ -176,7 +176,7 @@ def test_simulation_model():
     _parser_v.initialize_default_arguments(simulation_model=["version"])
     job_groups = _parser_v._action_groups
 
-    assert simulation_model_string in [str(group.title) for group in job_groups]
+    assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
         if str(group.title) == "simulation model":
             assert any(action.dest == "model_version" for action in group._group_actions)
@@ -187,7 +187,7 @@ def test_simulation_model():
     _parser_s = parser.CommandLineParser()
     _parser_s.initialize_default_arguments(simulation_model=["site"])
     job_groups = _parser_s._action_groups
-    assert simulation_model_string in [str(group.title) for group in job_groups]
+    assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
         if str(group.title) == "simulation model":
             assert any(action.dest == "model_version" for action in group._group_actions)
@@ -198,9 +198,9 @@ def test_simulation_model():
     _parser_t = parser.CommandLineParser()
     _parser_t.initialize_default_arguments(simulation_model=["telescope", "site"])
     job_groups = _parser_t._action_groups
-    assert simulation_model_string in [str(group.title) for group in job_groups]
+    assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
-        if str(group.title) == simulation_model_string:
+        if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "model_version" for action in group._group_actions)
             assert any(action.dest == "site" for action in group._group_actions)
             assert any(action.dest == "telescope" for action in group._group_actions)
@@ -225,7 +225,7 @@ def test_layout_parsers():
     _parser_7.initialize_default_arguments(simulation_model=["layout"])
     job_groups = _parser_7._action_groups
     for group in job_groups:
-        if str(group.title) == simulation_model_string:
+        if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "array_layout_name" for action in group._group_actions)
             assert any(action.dest == "array_element_list" for action in group._group_actions)
 
@@ -233,7 +233,7 @@ def test_layout_parsers():
     _parser_8.initialize_default_arguments(simulation_model=["layout", "layout_file"])
     job_groups = _parser_8._action_groups
     for group in job_groups:
-        if str(group.title) == simulation_model_string:
+        if str(group.title) == SIMULATION_MODEL_STRING:
             assert any(action.dest == "array_layout_name" for action in group._group_actions)
             assert any(action.dest == "array_element_list" for action in group._group_actions)
             assert any(action.dest == "array_layout_file" for action in group._group_actions)

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -16,7 +16,6 @@ from simtools.configuration.configurator import (
 from simtools.io_operations import io_handler
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -9,7 +9,6 @@ import pytest
 from simtools.corsika.corsika_config import CorsikaConfig
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -295,6 +294,8 @@ def test_set_primary_particle(corsika_config_mock_array_model):
     assert p_pdg_id.name == "proton"
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_config_parameter(corsika_config_mock_array_model, caplog):
     cc = corsika_config_mock_array_model
     assert isinstance(cc.get_config_parameter("NSHOW"), int)

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -294,14 +294,13 @@ def test_set_primary_particle(corsika_config_mock_array_model):
     assert p_pdg_id.name == "proton"
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_config_parameter(corsika_config_mock_array_model, caplog):
     cc = corsika_config_mock_array_model
     assert isinstance(cc.get_config_parameter("NSHOW"), int)
     assert isinstance(cc.get_config_parameter("THETAP"), list)
-    with pytest.raises(KeyError):
-        cc.get_config_parameter("not_really_a_parameter")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(KeyError):
+            cc.get_config_parameter("not_really_a_parameter")
     assert "Parameter not_really_a_parameter" in caplog.text
 
 

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -86,10 +86,9 @@ def test_get_header_astropy_units(corsika_histograms_instance):
         assert isinstance(astropy_unit, u.core.CompositeUnit)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_hist_config_default_config(corsika_histograms_instance, caplog):
-    hist_config = corsika_histograms_instance.hist_config
+    with caplog.at_level("WARNING"):
+        hist_config = corsika_histograms_instance.hist_config
     assert "No histogram configuration was defined before." in caplog.text
     assert isinstance(hist_config, dict)
     assert hist_config == corsika_histograms_instance._create_histogram_default_config()
@@ -702,36 +701,32 @@ def test_magnetic_field(corsika_histograms_instance_set_histograms):
     assert corsika_histograms_instance_set_histograms.magnetic_field[0].unit == u.uT
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_event_parameter_info(corsika_histograms_instance_set_histograms, caplog):
     for parameter in corsika_histograms_instance_set_histograms.all_event_keys[1:]:
         assert isinstance(
             corsika_histograms_instance_set_histograms.get_event_parameter_info(parameter),
             u.quantity.Quantity,
         )
-
-    with pytest.raises(KeyError):
-        corsika_histograms_instance_set_histograms.get_event_parameter_info(
-            "non_existent_parameter"
-        )
+    with caplog.at_level("ERROR"):
+        with pytest.raises(KeyError):
+            corsika_histograms_instance_set_histograms.get_event_parameter_info(
+                "non_existent_parameter"
+            )
     assert (
         f"key is not valid. Valid entries are "
         f"{corsika_histograms_instance_set_histograms.all_event_keys}" in caplog.text
     )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_run_info(corsika_histograms_instance_set_histograms, caplog):
     for parameter in corsika_histograms_instance_set_histograms.all_run_keys[1:]:
         assert isinstance(
             corsika_histograms_instance_set_histograms.get_run_info(parameter),
             u.quantity.Quantity,
         )
-
-    with pytest.raises(KeyError):
-        corsika_histograms_instance_set_histograms.get_run_info("non_existent_parameter")
+    with caplog.at_level("ERROR"):
+        with pytest.raises(KeyError):
+            corsika_histograms_instance_set_histograms.get_run_info("non_existent_parameter")
     assert (
         f"key is not valid. Valid entries are "
         f"{corsika_histograms_instance_set_histograms.all_run_keys}" in caplog.text

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -192,11 +192,10 @@ def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
     assert np.count_nonzero(corsika_histograms_instance_fill.hist_direction[0].values()) > 0
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_hist_1d_projection(corsika_histograms_instance_set_histograms, caplog):
-    with pytest.raises(ValueError, match="label_not_valid is not valid."):
-        corsika_histograms_instance_set_histograms._get_hist_1d_projection("label_not_valid")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match="label_not_valid is not valid."):
+            corsika_histograms_instance_set_histograms._get_hist_1d_projection("label_not_valid")
     assert "label_not_valid is not valid." in caplog.text
 
     labels = ["wavelength", "time", "altitude"]

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -2,6 +2,7 @@
 
 
 import copy
+import logging
 from pathlib import Path
 
 import boost_histogram as bh
@@ -85,10 +86,11 @@ def test_get_header_astropy_units(corsika_histograms_instance):
         assert isinstance(astropy_unit, u.core.CompositeUnit)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_hist_config_default_config(corsika_histograms_instance, caplog):
-    with caplog.at_level("WARNING"):
-        hist_config = corsika_histograms_instance.hist_config
-        assert "No histogram configuration was defined before." in caplog.text
+    hist_config = corsika_histograms_instance.hist_config
+    assert "No histogram configuration was defined before." in caplog.text
     assert isinstance(hist_config, dict)
     assert hist_config == corsika_histograms_instance._create_histogram_default_config()
 
@@ -191,6 +193,8 @@ def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
     assert np.count_nonzero(corsika_histograms_instance_fill.hist_direction[0].values()) > 0
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_hist_1d_projection(corsika_histograms_instance_set_histograms, caplog):
     with pytest.raises(ValueError, match="label_not_valid is not valid."):
         corsika_histograms_instance_set_histograms._get_hist_1d_projection("label_not_valid")
@@ -698,6 +702,8 @@ def test_magnetic_field(corsika_histograms_instance_set_histograms):
     assert corsika_histograms_instance_set_histograms.magnetic_field[0].unit == u.uT
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_event_parameter_info(corsika_histograms_instance_set_histograms, caplog):
     for parameter in corsika_histograms_instance_set_histograms.all_event_keys[1:]:
         assert isinstance(
@@ -715,6 +721,8 @@ def test_get_event_parameter_info(corsika_histograms_instance_set_histograms, ca
     )
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_run_info(corsika_histograms_instance_set_histograms, caplog):
     for parameter in corsika_histograms_instance_set_histograms.all_run_keys[1:]:
         assert isinstance(

--- a/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
@@ -1,3 +1,5 @@
+import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -5,6 +7,8 @@ import pytest
 from simtools.corsika import corsika_histograms_visualize
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, caplog):
     corsika_histograms_instance_set_histograms.set_histograms(
         individual_telescopes=False, telescope_indices=[0, 1, 2]
@@ -58,6 +62,8 @@ def test_plot_2ds(corsika_histograms_instance_set_histograms):
         assert all(isinstance(fig, plt.Figure) for fig in figs)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_kernel_plot_1d_photons(corsika_histograms_instance_set_histograms, caplog):
     corsika_histograms_instance_set_histograms.set_histograms(
         individual_telescopes=False, telescope_indices=[0, 1, 2]

--- a/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms_visualize.py
@@ -7,8 +7,6 @@ import pytest
 from simtools.corsika import corsika_histograms_visualize
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, caplog):
     corsika_histograms_instance_set_histograms.set_histograms(
         individual_telescopes=False, telescope_indices=[0, 1, 2]
@@ -42,10 +40,11 @@ def test_kernel_plot_2d_photons(corsika_histograms_instance_set_histograms, capl
         for _, _ in enumerate(corsika_histograms_instance_set_histograms.telescope_indices):
             assert isinstance(all_figs[0], plt.Figure)
 
-    with pytest.raises(ValueError, match=r"This property does not exist. The valid entries"):
-        corsika_histograms_visualize._kernel_plot_2d_photons(
-            corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
-        )
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match=r"This property does not exist. The valid entries"):
+            corsika_histograms_visualize._kernel_plot_2d_photons(
+                corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
+            )
     assert "This property does not exist. " in caplog.text
 
 
@@ -62,8 +61,6 @@ def test_plot_2ds(corsika_histograms_instance_set_histograms):
         assert all(isinstance(fig, plt.Figure) for fig in figs)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_kernel_plot_1d_photons(corsika_histograms_instance_set_histograms, caplog):
     corsika_histograms_instance_set_histograms.set_histograms(
         individual_telescopes=False, telescope_indices=[0, 1, 2]
@@ -97,11 +94,11 @@ def test_kernel_plot_1d_photons(corsika_histograms_instance_set_histograms, capl
                 assert isinstance(all_figs[0], plt.Figure)
             else:
                 assert isinstance(all_figs[i_hist], plt.Figure)
-
-    with pytest.raises(ValueError, match=r"This property does not"):
-        corsika_histograms_visualize._kernel_plot_1d_photons(
-            corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
-        )
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ValueError, match=r"This property does not"):
+            corsika_histograms_visualize._kernel_plot_1d_photons(
+                corsika_histograms_instance_set_histograms, "this_property_does_not_exist"
+            )
     assert "This property does not exist. " in caplog.text
 
 

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -8,7 +8,6 @@ from particle import Corsika7ID
 from simtools.corsika.primary_particle import PrimaryParticle
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_init():

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -93,24 +93,23 @@ def test_read_value_from_file(tmp_test_directory, reference_point_altitude_file)
     )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_read_value_from_file_and_validate(
     caplog, tmp_test_directory, reference_point_altitude_file
 ):
-    # schema file from metadata in file
-    data_reader.read_value_from_file(reference_point_altitude_file, validate=True)
+    with caplog.at_level("DEBUG"):
+        # schema file from metadata in file
+        data_reader.read_value_from_file(reference_point_altitude_file, validate=True)
     assert "Successful validation of yaml/json file" in caplog.text
 
     # schema explicitly given
     schema_dir = files("simtools").joinpath("schemas/model_parameters/")
     schema_file = str(schema_dir) + "/reference_point_altitude.schema.yml"
-
-    data_reader.read_value_from_file(
-        reference_point_altitude_file,
-        schema_file=schema_file,
-        validate=True,
-    )
+    with caplog.at_level("DEBUG"):
+        data_reader.read_value_from_file(
+            reference_point_altitude_file,
+            schema_file=schema_file,
+            validate=True,
+        )
     assert "Successful validation of yaml/json file" in caplog.text
 
     # no schema given

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -93,24 +93,25 @@ def test_read_value_from_file(tmp_test_directory, reference_point_altitude_file)
     )
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_read_value_from_file_and_validate(
     caplog, tmp_test_directory, reference_point_altitude_file
 ):
     # schema file from metadata in file
-    with caplog.at_level(logging.DEBUG):
-        data_reader.read_value_from_file(reference_point_altitude_file, validate=True)
-        assert "Successful validation of yaml/json file" in caplog.text
+    data_reader.read_value_from_file(reference_point_altitude_file, validate=True)
+    assert "Successful validation of yaml/json file" in caplog.text
 
     # schema explicitly given
     schema_dir = files("simtools").joinpath("schemas/model_parameters/")
     schema_file = str(schema_dir) + "/reference_point_altitude.schema.yml"
-    with caplog.at_level(logging.DEBUG):
-        data_reader.read_value_from_file(
-            reference_point_altitude_file,
-            schema_file=schema_file,
-            validate=True,
-        )
-        assert "Successful validation of yaml/json file" in caplog.text
+
+    data_reader.read_value_from_file(
+        reference_point_altitude_file,
+        schema_file=schema_file,
+        validate=True,
+    )
+    assert "Successful validation of yaml/json file" in caplog.text
 
     # no schema given
     test_dict_1 = {"Value": 5.0}

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -117,8 +117,6 @@ def test_fill_associated_elements_from_args(args_dict_site):
         )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplog):
     metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     metadata_1.args_dict["input_meta"] = None
@@ -146,8 +144,9 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
     with open(tmp_test_directory / "test_read_input_metadata_file.json", "w") as f:
         json.dump(test_dict, f)
     metadata_1.args_dict["input_meta"] = tmp_test_directory / "test_read_input_metadata_file.json"
-    with pytest.raises(gen.InvalidConfigDataError):
-        metadata_1._read_input_metadata_from_file()
+    with caplog.at_level("ERROR"):
+        with pytest.raises(gen.InvalidConfigDataError):
+            metadata_1._read_input_metadata_from_file()
     assert "More than one metadata entry" in caplog.text
 
     metadata_1.args_dict["input_meta"] = "tests/resources/telescope_positions-North-utm.ecsv"

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -14,7 +14,6 @@ import simtools.utils.general as gen
 from simtools.data_model import metadata_model
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_get_data_model_schema_file_name():
@@ -118,6 +117,8 @@ def test_fill_associated_elements_from_args(args_dict_site):
         )
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplog):
     metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     metadata_1.args_dict["input_meta"] = None

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -50,6 +50,8 @@ def test_validate_schema(tmp_test_directory):
         metadata_model.validate_schema(invalid_data, schema_file)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_validate_schema_astropy_units(caplog):
     _schema = "simtools/schemas/model_parameter_and_data_schema.metaschema.yml"
 
@@ -58,38 +60,32 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1 = gen.collect_data_from_file_or_dict(
         file_name="tests/resources/num_gains.schema.yml", in_dict=None
     )
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # m and cm
     _dict_1["data"][0]["unit"] = "m"
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "cm"
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # combined units
     _dict_1["data"][0]["unit"] = "cm/s"
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "km/ s"
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # dimensionless
     _dict_1["data"][0]["unit"] = "dimensionless"
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = ""
-    with caplog.at_level(logging.DEBUG):
-        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # not good

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -50,8 +50,6 @@ def test_validate_schema(tmp_test_directory):
         metadata_model.validate_schema(invalid_data, schema_file)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_validate_schema_astropy_units(caplog):
     _schema = "simtools/schemas/model_parameter_and_data_schema.metaschema.yml"
 
@@ -60,32 +58,38 @@ def test_validate_schema_astropy_units(caplog):
     _dict_1 = gen.collect_data_from_file_or_dict(
         file_name="tests/resources/num_gains.schema.yml", in_dict=None
     )
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # m and cm
     _dict_1["data"][0]["unit"] = "m"
-
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "cm"
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # combined units
     _dict_1["data"][0]["unit"] = "cm/s"
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = "km/ s"
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # dimensionless
     _dict_1["data"][0]["unit"] = "dimensionless"
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
     _dict_1["data"][0]["unit"] = ""
-    metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
+    with caplog.at_level(logging.DEBUG):
+        metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text
 
     # not good

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -13,7 +13,6 @@ import simtools.data_model.model_data_writer as writer
 from simtools.data_model.model_data_writer import JsonNumpyEncoder
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 test_file_2 = "test_file_2.ecsv"

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -17,6 +17,7 @@ from astropy.utils.diff import report_diff_values
 from simtools.data_model import validate_data
 
 logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 mirror_file = "tests/resources/MLTdata-preproduction.ecsv"
@@ -95,8 +96,6 @@ def reference_columns_name():
     ]
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_validate_and_transform(caplog, mocker):
     data_validator = validate_data.DataValidator()
     # no input file defined
@@ -107,8 +106,9 @@ def test_validate_and_transform(caplog, mocker):
 
     data_validator.data_file_name = mirror_file
     data_validator.schema_file_name = mirror_2f_schema_file
-    _table = data_validator.validate_and_transform()
-    assert isinstance(_table, Table)
+    with caplog.at_level(logging.INFO):
+        _table = data_validator.validate_and_transform()
+        assert isinstance(_table, Table)
     assert "Validating tabled data from:" in caplog.text
 
     data_validator.data_file_name = "tests/resources/model_parameters/num_gains.json"
@@ -116,25 +116,26 @@ def test_validate_and_transform(caplog, mocker):
     mock_prepare_model_parameter = mocker.patch(
         "simtools.data_model.validate_data.DataValidator._prepare_model_parameter"
     )
-    _dict = data_validator.validate_and_transform(True)
-    assert isinstance(_dict, dict)
+    with caplog.at_level(logging.INFO):
+        _dict = data_validator.validate_and_transform(True)
+        assert isinstance(_dict, dict)
     assert "Validating data from:" in caplog.text
     mock_prepare_model_parameter.assert_called_once()
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_validate_data_file(caplog):
     data_validator = validate_data.DataValidator()
     # no input file defined, should pass
     data_validator.validate_data_file()
 
     data_validator.data_file_name = mirror_file
-    data_validator.validate_data_file()
+    with caplog.at_level(logging.INFO):
+        data_validator.validate_data_file()
     assert "Validating tabled data from:" in caplog.text
 
     data_validator.data_file_name = "tests/resources/reference_point_altitude.json"
-    data_validator.validate_data_file()
+    with caplog.at_level(logging.INFO):
+        data_validator.validate_data_file()
     assert "Validating data from:" in caplog.text
 
 
@@ -193,8 +194,6 @@ def test_validate_data_columns(tmp_test_directory, caplog):
     assert "Error reading validation schema from" in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_sort_data(reference_columns, caplog):
     data_validator = validate_data.DataValidator()
     data_validator._data_description = reference_columns
@@ -219,8 +218,9 @@ def test_sort_data(reference_columns, caplog):
     )
 
     data_validator.data_table = None
-    with pytest.raises(AttributeError):
-        data_validator._sort_data()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(AttributeError):
+            data_validator._sort_data()
     assert "No data table defined for sorting" in caplog.text
 
     reverse_sorted_data_columns = reference_columns
@@ -239,8 +239,9 @@ def test_sort_data(reference_columns, caplog):
     assert identical_reverse_sorted
 
     data_validator_reverse.data_table = None
-    with pytest.raises(AttributeError):
-        data_validator_reverse._sort_data()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(AttributeError):
+            data_validator_reverse._sort_data()
     assert "No data table defined for reverse sorting" in caplog.text
 
 
@@ -406,8 +407,6 @@ def test_check_and_convert_units_simple_numbers(reference_columns):
     )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_check_and_convert_units_dimensionless(reference_columns, caplog):
     data_validator = validate_data.DataValidator()
     data_validator._data_description = reference_columns
@@ -418,8 +417,11 @@ def test_check_and_convert_units_dimensionless(reference_columns, caplog):
     )
 
     # reference column requires a unit, give no unit
-    with pytest.raises(u.core.UnitConversionError):
-        data_validator._check_and_convert_units(300.0, unit="dimensionless", col_name="wavelength")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(u.core.UnitConversionError):
+            data_validator._check_and_convert_units(
+                300.0, unit="dimensionless", col_name="wavelength"
+            )
     assert "Invalid unit in data column " in caplog.text
 
 

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -17,7 +17,6 @@ from astropy.utils.diff import report_diff_values
 from simtools.data_model import validate_data
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 mirror_file = "tests/resources/MLTdata-preproduction.ecsv"

--- a/tests/unit_tests/db/test_db_from_repo_handler.py
+++ b/tests/unit_tests/db/test_db_from_repo_handler.py
@@ -7,7 +7,6 @@ import pytest
 from simtools.db import db_from_repo_handler
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_update_parameters_from_repo(caplog, db_config, simulation_model_url):

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -10,7 +10,6 @@ from astropy import units as u
 from simtools.db import db_handler
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/io_operations/test_io_handler.py
+++ b/tests/unit_tests/io_operations/test_io_handler.py
@@ -10,7 +10,6 @@ import pytest
 import simtools.io_operations.io_handler as io_handler_module
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 test_file = "test-file.txt"

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -12,7 +12,6 @@ OS_SYSTEM = "os.system"
 PATHLIB_PATH_EXISTS = "pathlib.Path.exists"
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -11,7 +11,6 @@ from simtools.data_model import data_reader
 from simtools.layout.array_layout import ArrayLayout, InvalidTelescopeListFileError
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/layout/test_telescope_position.py
+++ b/tests/unit_tests/layout/test_telescope_position.py
@@ -14,7 +14,6 @@ from simtools.layout.telescope_position import (
 )
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -10,7 +10,6 @@ from astropy.table import QTable
 from simtools.model.array_model import ArrayModel
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/model/test_camera_model.py
+++ b/tests/unit_tests/model/test_camera_model.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_get_number_of_pixels(telescope_model_lst):

--- a/tests/unit_tests/model/test_mirrors.py
+++ b/tests/unit_tests/model/test_mirrors.py
@@ -7,7 +7,6 @@ import pytest
 from simtools.model.mirrors import InvalidMirrorListFileError, Mirrors
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -13,7 +13,6 @@ from simtools.model.model_parameter import InvalidModelParameterError
 from simtools.model.telescope_model import TelescopeModel
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_get_parameter_type(telescope_model_lst, caplog):

--- a/tests/unit_tests/model/test_site_model.py
+++ b/tests/unit_tests/model/test_site_model.py
@@ -7,7 +7,6 @@ import pytest
 from simtools.model.site_model import SiteModel
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 def test_site_model(db_config, model_version):

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -9,7 +9,6 @@ import pytest
 from simtools.model.model_parameter import InvalidModelParameterError
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.mark.xfail(reason="Missing ray_tracing for prod6 in Derived-DB")
@@ -99,6 +98,8 @@ def test_get_telescope_effective_focal_length(telescope_model_lst, telescope_mod
     assert tel_model_sst.get_telescope_effective_focal_length("m", True) == pytest.approx(2.15)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_position(telescope_model_lst, caplog):
     tel_model = telescope_model_lst
     xyz = tel_model.position(coordinate_system="ground")
@@ -113,6 +114,4 @@ def test_position(telescope_model_lst, caplog):
     with pytest.raises(InvalidModelParameterError):
         tel_model.position(coordinate_system="invalid")
 
-    assert any(
-        "Coordinate system invalid not found." in message for message in caplog.text.splitlines()
-    )
+    assert "Coordinate system invalid not found." in caplog.text

--- a/tests/unit_tests/model/test_telescope_model.py
+++ b/tests/unit_tests/model/test_telescope_model.py
@@ -98,8 +98,6 @@ def test_get_telescope_effective_focal_length(telescope_model_lst, telescope_mod
     assert tel_model_sst.get_telescope_effective_focal_length("m", True) == pytest.approx(2.15)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_position(telescope_model_lst, caplog):
     tel_model = telescope_model_lst
     xyz = tel_model.position(coordinate_system="ground")
@@ -110,8 +108,7 @@ def test_position(telescope_model_lst, caplog):
     assert pytest.approx(utm_xyz[0].value) == 217659.6
     assert pytest.approx(utm_xyz[1].value) == 3184995.1
     assert pytest.approx(utm_xyz[2].value) == 2185.0
-
-    with pytest.raises(InvalidModelParameterError):
-        tel_model.position(coordinate_system="invalid")
-
+    with caplog.at_level("ERROR"):
+        with pytest.raises(InvalidModelParameterError):
+            tel_model.position(coordinate_system="invalid")
     assert "Coordinate system invalid not found." in caplog.text

--- a/tests/unit_tests/runners/test_corsika_runner.py
+++ b/tests/unit_tests/runners/test_corsika_runner.py
@@ -7,7 +7,6 @@ import re
 import pytest
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -13,7 +13,6 @@ from simtools.runners.corsika_simtel_runner import (
 )
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -10,7 +10,6 @@ import pytest
 import simtools.runners.runner_services as runner_services
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -222,6 +221,8 @@ def test_get_run_number_string(runner_service_config_only):
         runner_service_config_only._get_run_number_string(1234567)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_resources(runner_service_mock_array_model, caplog):
     sub_log_file = runner_service_mock_array_model.get_file_name(
         file_type="sub_log", run_number=None, mode="out"

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -221,8 +221,6 @@ def test_get_run_number_string(runner_service_config_only):
         runner_service_config_only._get_run_number_string(1234567)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_resources(runner_service_mock_array_model, caplog):
     sub_log_file = runner_service_mock_array_model.get_file_name(
         file_type="sub_log", run_number=None, mode="out"

--- a/tests/unit_tests/runners/test_simtel_runner.py
+++ b/tests/unit_tests/runners/test_simtel_runner.py
@@ -9,7 +9,6 @@ import pytest
 from simtools.runners.simtel_runner import SimtelExecutionError, SimtelRunner
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -120,12 +120,15 @@ def test_compare_simtel_config_with_schema(
     _config_ng = config_reader_num_gains
 
     # no differences; should result in no output
-    _config_ng.compare_simtel_config_with_schema()
-    assert caplog.text == ""
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        _config_ng.compare_simtel_config_with_schema()
+        assert caplog.text == ""
 
     # no limits defined for telescope_transmission
-    with caplog.at_level("WARNING"):
-        _config_tt = config_reader_telescope_transmission
+    caplog.clear()
+    _config_tt = config_reader_telescope_transmission
+    with caplog.at_level(logging.WARNING):
         _config_tt.compare_simtel_config_with_schema()
     assert "Values for limits do not match" in caplog.text
     assert "from simtel: TELESCOPE_TRANSMISSION None" in caplog.text
@@ -139,6 +142,7 @@ def test_compare_simtel_config_with_schema(
     assert "Values for limits do not match" not in caplog.text
 
     # remove keys and elements to enforce error tests
+    caplog.clear()
     with caplog.at_level("WARNING"):
         _config_ng.schema_dict["data"][0].pop("default")
         _config_ng.compare_simtel_config_with_schema()

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -10,7 +10,6 @@ import pytest
 from simtools.simtel.simtel_config_reader import SimtelConfigReader
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -114,6 +113,8 @@ def test_export_parameter_dict_to_json(tmp_test_directory, config_reader_num_gai
     assert _json_file.exists()
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_compare_simtel_config_with_schema(
     config_reader_num_gains, config_reader_telescope_transmission, caplog
 ):
@@ -121,41 +122,34 @@ def test_compare_simtel_config_with_schema(
     _config_ng = config_reader_num_gains
 
     # no differences; should result in no output
-    caplog.clear()
-    with caplog.at_level(logging.WARNING):
-        _config_ng.compare_simtel_config_with_schema()
-        assert caplog.text == ""
+    _config_ng.compare_simtel_config_with_schema()
+    assert caplog.text == ""
 
     # no limits defined for telescope_transmission
-    caplog.clear()
     _config_tt = config_reader_telescope_transmission
-    with caplog.at_level(logging.WARNING):
-        _config_tt.compare_simtel_config_with_schema()
-        assert "Values for limits do not match" in caplog.text
-        assert "from simtel: TELESCOPE_TRANSMISSION None" in caplog.text
-        assert "from schema: telescope_transmission [0. 1.]" in caplog.text
+    _config_tt.compare_simtel_config_with_schema()
+    assert "Values for limits do not match" in caplog.text
+    assert "from simtel: TELESCOPE_TRANSMISSION None" in caplog.text
+    assert "from schema: telescope_transmission [0. 1.]" in caplog.text
 
     # change parameter type to bool; should result in no limit check
     caplog.clear()
     _config_tt.parameter_dict["type"] = "bool"
-    with caplog.at_level(logging.WARNING):
-        _config_tt.compare_simtel_config_with_schema()
-        assert "Values for limits do not match" not in caplog.text
+    _config_tt.compare_simtel_config_with_schema()
+    assert "Values for limits do not match" not in caplog.text
 
     # remove keys and elements to enforce error tests
-    caplog.clear()
     _config_ng.schema_dict["data"][0].pop("default")
-    with caplog.at_level(logging.WARNING):
-        _config_ng.compare_simtel_config_with_schema()
-        assert "from schema: num_gains None" in caplog.text
+    _config_ng.compare_simtel_config_with_schema()
+    assert "from schema: num_gains None" in caplog.text
 
-    caplog.clear()
     _config_ng.schema_dict["data"].pop(0)
-    with caplog.at_level(logging.WARNING):
-        _config_ng.compare_simtel_config_with_schema()
-        assert "from schema: num_gains None" in caplog.text
+    _config_ng.compare_simtel_config_with_schema()
+    assert "from schema: num_gains None" in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, caplog):
 
     _config_ng = config_reader_num_gains

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -113,8 +113,6 @@ def test_export_parameter_dict_to_json(tmp_test_directory, config_reader_num_gai
     assert _json_file.exists()
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_compare_simtel_config_with_schema(
     config_reader_num_gains, config_reader_telescope_transmission, caplog
 ):
@@ -126,30 +124,31 @@ def test_compare_simtel_config_with_schema(
     assert caplog.text == ""
 
     # no limits defined for telescope_transmission
-    _config_tt = config_reader_telescope_transmission
-    _config_tt.compare_simtel_config_with_schema()
+    with caplog.at_level("WARNING"):
+        _config_tt = config_reader_telescope_transmission
+        _config_tt.compare_simtel_config_with_schema()
     assert "Values for limits do not match" in caplog.text
     assert "from simtel: TELESCOPE_TRANSMISSION None" in caplog.text
     assert "from schema: telescope_transmission [0. 1.]" in caplog.text
 
     # change parameter type to bool; should result in no limit check
     caplog.clear()
-    _config_tt.parameter_dict["type"] = "bool"
-    _config_tt.compare_simtel_config_with_schema()
+    with caplog.at_level("WARNING"):
+        _config_tt.parameter_dict["type"] = "bool"
+        _config_tt.compare_simtel_config_with_schema()
     assert "Values for limits do not match" not in caplog.text
 
     # remove keys and elements to enforce error tests
-    _config_ng.schema_dict["data"][0].pop("default")
-    _config_ng.compare_simtel_config_with_schema()
+    with caplog.at_level("WARNING"):
+        _config_ng.schema_dict["data"][0].pop("default")
+        _config_ng.compare_simtel_config_with_schema()
+    assert "from schema: num_gains None" in caplog.text
+    with caplog.at_level("WARNING"):
+        _config_ng.schema_dict["data"].pop(0)
+        _config_ng.compare_simtel_config_with_schema()
     assert "from schema: num_gains None" in caplog.text
 
-    _config_ng.schema_dict["data"].pop(0)
-    _config_ng.compare_simtel_config_with_schema()
-    assert "from schema: num_gains None" in caplog.text
 
-
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, caplog):
 
     _config_ng = config_reader_num_gains
@@ -165,7 +164,8 @@ def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, ca
     assert "CT1000" not in _para_dict
 
     # non existing parameter
-    _config_ng.simtel_parameter_name = "this parameter does not exist"
+    with caplog.at_level("INFO"):
+        _config_ng.simtel_parameter_name = "this parameter does not exist"
     assert _config_ng._read_simtel_config_file(simtel_config_file, "CT1") is None
     assert "No entries found for parameter" in caplog.text
 

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -9,7 +9,6 @@ import pytest
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simtel_io_events.py
+++ b/tests/unit_tests/simtel/test_simtel_io_events.py
@@ -8,7 +8,6 @@ import pytest
 from simtools.simtel.simtel_io_events import SimtelIOEvents
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -12,7 +12,6 @@ from ctao_cr_spectra.spectral import PowerLaw
 from simtools.simtel.simtel_io_histogram import HistogramIdNotFoundError, SimtelIOHistogram
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -43,21 +42,22 @@ def simtel_hist_hdata_io_instance(simtel_io_file_hdata):
     )
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_init_errors(simtel_io_file_hdata, caplog):
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError, match=r"view_cone needs to be passed as argument"):
-            _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
+    with pytest.raises(ValueError, match=r"view_cone needs to be passed as argument"):
+        _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
     assert "view_cone needs to be passed as argument" in caplog.text
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError, match=r"energy_range needs to be passed as argument"):
-            _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
+    with pytest.raises(ValueError, match=r"energy_range needs to be passed as argument"):
+        _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
     assert "energy_range needs to be passed as argument" in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_file_does_not_exist(caplog):
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(FileNotFoundError):
-            _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
+    with pytest.raises(FileNotFoundError):
+        _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
     assert "does not exist." in caplog.text
 
 
@@ -86,6 +86,8 @@ def test_total_num_triggered_events(simtel_hist_io_instance):
     assert total_num_triggered_events == 1.0
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_fill_event_histogram_dicts(simtel_hist_io_instance, caplog):
     (
         events_histogram,
@@ -105,9 +107,8 @@ def test_fill_event_histogram_dicts(simtel_hist_io_instance, caplog):
             new_instance.histogram[histogram_index]["id"] = 99
         if hist["id"] == 2:
             new_instance.histogram[histogram_index]["id"] = 99
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(HistogramIdNotFoundError):
-            new_instance.fill_event_histogram_dicts()
+    with pytest.raises(HistogramIdNotFoundError):
+        new_instance.fill_event_histogram_dicts()
     assert "Histograms ids not found. Please check your files." in caplog.text
 
 
@@ -143,6 +144,8 @@ def test_initialize_histogram_axes(simtel_hist_io_instance):
     assert np.array_equal(simtel_hist_io_instance.energy_axis, expected_energy_axis)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_particle_distribution_function(
     simtel_hist_io_instance, simtel_hist_hdata_io_instance, caplog
 ):
@@ -159,9 +162,8 @@ def test_get_particle_distribution_function(
         label="simulation"
     )
     assert simulation_function.index == -2.0
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
-            simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
+    with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
+        simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
     assert_string = (
         "spectral_index not found in the configuration of the file. "
         "Consider using a .simtel file instead."
@@ -169,9 +171,8 @@ def test_get_particle_distribution_function(
     assert assert_string in caplog.text
 
     # Test invalid label
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(ValueError, match=r"Please use either"):
-            simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
+    with pytest.raises(ValueError, match=r"Please use either"):
+        simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
     assert "Please use either 'reference' or 'simulation'" in caplog.text
 
 

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -42,22 +42,21 @@ def simtel_hist_hdata_io_instance(simtel_io_file_hdata):
     )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_init_errors(simtel_io_file_hdata, caplog):
-    with pytest.raises(ValueError, match=r"view_cone needs to be passed as argument"):
-        _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match=r"view_cone needs to be passed as argument"):
+            _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata)
     assert "view_cone needs to be passed as argument" in caplog.text
-    with pytest.raises(ValueError, match=r"energy_range needs to be passed as argument"):
-        _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match=r"energy_range needs to be passed as argument"):
+            _ = SimtelIOHistogram(histogram_file=simtel_io_file_hdata, view_cone=[0, 10])
     assert "energy_range needs to be passed as argument" in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_file_does_not_exist(caplog):
-    with pytest.raises(FileNotFoundError):
-        _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(FileNotFoundError):
+            _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
     assert "does not exist." in caplog.text
 
 
@@ -86,8 +85,6 @@ def test_total_num_triggered_events(simtel_hist_io_instance):
     assert total_num_triggered_events == 1.0
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_fill_event_histogram_dicts(simtel_hist_io_instance, caplog):
     (
         events_histogram,
@@ -107,8 +104,9 @@ def test_fill_event_histogram_dicts(simtel_hist_io_instance, caplog):
             new_instance.histogram[histogram_index]["id"] = 99
         if hist["id"] == 2:
             new_instance.histogram[histogram_index]["id"] = 99
-    with pytest.raises(HistogramIdNotFoundError):
-        new_instance.fill_event_histogram_dicts()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(HistogramIdNotFoundError):
+            new_instance.fill_event_histogram_dicts()
     assert "Histograms ids not found. Please check your files." in caplog.text
 
 
@@ -144,8 +142,6 @@ def test_initialize_histogram_axes(simtel_hist_io_instance):
     assert np.array_equal(simtel_hist_io_instance.energy_axis, expected_energy_axis)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_particle_distribution_function(
     simtel_hist_io_instance, simtel_hist_hdata_io_instance, caplog
 ):
@@ -162,17 +158,19 @@ def test_get_particle_distribution_function(
         label="simulation"
     )
     assert simulation_function.index == -2.0
-    with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
-        simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
-    assert_string = (
-        "spectral_index not found in the configuration of the file. "
-        "Consider using a .simtel file instead."
-    )
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match=r"spectral_index not found in the configuration"):
+            simtel_hist_hdata_io_instance._get_simulation_spectral_distribution_function()
+        assert_string = (
+            "spectral_index not found in the configuration of the file. "
+            "Consider using a .simtel file instead."
+        )
     assert assert_string in caplog.text
 
     # Test invalid label
-    with pytest.raises(ValueError, match=r"Please use either"):
-        simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValueError, match=r"Please use either"):
+            simtel_hist_io_instance.get_particle_distribution_function(label="invalid_label")
     assert "Please use either 'reference' or 'simulation'" in caplog.text
 
 

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -62,28 +62,26 @@ def simtel_array_histograms_instance_file_list(simtel_io_file_list):
     return SimtelIOHistograms(histogram_files=simtel_io_file_list, test=True)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_file_does_not_exist(caplog):
-    with pytest.raises(FileNotFoundError):
-        _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(FileNotFoundError):
+            _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
     assert "does not exist." in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_calculate_trigger_rates(
     simtel_array_histograms_instance,
     simtel_array_histograms_instance_file_list,
     simtel_hists_hdata_io_instance,
     caplog,
 ):
-    (
-        sim_event_rates,
-        triggered_event_rates,
-        triggered_event_rate_uncertainties,
-        trigger_rate_in_tables,
-    ) = simtel_array_histograms_instance.calculate_trigger_rates(print_info=False)
+    with caplog.at_level(logging.INFO):
+        (
+            sim_event_rates,
+            triggered_event_rates,
+            triggered_event_rate_uncertainties,
+            trigger_rate_in_tables,
+        ) = simtel_array_histograms_instance.calculate_trigger_rates(print_info=False)
     assert pytest.approx(sim_event_rates[0].value, 0.2) == 2e7
     assert sim_event_rates[0].unit == 1 / u.s
     assert pytest.approx(triggered_event_rate_uncertainties[0].value, 0.1) == 9008

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -19,7 +19,6 @@ from simtools.simtel.simtel_io_histogram import (
 from simtools.simtel.simtel_io_histograms import SimtelIOHistograms
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -63,31 +62,32 @@ def simtel_array_histograms_instance_file_list(simtel_io_file_list):
     return SimtelIOHistograms(histogram_files=simtel_io_file_list, test=True)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_file_does_not_exist(caplog):
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(FileNotFoundError):
-            _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
+    with pytest.raises(FileNotFoundError):
+        _ = SimtelIOHistogram(histogram_file="non_existent_file.simtel.zst")
     assert "does not exist." in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_calculate_trigger_rates(
     simtel_array_histograms_instance,
     simtel_array_histograms_instance_file_list,
     simtel_hists_hdata_io_instance,
     caplog,
 ):
-
-    with caplog.at_level(logging.INFO):
-        (
-            sim_event_rates,
-            triggered_event_rates,
-            triggered_event_rate_uncertainties,
-            trigger_rate_in_tables,
-        ) = simtel_array_histograms_instance.calculate_trigger_rates(print_info=False)
-        assert pytest.approx(sim_event_rates[0].value, 0.2) == 2e7
-        assert sim_event_rates[0].unit == 1 / u.s
-        assert pytest.approx(triggered_event_rate_uncertainties[0].value, 0.1) == 9008
-        assert trigger_rate_in_tables[0]["Energy (TeV)"][0] == 0.001 * u.TeV
+    (
+        sim_event_rates,
+        triggered_event_rates,
+        triggered_event_rate_uncertainties,
+        trigger_rate_in_tables,
+    ) = simtel_array_histograms_instance.calculate_trigger_rates(print_info=False)
+    assert pytest.approx(sim_event_rates[0].value, 0.2) == 2e7
+    assert sim_event_rates[0].unit == 1 / u.s
+    assert pytest.approx(triggered_event_rate_uncertainties[0].value, 0.1) == 9008
+    assert trigger_rate_in_tables[0]["Energy (TeV)"][0] == 0.001 * u.TeV
     assert "Histogram" in caplog.text
     assert "Total number of simulated events" in caplog.text
     assert "Total number of triggered events" in caplog.text
@@ -205,6 +205,8 @@ def test_list_of_histograms(simtel_array_histograms_instance):
     assert len(list_of_histograms) == 2
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_combine_histogram_files(simtel_io_file, caplog):
     # Reading one histogram file
     instance_alone = SimtelIOHistograms(histogram_files=simtel_io_file, test=True)

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -205,8 +205,6 @@ def test_list_of_histograms(simtel_array_histograms_instance):
     assert len(list_of_histograms) == 2
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_combine_histogram_files(simtel_io_file, caplog):
     # Reading one histogram file
     instance_alone = SimtelIOHistograms(histogram_files=simtel_io_file, test=True)
@@ -221,8 +219,9 @@ def test_combine_histogram_files(simtel_io_file, caplog):
     instance_all.combined_hists[0]["lower_x"] = instance_all.combined_hists[0]["lower_x"] + 1
     instance_all._combined_hists = None
     assert instance_all._combined_hists is None
-    with pytest.raises(InconsistentHistogramFormatError):
-        _ = instance_all.combined_hists
+    with caplog.at_level("ERROR"):
+        with pytest.raises(InconsistentHistogramFormatError):
+            _ = instance_all.combined_hists
     assert "Trying to add histograms with inconsistent dimensions" in caplog.text
 
 

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -9,7 +9,6 @@ from simtools.runners.simtel_runner import InvalidOutputFileError
 from simtools.simtel.simulator_array import SimulatorArray
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -9,7 +9,6 @@ from simtools.camera_efficiency import CameraEfficiency
 from simtools.simtel.simulator_camera_efficiency import SimulatorCameraEfficiency
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -9,7 +9,6 @@ from simtools.ray_tracing import RayTracing
 from simtools.simtel.simulator_ray_tracing import SimulatorRayTracing
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_camera_efficiency.py
+++ b/tests/unit_tests/test_camera_efficiency.py
@@ -13,7 +13,6 @@ from simtools.model.telescope_model import TelescopeModel
 from simtools.simtel.simulator_camera_efficiency import SimulatorCameraEfficiency
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -155,7 +154,8 @@ def test_calc_nsb_rate(camera_efficiency_lst, prepare_results_file):
 
 def test_export_results(mocker, camera_efficiency_lst, caplog, prepare_results_file):
     # no results available yet
-    camera_efficiency_lst.export_results()
+    with caplog.at_level(logging.ERROR):
+        camera_efficiency_lst.export_results()
     assert "Cannot export results because they do not exist" in caplog.text
 
     # results available
@@ -165,7 +165,7 @@ def test_export_results(mocker, camera_efficiency_lst, caplog, prepare_results_f
     mocker.patch("builtins.open", mock_file)
     with caplog.at_level(logging.INFO):
         camera_efficiency_lst.export_results()
-        assert "Exporting summary results" in caplog.text
+    assert "Exporting summary results" in caplog.text
     mock_file().write.assert_called_once_with("TestString")
 
 
@@ -207,4 +207,4 @@ def test_save_plot(camera_efficiency_lst, mocker, caplog):
     fig_mock = mocker.MagicMock()
     with caplog.at_level(logging.INFO):
         camera_efficiency_lst._save_plot(fig_mock, "test_plot")
-        assert "Plotted test_plot efficiency in" in caplog.text
+    assert "Plotted test_plot efficiency in" in caplog.text

--- a/tests/unit_tests/test_psf_analysis.py
+++ b/tests/unit_tests/test_psf_analysis.py
@@ -152,8 +152,6 @@ def test_get_effective_area(psf_image, caplog):
     assert "Effective Area could not be calculated" in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_psf(psf_image, caplog):
     image = psf_image
 

--- a/tests/unit_tests/test_psf_analysis.py
+++ b/tests/unit_tests/test_psf_analysis.py
@@ -9,7 +9,6 @@ from astropy import units as u
 from simtools.psf_analysis import PSFImage
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -153,6 +152,8 @@ def test_get_effective_area(psf_image, caplog):
     assert "Effective Area could not be calculated" in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_get_psf(psf_image, caplog):
     image = psf_image
 

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -71,6 +71,8 @@ def ray_tracing_lst_single_mirror_mode(telescope_model_lst, simtel_path, io_hand
     )
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_init(simtel_path, io_handler, telescope_model_mst, caplog):
 
     with caplog.at_level(logging.DEBUG):
@@ -89,6 +91,8 @@ def test_ray_tracing_init(simtel_path, io_handler, telescope_model_mst, caplog):
     assert repr(ray) == f"RayTracing(label={telescope_model_mst.label})\n"
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_single_mirror_mode(simtel_path, io_handler, telescope_model_mst, caplog):
     telescope_model_mst.export_config_file()
 
@@ -133,6 +137,8 @@ def test_ray_tracing_read_results(ray_tracing_lst):
     assert ray_tracing_lst.get_mean("d80_cm") == pytest.approx(4.256768651160611, abs=1e-5)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_export_results(simtel_path, ray_tracing_lst, caplog):
     """
     Test the export_results method of the RayTracing class without results
@@ -143,6 +149,8 @@ def test_export_results(simtel_path, ray_tracing_lst, caplog):
     assert "No results to export" in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_message):
     """
     Test the plot method of the RayTracing class with an invalid key and a valid key
@@ -155,9 +163,8 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_mess
     assert invalid_key_message in caplog.text
 
     # Now test a valid key
-    with caplog.at_level(logging.INFO):
-        ray_tracing_lst.plot(key="d80_cm", save=True)
-        assert "Saving fig in" in caplog.text
+    ray_tracing_lst.plot(key="d80_cm", save=True)
+    assert "Saving fig in" in caplog.text
     plot_file_name = names.generate_file_name(
         file_type="ray-tracing",
         suffix=".pdf",
@@ -172,6 +179,8 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_mess
     assert plot_file.exists() is True
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_invalid_key(ray_tracing_lst, caplog, invalid_key, invalid_key_message):
     """
     Test the a few methods of the RayTracing class with an invalid key
@@ -197,6 +206,8 @@ def test_ray_tracing_get_std_dev(ray_tracing_lst):
     assert ray_tracing_lst.get_std_dev(key="d80_cm") == pytest.approx(0.8418404935128992, abs=1e-5)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_ray_tracing_no_images(ray_tracing_lst, caplog):
     """Test the images method of the RayTracing class with no images"""
 
@@ -204,6 +215,8 @@ def test_ray_tracing_no_images(ray_tracing_lst, caplog):
     assert "No image found" in caplog.text
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_simulate(ray_tracing_lst, caplog, mocker):
     mock_simulator = mocker.patch("simtools.ray_tracing.SimulatorRayTracing")
     mock_simulator_instance = mock_simulator.return_value
@@ -213,9 +226,7 @@ def test_ray_tracing_simulate(ray_tracing_lst, caplog, mocker):
     mock_copyfileobj = mocker.patch("shutil.copyfileobj")
     mock_unlink = mocker.patch("pathlib.Path.unlink")
 
-    with caplog.at_level(logging.INFO):
-        ray_tracing_lst.simulate(test=True, force=True)
-
+    ray_tracing_lst.simulate(test=True, force=True)
     assert "Simulating RayTracing for off_axis=0.0, mirror=0" in caplog.text
     mock_simulator.assert_called_once_with(
         simtel_path=ray_tracing_lst.simtel_path,
@@ -374,11 +385,12 @@ def test_images_with_psf_images(ray_tracing_lst, mocker):
     assert images[0] == mock_psf_image
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_images_no_psf_images(ray_tracing_lst, caplog):
     ray_tracing_lst._psf_images = {}
 
-    with caplog.at_level(logging.WARNING):
-        images = ray_tracing_lst.images()
+    images = ray_tracing_lst.images()
 
     assert images is None
     assert "No image found" in caplog.text

--- a/tests/unit_tests/test_ray_tracing.py
+++ b/tests/unit_tests/test_ray_tracing.py
@@ -71,8 +71,6 @@ def ray_tracing_lst_single_mirror_mode(telescope_model_lst, simtel_path, io_hand
     )
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_init(simtel_path, io_handler, telescope_model_mst, caplog):
 
     with caplog.at_level(logging.DEBUG):
@@ -91,8 +89,6 @@ def test_ray_tracing_init(simtel_path, io_handler, telescope_model_mst, caplog):
     assert repr(ray) == f"RayTracing(label={telescope_model_mst.label})\n"
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_single_mirror_mode(simtel_path, io_handler, telescope_model_mst, caplog):
     telescope_model_mst.export_config_file()
 
@@ -137,20 +133,16 @@ def test_ray_tracing_read_results(ray_tracing_lst):
     assert ray_tracing_lst.get_mean("d80_cm") == pytest.approx(4.256768651160611, abs=1e-5)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_export_results(simtel_path, ray_tracing_lst, caplog):
     """
     Test the export_results method of the RayTracing class without results
     """
-
-    ray = ray_tracing_lst
-    ray.export_results()
+    with caplog.at_level("ERROR"):
+        ray = ray_tracing_lst
+        ray.export_results()
     assert "No results to export" in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_message):
     """
     Test the plot method of the RayTracing class with an invalid key and a valid key
@@ -158,8 +150,9 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_mess
 
     ray_tracing_lst.analyze(force=False)
     # First test a wrong key
-    with pytest.raises(KeyError):
-        ray_tracing_lst.plot(key=invalid_key)
+    with caplog.at_level("INFO"):
+        with pytest.raises(KeyError):
+            ray_tracing_lst.plot(key=invalid_key)
     assert invalid_key_message in caplog.text
 
     # Now test a valid key
@@ -179,23 +172,21 @@ def test_ray_tracing_plot(ray_tracing_lst, caplog, invalid_key, invalid_key_mess
     assert plot_file.exists() is True
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_invalid_key(ray_tracing_lst, caplog, invalid_key, invalid_key_message):
     """
     Test the a few methods of the RayTracing class with an invalid key
     """
-
-    with pytest.raises(KeyError):
-        ray_tracing_lst.plot_histogram(key=invalid_key)
+    with caplog.at_level("INFO"):
+        with pytest.raises(KeyError):
+            ray_tracing_lst.plot_histogram(key=invalid_key)
     assert invalid_key_message in caplog.text
-
-    with pytest.raises(KeyError):
-        ray_tracing_lst.get_mean(key=invalid_key)
+    with caplog.at_level("INFO"):
+        with pytest.raises(KeyError):
+            ray_tracing_lst.get_mean(key=invalid_key)
     assert invalid_key_message in caplog.text
-
-    with pytest.raises(KeyError):
-        ray_tracing_lst.get_std_dev(key=invalid_key)
+    with caplog.at_level("INFO"):
+        with pytest.raises(KeyError):
+            ray_tracing_lst.get_std_dev(key=invalid_key)
     assert invalid_key_message in caplog.text
 
 
@@ -206,17 +197,13 @@ def test_ray_tracing_get_std_dev(ray_tracing_lst):
     assert ray_tracing_lst.get_std_dev(key="d80_cm") == pytest.approx(0.8418404935128992, abs=1e-5)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_ray_tracing_no_images(ray_tracing_lst, caplog):
     """Test the images method of the RayTracing class with no images"""
-
-    assert ray_tracing_lst.images() is None
+    with caplog.at_level("WARNING"):
+        assert ray_tracing_lst.images() is None
     assert "No image found" in caplog.text
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.INFO], indirect=True)
 def test_ray_tracing_simulate(ray_tracing_lst, caplog, mocker):
     mock_simulator = mocker.patch("simtools.ray_tracing.SimulatorRayTracing")
     mock_simulator_instance = mock_simulator.return_value
@@ -225,8 +212,8 @@ def test_ray_tracing_simulate(ray_tracing_lst, caplog, mocker):
     mock_gzip_open = mocker.patch("gzip.open", mocker.mock_open())
     mock_copyfileobj = mocker.patch("shutil.copyfileobj")
     mock_unlink = mocker.patch("pathlib.Path.unlink")
-
-    ray_tracing_lst.simulate(test=True, force=True)
+    with caplog.at_level("INFO"):
+        ray_tracing_lst.simulate(test=True, force=True)
     assert "Simulating RayTracing for off_axis=0.0, mirror=0" in caplog.text
     mock_simulator.assert_called_once_with(
         simtel_path=ray_tracing_lst.simtel_path,
@@ -385,12 +372,10 @@ def test_images_with_psf_images(ray_tracing_lst, mocker):
     assert images[0] == mock_psf_image
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_images_no_psf_images(ray_tracing_lst, caplog):
     ray_tracing_lst._psf_images = {}
-
-    images = ray_tracing_lst.images()
+    with caplog.at_level("WARNING"):
+        images = ray_tracing_lst.images()
 
     assert images is None
     assert "No image found" in caplog.text
@@ -408,8 +393,9 @@ def test_plot_histogram_valid_key(ray_tracing_lst, mocker):
 
 
 def test_plot_histogram_invalid_key(ray_tracing_lst, caplog, invalid_key, invalid_key_message):
-    with pytest.raises(KeyError):
-        ray_tracing_lst.plot_histogram(key=invalid_key)
+    with caplog.at_level("INFO"):
+        with pytest.raises(KeyError):
+            ray_tracing_lst.plot_histogram(key=invalid_key)
     assert invalid_key_message in caplog.text
 
 

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -16,7 +16,6 @@ from simtools.simtel.simulator_array import SimulatorArray
 from simtools.simulator import InvalidRunsToSimulateError, Simulator
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -327,19 +326,18 @@ def test_get_runs_to_simulate(shower_simulator):
     assert isinstance(shower_simulator._get_runs_to_simulate(), list)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_save_file_lists(shower_simulator, mocker, caplog):
-    with caplog.at_level(logging.DEBUG):
-        shower_simulator.save_file_lists()
-        assert "No files to save for output files." in caplog.text
+    shower_simulator.save_file_lists()
+    assert "No files to save for output files." in caplog.text
 
     mock_shower_simulator = copy.deepcopy(shower_simulator)
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=["file1", "file2"])
 
-    with caplog.at_level(logging.INFO):
-        mock_shower_simulator.save_file_lists()
-        assert "Saving list of output files to" in caplog.text
+    mock_shower_simulator.save_file_lists()
+    assert "Saving list of output files to" in caplog.text
 
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=[None, None])
-    with caplog.at_level(logging.DEBUG):
-        mock_shower_simulator.save_file_lists()
-        assert "No files to save for output files." in caplog.text
+    mock_shower_simulator.save_file_lists()
+    assert "No files to save for output files." in caplog.text

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -16,7 +16,6 @@ from simtools.simtel.simulator_array import SimulatorArray
 from simtools.simulator import InvalidRunsToSimulateError, Simulator
 
 logger = logging.getLogger()
-logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -123,8 +122,8 @@ def test_initialize_run_list(shower_simulator, caplog):
     assert shower_simulator._initialize_run_list() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     test_shower_simulator = copy.deepcopy(shower_simulator)
     test_shower_simulator.args_dict.pop("run_number_start", None)
-    with pytest.raises(KeyError):
-        with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(KeyError):
             test_shower_simulator._initialize_run_list()
     assert (
         "Error in initializing run list (missing 'run_number_start' or 'number_of_runs')"
@@ -330,16 +329,16 @@ def test_get_runs_to_simulate(shower_simulator):
 def test_save_file_lists(shower_simulator, mocker, caplog):
     with caplog.at_level(logging.DEBUG):
         shower_simulator.save_file_lists()
-        assert "No files to save for output files." in caplog.text
+    assert "No files to save for output files." in caplog.text
 
     mock_shower_simulator = copy.deepcopy(shower_simulator)
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=["file1", "file2"])
 
     with caplog.at_level(logging.INFO):
         mock_shower_simulator.save_file_lists()
-        assert "Saving list of output files to" in caplog.text
+    assert "Saving list of output files to" in caplog.text
 
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=[None, None])
     with caplog.at_level(logging.DEBUG):
         mock_shower_simulator.save_file_lists()
-        assert "No files to save for output files." in caplog.text
+    assert "No files to save for output files." in caplog.text

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -16,6 +16,7 @@ from simtools.simtel.simulator_array import SimulatorArray
 from simtools.simulator import InvalidRunsToSimulateError, Simulator
 
 logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
 
 
 @pytest.fixture
@@ -326,18 +327,19 @@ def test_get_runs_to_simulate(shower_simulator):
     assert isinstance(shower_simulator._get_runs_to_simulate(), list)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.DEBUG], indirect=True)
 def test_save_file_lists(shower_simulator, mocker, caplog):
-    shower_simulator.save_file_lists()
-    assert "No files to save for output files." in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        shower_simulator.save_file_lists()
+        assert "No files to save for output files." in caplog.text
 
     mock_shower_simulator = copy.deepcopy(shower_simulator)
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=["file1", "file2"])
 
-    mock_shower_simulator.save_file_lists()
-    assert "Saving list of output files to" in caplog.text
+    with caplog.at_level(logging.INFO):
+        mock_shower_simulator.save_file_lists()
+        assert "Saving list of output files to" in caplog.text
 
     mocker.patch.object(mock_shower_simulator, "get_file_list", return_value=[None, None])
-    mock_shower_simulator.save_file_lists()
-    assert "No files to save for output files." in caplog.text
+    with caplog.at_level(logging.DEBUG):
+        mock_shower_simulator.save_file_lists()
+        assert "No files to save for output files." in caplog.text

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -23,6 +23,8 @@ url_simtools = "https://raw.githubusercontent.com/gammasim/simtools/main/"
 test_data = "Test data"
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_collect_dict_data(args_dict, io_handler, tmp_test_directory, caplog) -> None:
     in_dict = {"k1": 2, "k2": "bla"}
     dict_for_yaml = {"k3": {"kk3": 4, "kk4": 3.0}, "k4": ["bla", 2]}
@@ -393,6 +395,8 @@ def test_join_url_or_path():
     assert gen.join_url_or_path("/Volume/fs01", "CTA") == Path("/Volume/fs01").joinpath("CTA")
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.ERROR], indirect=True)
 def test_change_dict_keys_case(caplog) -> None:
     # note that entries in DATA_COLUMNS:ATTRIBUTE should not be changed (not keys)
     _upper_dict = {
@@ -618,10 +622,10 @@ def test_read_file_encoded_in_utf_or_latin(tmp_test_directory, caplog) -> None:
     latin1_content = "This is a Latin-1 encoded file with latin character ñ.\n"
     with open(latin1_file, "w", encoding="latin-1") as file:
         file.write(latin1_content)
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.ERROR):
         lines = gen.read_file_encoded_in_utf_or_latin(latin1_file)
         assert lines == [latin1_content]
-        assert "Unable to decode file using UTF-8. Trying Latin-1." in caplog.text
+    assert "Unable to decode file using UTF-8. Trying Latin-1." in caplog.text
 
     # I could not find a way to create a file that cannot be decoded with Latin-1
     # and raises a UnicodeDecodeError. I left the raise statement in the function

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -1,3 +1,5 @@
+import logging
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -64,6 +66,8 @@ def test_rotate_telescope_position(caplog) -> None:
         transf.rotate(x_new_array, y_new_array, 30 * u.m)
 
 
+@pytest.mark.usefixtures("_log_level")
+@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_convert_2d_to_radial_distr(caplog) -> None:
     # Test normal functioning
     max_dist = 100

--- a/tests/unit_tests/utils/test_geometry.py
+++ b/tests/unit_tests/utils/test_geometry.py
@@ -1,5 +1,3 @@
-import logging
-
 import astropy.units as u
 import numpy as np
 import pytest
@@ -66,8 +64,6 @@ def test_rotate_telescope_position(caplog) -> None:
         transf.rotate(x_new_array, y_new_array, 30 * u.m)
 
 
-@pytest.mark.usefixtures("_log_level")
-@pytest.mark.parametrize("_log_level", [logging.WARNING], indirect=True)
 def test_convert_2d_to_radial_distr(caplog) -> None:
     # Test normal functioning
     max_dist = 100
@@ -85,8 +81,9 @@ def test_convert_2d_to_radial_distr(caplog) -> None:
     assert pytest.approx(difference[:-1], abs=1) == 0  # last value deviates
 
     # Test warning in caplog
-    transf.convert_2d_to_radial_distr(
-        distance_to_center_2d, xaxis, yaxis, bins=4 * bins, max_dist=max_dist
-    )
+    with caplog.at_level("WARNING"):
+        transf.convert_2d_to_radial_distr(
+            distance_to_center_2d, xaxis, yaxis, bins=4 * bins, max_dist=max_dist
+        )
     msg = "The histogram with number of bins"
     assert msg in caplog.text

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -15,7 +15,6 @@ from simtools.utils import names
 from simtools.visualization import visualize
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
 
 
 def test_plot_1d(db, io_handler):


### PR DESCRIPTION
This PR adds a fixture to set the log level context. In some cases the context was added where it was previously missing. In some cases log levels where adjusted to better reflect the log message.

This adresses the problem that previously we set `logger.setLevel(logging.DEBUG) `for almost all unit tests.
