### PR TITLE
Handle return codes correctly for simulation productions

### DIFF
--- a/docs/changes/1289.bugfix
+++ b/docs/changes/1289.bugfix
@@ -1,0 +1,1 @@
+Add correct handling of return codes from simulation software to prevent reports of success even though a job failed (`simulate_prod`)

--- a/src/simtools/job_execution/job_manager.py
+++ b/src/simtools/job_execution/job_manager.py
@@ -116,7 +116,7 @@ class JobManager:
         else:
             submit_result = getattr(self, f"_submit_{self.submit_engine}")()
 
-        if submit_result:
+        if submit_result != 0:
             raise JobExecutionError(f"Job submission failed with return code {submit_result}")
 
     def _submit_local(self, log_file):
@@ -138,7 +138,7 @@ class JobManager:
 
         if self.test:
             self._logger.info("Testing (local)")
-            return None
+            return 0
 
         result = None
         try:

--- a/src/simtools/job_execution/job_manager.py
+++ b/src/simtools/job_execution/job_manager.py
@@ -110,10 +110,14 @@ class JobManager:
         self._logger.info(f"Job error stream {self.run_out_file + '.err'}")
         self._logger.info(f"Job log stream {self.run_out_file + '.job'}")
 
+        submit_result = 0
         if self.submit_engine == "local":
-            self._submit_local(log_file)
+            submit_result = self._submit_local(log_file)
         else:
-            getattr(self, f"_submit_{self.submit_engine}")()
+            submit_result = getattr(self, f"_submit_{self.submit_engine}")()
+
+        if submit_result:
+            raise JobExecutionError(f"Job submission failed with return code {submit_result}")
 
     def _submit_local(self, log_file):
         """
@@ -124,19 +128,25 @@ class JobManager:
         log_file: str or Path
             The log file of the actual simulator (CORSIKA or sim_telarray).
             Provided in order to print the log excerpt in case of run time error.
+
+        Returns
+        -------
+        int
+            Return code of the executed script
         """
         self._logger.info("Running script locally")
 
         if self.test:
             self._logger.info("Testing (local)")
-            return
+            return None
 
+        result = None
         try:
             with (
                 open(f"{self.run_out_file}.out", "w", encoding="utf-8") as stdout,
                 open(f"{self.run_out_file}.err", "w", encoding="utf-8") as stderr,
             ):
