### PR TITLE
Add deployment environment for pypi deploy

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi-release
     permissions:
       id-token: write
     steps:

--- a/docs/changes/1256.bugfix.md
+++ b/docs/changes/1256.bugfix.md
@@ -1,0 +1,1 @@
+Fix authentication and writing permits for deployment of simtools to pypi.


### PR DESCRIPTION
Recommendations from github and pypi is to run the deployment in a separate requirement, which allows e.g. to set user rights for deployment more fine grained (see [github docs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#deployment-protection-rules)) 