### PR TITLE
Change schema url to scr-layout

### DIFF
--- a/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for adjust_gain model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: adjust_gain
 description: |-

--- a/src/simtools/schemas/model_parameters/altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/altitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for altitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: altitude
 description: |-

--- a/src/simtools/schemas/model_parameters/array_coordinates.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_coordinates.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_coordinates model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: array_coordinates

--- a/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_coordinates_utm input data
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: array_coordinates_utm
 description: |-

--- a/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_element_position_ground model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: array_element_position_ground
 description: |-

--- a/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_element_position_utm model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: array_element_position_utm
 description: |-

--- a/src/simtools/schemas/model_parameters/array_layouts.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_layouts.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_layouts model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: array_layouts
 description: |-

--- a/src/simtools/schemas/model_parameters/array_triggers.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_triggers.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for array_triggers model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: array_triggers
 description: |-

--- a/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for asum_clipping model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: asum_clipping
 description: |-

--- a/src/simtools/schemas/model_parameters/asum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for asum_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: asum_offset
 description: Offset in time where shaping convolution is done.

--- a/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for asum_shaping model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: asum_shaping

--- a/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for asum_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: asum_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
+++ b/src/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for atmospheric_profile model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: atmospheric_profile

--- a/src/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for atmospheric_transmission model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: atmospheric_transmission

--- a/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
+++ b/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for axes_offsets model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: axes_offsets
 description: |-

--- a/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_body_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_body_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_body_shape model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_body_shape
 description: |-

--- a/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_config_file model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: camera_config_file

--- a/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_config_rotate model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_config_rotate
 developer_note: Part of sim_telarray camera_config_file (parameter Rotate).

--- a/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_degraded_efficiency model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_degraded_efficiency
 description: |-

--- a/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_degraded_map model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: |-
   To be replaced by a data table. Accepted range is 0 to 1

--- a/src/simtools/schemas/model_parameters/camera_depth.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_depth.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_depth model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_depth
 description: |-

--- a/src/simtools/schemas/model_parameters/camera_filter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_filter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_filter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: camera_filter

--- a/src/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_filter_incidence_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: camera_filter_incidence_angle

--- a/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_pixels model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_pixels
 description: Number of pixels in the camera.

--- a/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for camera_transmission model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: camera_transmission
 description: |-

--- a/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for channels_per_chip model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: channels_per_chip
 description: |-

--- a/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for correct_nsb_spectrum_to_telescope_altitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: correct_nsb_spectrum_to_telescope_altitude
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_cherenkov_photon_bunch_size.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_cherenkov_photon_bunch_size.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_cherenkov_photon_bunch_size model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: |-
   Different default than sim_telarray. No use of having HEGRA defaults.

--- a/src/simtools/schemas/model_parameters/corsika_cherenkov_photon_wavelength_range.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_cherenkov_photon_wavelength_range.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_cherenkov_photon_wavelength_range model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_cherenkov_photon_wavelength_range
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_first_interaction_height.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_first_interaction_height model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_first_interaction_height
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_iact_io_buffer model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_iact_io_buffer
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_iact_max_bunches model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_iact_max_bunches
 short_description: |-

--- a/src/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_iact_split_auto model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_iact_split_auto
 short_description: |-

--- a/src/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_longitudinal_shower_development.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_longitudinal_shower_development model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_longitudinal_shower_development
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_observation_level model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_observation_level
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_particle_kinetic_energy_cutoff.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_particle_kinetic_energy_cutoff model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_particle_kinetic_energy_cutoff
 description: |-

--- a/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for corsika_starting_grammage model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: corsika_starting_grammage
 description: |-

--- a/src/simtools/schemas/model_parameters/dark_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/dark_events.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dark_events model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dark_events
 description: |-

--- a/src/simtools/schemas/model_parameters/default_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/default_trigger.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for default_trigger model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: default_trigger
 description: Trigger algorithm used.

--- a/src/simtools/schemas/model_parameters/design_model.schema.yml
+++ b/src/simtools/schemas/model_parameters/design_model.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for design_model model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: design_model
 description: |-

