### PR TITLE
Improve metadata collection

### DIFF
--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -179,6 +179,8 @@ class MetadataCollector:
         """
         Append association metadata set through configurator.
 
+        TODO - check how this is used for derivation tools.
+
         Parameters
         ----------
         associated_elements_dict: dict
@@ -212,7 +214,7 @@ class MetadataCollector:
 
     def _fill_context_meta(self, context_dict):
         """
-        Fill context metadata fields.
+        Fill context metadata fields with product metadata from input data.
 
         Parameters
         ----------
@@ -220,37 +222,13 @@ class MetadataCollector:
             Dictionary for context metadata fields.
 
         """
-        self._fill_context_from_input_meta(context_dict)
-        self._fill_associated_elements_from_args(context_dict["associated_elements"])
-
-    def _fill_context_from_input_meta(self, context_dict):
-        """
-        Read and validate input metadata from file and fill CONTEXT metadata fields.
-
-        Parameters
-        ----------
-        context_dict: dict
-            Dictionary with context level metadata.
-
-        Raises
-        ------
-        KeyError
-            if corresponding fields cannot by accessed in the top-level or metadata dictionaries.
-
-        """
-        try:
-            self._merge_config_dicts(context_dict, self.input_metadata[self.observatory]["context"])
-            for key in ("document", "associated_elements", "associated_data"):
-                self._copy_list_type_metadata(
-                    context_dict, self.input_metadata[self.observatory], key
-                )
-        except KeyError:
-            self._logger.debug("No context metadata defined in input metadata file.")
-
-        try:
-            self._fill_context_sim_list(
-                context_dict["associated_data"], self.input_metadata[self.observatory]["product"]
-            )
+        try:  # wide try..except as for some cases we expect that there is no product metadata
+            reduced_product_meta = {
+                key: value
+                for key, value in self.input_metadata[self.observatory]["product"].items()
+                if key in {"description", "id", "creation_time", "valid", "format", "filename"}
+            }
+            self._fill_context_sim_list(context_dict["associated_data"], reduced_product_meta)
         except (KeyError, TypeError):
             self._logger.debug("No input product metadata appended to associated data.")
 

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -185,43 +185,6 @@ class MetadataCollector:
         if contact_dict.get("name", None) is None:
             contact_dict["name"] = getpass.getuser()
 
-    def _fill_associated_elements_from_args(self, associated_elements_dict):
-        """
-        Append association metadata set through configurator.
-
-        TODO - check how this is used for derivation tools.
-
-        Parameters
-        ----------
-        associated_elements_dict: dict
-            Dictionary for associated elements field.
-
-        Raises
-        ------
-        TypeError, KeyError
-            if error reading association metadata from args.
-        KeyError
-            if metadata description cannot be filled.
-
-        """
-        self._logger.debug(f"Fill metadata from args: {self.args_dict}")
-
-        _association = {}
-
-        try:
-            if "site" in self.args_dict:
-                _association["site"] = names.validate_site_name(self.args_dict["site"])
-            if "telescope" in self.args_dict:
-                _telescope_name = names.validate_array_element_name(self.args_dict["telescope"])
-                _association["class"] = "telescope"
-                _association["type"] = names.get_array_element_type_from_name(_telescope_name)
-                _association["subtype"] = ""
-        except (TypeError, KeyError) as exc:
-            self._logger.error("Error reading association metadata from args")
-            raise exc
-
-        self._fill_context_sim_list(associated_elements_dict, _association)
-
     def _fill_context_meta(self, context_dict):
         """
         Fill context metadata fields with product metadata from input data.

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -67,6 +67,7 @@ class MetadataCollector:
         """Collect and verify product metadata from different sources."""
         self._fill_contact_meta(self.top_level_meta[self.observatory]["contact"])
         self._fill_product_meta(self.top_level_meta[self.observatory]["product"])
+        self._fill_instrument_meta(self.top_level_meta[self.observatory]["instrument"])
         self._fill_activity_meta(self.top_level_meta[self.observatory]["activity"])
         self._fill_process_meta(self.top_level_meta[self.observatory]["process"])
         self._fill_context_from_input_meta(self.top_level_meta[self.observatory]["context"])
