### PR TITLE
Release of 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/)
 
 <!-- towncrier release notes start -->
 
+## [0.8.2](https://github.com/gammasim/simtools/tree/0.8.2) - 2024-12-03
+
+### Maintenance
+
+- Move simtools package layout to src-layout. ([#1264](https://github.com/gammasim/simtools/pull/1264))
+
+
 ## [v0.8.1](https://github.com/gammasim/simtools/tree/v0.8.1) - 2024-11-26
 
 ### Bugfixes

--- a/docs/changes/1264.maintenance.md
+++ b/docs/changes/1264.maintenance.md
@@ -1,1 +1,0 @@
-Move simtools package layout to src-layout.


### PR DESCRIPTION
Release 0.8.2 to test the pypi / conda packaging with the new source layout.

Please check also the release text for 0.8.2 at https://github.com/gammasim/simtools/releases