### PR TITLE
Fix site in integration test

### DIFF
--- a/tests/integration_tests/config/db_get_array_layouts_from_db_layout_list.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_layout_list.yml
@@ -2,7 +2,7 @@ CTA_SIMPIPE:
   APPLICATION: simtools-db-get-array-layouts-from-db
   TEST_NAME: layout_list
   CONFIGURATION:
-    SITE: North
+    SITE: South
     MODEL_VERSION: "6.0.0"
     ARRAY_ELEMENT_LIST: ["LSTS", "MSTS", "SSTS"]
     COORDINATE_SYSTEM: ground


### PR DESCRIPTION
Array elements for this tests are all for the southern site; site element should therefore be set to South.