### PR TITLE
Change in optimization algorithm for the derivation of the random reflection angle parameter.

### DIFF
--- a/src/simtools/applications/derive_mirror_rnda.py
+++ b/src/simtools/applications/derive_mirror_rnda.py
@@ -179,6 +179,13 @@ def _parse(label):
         required=False,
     )
     config.parser.add_argument(
+        "--rtol_psf_containment",
+        help=("Relative tolerance for the containment diameter. " "Default is 0.1 (10%)."),
+        type=float,
+        required=False,
+        default=0.1,
+    )
+    config.parser.add_argument(
         "--use_random_focal_length",
         help=("Use random focal lengths."),
         action="store_true",

--- a/src/simtools/applications/derive_mirror_rnda.py
+++ b/src/simtools/applications/derive_mirror_rnda.py
@@ -180,7 +180,7 @@ def _parse(label):
     )
     config.parser.add_argument(
         "--rtol_psf_containment",
-        help=("Relative tolerance for the containment diameter. " "Default is 0.1 (10%)."),
+        help="Relative tolerance for the containment diameter (default is 0.1).",
         type=float,
         required=False,
         default=0.1,

--- a/src/simtools/ray_tracing/mirror_panel_psf.py
+++ b/src/simtools/ray_tracing/mirror_panel_psf.py
@@ -132,24 +132,18 @@ class MirrorPanelPSF:
         if self.args_dict["no_tuning"]:
             self.rnda_opt = self.rnda_start
         else:
-            self._optimize_reflection_angle(
-                relative_tolerance_d80=self.args_dict["rtol_psf_containment"],
-            )
+            self._optimize_reflection_angle()
 
         self.mean_d80, self.sig_d80 = self.run_simulations_and_analysis(
             self.rnda_opt, save_figures=save_figures
         )
 
-    def _optimize_reflection_angle(
-        self, relative_tolerance_d80=0.1, step_size=0.1, max_iteration=100
-    ):
+    def _optimize_reflection_angle(self, step_size=0.1, max_iteration=100):
         """
         Optimize the random reflection angle to minimize the difference in D80 containment.
 
         Parameters
         ----------
-        relative_tolerance_d80: float
-            Relative tolerance for the D80 containment.
         step_size: float
             Initial step size for optimization.
         max_iteration: int
@@ -161,6 +155,7 @@ class MirrorPanelPSF:
             If the optimization reaches the maximum number of iterations without converging.
 
         """
+        relative_tolerance_d80 = self.args_dict["rtol_psf_containment"]
         self._logger.info(
             "Optimizing random reflection angle "
             f"(relative tolerance = {relative_tolerance_d80}, "

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -235,6 +235,7 @@ def compare_ecsv_files(file1, file2, tolerance=1.0e-5, test_columns=None):
 
         if np.issubdtype(table1_masked[col_name].dtype, np.floating):
             if not np.allclose(table1_masked[col_name], table2_masked[col_name], rtol=tolerance):
+                _logger.warning(f"Column {col_name} outside of relative tolerance {tolerance}")
                 return False
 
     return True

--- a/tests/integration_tests/config/derive_mirror_rnda_psf_measurement.yml
+++ b/tests/integration_tests/config/derive_mirror_rnda_psf_measurement.yml
@@ -9,6 +9,7 @@ CTA_SIMPIPE:
     PSF_MEASUREMENT: ./tests/resources/MLTdata-preproduction.ecsv
     USE_RANDOM_FOCAL_LENGTH: true
     RNDA: 0.0063
+    RTOL_PSF_CONTAINMENT: 0.1
     TEST: true
     OUTPUT_PATH: simtools-output
     OUTPUT_FILE: test_derive_mirror_rnda_psf_measurement.ecsv

--- a/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
+++ b/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
@@ -325,7 +325,7 @@ def test_optimize_reflection_angle(mock_mirror_panel_psf, mock_run_simulations_a
         ],
     ) as mock_run_simulations:
 
-        mirror_psf._optimize_reflection_angle(relative_tolerance_d80=0.1)
+        mirror_psf._optimize_reflection_angle()
 
         assert mirror_psf.results_rnda == pytest.approx([0.1, 0.09, 0.08])
         assert mirror_psf.results_mean == pytest.approx([0.7, 0.6, 0.45])
@@ -340,4 +340,4 @@ def test_optimize_reflection_angle(mock_mirror_panel_psf, mock_run_simulations_a
             ValueError,
             match=re.escape("Maximum iterations (100) reached without convergence."),
         ):
-            mirror_psf._optimize_reflection_angle(relative_tolerance_d80=0.1)
+            mirror_psf._optimize_reflection_angle()


### PR DESCRIPTION
The derivation of the random reflection angle parameter fails in rare cases (e.g., see issue #1259) with a value which results in PSFs too different from the input measurement. The integration test already allows a 30% difference, and we probably don't want to increase this value.

This PR changes the algorithm allowing to give an optimisation goal: e.g., try to reach a value which results in a psf containment parameter within 10% of the measured input value. This is given by a new command line parameter `--rtol_psf_containment`.

As a reminder, the existing algorithm does the following:

- decrease or increase rnda (random reflection angle) with a fixed step size until we 'pass' the input psf value (e.g., if we want to reproduce a psf of 0.05 deg and start at 0.07 deg, we decrease until we reach a value lower than 0.05 deg)
- a second step then interpolates the derived valued to obtain the best value.
- step size is fixed in this approach and no metric on how good this value is is derived.

The new algorithm does:

- iteratively run the PSF simulations
- in each step change increase/decrease the rnda value
- check if the simulated PSF with this new value is within the tolerance given
- if necessary change the step size to reach this tolerance.
- there is a limit on the maximum iteration (currently set to 100 steps).

I ran the test 100 times without any issues.

Closes #1259 