--- a/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for disc_ac_coupled model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: disc_ac_coupled
 description: Discriminators/comparator are AC coupled (if true).

--- a/src/simtools/schemas/model_parameters/disc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_bins.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for disc_bins model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: disc_bins
 description: |-

--- a/src/simtools/schemas/model_parameters/disc_start.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_start.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for disc_start model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: disc_start
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_amplitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_amplitude
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_fall_time model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_fall_time
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_gate_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_gate_length
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_hysteresis model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_hysteresis
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_output_amplitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_output_amplitude
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_output_var_percent model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_output_var_percent
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_pulse_shape model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: discriminator_pulse_shape

--- a/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_rise_time model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_rise_time
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_scale_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_scale_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_sigsum_over_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_sigsum_over_threshold
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_threshold
 description: Discriminator/comparator threshold.

--- a/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_time_over_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_time_over_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_var_gate_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_var_gate_length
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_var_sigsum_over_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_var_sigsum_over_threshold
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_var_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_var_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for discriminator_var_time_over_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: discriminator_var_time_over_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dish_shape_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dish_shape_length
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_clipping model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_clipping
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_ignore_below model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_ignore_below
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_pedsub model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_pedsub
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_pre_clipping model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_pre_clipping
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_prescale model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_prescale
 developer_note: TODO - Remove comment on DDSUM_DOUBLE?

--- a/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_presum_max model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_presum_max
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_presum_shift model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_presum_shift
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_shaping model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: dsum_shaping

--- a/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_shaping_renormalize model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_shaping_renormalize
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_threshold model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_threshold
 description: |-

--- a/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for dsum_zero_clip model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: dsum_zero_clip
 description: |-

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for effective_focal_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: effective_focal_length
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/epsg_code.schema.yml
+++ b/src/simtools/schemas/model_parameters/epsg_code.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for epsg_code model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: epsg_code
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_ac_coupled model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_ac_coupled
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_amplitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_amplitude
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_bins model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_bins
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_compensate_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_compensate_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_dev_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_dev_pedestal
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_err_compensate_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_err_compensate_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_err_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_err_pedestal
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_amplitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_amplitude
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_compensate_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_compensate_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_dev_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_dev_pedestal
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_err_compensate_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_err_compensate_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_err_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_err_pedestal
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_max_signal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_max_signal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_max_sum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_max_sum
 developer_note: Not applicable for CTA telescopes.

--- a/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_noise model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_noise
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_pedestal
 description: (F)ADC pedestal value per time slice (low-gain channels).

--- a/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_sensitivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_sensitivity
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_sysvar_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_sysvar_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_var_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_var_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_lg_var_sensitivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_lg_var_sensitivity
 description: Relative variations in sensitivity (even for FADCs of the same channel; low-gain channels).

--- a/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_max_signal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_max_signal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_max_sum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_max_sum
 developer_note: Not applicable for CTA telescopes.

--- a/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_mhz model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_mhz
 description: FADC sampling rate.

--- a/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_noise model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_noise
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_pulse_shape model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: fadc_pulse_shape

--- a/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_sensitivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_sensitivity
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_sum_bins model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_sum_bins
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_sum_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_sum_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_sysvar_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_sysvar_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_var_pedestal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_var_pedestal
 description: |-

--- a/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for fadc_var_sensitivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: fadc_var_sensitivity
 description: |-

--- a/src/simtools/schemas/model_parameters/flatfielding.schema.yml
+++ b/src/simtools/schemas/model_parameters/flatfielding.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for flatfielding model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: flatfielding
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for focal_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: focal_length
 description: |-

--- a/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for focal_surface_parameters model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: focal_surface_parameters
 description: |-

--- a/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for focal_surface_ref_radius model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: focal_surface_ref_radius
 description: The length scale to which the focal_surface_parameters apply.

--- a/src/simtools/schemas/model_parameters/focus_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/focus_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for focus_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: focus_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/gain_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/gain_variation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for gain_variation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: gain_variation
 short_description: |-

--- a/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for geomag_horizontal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: geomag_horizontal
 short_description: Horizontal component of geomagnetic field.

