### PR TITLE
Release preparation 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/)
 
 <!-- towncrier release notes start -->
 
+## [v0.8.0](https://github.com/gammasim/simtools/tree/v0.8.0) - 2024-11-26
+
+### API Changes
+
+- Improve primary particle API and validate consistency of user input. ([#1127](https://github.com/gammasim/simtools/pull/1127))
+- Refactor old style configuration of ray-tracing tools. ([#1142](https://github.com/gammasim/simtools/pull/1142))
+
+### Bug Fixes
+
+- Fix triggering of telescopes in light emission package. ([#1128](https://github.com/gammasim/simtools/pull/1128))
+
+### Documentation
+
+- Add missing API documentation for several applications. ([#1194](https://github.com/gammasim/simtools/pull/1194))
+- Add Towncrier for CHANGELOG generation for each release. ([#1236](https://github.com/gammasim/simtools/pull/1236))
+
+### New Features
+
+- Added application `submit_model_parameter_from_external.py to submit and validate a new model parameter to SimPipe. ([#1224](https://github.com/gammasim/simtools/pull/1224))
+- Add simulation production configuration tool. ([#1244](https://github.com/gammasim/simtools/pull/1244))
+
+### Maintenance
+
+- Update build command for CORSIKA/sim\_telarray to prod6-sc. ([#1235](https://github.com/gammasim/simtools/pull/1235))
+- Refactoring of integration test routines into `simtools.testing` modules. ([#1238](https://github.com/gammasim/simtools/pull/1238))
+
+### Simulation model
+
+- Move to strictly using semantic versions for models (remove e.g., 'prod5', 'prod6', 'Latest', 'Released'). ([#1123](https://github.com/gammasim/simtools/pull/1123))
+- Add schema for correction of NSB spectrum to the telescope altitude. ([#1171](https://github.com/gammasim/simtools/pull/1171))
+- Allow for class Telescope in model parameters. ([#1173](https://github.com/gammasim/simtools/pull/1173))
+
+
 ## [0.7.0](https://github.com/gammasim/simtools/tree/0.7.0) - 2024-11-12
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/)
 - Improve primary particle API and validate consistency of user input. ([#1127](https://github.com/gammasim/simtools/pull/1127))
 - Refactor old style configuration of ray-tracing tools. ([#1142](https://github.com/gammasim/simtools/pull/1142))
 
-### Bug Fixes
+### Bugfixes
 
 - Fix triggering of telescopes in light emission package. ([#1128](https://github.com/gammasim/simtools/pull/1128))
 

--- a/docs/changes/1123.model.md
+++ b/docs/changes/1123.model.md
@@ -1,1 +1,0 @@
-Move to strictly using semantic versions for models (remove e.g., 'prod5', 'prod6', 'Latest', 'Released').

--- a/docs/changes/1127.api.md
+++ b/docs/changes/1127.api.md
@@ -1,1 +1,0 @@
-Improve primary particle API and validate consistency of user input.

--- a/docs/changes/1128.bugfix.md
+++ b/docs/changes/1128.bugfix.md
@@ -1,1 +1,0 @@
-Fix triggering of telescopes in light emission package.

--- a/docs/changes/1142.api.md
+++ b/docs/changes/1142.api.md
@@ -1,1 +1,0 @@
-Refactore old style configuration of ray-tracing tools.

--- a/docs/changes/1171.model.md
+++ b/docs/changes/1171.model.md
@@ -1,1 +1,0 @@
-Add schema for correction of NSB spectrum to the telescope altitude.

--- a/docs/changes/1173.model.md
+++ b/docs/changes/1173.model.md
@@ -1,1 +1,0 @@
-Allow for class Telescope in model parameters.

--- a/docs/changes/1194.doc.md
+++ b/docs/changes/1194.doc.md
@@ -1,1 +1,0 @@
-Add missing API documentation for several applications.

--- a/docs/changes/1224.feature.md
+++ b/docs/changes/1224.feature.md
@@ -1,1 +1,0 @@
-Added application `submit_model_parameter_from_external.py to submit and validate a new model parameter to SimPipe.

--- a/docs/changes/1235.maintenance.md
+++ b/docs/changes/1235.maintenance.md
@@ -1,1 +1,0 @@
-Update build command for CORSIKA/sim\_telarray to prod6-sc.

--- a/docs/changes/1236.doc.md
+++ b/docs/changes/1236.doc.md
@@ -1,1 +1,0 @@
-Add Towncrier for CHANGELOG generation for each release.

--- a/docs/changes/1238.maintenance.md
+++ b/docs/changes/1238.maintenance.md
@@ -1,1 +1,0 @@
-Refactoring of integration test routines into `simtools.testing` modules.

--- a/docs/changes/1244.feature.md
+++ b/docs/changes/1244.feature.md
@@ -1,1 +1,0 @@
-Add simulation production configuration tool.


### PR DESCRIPTION
Preparation of simtools release v0.8.0.

The changelog has been generated using Towncrier from the files in `docs/changes` (which Towncrier deletes). So all what requires a read is the CHANGELOG.md

Let me know if we should add anything.