### PR TITLE
Require explicit selection of `model_version` as command line parameter

### DIFF
--- a/src/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/src/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -103,7 +103,7 @@ def _parse(label=None, description=None):
         type=str,
         required=True,
     )
-    return config.initialize(simulation_model="telescope")
+    return config.initialize(simulation_model=["telescope", "model_version"])
 
 
 def get_list_of_parameters_and_schema_files(schema_directory):

--- a/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
+++ b/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
@@ -130,7 +130,10 @@ def _parse(label=None, description=None):
         action="store_true",
     )
     return config.initialize(
-        output=True, require_command_line=True, db_config=True, simulation_model=["version", "site"]
+        output=True,
+        require_command_line=True,
+        db_config=True,
+        simulation_model=["model_version", "site"],
     )
 
 

--- a/src/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/src/simtools/applications/convert_model_parameter_from_simtel.py
@@ -78,7 +78,7 @@ def _parse(label=None, description=None):
         type=str,
         required=True,
     )
-    return config.initialize(simulation_model="telescope", output=True)
+    return config.initialize(simulation_model=["telescope", "model_version"], output=True)
 
 
 def main():  # noqa: D103

--- a/src/simtools/applications/db_get_array_layouts_from_db.py
+++ b/src/simtools/applications/db_get_array_layouts_from_db.py
@@ -94,7 +94,9 @@ def _parse(label, description):
         default="ground",
         choices=["ground", "utm"],
     )
-    return config.initialize(db_config=True, simulation_model=["site", "layout"], output=True)
+    return config.initialize(
+        db_config=True, simulation_model=["site", "layout", "model_version"], output=True
+    )
 
 
 def _layout_from_db(args_dict, db_config):

--- a/src/simtools/applications/db_get_parameter_from_db.py
+++ b/src/simtools/applications/db_get_parameter_from_db.py
@@ -83,7 +83,7 @@ def _parse():
         required=False,
     )
 
-    return config.initialize(db_config=True, simulation_model="telescope")
+    return config.initialize(db_config=True, simulation_model=["telescope", "model_version"])
 
 
 def main():  # noqa: D103

--- a/src/simtools/applications/derive_mirror_rnda.py
+++ b/src/simtools/applications/derive_mirror_rnda.py
@@ -207,7 +207,9 @@ def _parse(label):
         action="store_true",
         required=False,
     )
-    return config.initialize(db_config=True, output=True, simulation_model="telescope")
+    return config.initialize(
+        db_config=True, output=True, simulation_model=["telescope", "model_version"]
+    )
 
 
 def main():  # noqa: D103

--- a/src/simtools/applications/derive_psf_parameters.py
+++ b/src/simtools/applications/derive_psf_parameters.py
@@ -150,7 +150,7 @@ def _parse():
         help=("Keep the first entry of mirror_reflection_random_angle fixed."),
         action="store_true",
     )