--- a/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for geomag_rotation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: geomag_rotation
 short_description: Rotation angle between geographic South and geomagnetic North.

--- a/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for geomag_vertical model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: geomag_vertical
 short_description: Vertical component of geomagnetic field.

--- a/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for hg_lg_variation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: hg_lg_variation
 description: |-

--- a/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for iobuf_maximum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: iobuf_maximum
 description: |-

--- a/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for iobuf_output_maximum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: iobuf_output_maximum
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_events model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_events
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_external_trigger model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_external_trigger
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_photons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_photons
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_pulse_exptime model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_pulse_exptime
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_pulse_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_pulse_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_pulse_sigtime model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_pulse_sigtime
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_pulse_twidth model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_pulse_twidth
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_var_photons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_var_photons
 description: |-

--- a/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for laser_wavelength model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: laser_wavelength
 description: |-

--- a/src/simtools/schemas/model_parameters/led_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_events.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for led_events model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: led_events
 description: |-

--- a/src/simtools/schemas/model_parameters/led_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_photons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for led_photons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: led_photons
 description: |-

--- a/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for led_pulse_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: led_pulse_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for led_pulse_sigtime model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: led_pulse_sigtime
 description: |-

--- a/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for led_var_photons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: led_var_photons
 description: |-

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for lightguide_efficiency_vs_incidence_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/data.metaschema.yml
 meta_schema_version: 0.1.0
 name: lightguide_efficiency_vs_incidence_angle
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for lightguide_efficiency_vs_wavelength model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/data.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/data.metaschema.yml
 meta_schema_version: 0.1.0
 name: lightguide_efficiency_vs_wavelength
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for min_photoelectrons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: min_photoelectrons
 short_description: |-

--- a/src/simtools/schemas/model_parameters/min_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for min_photons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: min_photons
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_align_random_distance model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_align_random_distance
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_align_random_horizontal model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_align_random_horizontal
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_align_random_vertical model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_align_random_vertical
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_class model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_class
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_degraded_reflection model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_degraded_reflection
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_focal_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_focal_length
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_list.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_list.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_list model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: mirror_list

--- a/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror panel 2F measurements
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_panel_2f_measurement
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_reflection_random_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_reflection_random_angle
 description: |-

--- a/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror_reflectivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: mirror_reflectivity

--- a/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for multiplicity_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: multiplicity_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_autoscale_airmass model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_autoscale_airmass
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_gain_drop_scale model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_gain_drop_scale
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_offaxis model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_offaxis
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nightsky_background model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_pixel_rate
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_reference_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_reference_spectrum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_reference_spectrum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: nsb_reference_spectrum

--- a/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_reference_value model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_reference_value
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_scaling_factor model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_scaling_factor
 description: |-

--- a/src/simtools/schemas/model_parameters/nsb_skymap.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_skymap.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for nsb_sky_map model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: nsb_sky_map

--- a/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for night_sky_background_spectrum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: nsb_background_spectrum
 developer_note: |

--- a/src/simtools/schemas/model_parameters/num_gains.schema.yml
+++ b/src/simtools/schemas/model_parameters/num_gains.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for num_gains model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: num_gains
 description: Number of different gains the input signal gets digitized.

--- a/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
+++ b/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for only_triggered_telescopes model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: only_triggered_telescopes
 description: |-

--- a/src/simtools/schemas/model_parameters/optics_properties.schema.yml
+++ b/src/simtools/schemas/model_parameters/optics_properties.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for optics_properties model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: optics_properties

--- a/src/simtools/schemas/model_parameters/parabolic_dish.schema.yml
+++ b/src/simtools/schemas/model_parameters/parabolic_dish.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for parabolic_dish model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: parabolic_dish
 description: |-

--- a/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pedestal_events model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pedestal_events
 description: |-

--- a/src/simtools/schemas/model_parameters/photon_delay.schema.yml
+++ b/src/simtools/schemas/model_parameters/photon_delay.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for photon_delay model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: photon_delay
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
+++ b/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for photons_per_run model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: photons_per_run
 description: |-