-                subprocess.run(
+                result = subprocess.run(
                     f"{self.run_script}",
                     shell=True,
                     check=True,
@@ -149,6 +159,8 @@ class JobManager:
             if log_file.exists() and gen.get_file_age(log_file) < 5:
                 self._logger.error(gen.get_log_excerpt(log_file))
             raise JobExecutionError("See excerpt from log file above\n") from exc
+
+        return result.returncode if result else 0
 
     def _submit_htcondor(self):
         """Submit a job described by a shell script to HTcondor."""
@@ -169,7 +181,7 @@ class JobManager:
             self._logger.error(f"Failed creating condor submission file {_condor_file}")
             raise JobExecutionError from exc
 
-        self._execute(self.submit_engine, [self.engines[self.submit_engine], _condor_file])
+        return self._execute(self.submit_engine, [self.engines[self.submit_engine], _condor_file])
 
     def _submit_gridengine(self):
         """Submit a job described by a shell script to gridengine."""
@@ -181,7 +193,7 @@ class JobManager:
             self.run_out_file + ".err",
             self.run_script,
         ]
-        self._execute(self.submit_engine, this_sub_cmd)
+        return self._execute(self.submit_engine, this_sub_cmd)
 
     def _execute(self, engine, shell_command):
         """
@@ -196,7 +208,10 @@ class JobManager:
         """
         self._logger.info(f"Submitting script to {engine}")
         self._logger.debug(shell_command)
+        result = None
         if not self.test:
-            subprocess.run(shell_command, shell=True, check=True)
+            result = subprocess.run(shell_command, shell=True, check=True)
         else:
             self._logger.info(f"Testing ({engine}: {shell_command})")
+
+        return result.returncode if result else 0

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -124,7 +124,7 @@ def test_submit_htcondor(mock_gen, job_submitter, mocker, output_log, logfile_lo
     job_submitter.submit_engine = "htcondor"
     mock_file = mocker.mock_open()
     mocker.patch("builtins.open", mock_file)
-    mock_execute = mocker.patch.object(job_submitter, "_execute")
+    mock_execute = mocker.patch.object(job_submitter, "_execute", return_value=0)
 
     job_submitter.submit(script_file, output_log, logfile_log)
 
@@ -176,7 +176,7 @@ def test_submit_htcondor_no_script(mock_gen, job_submitter, mocker, output_log, 
 @patch("simtools.utils.general")
 def test_submit_gridengine(mock_gen, job_submitter, mocker, output_log, logfile_log, script_file):
     job_submitter.submit_engine = "gridengine"
-    mock_execute = mocker.patch.object(job_submitter, "_execute")
+    mock_execute = mocker.patch.object(job_submitter, "_execute", return_value=0)
 
     job_submitter.submit(script_file, output_log, logfile_log)
 

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -214,9 +214,11 @@ def job_submitter_real():
     return submitter
 
 
-@patch("simtools.utils.general")
+@patch("simtools.utils.general.get_log_excerpt")
+@patch("simtools.utils.general.get_file_age")
 def test_submit_local_real_failure(
-    mock_gen,
+    mock_get_file_age,
+    mock_get_log_excerpt,
     job_submitter_real,
     mocker,
     output_log,
@@ -225,9 +227,9 @@ def test_submit_local_real_failure(
     job_messages,
     builtins_open,
 ):
-    mock_gen.get_log_excerpt.return_value = job_messages["log_excerpt"]
-    mocker.patch(PATHLIB_PATH_EXISTS, return_value=True)
-    mock_gen.get_file_age.return_value = 4
+    mock_get_log_excerpt.return_value = job_messages["log_excerpt"]
+    mock_get_file_age.return_value = 4
+    mocker.patch("pathlib.Path.exists", return_value=True)
 
     mocker.patch("simtools.utils.general.get_log_excerpt", return_value=LOG_EXCERPT)
     mocker.patch("simtools.utils.general.get_file_age", return_value=4)
@@ -257,6 +259,7 @@ def test_submit_local_success(
     subprocess_run,
 ):
     mock_subprocess_run = mocker.patch(subprocess_run)
+    mock_subprocess_run.return_value.returncode = 0
     mock_gen.get_log_excerpt.return_value = job_messages["log_excerpt"]
     mocker.patch(PATHLIB_PATH_EXISTS, return_value=False)
 
@@ -277,9 +280,15 @@ def test_submit_local_success(
         stderr=mocker.ANY,
     )
 
+    mock_subprocess_run = mocker.patch(subprocess_run)
+    mock_subprocess_run.return_value.returncode = 42
+    with patch(builtins_open, mock_open(read_data="")):
+        with pytest.raises(JobExecutionError, match="Job submission failed with return code 42"):
+            job_submitter_real.submit(script_file, output_log, logfile_log)
+
 
 @patch("simtools.utils.general")
-def ff_test_submit_local_failure(
+def test_submit_local_failure(
     mock_gen,
     job_submitter_real,
     mocker,
@@ -330,6 +339,7 @@ def test_submit_local_test_mode(
     subprocess_run,
 ):
     mock_subprocess_run = mocker.patch(subprocess_run)
+    mock_subprocess_run.return_value.returncode = 0
     mock_gen.get_log_excerpt.return_value = job_messages["log_excerpt"]
     mocker.patch(PATHLIB_PATH_EXISTS, return_value=False)
 


### PR DESCRIPTION
The `simulate_prod` application calls CORSIKA / sim_telarray but had no handling of the return codes when calling those processes. This means failed simulation runs could still be labeled as successful.

This PR collect the return value from `subprocess.run` and evaluates it. For any return values unequal zero, the code raises now a `JobExecutionError`.

This fixes also the issue "Skip pack_for_grid_register if the simulation fails" #1146.

Closes #1146 

