### PR TITLE
Preparation of data validation routines for db restructering

### DIFF
--- a/src/simtools/applications/validate_file_using_schema.py
+++ b/src/simtools/applications/validate_file_using_schema.py
@@ -41,6 +41,7 @@ import jsonschema
 
 import simtools.utils.general as gen
 from simtools.configuration import configurator
+from simtools.constants import MODEL_PARAMETER_SCHEMA_PATH
 from simtools.data_model import metadata_collector, metadata_model, validate_data
 
 
@@ -70,7 +71,7 @@ def _parse(label, description):
             "Directory with json files to be validated. "
             "If no schema file is provided, the assumption is that model "
             "parameters are validated and the schema files are taken from "
-            "simtools/schemas/model_parameters/."
+            f"{MODEL_PARAMETER_SCHEMA_PATH}."
         ),
     )
     config.parser.add_argument("--schema", help="Json schema file", required=False)

--- a/src/simtools/applications/validate_file_using_schema.py
+++ b/src/simtools/applications/validate_file_using_schema.py
@@ -33,10 +33,11 @@ r"""
 """
 
 import logging
-import jsonschema
 import re
 from importlib.resources import files
 from pathlib import Path
+
+import jsonschema
 
 import simtools.utils.general as gen
 from simtools.configuration import configurator

--- a/src/simtools/applications/validate_file_using_schema.py
+++ b/src/simtools/applications/validate_file_using_schema.py
@@ -34,7 +34,6 @@ r"""
 
 import logging
 import re
-from importlib.resources import files
 from pathlib import Path
 
 import jsonschema
@@ -151,9 +150,7 @@ def validate_data_files(args_dict, logger):
         for file_name in Path(file_directory).rglob("*.json"):
             tmp_args_dict["file_name"] = file_name
             parameter_name = re.sub(r"-\d+\.\d+\.\d+", "", file_name.stem)
-            schema_file = (
-                files("simtools") / "schemas/model_parameters" / f"{parameter_name}.schema.yml"
-            )
+            schema_file = MODEL_PARAMETER_SCHEMA_PATH / f"{parameter_name}.schema.yml"
             tmp_args_dict["schema"] = schema_file
             tmp_args_dict["data_type"] = "model_parameter"
             tmp_args_dict["require_exact_data_type"] = args_dict["require_exact_data_type"]

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import re
+from importlib.resources import files
 from pathlib import Path
 
 import jsonschema
@@ -57,7 +58,7 @@ class DataValidator:
         self.data_table = data_table
         self.check_exact_data_type = check_exact_data_type
 
-    def validate_and_transform(self, is_model_parameter=False):
+    def validate_and_transform(self, is_model_parameter=False, lists_as_strings=False):
         """
         Validate data and data file.
 
@@ -65,6 +66,8 @@ class DataValidator:
         ----------
         is_model_parameter: bool
             This is a model parameter (add some data preparation)
+        lists_as_strings: bool
+            Convert lists to strings (as needed for model parameters)
 
         Returns
         -------
@@ -80,13 +83,9 @@ class DataValidator:
         if self.data_file_name:
             self.validate_data_file()
         if isinstance(self.data_dict, dict):
-            if is_model_parameter:
-                self._prepare_model_parameter()
-            self._validate_data_dict()
-            return self.data_dict
+            return self._validate_data_dict(is_model_parameter, lists_as_strings)
         if isinstance(self.data_table, Table):
-            self._validate_data_table()
-            return self.data_table
+            return self._validate_data_table()
         self._logger.error("No data or data table to validate")
         raise TypeError
 
@@ -108,18 +107,48 @@ class DataValidator:
 
     def validate_parameter_and_file_name(self):
         """Validate that file name and key 'parameter_name' in data dict are the same."""
-        if self.data_dict.get("parameter") != Path(self.data_file_name).stem:
+        if not str(Path(self.data_file_name).stem).startswith(self.data_dict.get("parameter")):
             raise ValueError(
                 f"Parameter name in data dict {self.data_dict.get('parameter')} and "
                 f"file name {Path(self.data_file_name).stem} do not match."
             )
 