@@ -365,6 +366,23 @@ class MetadataCollector:
 
         product_dict["format"] = self.args_dict.get("output_file_format", None)
         product_dict["filename"] = str(self.args_dict.get("output_file", None))
+
+    def _fill_instrument_meta(self, instrument_dict):
+        """
+        Fill instrument metadata fields.
+
+        Parameters
+        ----------
+        instrument_dict: dict
+            Dictionary for instrument metadata fields.
+
+        """
+        instrument_dict["site"] = self.args_dict.get("site", None)
+        instrument_dict["ID"] = self.args_dict.get("instrument", None)
+        if instrument_dict["ID"]:
+            instrument_dict["class"] = names.get_collection_name_from_array_element_name(
+                instrument_dict["ID"]
+            )
 
     def _fill_process_meta(self, process_dict):
         """

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -64,6 +64,7 @@ class MetadataCollector:
             metadata_file_name=metadata_file_name
         )
         self.collect_meta_data()
+        self.top_level_meta = self.clean_meta_data(self.top_level_meta)
 
     def collect_meta_data(self):
         """Collect and verify product metadata for each main-level metadata type."""
@@ -580,3 +581,32 @@ class MetadataCollector:
             return input_dict is None
 
         return all(self._all_values_none(value) for value in input_dict.values())
+
+    def clean_meta_data(self, meta_dict):
+        """
+        Clean metadata dictionary from None values and empty lists.
+
+        Parameters
+        ----------
+        meta_dict: dict
+            Metadata dictionary.
+
+        """
+        cleaned = {}
+        for key, value in meta_dict.items():
+            if value is None or value == []:
+                continue
+            if isinstance(value, dict):
+                nested = self.clean_meta_data(value)
+                if nested:  # Only add if not empty
+                    cleaned[key] = nested
+            elif isinstance(value, list):
+                nested_list = [
+                    self.clean_meta_data(item) if isinstance(item, dict) else item for item in value
+                ]
+                nested_list = [item for item in nested_list if item not in (None, "", [], {})]
+                if nested_list:  # Only add if not empty
+                    cleaned[key] = nested_list
+            else:
+                cleaned[key] = value
+        return cleaned

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -401,7 +401,6 @@ class MetadataCollector:
             instrument_dict["class"] = names.get_collection_name_from_array_element_name(
                 instrument_dict["ID"]
             )
-            instrument_dict["type"] = names.get_array_element_type_from_name(instrument_dict["ID"])
 
     def _fill_process_meta(self, process_dict):
         """

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -580,19 +580,23 @@ class MetadataCollector:
             Metadata dictionary.
 
         """
+
+        def clean_list(value):
+            nested_list = [
+                self.clean_meta_data(item) if isinstance(item, dict) else item for item in value
+            ]
+            return [item for item in nested_list if item not in (None, "", [], {})]
+
         cleaned = {}
         for key, value in meta_dict.items():
-            if value is None or value == []:
+            if value in (None, []):
                 continue
             if isinstance(value, dict):
                 nested = self.clean_meta_data(value)
                 if nested:  # Only add if not empty
                     cleaned[key] = nested
             elif isinstance(value, list):
-                nested_list = [
-                    self.clean_meta_data(item) if isinstance(item, dict) else item for item in value
-                ]
-                nested_list = [item for item in nested_list if item not in (None, "", [], {})]
+                nested_list = clean_list(value)
                 if nested_list:  # Only add if not empty
                     cleaned[key] = nested_list
             else:

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -45,9 +45,18 @@ class MetadataCollector:
         Name of data model parameter
     observatory: str
         Name of observatory (default: "cta")
+    clean_meta: bool
+        Clean metadata from None values and empty lists (default: True)
     """
 
-    def __init__(self, args_dict, metadata_file_name=None, data_model_name=None, observatory="cta"):
+    def __init__(
+        self,
+        args_dict,
+        metadata_file_name=None,
+        data_model_name=None,
+        observatory="cta",
+        clean_meta=True,
+    ):
         """Initialize metadata collector."""
         self._logger = logging.getLogger(__name__)
         self.observatory = observatory
