### PR TITLE
Clear default sim_telarray cfg directories from all calls

### DIFF
--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from simtools.runners.corsika_runner import CorsikaRunner
 from simtools.simtel.simulator_array import SimulatorArray
+from simtools.utils.general import clear_default_sim_telarray_cfg_directories
 
 __all__ = ["CorsikaSimtelRunner"]
 
@@ -197,7 +198,8 @@ class CorsikaSimtelRunner:
         )
         command += f" | gzip > {_log_file} 2>&1 || exit"
 
-        return command
+        # Remove the default sim_telarray configuration directories
+        return clear_default_sim_telarray_cfg_directories(command)
 
     def get_file_name(self, simulation_software=None, file_type=None, run_number=None, mode=None):
         """

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -4,6 +4,7 @@ import logging
 
 from simtools.io_operations import io_handler
 from simtools.runners.simtel_runner import InvalidOutputFileError, SimtelRunner
+from simtools.utils.general import clear_default_sim_telarray_cfg_directories
 
 __all__ = ["SimulatorArray"]
 
@@ -88,7 +89,7 @@ class SimulatorArray(SimtelRunner):
         command += f" {input_file}"
         command += f" > {self._log_file} 2>&1 || exit"
 
-        return command
+        return clear_default_sim_telarray_cfg_directories(command)
 
     def _check_run_result(self, run_number=None):
         """

--- a/src/simtools/simtel/simulator_camera_efficiency.py
+++ b/src/simtools/simtel/simulator_camera_efficiency.py
@@ -155,6 +155,9 @@ class SimulatorCameraEfficiency(SimtelRunner):
         command += f" {self._telescope_model.get_parameter_value('atmospheric_profile')}"
         command += f" {self.zenith_angle}"
 
+        # Remove the default sim_telarray configuration directories
+        command = general.clear_default_sim_telarray_cfg_directories(command)
+
         return (
             f"cd {self._simtel_path.joinpath('sim_telarray')} && {command}",
             self._file_simtel,

--- a/src/simtools/simtel/simulator_light_emission.py
+++ b/src/simtools/simtel/simulator_light_emission.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from simtools.io_operations import io_handler
 from simtools.runners.simtel_runner import SimtelRunner
+from simtools.utils.general import clear_default_sim_telarray_cfg_directories
 
 __all__ = ["SimulatorLightEmission"]
 
@@ -360,7 +361,8 @@ class SimulatorLightEmission(SimtelRunner):
             f"{self.le_application[0]}_{self.le_application[1]}.ctsim.hdata\n",
         )
 
-        return command
+        # Remove the default sim_telarray configuration directories
+        return clear_default_sim_telarray_cfg_directories(command)
 
     def _remove_line_from_config(self, file_path, line_prefix):
         """

--- a/src/simtools/simtel/simulator_ray_tracing.py
+++ b/src/simtools/simtel/simulator_ray_tracing.py
@@ -8,6 +8,7 @@ import astropy.units as u
 from simtools.io_operations import io_handler
 from simtools.runners.simtel_runner import SimtelRunner
 from simtools.utils import names
+from simtools.utils.general import clear_default_sim_telarray_cfg_directories
 
 __all__ = ["SimulatorRayTracing"]
 
@@ -192,7 +193,7 @@ class SimulatorRayTracing(SimtelRunner):
             command += super().get_config_option("mirror_align_random_vertical", "0.,28.,0.,0.")
         command += " " + str(self._corsika_file)
 
-        return command, self._log_file, self._log_file
+        return clear_default_sim_telarray_cfg_directories(command), self._log_file, self._log_file
 
     def _check_run_result(self, run_number=None):  # pylint: disable=unused-argument
         """

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -17,6 +17,7 @@ import yaml
 __all__ = [
     "InvalidConfigDataError",
     "change_dict_keys_case",
+    "clear_default_sim_telarray_cfg_directories",
     "collect_data_from_file",
     "collect_final_lines",
     "collect_kwargs",
@@ -832,3 +833,20 @@ def convert_keys_in_dict_to_lowercase(data):
     if isinstance(data, list):
         return [convert_keys_in_dict_to_lowercase(i) for i in data]
     return data
+
+
+def clear_default_sim_telarray_cfg_directories(command):
+    """Prefix the command to clear default sim_telarray configuration directories.
+
+    Parameters
+    ----------
+    command: str
+        Command to be prefixed.
+
+    Returns
+    -------
+    str
+        Prefixed command.
+
+    """
+    return f"SIM_TELARRAY_CONFIG_PATH='' {command}"

--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -355,6 +355,7 @@ def test_make_simtel_script(mock_simulator):
         mock_simulator.output_directory = "/directory"
 
         expected_command = (
+            "SIM_TELARRAY_CONFIG_PATH='' "
             "/path/to/sim_telarray/bin/sim_telarray/ "
             "-I -I/path/to/config/ "
             "-c /path/to/config/config.cfg "

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -714,3 +714,29 @@ def test_convert_keys_in_dict_to_lowercase():
     input_data = {"Key1": 123, "Key2": [1, 2, 3], "Key3": {"NestedKey1": "value1"}}
     expected_output = {"key1": 123, "key2": [1, 2, 3], "key3": {"nestedkey1": "value1"}}
     assert gen.convert_keys_in_dict_to_lowercase(input_data) == expected_output
+
+
+def test_clear_default_sim_telarray_cfg_directories():
+    """
+    Test the clear_default_sim_telarray_cfg_directories function.
+    """
+
+    # Test with a simple command.
+    command = "run_simulation"
+    expected_output = "SIM_TELARRAY_CONFIG_PATH='' run_simulation"
+    assert gen.clear_default_sim_telarray_cfg_directories(command) == expected_output
+
+    # Test with a command containing spaces.
+    command = "run_simulation --config config_file"
+    expected_output = "SIM_TELARRAY_CONFIG_PATH='' run_simulation --config config_file"
+    assert gen.clear_default_sim_telarray_cfg_directories(command) == expected_output
+
+    # Test with an empty command.
+    command = ""
+    expected_output = "SIM_TELARRAY_CONFIG_PATH='' "
+    assert gen.clear_default_sim_telarray_cfg_directories(command) == expected_output
+
+    # Test with a command containing special characters.
+    command = "run_simulation && echo 'done'"
+    expected_output = "SIM_TELARRAY_CONFIG_PATH='' run_simulation && echo 'done'"
+    assert gen.clear_default_sim_telarray_cfg_directories(command) == expected_output


### PR DESCRIPTION
A general function is added to do this in order to avoid a bit of code duplication with a hardcoded command. It might also be needed to expand in the future, so it is easier this way.

Closes #1132 