### PR TITLE
Set correct activity:end in metadata

### DIFF
--- a/docs/changes/1291.bugfix
+++ b/docs/changes/1291.bugfix
@@ -1,0 +1,1 @@
+Fix setting of activity:end time in the metadata collector.

--- a/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
+++ b/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
@@ -146,16 +146,12 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 
-    json_type = args_dict.get("input", "").endswith(".json")
-    # simplified metadata treatment for model parameter json files
-    if json_type:
+    if args_dict.get("input", "").endswith(".json"):
         site = args_dict.get("site", None)
-        top_level_meta = None
-        validate_schema_file = None
+        metadata, validate_schema_file = None, None
     else:
         metadata = MetadataCollector(args_dict=args_dict, data_model_name=data_model_name)
         site = metadata.get_site(from_input_meta=True)
-        top_level_meta = metadata.top_level_meta
         validate_schema_file = metadata.get_data_model_schema_file_name()
 
     layout = array_layout.ArrayLayout(
@@ -172,12 +168,12 @@ def main():
     if args_dict["export"] is not None:
         product_data = (
             layout.export_one_telescope_as_json(crs_name=args_dict["export"])
-            if json_type
+            if args_dict.get("input", "").endswith(".json")
             else layout.export_telescope_list_table(crs_name=args_dict["export"])
         )
         writer.ModelDataWriter.dump(
             args_dict=args_dict,
-            metadata=top_level_meta,
+            metadata=metadata.get_top_level_metadata() if metadata else None,
             product_data=product_data,
             validate_schema_file=validate_schema_file,
         )

--- a/src/simtools/applications/submit_data_from_external.py
+++ b/src/simtools/applications/submit_data_from_external.py
@@ -104,7 +104,7 @@ def main():  # noqa: D103
 
     writer.ModelDataWriter.dump(
         args_dict=args_dict,
-        metadata=_metadata.top_level_meta,
+        metadata=_metadata.get_top_level_metadata(),
         product_data=data_validator.validate_and_transform(),
     )
 

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -86,6 +86,24 @@ class MetadataCollector:
             except AttributeError:
                 self._logger.debug(f"Method _fill_{meta_type}_meta not implemented")
 
+    def get_top_level_metadata(self):
+        """
+        Return top level metadata dictionary (with updated activity end time).
+
+        Returns
+        -------
+        dict
+            Top level metadata dictionary.
+
+        """
+        try:
+            self.top_level_meta[self.observatory]["activity"][
+                "end"
+            ] = datetime.datetime.now().isoformat(timespec="seconds")
+        except KeyError:
+            pass
+        return self.top_level_meta
+
     def get_data_model_schema_file_name(self):
         """
         Return data model schema file name.

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -170,7 +170,7 @@ class ModelDataWriter:
             metadata_input_dict["output_file"] = output_file
             metadata_input_dict["output_file_format"] = Path(output_file).suffix.lstrip(".")
             writer.write_metadata_to_yml(
-                metadata=MetadataCollector(args_dict=metadata_input_dict).top_level_meta,
+                metadata=MetadataCollector(args_dict=metadata_input_dict).get_top_level_metadata(),
                 yml_file=output_path / f"{Path(output_file).stem}",
             )
         return _json_dict

--- a/src/simtools/ray_tracing/mirror_panel_psf.py
+++ b/src/simtools/ray_tracing/mirror_panel_psf.py
@@ -295,6 +295,6 @@ class MirrorPanelPSF:
         )
         writer.ModelDataWriter.dump(
             args_dict=self.args_dict,
-            metadata=MetadataCollector(args_dict=self.args_dict).top_level_meta,
+            metadata=MetadataCollector(args_dict=self.args_dict).get_top_level_metadata(),
             product_data=result_table,
         )

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -4,6 +4,7 @@ import copy
 import getpass
 import json
 import logging
+import time
 import uuid
 from importlib.resources import files
 from pathlib import Path
@@ -69,6 +70,26 @@ def test_get_data_model_schema_dict(args_dict_site):
 
     metadata.schema_file_name = "this_file_does_not_exist"
     assert metadata.get_data_model_schema_dict() == {}
+
+
+def test_get_top_level_metadata(args_dict_site):
+
+    collector = metadata_collector.MetadataCollector(args_dict=args_dict_site)
+    assert (
+        collector.top_level_meta["cta"]["activity"]["end"]
+        == collector.top_level_meta["cta"]["activity"]["start"]
+    )
+
+    # no update when activity cannot be found in the metadata
+    time.sleep(1)
+    collector.observatory = "not_cta"
+    top_level_meta = collector.get_top_level_metadata()
+    assert top_level_meta["cta"]["activity"]["end"] == top_level_meta["cta"]["activity"]["start"]
+
+    time.sleep(1)
+    collector.observatory = "cta"  # back to default
+    top_level_meta = collector.get_top_level_metadata()
+    assert top_level_meta["cta"]["activity"]["end"] > top_level_meta["cta"]["activity"]["start"]
 
 
 def test_fill_contact_meta(args_dict_site):


### PR DESCRIPTION
The metadata collector sets currently activity:end to activity:start time.

Fix this by introducing a new function MetadataCollector::get_top_level_metadata() which updates the activity:end time. This function is usually called when passing the metadata dictionary on to the data writer.

Closes #528