### PR TITLE
Simplify yaml/json file reading

### DIFF
--- a/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -121,7 +121,7 @@ def get_list_of_parameters_and_schema_files(schema_directory):
     schema_files = sorted(Path(schema_directory).rglob("*.schema.yml"))
     parameters = []
     for schema_file in schema_files:
-        schema_dict = gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)
+        schema_dict = gen.collect_data_from_file(file_name=schema_file)
         parameters.append(schema_dict.get("name"))
     return parameters, schema_files
 
@@ -350,7 +350,7 @@ def print_list_of_files(args_dict, logger):
     """
     model_files = sorted(Path(args_dict["output_path"]).rglob("*.json"))
     for file in model_files:
-        model_dict = gen.collect_data_from_file_or_dict(file_name=file, in_dict=None)
+        model_dict = gen.collect_data_from_file(file_name=file)
         if model_dict.get("file"):
             logger.info(f"{file.name}: {model_dict['value']}")
 

--- a/simtools/applications/db_add_model_parameters_from_repository_to_db.py
+++ b/simtools/applications/db_add_model_parameters_from_repository_to_db.py
@@ -102,7 +102,7 @@ def add_values_from_json_to_db(file, collection, db, db_name, file_prefix, logge
     logger : logging.Logger
         Logger object.
     """
