### PR TITLE
Minor changes to model parameter report generating

### DIFF
--- a/src/simtools/applications/docs_produce_reports.py
+++ b/src/simtools/applications/docs_produce_reports.py
@@ -47,7 +47,7 @@ def generate_markdown_report(output_path, args_dict, data):
     # Sort data by class to prepare for grouping
     data.sort(key=itemgetter(0))  # Sort by the first element (class)
 
-    output_filename = f'{output_path}/{args_dict["telescope"]}.md'
+    output_filename = output_path / Path(args_dict["telescope"] + ".md")
 
     # Start writing the Markdown file
     with Path(output_filename).open("w", encoding="utf-8") as file:
@@ -74,7 +74,7 @@ def main():  # noqa: D103
 
     io_handler_instance = io_handler.IOHandler()
     output_path = io_handler_instance.get_output_directory(
-        label=label_name, sub_dir=f"v{args['model_version']}"
+        label=label_name, sub_dir=f"{args['model_version']}"
     )
 
     logger = logging.getLogger()

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -14,19 +14,11 @@ from simtools.utils import names
 class ReadParameters:
     """Read and manage model parameter data."""
 
-    def __init__(self, telescope_model, output_folder):
+    def __init__(self, telescope_model, output_path):
         """Initialise class with a telescope model."""
         self._logger = logging.getLogger(__name__)
         self.telescope_model = telescope_model
-        self.output_folder = output_folder
-
-    def _get_parameter_classes(self):
-        """Load parameter classifications by category."""
-        return {
-            "Structure": set(names.load_model_parameters(class_key_list="Structure")),
-            "Camera": set(names.load_model_parameters(class_key_list="Camera")),
-            "Telescope": set(names.load_model_parameters(class_key_list="Telescope")),
-        }
+        self.output_path = output_path
 
     def _convert_to_md(self, input_file):
         """
@@ -34,19 +26,21 @@ class ReadParameters:
 
         Parameters
         ----------
-        - input_file: the '.dat' or '.ecsv' filename.
+        input_file: Path, str
+           Simulation data file (in '.dat' or '.ecsv' format).
 
         Returns
         -------
         - Path to the created Markdown file.
         """
-        input_path = Path(input_file)
-        subprocess.run(["mkdir", "-p", f"{self.output_folder}/data_files"], check=True)
-        output_path = Path(f"{self.output_folder}/data_files/" + input_path.stem + ".md")
+        input_file = Path(input_file)
+        output_data_path = Path(self.output_path, "data_files")
+        output_data_path.mkdir(parents=True, exist_ok=True)
+        output_file = output_data_path / Path(input_file.stem + ".md")
 
         with (
-            input_path.open("r", encoding="utf-8") as infile,
-            output_path.open("w", encoding="utf-8") as outfile,
+            input_file.open("r", encoding="utf-8") as infile,
+            output_file.open("w", encoding="utf-8") as outfile,
         ):
 
             for line in infile:
@@ -62,12 +56,12 @@ class ReadParameters:
                         continue
                     outfile.write("| " + " | ".join(row) + " |\n\n")
 
-        subprocess.run(["rm", input_path], check=True)
-        return output_path
+        subprocess.run(["rm", input_file], check=True)
+        return output_file
 
     def get_all_parameter_descriptions(self):
         """
-        Get descriptions of all available parameters.
+        Get descriptions for all model parameters.
 
         Returns
         -------
@@ -76,20 +70,17 @@ class ReadParameters:
                 - short_description: Maps parameter names to their short descriptions.
                 - inst_class: Maps parameter names to their respective class.
         """
-        all_parameters = names.telescope_parameters()
-        parameter_classes = self._get_parameter_classes()
-
         parameter_description = {}
         short_description = {}
         inst_class = {}
 
-        for parameter, details in all_parameters.items():
-            parameter_description[parameter] = details.get("description", "To be added.")
-            short_description[parameter] = details.get("short_description", "To be added.")
-            inst_class[parameter] = next(
-                (cls for cls, params in parameter_classes.items() if parameter in params),
-                None,
-            )
+        for instrument_class in names.instrument_classes("telescope"):
+            all_parameters = names.load_model_parameters(instrument_class)
+
+            for parameter, details in all_parameters.items():
+                parameter_description[parameter] = details.get("description", "To be added.")
+                short_description[parameter] = details.get("short_description", "To be added.")
+                inst_class[parameter] = instrument_class
 
         return parameter_description, short_description, inst_class
 
@@ -106,7 +97,7 @@ class ReadParameters:
         parameter_names = parameter_descriptions[0].keys()
 
         data = []
-        output_folder = io_handler.IOHandler().get_output_directory()
+        output_path = io_handler.IOHandler().get_output_directory()
 
         for parameter in parameter_names:
 
@@ -130,7 +121,7 @@ class ReadParameters:
                             check=True,
                         )
 
-                        input_filename = os.path.join(output_folder, os.path.basename(value))
+                        input_filename = os.path.join(output_path, os.path.basename(value))
                         output_filename = self._convert_to_md(input_filename)
                         value = f"[{os.path.basename(value)}]({output_filename.as_posix()})"
 

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -71,12 +71,21 @@ def load_model_parameters(class_key_list):
     return model_parameters
 
 
+def instrument_classes(instrument_type="telescope"):
+    """Return list of instrument classes for a given instrument type."""
+    if instrument_type == "site":
+        return "Site"
+    if instrument_type == "telescope":
+        return ("Structure", "Camera", "Telescope")
+    raise ValueError(f"Invalid instrument type {instrument_type}")
+
+
 def site_parameters():
-    return load_model_parameters(class_key_list="Site")
+    return load_model_parameters(class_key_list=instrument_classes("site"))
 
 
 def telescope_parameters():
-    return load_model_parameters(class_key_list=("Structure", "Camera", "Telescope"))
+    return load_model_parameters(class_key_list=instrument_classes("telescope"))
 
 
 def validate_array_element_id_name(name):


### PR DESCRIPTION
(this is a intermediate PR to be merged into the `model_reports` branches; full review should be applied before `model_reports` is merged to main)

This PR includes changes to align PR #1185 with the general simtools code base:

- use of db functions to read files form db
- use pathlib to make directories (if possible, we don't use subprocess)

Fixed a bug resulting in the addition of only list- or file type model parameters. Single values were excluded (e.g., `num_gains`).

Added also a new function to names to get the list of 'classes' for the instrument type (e.g., for `telescope`, this returns `("Structure", "Camera", "Telescope"))`. This allows to define this list once throughout the code (and avoid mistakes in future when these lists are changing.