### PR TITLE
Fix pypi deployment 

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -2,6 +2,7 @@
 name: Deploy to PyPi
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Pypi deployment failed with the release of v0.8.0, see [here](https://github.com/gammasim/simtools/actions/runs/12031751059/job/33541983185).

Seems like we are not following all of the instructions for deployment:

- the simtools repository and the `.github/workflows/pypi.yml` is a `Trusted publisher` for pypi, meaning we don't need an explicit setting of user name and passwords for publishing
- to set this up, we followed the instruction [here](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-pypi)

The permission statement was missing in the pypi workflow.

I might have to release v0.8.1 to test this (I've added a manual workflow trigger, but not sure that works)