-    return config.initialize(db_config=True, simulation_model="telescope")
+    return config.initialize(db_config=True, simulation_model=["telescope", "model_version"])
 
 
 def add_parameters(

--- a/src/simtools/applications/generate_array_config.py
+++ b/src/simtools/applications/generate_array_config.py
@@ -50,7 +50,7 @@ def _parse(label, description):
         Command line parser object.
     """
     config = configurator.Configurator(label=label, description=description)
-    return config.initialize(db_config=True, simulation_model=["site", "layout"])
+    return config.initialize(db_config=True, simulation_model=["site", "layout", "model_version"])
 
 
 def main():

--- a/src/simtools/applications/generate_regular_arrays.py
+++ b/src/simtools/applications/generate_regular_arrays.py
@@ -51,7 +51,9 @@ def _parse():
             f"  SST: {telescope_distance['SST']}\n"
         ),
     )
-    return config.initialize(db_config=False, simulation_model="site", output=True)
+    return config.initialize(
+        db_config=False, simulation_model=["site", "model_version"], output=True
+    )
 
 
 def main():

--- a/src/simtools/applications/plot_array_layout.py
+++ b/src/simtools/applications/plot_array_layout.py
@@ -146,7 +146,9 @@ def _parse(label, description, usage):
         required=False,
         default=None,
     )
-    return config.initialize(db_config=True, simulation_model=["site", "layout", "layout_file"])
+    return config.initialize(
+        db_config=True, simulation_model=["site", "model_version", "layout", "layout_file"]
+    )
 
 
 def _get_site_from_telescope_list_name(telescope_list_file):

--- a/src/simtools/applications/simulate_light_emission.py
+++ b/src/simtools/applications/simulate_light_emission.py
@@ -235,7 +235,7 @@ def _parse(label):
     )
     return config.initialize(
         db_config=True,
-        simulation_model="telescope",
+        simulation_model=["telescope", "model_version"],
         require_command_line=True,
     )
 

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -134,7 +134,7 @@ def _parse(description=None):
     return config.initialize(
         db_config=True,
         job_submission=True,
-        simulation_model=["site", "layout", "telescope"],
+        simulation_model=["site", "layout", "telescope", "model_version"],
         simulation_configuration={"software": None, "corsika_configuration": ["all"]},
     )
 

--- a/src/simtools/applications/simulate_prod_htcondor_generator.py
+++ b/src/simtools/applications/simulate_prod_htcondor_generator.py
@@ -77,7 +77,7 @@ def _parse(description=None):
     return config.initialize(
         db_config=False,
         job_submission=False,
-        simulation_model=["site", "layout", "telescope"],
+        simulation_model=["site", "layout", "telescope", "model_version"],
         simulation_configuration={"software": None, "corsika_configuration": ["all"]},
     )
 

--- a/src/simtools/applications/validate_camera_efficiency.py
+++ b/src/simtools/applications/validate_camera_efficiency.py
@@ -86,7 +86,7 @@ def _parse(label):
     )
     _args_dict, _db_config = config.initialize(
         db_config=True,
-        simulation_model="telescope",
+        simulation_model=["telescope", "model_version"],
         simulation_configuration={"corsika_configuration": ["zenith_angle", "azimuth_angle"]},
     )
     if _args_dict["site"] is None or _args_dict["telescope"] is None:

--- a/src/simtools/applications/validate_camera_fov.py
+++ b/src/simtools/applications/validate_camera_fov.py
@@ -83,7 +83,7 @@ def _parse():
         ),
         default=50,
     )
-    return config.initialize(db_config=True, simulation_model="telescope")
+    return config.initialize(db_config=True, simulation_model=["telescope", "model_version"])
 
 
 def main():  # noqa: D103

--- a/src/simtools/applications/validate_cumulative_psf.py
+++ b/src/simtools/applications/validate_cumulative_psf.py
@@ -110,7 +110,7 @@ def _parse(label):
         help="Data file name with the measured PSF vs radius [cm]",
         type=str,
     )
-    return config.initialize(db_config=True, simulation_model="telescope")
+    return config.initialize(db_config=True, simulation_model=["telescope", "model_version"])
 
 
 def load_data(datafile):

--- a/src/simtools/applications/validate_optics.py
+++ b/src/simtools/applications/validate_optics.py
@@ -115,7 +115,7 @@ def _parse(label):
         help="Produce a multiple pages pdf file with the image plots.",
         action="store_true",
     )
-    return config.initialize(db_config=True, simulation_model=["telescope"])
+    return config.initialize(db_config=True, simulation_model=["telescope", "model_version"])
 
 
 def main():  # noqa: D103

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -236,12 +236,13 @@ class CommandLineParser(argparse.ArgumentParser):
             return
 
         _job_group = self.add_argument_group("simulation model")
-        _job_group.add_argument(
-            "--model_version",
-            help="model version",
-            type=str,
-            default=None,
-        )
+        if "model_version" in model_options:
+            _job_group.add_argument(
+                "--model_version",
+                help="model version",
+                type=str,
+                default=None,
+            )
         if any(
             option in model_options for option in ["site", "telescope", "layout", "layout_file"]
         ):

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -169,7 +169,7 @@ def test_simulation_model():
 
     # Model version only, no site or telescope
     _parser_v = parser.CommandLineParser()
-    _parser_v.initialize_default_arguments(simulation_model=["version"])
+    _parser_v.initialize_default_arguments(simulation_model=["model_version"])
     job_groups = _parser_v._action_groups
 
     assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
@@ -181,7 +181,7 @@ def test_simulation_model():
 
     # Site model can exist without a telescope model
     _parser_s = parser.CommandLineParser()
-    _parser_s.initialize_default_arguments(simulation_model=["site"])
+    _parser_s.initialize_default_arguments(simulation_model=["site", "model_version"])
     job_groups = _parser_s._action_groups
     assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:
@@ -192,7 +192,7 @@ def test_simulation_model():
 
     # No telescope model without site model
     _parser_t = parser.CommandLineParser()
-    _parser_t.initialize_default_arguments(simulation_model=["telescope", "site"])
+    _parser_t.initialize_default_arguments(simulation_model=["telescope", "site", "model_version"])
     job_groups = _parser_t._action_groups
     assert SIMULATION_MODEL_STRING in [str(group.title) for group in job_groups]
     for group in job_groups:


### PR DESCRIPTION
The DB restructuring PR #1310 introduces both `model_version` and `parameter_version`. 

This PR here prepare for that by requiring now the explicit listing of `model_version` when initializing the command line.