@@ -64,7 +73,8 @@ class MetadataCollector:
             metadata_file_name=metadata_file_name
         )
         self.collect_meta_data()
-        self.top_level_meta = self.clean_meta_data(self.top_level_meta)
+        if clean_meta:
+            self.top_level_meta = self.clean_meta_data(self.top_level_meta)
 
     def collect_meta_data(self):
         """Collect and verify product metadata for each main-level metadata type."""

--- a/simtools/schemas/metadata.metaschema.yml
+++ b/simtools/schemas/metadata.metaschema.yml
@@ -76,6 +76,12 @@ definitions:
                 format: email
               - type: "null"
             default: null
+          ORCID:
+            description: ORCID identifier of the contact.
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
       ###############
       PRODUCT:
         title: Product

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -308,7 +308,15 @@ def get_collection_name_from_array_element_name(name):
     str
         Collection name .
     """
-    return array_elements()[get_array_element_type_from_name(name)]["collection"]
+    try:
+        return array_elements()[get_array_element_type_from_name(name)]["collection"]
+    except ValueError:
+        pass
+    try:
+        validate_site_name(name)
+        return "sites"
+    except ValueError as exc:
+        raise ValueError(f"Invalid array element name {name}") from exc
 
 
 def get_simulation_software_name_from_parameter_name(

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -316,7 +316,7 @@ def get_collection_name_from_array_element_name(name):
         validate_site_name(name)
         return "sites"
     except ValueError as exc:
-        raise ValueError(f"Invalid array element name {name}") from exc
+        raise ValueError(f"Invalid array element name {name}: {exc}") from exc
 
 
 def get_simulation_software_name_from_parameter_name(

--- a/simtools/utils/names.py
+++ b/simtools/utils/names.py
@@ -296,7 +296,7 @@ def get_site_from_array_element_name(name):
 
 def get_collection_name_from_array_element_name(name):
     """
-    Get collection name (e.g., telescopes, calibration_devices) of array element from name.
+    Get collection name (e.g., telescopes, calibration_devices, sites) of array element from name.
 
     Parameters
     ----------

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -433,3 +433,62 @@ def test_fill_instrument_meta(args_dict_site):
     else:
         assert "class" not in instrument_dict
         assert "type" not in instrument_dict
+
+
+def test_clean_meta_data():
+
+    pre_clean = {
+        "reference": {"version": "1.0.0"},
+        "contact": {"organization": "CTAO", "name": "not_me", "email": None, "orcid": None},
+        "product": {
+            "valid": {
+                "start": None,
+                "end": None,
+            }
+        },
+        "context": {
+            "notes": [{"title": None, "text": None, "creation_time": None}],
+            "document": [
+                {
+                    "type": "CTAO-MC-DOC",
+                    "title": "CTA Monte Carlo Model",
+                    "id": None,
+                }
+            ],
+            "associated_elements": [
+                {"site": "North", "class": None, "type": "LSTN", "id": "design"},
+                {"site": "North"},
+            ],
+        },
+    }
+
+    post_clean = {
+        "contact": {
+            "name": "not_me",
+            "organization": "CTAO",
+        },
+        "context": {
+            "associated_elements": [
+                {
+                    "id": "design",
+                    "site": "North",
+                    "type": "LSTN",
+                },
+                {
+                    "site": "North",
+                },
+            ],
+            "document": [
+                {
+                    "title": "CTA Monte Carlo Model",
+                    "type": "CTAO-MC-DOC",
+                },
+            ],
+        },
+        "reference": {
+            "version": "1.0.0",
+        },
+    }
+
+    collector = metadata_collector.MetadataCollector({})
+    assert collector.clean_meta_data(pre_clean) == post_clean

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -12,7 +12,6 @@ import pytest
 
 import simtools.data_model.metadata_collector as metadata_collector
 import simtools.utils.general as gen
-from simtools.data_model import metadata_model
 from simtools.utils import names
 
 logger = logging.getLogger()
@@ -91,32 +90,6 @@ def test_get_site(args_dict_site):
     )
     assert _collector_2.get_site(from_input_meta=True) == "North"
     assert _collector_2.get_site(from_input_meta=False) == "South"  # from args_dict
