### PR TITLE
Fix label setting in validate_camera_efficiency

### DIFF
--- a/src/simtools/applications/validate_camera_efficiency.py
+++ b/src/simtools/applications/validate_camera_efficiency.py
@@ -106,7 +106,7 @@ def main():  # noqa: D103
     ce = CameraEfficiency(
         db_config=_db_config,
         simtel_path=args_dict["simtel_path"],
-        label=label,
+        label=args_dict.get("label", label),
         config_data=args_dict,
     )
     ce.simulate()


### PR DESCRIPTION
Allows to set label through the command line. Default value is simply `validate_camera_efficiency`.

Closes #1318 