--- a/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pixel_cells model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pixel_cells
 description: |-

--- a/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pixels_parallel model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pixels_parallel
 description: |-

--- a/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pixeltrg_time_step model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pixeltrg_time_step
 description: |-

--- a/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_average_gain model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pm_average_gain
 description: |-

--- a/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_collection_efficiency model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pm_collection_efficiency
 developer_note: Always set to 1. for CTA cameras.

--- a/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_gain_index model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pm_gain_index
 description: |-

--- a/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_photoelectron_spectrum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: pm_photoelectron_spectrum

--- a/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_transit_time model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pm_transit_time
 description: Total transit time of the photodetector at the average voltage.

--- a/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for pm_voltage_variation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: pm_voltage_variation
 short_description: |-

--- a/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_degraded_map model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: |-
   To be replaced by a data table. Accepted range is 0 to 1

--- a/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: primary_mirror_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_hole_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: primary_mirror_hole_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_incidence_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: primary_mirror_incidence_angle

--- a/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_parameters model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: primary_mirror_parameters
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_ref_radius model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: primary_mirror_ref_radius
 description: |-

--- a/src/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for primary_mirror_segmentation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: primary_mirror_segmentation

--- a/src/simtools/schemas/model_parameters/qe_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/qe_variation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for qe_variation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: qe_variation
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for quantum_efficiency model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: quantum_efficiency

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for random_focal_length model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: random_focal_length
 developer_note: Note - Description changed significantly in the sim_telarray manual

--- a/src/simtools/schemas/model_parameters/random_generator.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_generator.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for random_generator model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: random_generator
 short_description: Random generator used.

--- a/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for reference_point_altitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: reference_point_altitude
 description: |-

--- a/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for reference_point_latitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: reference_point_latitude
 description: |-

--- a/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for reference_point_longitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: reference_point_longitude
 description: |-

--- a/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for reference_point_utm_east model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: reference_point_utm_east
 description: |-

--- a/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for reference_point_utm_north model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: reference_point_utm_north
 description: |-

--- a/src/simtools/schemas/model_parameters/sampled_output.schema.yml
+++ b/src/simtools/schemas/model_parameters/sampled_output.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for sampled_output model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: sampled_output
 description: |-

--- a/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for save_pe_with_amplitude model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: save_pe_with_amplitude
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_baffle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_baffle
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_degraded_map model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: |-
   To be replaced by a data table. Accepted range is 0 to 1

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_degraded_reflection model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_degraded_reflection
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_hole_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_hole_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_incidence_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: secondary_mirror_incidence_angle

--- a/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_parameters model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_parameters
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_ref_radius model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_ref_radius
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_reflectivity model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: secondary_mirror_reflectivity

--- a/src/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_segmentation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 developer_note: To be replaced by a data table
 name: secondary_mirror_segmentation

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_shadow_diameter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_shadow_diameter
 description: |-

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for secondary_mirror_shadow_offset model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: secondary_mirror_shadow_offset
 description: |-

--- a/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for store_photoelectrons model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: store_photoelectrons
 description: |-

--- a/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for tailcut_scale model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: tailcut_scale
 description: |-

--- a/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_axis_height model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_axis_height
 description: Height of telescope elevation axis above ground level.

--- a/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_random_angle model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_random_angle
 description: |-

--- a/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_random_error model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_random_error
 description: |-

--- a/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_sphere_radius model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_sphere_radius
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_transmission model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_transmission
 developer_note: |-

--- a/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for teltrig_min_sigsum model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: teltrig_min_sigsum
 description: |-

--- a/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for teltrig_min_time model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: teltrig_min_time
 description: Minimum time of sector trigger over threshold.

--- a/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for transit_time_calib_error model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: transit_time_calib_error
 description: |-

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for transit_time_compensate_error model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: transit_time_compensate_error
 description: |-

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for transit_time_compensate_step model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: transit_time_compensate_step
 description: |-

--- a/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for transit_time_error model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: transit_time_error
 short_description: Errors (r.m.s.) in transit time, not related to high voltage.

