### PR TITLE
Fix validation of model parameters using schemas.

### DIFF
--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -731,6 +731,8 @@ class DataValidator:
                 )
             )
         except IndexError as exc:
+            if len(self._data_description) == 1:  # all columns are described by the same schema
+                return self._data_description[0]
             self._logger.error(
                 f"Data column '{column_name}' not found in reference column definition"
             )

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -192,7 +192,9 @@ class DataValidator:
             1 if v is None else u.Unit(v).to(u.Unit(t)) for v, t in zip(unit, target_unit)
         ]
         try:
-            return [v * c for v, c in zip(value, conversion_factor)], target_unit
+            return [
+                v * c if not isinstance(v, bool) else v for v, c in zip(value, conversion_factor)
+            ], target_unit
         except TypeError:
             return [None], target_unit
 

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -191,7 +191,10 @@ class DataValidator:
         conversion_factor = [
             1 if v is None else u.Unit(v).to(u.Unit(t)) for v, t in zip(unit, target_unit)
         ]
-        return [v * c for v, c in zip(value, conversion_factor)], target_unit
+        try:
+            return [v * c for v, c in zip(value, conversion_factor)], target_unit
+        except TypeError:
+            return [None], target_unit
 
     def _validate_data_dict_using_json_schema(self, data, json_schema):
         """

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -42,7 +42,7 @@ data:
       min: 0.0
       max: 10000.0
   - description: |-
-      Effective length for incidence directions in mirror/camera x−z plane
+      Effective length for incidence directions in mirror/camera x-z plane
       (if non-zero).
     type: double
     unit: cm
@@ -51,7 +51,7 @@ data:
       min: 0.0
       max: 10000.0
   - description: |-
-      Effective length for incidence directions in mirror/camera y−z plane
+      Effective length for incidence directions in mirror/camera y-z plane
       (if non-zero).
     type: double
     unit: cm

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -33,12 +33,42 @@ short_description: |-
   Effective focal length.
   Only to be used for image analysis, has no effect on the simulation.
 data:
-  - type: double
+  - description: |-
+      Mean effective length for all directions of incidence.
+    type: double
     unit: cm
     default: 0.0
     allowed_range:
       min: 0.0
       max: 10000.0
+  - description: |-
+      Effective length for incidence directions in mirror/camera x−z plane
+      (if non-zero).
+    type: double
+    unit: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+  - description: |-
+      Effective length for incidence directions in mirror/camera y−z plane
+      (if non-zero).
+    type: double
+    unit: cm
+    default: 0.0
+    allowed_range:
+      min: 0.0
+      max: 10000.0
+  - description: |-
+      Any displacement along x in the focal plane from asymmetric PSF behavior.
+    type: double
+    unit: cm
+    default: 0.0
+  - description: |-
+      Any displacement along y in the focal plane from asymmetric PSF behavior.
+    type: double
+    unit: cm
+    default: 0.0
 instrument:
   class: Structure
   type:

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -830,6 +830,12 @@ def test_get_value_and_units_as_lists():
     assert values == [100, 0.2]
     assert units == ["m", "km"]
 
+    # Test with None value
+    data_validator.data_dict = {"value": None, "unit": None}
+    values, units = data_validator._get_value_and_units_as_lists()
+    assert values == [None]
+    assert units == [None]
+
 
 def test_validate_value_and_unit_for_dict(reference_columns):
     data_validator = validate_data.DataValidator()

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -836,6 +836,11 @@ def test_get_value_and_units_as_lists():
     assert values == [None]
     assert units == [None]
 
+    # Test with Boolean value
+    data_validator.data_dict = {"value": True, "unit": None}
+    values, units = data_validator._get_value_and_units_as_lists()
+    assert values == [True]
+
 
 def test_validate_value_and_unit_for_dict(reference_columns):
     data_validator = validate_data.DataValidator()


### PR DESCRIPTION
The validation of model parameters using schema generates several errors (see #1301).

This PR fixes those:

- correct handling of `"value": null` cases (values are None)
- correct handling of `booleans` (values where wrongly converted to int along the way in the code)
- incomplete effective focal length schema description (added 4 additional columns)
- fix getting of column type description for cases where the schema file has one single entry to describe several entries of identical type (as e.g., in `nsb_pixel_rate`)

Closes #1301 