### PR TITLE
CTAO CR spectra package now available from conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.11
   - astropy
   - boost-histogram
+  - ctao-dpps-cosmic-ray-spectra
   - ctapipe-base
   - eventio
   - jsonschema
@@ -34,7 +35,6 @@ dependencies:
   - towncrier
   - toml
   - pip:
-      - ctao-dpps-cosmic-ray-spectra
       - pytest-random-order
 
 # cheatsheet


### PR DESCRIPTION
Packages in `environment.yml` should preferably be installed through conda. Add `ctao-dpps-cosmic-ray-spectra`, which is since yesterday available through conda.