--- a/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for transit_time_jitter model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: transit_time_jitter
 description: |-

--- a/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for trigger_current_limit model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: trigger_current_limit
 description: Pixels above this limit are excluded from the trigger.

--- a/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for trigger_delay_compensation model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: trigger_delay_compensation
 developer_note: Always zero for all cameras. Not clear what parameter 4 is.

--- a/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for trigger_pixels model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: trigger_pixels
 description: |-

--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -43,7 +43,7 @@ CTA:
       MODEL:
         NAME: simpipe-schema
         VERSION: 0.1.0
-        URL: "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml"
+        URL: "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml"
   CONTEXT:
     ASSOCIATED_ELEMENTS:
       - SITE: South

--- a/tests/resources/MST_mirror_2f_measurements.schema.yml
+++ b/tests/resources/MST_mirror_2f_measurements.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for mirror panel 2F measurements
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: mirror_2f_measurement
 description: |-

--- a/tests/resources/num_gains.meta.yml
+++ b/tests/resources/num_gains.meta.yml
@@ -43,7 +43,7 @@ CTA:
       MODEL:
         NAME: num_gains
         VERSION: 0.1.0
-        URL: https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/simtools/schemas/model_parameters/num_gains.schema.yml
+        URL: https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/src/simtools/schemas/model_parameters/num_gains.schema.yml
   # Additional information about the data product.
   CONTEXT:
     # List of relevant documents

--- a/tests/resources/num_gains.schema.yml
+++ b/tests/resources/num_gains.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for num_gains model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: num_gains
 description: Number of different gains the input signal gets digitized.

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -26,7 +26,7 @@
                     "MODEL": {
                         "NAME": "reference_point_altitude",
                         "VERSION": "0.1.0",
-                        "URL": "https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/reference_point_altitude.schema.yml"
+                        "URL": "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml"
                     }
                 },
                 "FORMAT": "json",

--- a/tests/resources/telescope_positions-North-ground.ecsv
+++ b/tests/resources/telescope_positions-North-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
+#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/resources/telescope_positions-North-utm.ecsv
+++ b/tests/resources/telescope_positions-North-utm.ecsv
@@ -25,7 +25,7 @@
 #         CATEGORY: CAL
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates_utm,
-#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml',
+#           URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions for the CTAO Northern site (UTM coordinate system). Consistent with document CTA-SPE-PSC-000000-0001

--- a/tests/resources/telescope_positions-North-utm.meta.yml
+++ b/tests/resources/telescope_positions-North-utm.meta.yml
@@ -43,7 +43,7 @@ CTA:
       MODEL:
         NAME: array_coordinates_utm
         VERSION: 0.1.0
-        URL: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+        URL: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
   CONTEXT:
     DOCUMENT:
       - TYPE: CTAO-DOC

--- a/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
+++ b/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
+#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/resources/telescope_positions-South-ground.ecsv
+++ b/tests/resources/telescope_positions-South-ground.ecsv
@@ -43,7 +43,7 @@
 #         CATEGORY: SIM
 #         LEVEL: R1
 #         MODEL: {NAME: array_coordinates, TYPE: simpipe-schema,
-#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameters/array_coordinates.schema.yml',
+#         URL: 'https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates.schema.yml',
 #           VERSION: 0.1.0}
 #         TYPE: Service
 #       DESCRIPTION: Telescope positions.

--- a/tests/resources/telescope_transmission.schema.yml
+++ b/tests/resources/telescope_transmission.schema.yml
@@ -3,7 +3,7 @@
 title: Schema for telescope_transmission model parameter
 version: 0.1.0
 meta_schema: simpipe-schema
-meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: telescope_transmission
 developer_note: |-


### PR DESCRIPTION
All schema files include a field called `meta_schema_url`, which is the url of the metaschema on the github. This file is now in `src/simtools/schema` and all URLs have been changed.

Also had to changed the URLs in the metadata of the test files in `tests/resources`.

Note that two unit tests and one integration test are still failing, as they require to see above changes in 'main'. I suggest to merge this PR and check that this is the case (otherwise we need to apply another fix).