-    def _validate_data_dict(self):
+    @staticmethod
+    def validate_model_parameter(par_dict):
+        """
+        Validate a simulation model parameter (static method).
+
+        Parameters
+        ----------
+        par_dict: dict
+            Data dictionary
+
+        Returns
+        -------
+        dict
+            Validated data dictionary
+        """
+        data_validator = DataValidator(
+            schema_file=files("simtools")
+            / f"schemas/model_parameters/{par_dict['parameter']}.schema.yml",
+            data_dict=par_dict,
+            check_exact_data_type=False,
+        )
+        return data_validator.validate_and_transform(is_model_parameter=True)
+
+    def _validate_data_dict(self, is_model_parameter=False, lists_as_strings=False):
         """
         Validate values in a dictionary.
 
         Handles different types of naming in data dicts (using 'name' or 'parameter'
         keys for name fields).
+
+        Parameters
+        ----------
+        is_model_parameter: bool
+            This is a model parameter (add some data preparation)
+        lists_as_strings: bool
+            Convert lists to strings (as needed for model parameters)
 
         Raises
         ------
@@ -127,6 +156,9 @@ class DataValidator:
             if data dict does not contain a 'name' or 'parameter' key.
 
         """
+        if is_model_parameter:
+            self._prepare_model_parameter()
+
         if not (_name := self.data_dict.get("name") or self.data_dict.get("parameter")):
             raise KeyError("Data dict does not contain a 'name' or 'parameter' key.")
         self._data_description = self._read_validation_schema(self.schema_file_name, _name)
@@ -144,6 +176,11 @@ class DataValidator:
             self.data_dict["value"], self.data_dict["unit"] = value_as_list, unit_as_list
 
         self._check_version_string(self.data_dict.get("version"))
+
+        if lists_as_strings:
+            self._convert_results_to_model_format()
+
+        return self.data_dict
 
     def _validate_value_and_unit(self, value, unit, index):
         """
@@ -193,7 +230,8 @@ class DataValidator:
         ]
         try:
             return [
-                v * c if not isinstance(v, bool) else v for v, c in zip(value, conversion_factor)
+                v * c if not isinstance(v, bool) and not isinstance(v, dict) else v
+                for v, c in zip(value, conversion_factor)
             ], target_unit
         except TypeError:
             return [None], target_unit
@@ -233,6 +271,7 @@ class DataValidator:
             self._validate_data_columns()
             self._check_data_for_duplicates()
             self._sort_data()
+        return self.data_table
 
     def _validate_data_columns(self):
         """
@@ -777,6 +816,18 @@ class DataValidator:
 
         if self.data_dict["unit"] is not None:
             self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])
+
+    def _convert_results_to_model_format(self):
+        """
+        Convert results to model format.
+
+        Convert lists to strings (as needed for model parameters).
+        """
+        value = self.data_dict["value"]
+        if isinstance(value, list):
+            self.data_dict["value"] = gen.convert_list_to_string(value)
+        if isinstance(self.data_dict["unit"], list):
+            self.data_dict["unit"] = gen.convert_list_to_string(self.data_dict["unit"])
 
     def _check_version_string(self, version):
         """

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import re
-from importlib.resources import files
 from pathlib import Path
 
 import jsonschema
@@ -13,6 +12,7 @@ from astropy.table import Column, Table, unique
 from astropy.utils.diff import report_diff_values
 
 import simtools.utils.general as gen
+from simtools.constants import MODEL_PARAMETER_SCHEMA_PATH
 from simtools.data_model import format_checkers
 from simtools.utils import value_conversion
 
@@ -129,8 +129,7 @@ class DataValidator:
             Validated data dictionary
         """
         data_validator = DataValidator(
-            schema_file=files("simtools")
-            / f"schemas/model_parameters/{par_dict['parameter']}.schema.yml",
+            schema_file=MODEL_PARAMETER_SCHEMA_PATH / "f{par_dict['parameter']}.schema.yml",
             data_dict=par_dict,
             check_exact_data_type=False,
         )

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -58,6 +58,8 @@ definitions:
           - type: boolean
           - type: number
           - type: string
+          - type: "null"
+          - type: array
         description: "Value of the parameter."
       parameter_version:
         anyOf:

--- a/tests/integration_tests/config/validate_file_using_schema_validate_directory_of_model_parameters.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_validate_directory_of_model_parameters.yml
@@ -2,4 +2,4 @@ CTA_SIMPIPE:
   APPLICATION: simtools-validate-file-using-schema
   TEST_NAME: validate_directory_of_model_parameters
   CONFIGURATION:
-    MODEL_PARAMETERS_DIRECTORY: tests/resources/model_parameters
+    FILE_DIRECTORY: tests/resources/model_parameters

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -5,7 +5,6 @@ import re
 import shutil
 import sys
 from importlib.resources import files
-from pathlib import Path
 
 import jsonschema
 import numpy as np
@@ -899,7 +898,6 @@ def test_validate_value_and_unit_for_dict(reference_columns):
 
 
 def test_validate_model_parameter(mocker):
-    mocker.patch("simtools.data_model.validate_data.files", return_value=Path("tests/resources"))
     mocker.patch(
         "simtools.data_model.validate_data.DataValidator._read_validation_schema",
         return_value=[{"name": "parameter", "type": "float", "unit": "km"}],

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import sys
 from importlib.resources import files
+from pathlib import Path
 
 import jsonschema
 import numpy as np
@@ -661,6 +662,34 @@ def test_validate_data_dict():
     data_validator_2.data_dict = {"name": "num_gains", "value": [2], "unit": ["null"]}
     data_validator_2._validate_data_dict()
 
+    data_validator_3 = validate_data.DataValidator(
+        schema_file=str(schema_dir) + "/random_focal_length.schema.yml"
+    )
+    data_validator_3.data_dict = {
+        "name": "random_focal_length",
+        "value": [1.0, 2.0],
+        "unit": ["m", "m"],
+    }
+    result_3 = data_validator_3._validate_data_dict()
+    assert isinstance(result_3["value"], list)
+    result_3_str = data_validator_3._validate_data_dict(lists_as_strings=True)
+    assert isinstance(result_3_str["value"], str)
+
+
+def test_convert_results_to_model_format():
+    schema_dir = files("simtools").joinpath("schemas/model_parameters/")
+    data_validator_3 = validate_data.DataValidator(
+        schema_file=str(schema_dir) + "/random_focal_length.schema.yml"
+    )
+    data_validator_3.data_dict = {
+        "name": "random_focal_length",
+        "value": [1.0, 2.0],
+        "unit": ["m", "m"],
+    }
+    data_validator_3._convert_results_to_model_format()
+    assert data_validator_3.data_dict["value"] == "1.0 2.0"
+    assert data_validator_3.data_dict["unit"] == "m m"
+
 
 def test_prepare_model_parameter():
     data_validator = validate_data.DataValidator()
@@ -867,3 +896,17 @@ def test_validate_value_and_unit_for_dict(reference_columns):
     )
     assert value == {"key": "value"}
     assert unit == "null"
+
+
+def test_validate_model_parameter(mocker):
+    mocker.patch("simtools.data_model.validate_data.files", return_value=Path("tests/resources"))
+    mocker.patch(
+        "simtools.data_model.validate_data.DataValidator._read_validation_schema",
+        return_value=[{"name": "parameter", "type": "float", "unit": "km"}],
+    )
+
+    par_dict = {"parameter": "reference_point_altitude", "value": 1000.0, "unit": "km"}
+
+    validated_data = validate_data.DataValidator.validate_model_parameter(par_dict)
+    assert validated_data["value"] == 1000.0
+    assert validated_data["unit"] == "km"


### PR DESCRIPTION
Improvements to the data validation routines:

- generalize validation of all json files in a directory. The command line was called `--model_parameters_directory` and is now called `--file_directory`, as the validation application can be applied to files other than model parameter files
- the validation of all files in a directory using `--file_directory` can now be applied to schema validation (validating that all keys are there; fields are the correct type) and the more extensive validation using the schemas in `model_parameters` (which determine for each parameter the correctness of entries)
- allow for array-type `value` entries either the sim_tel-like string ("1 2 3 4") or an actual list ([1,2,3,4]); at the necessary conversion (I think on the long-term we want to get rid of the sim_tel-like strings)
- `value`-entries can be `None` now.
- added a static function `validate_model_parameter(parameter_dict)` for simple and fast validation of a model parameter dictionary

This is an updated required for the DB restructuring #1310 .