### PR TITLE
Change dependency from ctapipe to ctapipe-base

### DIFF
--- a/docs/changes/1247.maintence.md
+++ b/docs/changes/1247.maintence.md
@@ -1,0 +1,1 @@
+Change dependency from ctapipe to ctapipe-base for ctapipe v0.23

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.11
   - astropy
   - boost-histogram
-  - ctapipe
+  - ctapipe-base
   - eventio
   - jsonschema
   - matplotlib-base


### PR DESCRIPTION
Closes #1246 

ctapipe-base does not include optimal packages like matplotlib, bokeh, etc. (see https://ctapipe.readthedocs.io/en/stable/changelog.html#ctapipe-v0-23-0-2024-11-21)