### PR TITLE
Address warnings in pypi building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,9 @@ scripts.simtools-validate-cumulative-psf = "simtools.applications.validate_cumul
 scripts.simtools-validate-file-using-schema = "simtools.applications.validate_file_using_schema:main"
 scripts.simtools-validate-optics = "simtools.applications.validate_optics:main"
 
-[tool.setuptools]
-packages = [
-  "simtools",
-]
-include-package-data = true
+[tool.setuptools.packages.find]
+where = [ "simtools" ]
+exclude = [ "simtools._dev_version" ]
 
 [tool.setuptools_scm]
 write_to = "simtools/_version.py"


### PR DESCRIPTION
Building simtools generates warnings related to the finding of packages, see e.g. [here](https://github.com/gammasim/simtools/actions/runs/12032739454/job/33545254687#step:5:876).

This PR resolves this issue (with input from the [python build manual](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/) and in comparison with other CTAO projects, e.g., [ctapipe pyproject.toml](https://github.com/cta-observatory/ctapipe/blob/7a26885d0c8d18007e749533e1720de825bf945d/pyproject.toml#L132)).

I've attached the output from `python -m build` to show that now warnings are issued now during the build process.
[build_v7.txt](https://github.com/user-attachments/files/17944912/build_v7.txt)
