### PR TITLE
Move ignore word list from .codespell-ignores to pyproject.toml

### DIFF
--- a/.codespell-ignores
+++ b/.codespell-ignores
@@ -1,3 +1,0 @@
-chec
-arrang
-livetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,7 +246,7 @@ max-statements = 80
 max-public-methods = 50
 
 [tool.codespell]
-ignore-words = ".codespell-ignores"
+ignore-words-list = "chec,arrang,livetime"
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
No need to keep a separate configuration file for the ignore list for codespell (especially as we have only 3 words in the ignore list!).

Remove the .codespell-ignores and moved those words to pyproject.toml