### PR TITLE
Implement CHANGELOG generation using Towncrier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,10 @@ repos:
     hooks:
       - id: yamllint
         args: ["--strict", "-d", '{rules: {line-length: {max: 250}}}']
+  # towncrier
+  - repo: https://github.com/twisted/towncrier
+    rev: 23.11.0  # run 'pre-commit autoupdate' to update
+    hooks:
+      - id: towncrier-update
+        files: $docs/changes/
+        args: ['--keep']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         args: ["--strict", "-d", '{rules: {line-length: {max: 250}}}']
   # towncrier
   - repo: https://github.com/twisted/towncrier
-    rev: 24.8.0  # run 'pre-commit autoupdate' to update
+    rev: 24.8.0
     hooks:
       - id: towncrier-update
         files: $docs/changes/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
         args: ["--strict", "-d", '{rules: {line-length: {max: 250}}}']
   # towncrier
   - repo: https://github.com/twisted/towncrier
-    rev: 23.11.0  # run 'pre-commit autoupdate' to update
+    rev: 24.8.0  # run 'pre-commit autoupdate' to update
     hooks:
       - id: towncrier-update
         files: $docs/changes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,3 @@
-# Changelog
+## Changelog updates
 
-Notable changes relevant for the user of simtools are documented in this file. Please keep this file up to date and stick to the format.
-
-## v0.7.0 - 2024-07-11
-
-This is an intermediate development release with significant changes to the handling of model parameters and the reading of databases.
-Belows's release statements are incomplete.
-
-### Added
-
-- application `simulate_light_emission` to simulate the light emission from an artificial light source
-- application `calculate_trigger_rate` to derive the trigger rate for a given telescope type
-
-### Changed
-
-- interface to databases and model parameters
-- improved user and developer documentation
-
-### Removed
-
-- (removed files are not listed)
-
-### Fixed
-
-- (bugfixes are not listed)
-
-
-<!-- towncrier release notes start -->
+This changelog is generated using Towncrier, see the developer documentation for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
-## Changelog updates
+# CHANGELOG
 