-
-
-def test_fill_associated_elements_from_args(args_dict_site):
-    metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site)
-    metadata_1.top_level_meta = gen.change_dict_keys_case(
-        metadata_model.get_default_metadata_dict(), True
-    )
-    metadata_1._fill_associated_elements_from_args(
-        metadata_1.top_level_meta["cta"]["context"]["associated_elements"]
-    )
-
-    assert metadata_1.top_level_meta["cta"]["context"]["associated_elements"][0]["site"] == "South"
-    assert (
-        metadata_1.top_level_meta["cta"]["context"]["associated_elements"][0]["class"]
-        == "telescope"
-    )
-    assert metadata_1.top_level_meta["cta"]["context"]["associated_elements"][0]["type"] == "MSTS"
-    assert metadata_1.top_level_meta["cta"]["context"]["associated_elements"][0]["subtype"] == ""
-
-    metadata_1.top_level_meta["cta"]["context"]["associated_elements"][0].pop("site")
-
-    metadata_1.args_dict = None
-    with pytest.raises(TypeError):
-        metadata_1._fill_associated_elements_from_args(
-            metadata_1.top_level_meta["cta"]["context"]["associated_elements"]
-        )
 
 
 def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplog):

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -430,9 +430,6 @@ def test_fill_instrument_meta(args_dict_site):
         assert instrument_dict["class"] == names.get_collection_name_from_array_element_name(
             instrument_dict["ID"]
         )
-        assert instrument_dict["type"] == names.get_array_element_type_from_name(
-            instrument_dict["ID"]
-        )
     else:
         assert "class" not in instrument_dict
         assert "type" not in instrument_dict

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -159,22 +159,8 @@ def test_read_input_metadata_from_file(args_dict_site, tmp_test_directory, caplo
         metadata_1._read_input_metadata_from_file()
 
 
-def test_fill_context_from_input_meta(args_dict_site):
-    metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site)
-
-    metadata_1.args_dict["input_meta"] = "tests/resources/MLTdata-preproduction.meta.yml"
-    metadata_1.input_metadata = metadata_1._read_input_metadata_from_file()
-    metadata_1._fill_context_from_input_meta(metadata_1.top_level_meta["cta"]["context"])
-
-    assert metadata_1.top_level_meta["cta"]["context"]["document"][1]["type"] == "Presentation"
-    assert (
-        metadata_1.top_level_meta["cta"]["context"]["associated_data"][0]["description"][0:6]
-        == "Mirror"
-    )
-
-
 def test_fill_product_meta(args_dict_site):
-    metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site)
+    metadata_1 = metadata_collector.MetadataCollector(args_dict=args_dict_site, clean_meta=False)
 
     with pytest.raises(TypeError):
         metadata_1._fill_product_meta(product_dict=None)

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -148,6 +148,9 @@ def test_get_class_from_telescope_name(invalid_name):
     assert "calibration_devices" == names.get_collection_name_from_array_element_name("ILLS-01")
     with pytest.raises(ValueError, match=rf"^{invalid_name}"):
         names.get_site_from_array_element_name("SATW")
+    assert "sites" == names.get_collection_name_from_array_element_name("North")
+    with pytest.raises(ValueError, match="Invalid array element name Not_a_collection"):
+        names.get_collection_name_from_array_element_name("Not_a_collection")
 
 
 def test_sanitize_name(caplog):


### PR DESCRIPTION
Revisit the `MetadataCollector` class and improve collection of metadata:

- added filling of instrument fields
- correctly distinguish between `activity_id` and `product_id` (one activity can generate several products; so obviously the ids must be different)
- fixed `CONTEXT:ASSOCIATED_DATA`: add context data (what data has been used for this tool); note that this works for the simplest cases, but will have to be expanded for cases with several input files. Removed `_fill_associated_elements_from_args`, this was incorrectly filled.
- added a function to 'clean' generated metadata dict and remove all 'None' and empty list entries.
- allow to add `ORDCID` to identify the user generating the data
- simplify code and improve testing