### PR TITLE
Preparation 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ This changelog is generated using [Towncrier](https://towncrier.readthedocs.io/)
 
 <!-- towncrier release notes start -->
 
+## [0.9.0](https://github.com/gammasim/simtools/tree/0.9.0) - 2025-01-22
+
+### Bugfixes
+
+- Add correct handling of return codes from simulation software to prevent reports of success even though a job failed (`simulate_prod`) ([#1289](https://github.com/gammasim/simtools/pull/1289))
+- Fix setting of activity:end time in the metadata collector. ([#1291](https://github.com/gammasim/simtools/pull/1291))
+
+### New Features
+
+- Add an application to plot tables from a file (from file system or for a model parameter file downloaded from the DB). ([#1267](https://github.com/gammasim/simtools/pull/1267))
+- Enhancements to file testing within integration tests. ([#1279](https://github.com/gammasim/simtools/pull/1279))
+- Add a tool to prepare job submission with `simulate_prod` for a HTCondor system. ([#1290](https://github.com/gammasim/simtools/pull/1290))
+- Remove functionality in `db_handler` to read from simulation model repository. ([#1306](https://github.com/gammasim/simtools/pull/1306))
+
+### Maintenance
+
+- Change dependency from ctapipe to ctapipe-base for ctapipe v0.23 ([#1247](https://github.com/gammasim/simtools/pull/1247))
+- Remove pytest dependent from user installation. ([#1286](https://github.com/gammasim/simtools/pull/1286))
+
+
 ## [0.8.2](https://github.com/gammasim/simtools/tree/0.8.2) - 2024-12-03
 
 ### Maintenance

--- a/docs/changes/1247.maintenance.md
+++ b/docs/changes/1247.maintenance.md
@@ -1,1 +1,0 @@
-Change dependency from ctapipe to ctapipe-base for ctapipe v0.23

--- a/docs/changes/1267.feature.md
+++ b/docs/changes/1267.feature.md
@@ -1,1 +1,0 @@
-Add an application to plot tables from a file (from file system or for a model parameter file downloaded from the DB).

--- a/docs/changes/1279.feature.md
+++ b/docs/changes/1279.feature.md
@@ -1,1 +1,0 @@
-Enhancements to file testing within integration tests.

--- a/docs/changes/1286.maintenance.md
+++ b/docs/changes/1286.maintenance.md
@@ -1,1 +1,0 @@
-Remove pytest dependent from user installation.

--- a/docs/changes/1289.bugfix
+++ b/docs/changes/1289.bugfix
@@ -1,1 +1,0 @@
-Add correct handling of return codes from simulation software to prevent reports of success even though a job failed (`simulate_prod`)

--- a/docs/changes/1290.feature.md
+++ b/docs/changes/1290.feature.md
@@ -1,1 +1,0 @@
-Add a tool to prepare job submission with `simulate_prod` for a HTCondor system.

--- a/docs/changes/1291.bugfix
+++ b/docs/changes/1291.bugfix
@@ -1,1 +1,0 @@
-Fix setting of activity:end time in the metadata collector.

--- a/docs/changes/1306.feature.md
+++ b/docs/changes/1306.feature.md
@@ -1,1 +1,0 @@
-Remove functionality in `db_handler` to read from simulation model repository.


### PR DESCRIPTION
Prepares changelog for release 0.9.0. This is the release *before* the major changes in DB restructuring.

See also the draft of the release notes here: https://github.com/gammasim/simtools/releases