-    par_dict = gen.collect_data_from_file_or_dict(file_name=file, in_dict=None)
+    par_dict = gen.collect_data_from_file(file_name=file)
     logger.info(
         f"Adding the following parameter to the DB: {par_dict['parameter']} "
         f"(collection {collection} in database {db_name})"

--- a/simtools/applications/db_add_value_from_json_to_db.py
+++ b/simtools/applications/db_add_value_from_json_to_db.py
@@ -77,9 +77,7 @@ def main():  # noqa: D103
 
     if gen.user_confirm():
         for file_to_insert_now in files_to_insert:
-            par_dict = gen.collect_data_from_file_or_dict(
-                file_name=file_to_insert_now, in_dict=None
-            )
+            par_dict = gen.collect_data_from_file(file_name=file_to_insert_now)
             logger.info(f"Adding the following parameter to the DB: {par_dict['parameter']}")
             db.add_new_parameter(
                 db_name=db_config["db_simulation_model"],

--- a/simtools/applications/validate_file_using_schema.py
+++ b/simtools/applications/validate_file_using_schema.py
@@ -122,7 +122,7 @@ def validate_schema(args_dict, logger):
 
     """
     try:
-        data = gen.collect_data_from_file_or_dict(file_name=args_dict["file_name"], in_dict=None)
+        data = gen.collect_data_from_file(file_name=args_dict["file_name"])
     except FileNotFoundError as exc:
         logger.error(f"Error reading schema file from {args_dict['file_name']}")
         raise exc

--- a/simtools/configuration/configurator.py
+++ b/simtools/configuration/configurator.py
@@ -281,8 +281,8 @@ class Configurator:
         """
         try:
             self._logger.debug(f"Reading configuration from {config_file}")
-            _config_dict = gen.collect_data_from_file_or_dict(
-                file_name=config_file, in_dict=None, allow_empty=True
+            _config_dict = (
+                gen.collect_data_from_file(file_name=config_file) if config_file else None
             )
             # yaml parser adds \n in multiline strings, remove them
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")

--- a/simtools/corsika/corsika_histograms.py
+++ b/simtools/corsika/corsika_histograms.py
@@ -19,7 +19,7 @@ from eventio import IACTFile
 from simtools import version
 from simtools.io_operations import io_handler
 from simtools.io_operations.hdf5_handler import fill_hdf5_table
-from simtools.utils.general import collect_data_from_file_or_dict
+from simtools.utils.general import collect_data_from_file
 from simtools.utils.geometry import convert_2d_to_radial_distr, rotate
 from simtools.utils.names import sanitize_name
 
@@ -343,12 +343,10 @@ class CorsikaHistograms:
             Alternatively, it can be a dictionary with the configuration parameters to create
             the histograms.
         """
-        input_dict, input_yaml = None, None
         if isinstance(input_config, dict):
-            input_dict = input_config
+            self._hist_config = input_config
         else:
-            input_yaml = input_config
-        self._hist_config = collect_data_from_file_or_dict(input_yaml, input_dict, allow_empty=True)
+            self._hist_config = collect_data_from_file(input_config) if input_config else None
 
     def hist_config_to_yaml(self, file_name=None):
         """

--- a/simtools/data_model/data_reader.py
+++ b/simtools/data_model/data_reader.py
@@ -105,7 +105,7 @@ def read_value_from_file(file_name, schema_file=None, validate=False):
 
     """
     try:
-        data = gen.collect_data_from_file_or_dict(file_name=file_name, in_dict=None)
+        data = gen.collect_data_from_file(file_name=file_name)
     except FileNotFoundError as exc:
         _logger.error("Error reading data from %s", file_name)
         raise exc

--- a/simtools/data_model/metadata_collector.py
+++ b/simtools/data_model/metadata_collector.py
@@ -141,8 +141,8 @@ class MetadataCollector:
 
         """
         try:
-            return gen.collect_data_from_file_or_dict(file_name=self.schema_file, in_dict=None)
-        except AttributeError:
+            return gen.collect_data_from_file(file_name=self.schema_file)
+        except TypeError:
             self._logger.debug(f"No valid schema file provided ({self.schema_file}).")
         return {}
 
@@ -275,9 +275,7 @@ class MetadataCollector:
     def _read_input_metadata_from_yml_or_json(self, metadata_file_name):
         """Read input metadata from yml or json file."""
         try:
-            _input_metadata = gen.collect_data_from_file_or_dict(
-                file_name=metadata_file_name, in_dict=None
-            )
+            _input_metadata = gen.collect_data_from_file(file_name=metadata_file_name)
             _json_type_metadata = {"Metadata", "metadata", "METADATA"}.intersection(_input_metadata)
             if len(_json_type_metadata) == 1:
                 _input_metadata = _input_metadata[_json_type_metadata.pop()]

--- a/simtools/data_model/metadata_model.py
+++ b/simtools/data_model/metadata_model.py
@@ -94,10 +94,10 @@ def _load_schema(schema_file=None):
         schema_file = files("simtools").joinpath(simtools.constants.METADATA_JSON_SCHEMA)
 
     try:
-        schema = gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)
+        schema = gen.collect_data_from_file(file_name=schema_file)
     except FileNotFoundError:
         schema_file = files("simtools").joinpath("schemas") / schema_file
-        schema = gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)
+        schema = gen.collect_data_from_file(file_name=schema_file)
     _logger.debug(f"Loading schema from {schema_file}")
     _add_array_elements("InstrumentTypeElement", schema)
 

--- a/simtools/data_model/model_data_writer.py
+++ b/simtools/data_model/model_data_writer.py
@@ -238,9 +238,7 @@ class ModelDataWriter:
         """
         schema_file = MODEL_PARAMETER_SCHEMA_PATH / f"{parameter_name}.schema.yml"
         try:
-            self.schema_dict = gen.collect_data_from_file_or_dict(
-                file_name=schema_file, in_dict=None
-            )
+            self.schema_dict = gen.collect_data_from_file(file_name=schema_file)
         except FileNotFoundError as exc:
             raise FileNotFoundError(f"Schema file not found: {schema_file}") from exc
         return schema_file

--- a/simtools/data_model/validate_data.py
+++ b/simtools/data_model/validate_data.py
@@ -98,7 +98,7 @@ class DataValidator:
         """
         try:
             if Path(self.data_file_name).suffix in (".yml", ".yaml", ".json"):
-                self.data_dict = gen.collect_data_from_file_or_dict(self.data_file_name, None)
+                self.data_dict = gen.collect_data_from_file(self.data_file_name)
                 self._logger.info(f"Validating data from: {self.data_file_name}")
             else:
                 self.data_table = Table.read(self.data_file_name, guess=True, delimiter=r"\s")
@@ -676,11 +676,10 @@ class DataValidator:
         """
         try:
             if Path(schema_file).is_dir():
-                return gen.collect_data_from_file_or_dict(
+                return gen.collect_data_from_file(
                     file_name=Path(schema_file) / (parameter + ".schema.yml"),
-                    in_dict=None,
                 )["data"]
-            return gen.collect_data_from_file_or_dict(file_name=schema_file, in_dict=None)["data"]
+            return gen.collect_data_from_file(file_name=schema_file)["data"]
         except KeyError:
             self._logger.error(f"Error reading validation schema from {schema_file}")
             raise

--- a/simtools/db/db_from_repo_handler.py
+++ b/simtools/db/db_from_repo_handler.py
@@ -83,7 +83,7 @@ def update_model_parameters_from_repo(
         _tmp_par = {}
         _parameter_file = gen.join_url_or_path(_file_path, f"{key}.json")
         try:
-            _tmp_par = gen.collect_data_from_file_or_dict(file_name=_parameter_file, in_dict=None)
+            _tmp_par = gen.collect_data_from_file(file_name=_parameter_file)
         except (FileNotFoundError, gen.InvalidConfigDataError):
             # use design array element model in case there is no model defined for this
             #  array element ID. Accept errors, as not all parameters are defined in the repository
@@ -94,8 +94,8 @@ def update_model_parameters_from_repo(
                     model_version,
                     _design_model,
                 )
-                _tmp_par = gen.collect_data_from_file_or_dict(
-                    file_name=gen.join_url_or_path(_file_path, f"{key}.json"), in_dict=None
+                _tmp_par = gen.collect_data_from_file(
+                    file_name=gen.join_url_or_path(_file_path, f"{key}.json")
                 )
             except (FileNotFoundError, TypeError, gen.InvalidConfigDataError):
                 pass

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -468,9 +468,7 @@ class ModelParameter:
             "Insufficient validation of parameters."
         )
         self._logger.debug(f"Changing parameters from file {file_name}")
-        self.change_multiple_parameters(
-            **gen.collect_data_from_file_or_dict(file_name=file_name, in_dict=None)
-        )
+        self.change_multiple_parameters(**gen.collect_data_from_file(file_name=file_name))
 
     def change_multiple_parameters(self, **kwargs):
         """

--- a/simtools/simtel/simtel_config_reader.py
+++ b/simtools/simtel/simtel_config_reader.py
@@ -56,7 +56,7 @@ class SimtelConfigReader:
 
         self.schema_file = schema_file
         self.schema_dict = (
-            gen.collect_data_from_file_or_dict(file_name=self.schema_file, in_dict=None)
+            gen.collect_data_from_file(file_name=self.schema_file)
             if self.schema_file is not None
             else None
         )

--- a/simtools/testing/configuration.py
+++ b/simtools/testing/configuration.py
@@ -66,7 +66,7 @@ def _read_configs_from_files(config_files):
         # remove new line characters from config - otherwise issues
         # with especially long file names
         _dict = gen.remove_substring_recursively_from_dict(
-            gen.collect_data_from_file_or_dict(file_name=config_file, in_dict=None), substring="\n"
+            gen.collect_data_from_file(file_name=config_file), substring="\n"
         )
         configs.append(_dict.get("CTA_SIMPIPE", None))
     return configs

--- a/simtools/testing/validate_output.py
+++ b/simtools/testing/validate_output.py
@@ -161,8 +161,8 @@ def compare_json_or_yaml_files(file1, file2, tolerance=1.0e-2):
         True if the files are equal, False otherwise.
 
     """
-    data1 = gen.collect_data_from_file_or_dict(file1, in_dict=None)
-    data2 = gen.collect_data_from_file_or_dict(file2, in_dict=None)
+    data1 = gen.collect_data_from_file(file1)
+    data2 = gen.collect_data_from_file(file2)
 
     _logger.debug(f"Comparing json/yaml files: {file1} and {file2}")
 

--- a/simtools/utils/general.py
+++ b/simtools/utils/general.py
@@ -16,7 +16,7 @@ import yaml
 
 __all__ = [
     "change_dict_keys_case",
-    "collect_data_from_file_or_dict",
+    "collect_data_from_file",
     "collect_final_lines",
     "collect_kwargs",
     "InvalidConfigDataError",
@@ -135,45 +135,7 @@ def collect_data_from_http(url):
     return data
 
 
-def collect_data_from_file_or_dict(file_name, in_dict, allow_empty=False):
-    """
-    Collect input data from file or dictionary.
-
-    Parameters
-    ----------
-    file_name: str
-        Name of the yaml/json/ascii file.
-    in_dict: dict
-        Data as dict.
-    allow_empty: bool
-        If True, an error won't be raised in case both file_name and dict are None.
-
-    Returns
-    -------
-    data: dict or list
-        Data as dict or list.
-
-    Raises
-    ------
-    AttributeError
-        If no input has been provided (neither by file, nor by dict).
-    """
-    if file_name is not None:
-        return collect_data_from_file(file_name, in_dict)
-
-    if in_dict is not None:
-        return dict(in_dict)
-
-    if allow_empty:
-        _logger.debug("Input has not been provided (neither by file, nor by dict)")
-        return None
-
-    msg = "Input has not been provided (neither by file, nor by dict)"
-    _logger.debug(msg)
-    raise AttributeError(msg)
-
-
-def collect_data_from_file(file_name, in_dict):
+def collect_data_from_file(file_name):
     """
     Collect data from file based on its extension.
 
@@ -181,17 +143,12 @@ def collect_data_from_file(file_name, in_dict):
     ----------
     file_name: str
         Name of the yaml/json/ascii file.
-    in_dict: dict
-        Data as dict.
 
     Returns
     -------
     data: dict or list
         Data as dict or list.
     """
-    if in_dict is not None:
-        _logger.warning("Both in_dict and file_name were given - file_name will be used")
-
     if is_url(file_name):
         return collect_data_from_http(file_name)
 
@@ -391,7 +348,7 @@ def program_is_executable(program):
                 if is_exe(exe_file):
                     return exe_file
         except KeyError:
-            _logger.debug("PATH environment variable is not set.")
+            _logger.warning("PATH environment variable is not set.")
             return None
 
     return None

--- a/tests/unit_tests/data_model/test_data_reader.py
+++ b/tests/unit_tests/data_model/test_data_reader.py
@@ -61,7 +61,7 @@ def test_read_value_from_file(tmp_test_directory, reference_point_altitude_file)
     with pytest.raises(FileNotFoundError):
         data_reader.read_value_from_file("this_file_does_not_exist.json", validate=True)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         data_reader.read_value_from_file(None, validate=False)
 
     test_dict_1 = {"value": 5.0}

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -55,9 +55,7 @@ def test_validate_schema_astropy_units(caplog):
 
     success_string = "Successful validation of data using schema from"
 
-    _dict_1 = gen.collect_data_from_file_or_dict(
-        file_name="tests/resources/num_gains.schema.yml", in_dict=None
-    )
+    _dict_1 = gen.collect_data_from_file(file_name="tests/resources/num_gains.schema.yml")
     with caplog.at_level(logging.DEBUG):
         metadata_model.validate_schema(data=_dict_1, schema_file=_schema)
     assert success_string in caplog.text

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -27,10 +27,7 @@ def num_gains_schema_file():
 
 @pytest.fixture
 def num_gains_schema(num_gains_schema_file):
-    return gen.collect_data_from_file_or_dict(
-        file_name=num_gains_schema_file,
-        in_dict=None,
-    )
+    return gen.collect_data_from_file(file_name=num_gains_schema_file)
 
 
 def test_write(tmp_test_directory):

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -216,9 +216,7 @@ def test_change_parameter(telescope_model_lst):
 
 def test_change_multiple_parameters_from_file(telescope_model_lst, mocker):
     telescope_copy = copy.deepcopy(telescope_model_lst)
-    mocker_gen = mocker.patch(
-        "simtools.utils.general.collect_data_from_file_or_dict", return_value={}
-    )
+    mocker_gen = mocker.patch("simtools.utils.general.collect_data_from_file", return_value={})
     telescope_copy.change_multiple_parameters_from_file(file_name="test_file")
     mocker_gen.assert_called_once()
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -22,52 +22,36 @@ test_data = "Test data"
 
 
 def test_collect_dict_data(io_handler, caplog) -> None:
-    in_dict = {"k1": 2, "k2": "bla"}
     dict_for_yaml = {"k3": {"kk3": 4, "kk4": 3.0}, "k4": ["bla", 2]}
     test_yaml_file = io_handler.get_output_file(file_name="test_collect_dict_data.yml")
     if not Path(test_yaml_file).exists():
         with open(test_yaml_file, "w") as output:
             yaml.dump(dict_for_yaml, output, sort_keys=False)
 
-    d1 = gen.collect_data_from_file_or_dict(None, in_dict)
-    assert "k2" in d1.keys()
-    assert d1["k1"] == 2
-
-    d2 = gen.collect_data_from_file_or_dict(test_yaml_file, None)
+    d2 = gen.collect_data_from_file(test_yaml_file)
     assert "k3" in d2.keys()
     assert d2["k4"] == ["bla", 2]
 
-    with caplog.at_level("WARNING"):
-        d3 = gen.collect_data_from_file_or_dict(test_yaml_file, in_dict)
-    assert d3 == d2
-    assert gen.collect_data_from_file_or_dict(None, None, allow_empty=True) is None
-    assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
-
-    with caplog.at_level("WARNING"):
-        with pytest.raises(AttributeError):
-            gen.collect_data_from_file_or_dict(None, None, allow_empty=False)
-    assert "Input has not been provided (neither by file, nor by dict)" in caplog.text
-
-    _lines = gen.collect_data_from_file_or_dict("tests/resources/test_file.list", None)
+    _lines = gen.collect_data_from_file("tests/resources/test_file.list")
     assert len(_lines) == 2
 
     # astropy-type yaml file
     _file = "tests/resources/corsikaConfigTest_astropy_headers.yml"
-    _dict = gen.collect_data_from_file_or_dict(_file, None)
+    _dict = gen.collect_data_from_file(_file)
     assert isinstance(_dict, dict)
     assert len(_dict) > 0
 
 
 def test_collect_dict_from_url(io_handler) -> None:
     _file = "tests/resources/num_gains.schema.yml"
-    _reference_dict = gen.collect_data_from_file_or_dict(_file, None)
+    _reference_dict = gen.collect_data_from_file(_file)
 
     _url = url_simtools
     _url_dict = gen.collect_data_from_http(_url + _file)
 
     assert _reference_dict == _url_dict
 
-    _dict = gen.collect_data_from_file_or_dict(_url + _file, None)
+    _dict = gen.collect_data_from_file(_url + _file)
     assert isinstance(_dict, dict)
     assert len(_dict) > 0
 
@@ -362,7 +346,7 @@ def test_is_url():
 
 def test_collect_data_dict_from_json():
     _file = "tests/resources/reference_point_altitude.json"
-    data = gen.collect_data_from_file_or_dict(_file, None)
+    data = gen.collect_data_from_file(_file)
     assert len(data) == 6
     assert data["unit"] == "m"
 


### PR DESCRIPTION
This is a small maintenance PR which simplifies the often used function `general.collect_data_from_file_or_dict` to `general_collect_data_from_file`.

Reason for changes:

- simplification
- the second argument of `in_dict` in general.collect_data_from_file_or_dict` is counterintuitive, as all the function does is to return the original dict (so why call it at all?)
- the second argument was used once only in the whole code base and not using it actually simplifies the code
