### PR TITLE
Improve help and printout for `--telescope_model_file` command line option.

### DIFF
--- a/simtools/configuration/commandline_parser.py
+++ b/simtools/configuration/commandline_parser.py
@@ -263,8 +263,8 @@ class CommandLineParser(argparse.ArgumentParser):
             _job_group.add_argument(
                 "--telescope_model_file",
                 help=(
-                    "File with changes to telescope model "
-                    " (yaml format; experimental with insufficient validation steps)."
+                    "Path to a YAML file containing modifications to the telescope model. "
+                    "This feature is intended for developers and lacks validation."
                 ),
                 type=Path,
                 required=False,

--- a/simtools/model/model_parameter.py
+++ b/simtools/model/model_parameter.py
@@ -456,7 +456,7 @@ class ModelParameter:
         Change values of multiple existing parameters in the model from a file.
 
         This function does not modify the DB, it affects only the current instance.
-        Experimental feature: insufficient validation of parameters.
+        This feature is intended for developers and lacks validation.
 
         Parameters
         ----------
@@ -464,7 +464,7 @@ class ModelParameter:
             File containing the parameters to be changed.
         """
         self._logger.warning(
-            "Changing multiple parameters from file is an experimental feature."
+            "Changing multiple parameters from file is a feature for developers."
             "Insufficient validation of parameters."
         )
         self._logger.debug(f"Changing parameters from file {file_name}")

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -214,10 +214,12 @@ def test_change_parameter(telescope_model_lst):
         tel_model.change_parameter("bla_bla", 9999.9)
 
 
-def test_change_multiple_parameters_from_file(telescope_model_lst, mocker):
+def test_change_multiple_parameters_from_file(telescope_model_lst, caplog, mocker):
     telescope_copy = copy.deepcopy(telescope_model_lst)
     mocker_gen = mocker.patch("simtools.utils.general.collect_data_from_file", return_value={})
-    telescope_copy.change_multiple_parameters_from_file(file_name="test_file")
+    with caplog.at_level(logging.WARNING):
+        telescope_copy.change_multiple_parameters_from_file(file_name="test_file")
+    assert "Changing multiple parameters from file is a feature for developers." in caplog.text
     mocker_gen.assert_called_once()
 
 


### PR DESCRIPTION
Tiny PR addressing issue #1084 and change warning from 'experimental' to 'for developers'.

Closes #1084