-This changelog is generated using Towncrier, see the developer documentation for more information.
+All notable changes to the simtools project will be documented in this file.
+Changes for upcoming releases can be found in the [docs/changes](docs/changes) directory.
+
+This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/), see the developer documentation for more information.
+
+<!-- towncrier release notes start -->
+
+## [0.7.0](https://github.com/gammasim/simtools/tree/0.7.0) - 2024-11-12
+
+### New Features
+
+- Added application `calculate_trigger_rate` to derive the trigger rate for a given telescope type. ([#801](https://github.com/gammasim/simtools/pull/801))
+- Added application `simulate_light_emission` to simulate the light emission from an artificial light source. ([#802](https://github.com/gammasim/simtools/pull/802))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,5 @@ Belows's release statements are incomplete.
 
 - (bugfixes are not listed)
 
-## Template for new release
 
-### Added
-
-### Changed
-
-### Removed
-
-### Fixed
+<!-- towncrier release notes start -->

--- a/docs/changes/1123.model.md
+++ b/docs/changes/1123.model.md
@@ -1,0 +1,1 @@
+Move to strictly using semantic versions for models (remove e.g., 'prod5', 'prod6', 'Latest', 'Released').

--- a/docs/changes/1127.api.md
+++ b/docs/changes/1127.api.md
@@ -1,0 +1,1 @@
+Improve primary particle API and validate consistency of user input.

--- a/docs/changes/1128.bugfix.md
+++ b/docs/changes/1128.bugfix.md
@@ -1,0 +1,1 @@
+Fix triggering of telescopes in light emission package.

--- a/docs/changes/1142.api.md
+++ b/docs/changes/1142.api.md
@@ -1,0 +1,1 @@
+Refactore old style configuration of ray-tracing tools.

--- a/docs/changes/1171.model.md
+++ b/docs/changes/1171.model.md
@@ -1,0 +1,1 @@
+Add schema for correction of NSB spectrum to the telescope altitude.

--- a/docs/changes/1173.model.md
+++ b/docs/changes/1173.model.md
@@ -1,0 +1,1 @@
+Allow for class Telescope in model parameters.

--- a/docs/changes/1194.doc.md
+++ b/docs/changes/1194.doc.md
@@ -1,0 +1,1 @@
+Add missing API documentation for several applications.

--- a/docs/changes/1235.maintenance.md
+++ b/docs/changes/1235.maintenance.md
@@ -1,0 +1,1 @@
+Update build command for CORSIKA/sim\_telarray to prod6-sc.

--- a/docs/changes/1236.doc.md
+++ b/docs/changes/1236.doc.md
@@ -1,0 +1,1 @@
+Add Towncrier for CHANGELOG generation for each release.

--- a/docs/changes/801.feature.md
+++ b/docs/changes/801.feature.md
@@ -1,1 +1,0 @@
-Added application `calculate_trigger_rate` to derive the trigger rate for a given telescope type.

--- a/docs/changes/801.feature.md
+++ b/docs/changes/801.feature.md
@@ -1,0 +1,1 @@
+Added application `calculate_trigger_rate` to derive the trigger rate for a given telescope type.

--- a/docs/changes/802.feature.md
+++ b/docs/changes/802.feature.md
@@ -1,1 +1,0 @@
-Added application `simulate_light_emission` to simulate the light emission from an artificial light source.

--- a/docs/changes/802.feature.md
+++ b/docs/changes/802.feature.md
@@ -1,0 +1,1 @@
+Added application `simulate_light_emission` to simulate the light emission from an artificial light source.

--- a/docs/source/developer-guide/maintainer_documentation.md
+++ b/docs/source/developer-guide/maintainer_documentation.md
@@ -2,17 +2,30 @@
 
 # Maintainer documentation
 
+## Changelog
+
+All notable changes to the simtools project are documented in the CHANGELOG file.
+
+Before a release, the maintainer is building the changelog using the following steps:
+
+```console
+towncrier build --yes --version <version string>
+```
+
+The maintainer should review the `CHANGELOG.md`, apply any necessary changes, and open a release pull request. This should be the last pull request before a release.
+The change files in the `docs/changes` directory will be deleted with the release pull request.
+
 ## Releases
 
 Simtools releases are versioned following the [Semantic Versioning 2.0.0](https://semver.org/) guidelines.
 
 To prepare a release, the following steps are required:
 
-1. Open a pull request to prepare a release.  Review the entries added to the `CHANGELOG.md` since the last release. This should be the last pull request to be merged before making the actual release.
-1. Prepare a GitHub release with the version number and a summary of the changes.
-1. Pypi deployment is done automatically by the CI/CD pipeline.
-1. Docker images are automatically built, tagged with the version number, and pushed to the [gammasim/simtools](https://github.com/orgs/gammasim/packages?repo_name=simtools).
-1. A DOI is issued automatically by Zenodo.
+1. Open a pull request to prepare a release.  Run the changelog workflow using Towncrier to add entries to `CHANGELOG.md`. This should be the last pull request to be merged before making the actual release.
+2. Prepare a GitHub release with the version number and a summary of the changes.
+3. Pypi deployment is done automatically by the CI/CD pipeline.
+4. Docker images are automatically built, tagged with the version number, and pushed to the [gammasim/simtools](https://github.com/orgs/gammasim/packages?repo_name=simtools).
+5. A DOI is issued automatically by Zenodo.
 
 ## Conda feedstock
 

--- a/docs/source/developer-guide/pull_requests.md
+++ b/docs/source/developer-guide/pull_requests.md
@@ -42,6 +42,7 @@ Possible categories are (here for the example of pull request #1234):
 - `1234.api.md` for changes to the API
 - `1234.doc.md` for documentation changes
 - `1234.maintenance.md` for maintenance changes
+- `1234.model.md` for changes to the simulation model
 
 Add these file to the pull request.
 

--- a/docs/source/developer-guide/pull_requests.md
+++ b/docs/source/developer-guide/pull_requests.md
@@ -38,7 +38,7 @@ Pull requests with changes relevant enough to be noted in the CHANGELOG should a
 Possible categories are (here for the example of pull request #1234):
 
 - `1234.feature.md` for new features
-- `1234.bugfix.md` for bug fixes
+- `1234.bugfix.md` for bugfixes
 - `1234.api.md` for changes to the API
 - `1234.doc.md` for documentation changes
 - `1234.maintenance.md` for maintenance changes

--- a/docs/source/developer-guide/pull_requests.md
+++ b/docs/source/developer-guide/pull_requests.md
@@ -26,6 +26,25 @@ The following thoughts might help to obtain an efficient and pleasant reviewing 
 - pull request should focus on one problem and should be short (even though it is easier to make big ones)
 - if the problem to be solved requires many changes: break down the problem in logical pieces; explain the breakdown of the problem in an issue
 
+### CHANGELOG
+
+All notable changes to the simtools project are documented in the CHANGELOG file. Do not modify this file!
+
+```{important}
+The CHANGELOG should be written for the end-user and should not contain too many technical details.
+```
+
+Pull requests with changes relevant enough to be noted in the CHANGELOG should add a file containing a short summary of the changes to the [docs/changes](docs/changes) directory.
+Possible categories are (here for the example of pull request #1234):
+
+- `1234.feature.md` for new features
+- `1234.bugfix.md` for bug fixes
+- `1234.api.md` for changes to the API
+- `1234.doc.md` for documentation changes
+- `1234.maintenance.md` for maintenance changes
+
+Add these file to the pull request.
+
 ## Reviewing a pull request
 
 - seek to understand the purpose of the pull request; reach out to the author before reviewing if it is not clear which problem will be solved
@@ -39,3 +58,4 @@ The following thoughts might help to obtain an efficient and pleasant reviewing 
 - limit the review to the changes in the pull request. Open an issue or a follow-up pull request for anything else.
 - clearly indicate if you have no time for a review (this is OK if it is known)
 - fix small typos directly
+- confirm the changes are documented sufficiently in the `docs/changes` directory.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,7 @@
 ## Table of Contents
 
 ```{toctree}
-:maxdepth: 2
+:maxdepth: 1
 User Guide <user-guide/index>
 API Docs <api-reference/index>
 Developer Guide <developer-guide/index>

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,8 +4,10 @@
 ## Table of Contents
 
 ```{toctree}
-:maxdepth: 1
+:maxdepth: 2
 User Guide <user-guide/index>
 API Docs <api-reference/index>
 Developer Guide <developer-guide/index>
 ```
+
+[Changelog](https://github.com/gammasim/simtools/blob/main/CHANGELOG.md)

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,7 @@ dependencies:
   - sphinx
   - sphinx-book-theme
   - toml
+  - towncrier
   - pip:
       - ctao-dpps-cosmic-ray-spectra
       - pytest-random-order

--- a/environment.yml
+++ b/environment.yml
@@ -31,8 +31,8 @@ dependencies:
   - scipy
   - sphinx
   - sphinx-book-theme
-  - toml
   - towncrier
+  - toml
   - pip:
       - ctao-dpps-cosmic-ray-spectra
       - pytest-random-order

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,7 +303,3 @@ showcontent = true
 [tool.towncrier.fragment.doc]
 name = "Documentation"
 showcontent = true
-
-[[tool.towncrier.section]]
-name = ""
-path = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies."doc" = [
   "numpydoc",
   "sphinx",
   "sphinx-book-theme",
+  "towncrier",
 ]
 optional-dependencies."tests" = [
   "pytest",
@@ -277,10 +278,10 @@ source = [
 [tool.towncrier]
 package = "simtools"
 directory = "docs/changes"
-filename = "CHANGES.md"
+filename = "CHANGELOG.md"
 underlines = [ "", "", "" ]
-title_format = "## [{version}]https://github.com/gammasim/simtools/tree/{version}) - {project_date}"
-issue_format = "`#{issue} <https://github.com/gammasim/simtools/pull/{issue}>`__"
+title_format = "## [{version}](https://github.com/gammasim/simtools/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/gammasim/simtools/pull/{issue})"
 
 [tool.towncrier.fragment.feature]
 name = "New Features"
@@ -294,12 +295,12 @@ showcontent = true
 name = "API Changes"
 showcontent = true
 
-[tool.towncrier.fragment.optimization]
-name = "Refactoring and Optimization"
-showcontent = true
-
 [tool.towncrier.fragment.maintenance]
 name = "Maintenance"
+showcontent = true
+
+[tool.towncrier.fragment.doc]
+name = "Documentation"
 showcontent = true
 
 [[tool.towncrier.section]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,7 @@ filename = "CHANGELOG.md"
 underlines = [ "", "", "" ]
 title_format = "## [{version}](https://github.com/gammasim/simtools/tree/{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/gammasim/simtools/pull/{issue})"
+start_string = "<!-- towncrier release notes start -->\n"
 
 [tool.towncrier.fragment.feature]
 name = "New Features"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,3 +303,7 @@ showcontent = true
 [tool.towncrier.fragment.doc]
 name = "Documentation"
 showcontent = true
+
+[tool.towncrier.fragment.model]
+name = "Simulation model"
+showcontent = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -273,3 +273,35 @@ relative_files = true
 source = [
   "simtools",
 ]
+
+[tool.towncrier]
+package = "simtools"
+directory = "docs/changes"
+filename = "CHANGES.md"
+underlines = [ "", "", "" ]
+title_format = "## [{version}]https://github.com/gammasim/simtools/tree/{version}) - {project_date}"
+issue_format = "`#{issue} <https://github.com/gammasim/simtools/pull/{issue}>`__"
+
+[tool.towncrier.fragment.feature]
+name = "New Features"
+showcontent = true
+
+[tool.towncrier.fragment.bugfix]
+name = "Bug Fixes"
+showcontent = true
+
+[tool.towncrier.fragment.api]
+name = "API Changes"
+showcontent = true
+
+[tool.towncrier.fragment.optimization]
+name = "Refactoring and Optimization"
+showcontent = true
+
+[tool.towncrier.fragment.maintenance]
+name = "Maintenance"
+showcontent = true
+
+[[tool.towncrier.section]]
+name = ""
+path = ""


### PR DESCRIPTION
CTAO Software Programming Standards require having change logs in the software documentation (see [description here](http://cta-computing.gitlab-pages.cta-observatory.org/documentation/developer-documentation/languages/python/index.html#changelog)).

This PR adds the functionality to use Towncrier to add entries to CHANGELOG.md for each release.

The functionality is the following:

Pull requests with changes relevant enough to be noted in the CHANGELOG should add a file containing a short summary of the changes to the [docs/changes](docs/changes) directory (these files are transient and deleted for each release).
Possible categories are (here for the example of pull request #1234):

- `1234.feature.md` for new features
- `1234.bugfix.md` for bug fixes
- `1234.api.md` for changes to the API
- `1234.doc.md` for documentation changes
- `1234.maintenance.md` for maintenance changes
- `1234.model.md` for changes to the simulation model

see also the [docs/changes](docs/changes) directory of this branch.

Add these file to the pull request. The maintainer will use `towncrier` the generate the CHANGELOG for each release.

Note that only items of interest for the user should be added to the CHANGELOG (not too technical).

Closes #1234