### PR TITLE
Schema validation bug fixes.

### DIFF
--- a/src/simtools/applications/validate_file_using_schema.py
+++ b/src/simtools/applications/validate_file_using_schema.py
@@ -116,7 +116,7 @@ def _get_schema_file_name(args_dict, data_dict=None):
     return schema_file
 
 
-def _get_file_list(file_directory=None, file_name=None):
+def _get_json_file_list(file_directory=None, file_name=None):
     """Return list of json files in a directory."""
     file_list = []
     if file_directory is not None:
@@ -137,7 +137,9 @@ def validate_schema(args_dict, logger):
     the metadata section of the data dictionary.
 
     """
-    for file_name in _get_file_list(args_dict.get("file_directory"), args_dict.get("file_name")):
+    for file_name in _get_json_file_list(
+        args_dict.get("file_directory"), args_dict.get("file_name")
+    ):
         try:
             data = gen.collect_data_from_file(file_name=file_name)
         except FileNotFoundError as exc:
@@ -155,7 +157,7 @@ def validate_data_files(args_dict, logger):
     """Validate data files."""
     if args_dict.get("file_directory") is not None:
         tmp_args_dict = {}
-        for file_name in _get_file_list(args_dict.get("file_directory")):
+        for file_name in _get_json_file_list(args_dict.get("file_directory")):
             tmp_args_dict["file_name"] = file_name
             parameter_name = re.sub(r"-\d+\.\d+\.\d+", "", file_name.stem)
             schema_file = MODEL_PARAMETER_SCHEMA_PATH / f"{parameter_name}.schema.yml"

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -25,14 +25,19 @@ definitions:
         type: boolean
         description: "This parameter is a file."
       instrument:
-        type: string
+        type:
+          - string
+          - "null"
         description: "Associated instrument."
       site:
-        type: string
+        type:
+          - string
+          - "null"
         description: "Associated CTAO site."
         enum:
           - North
           - South
+          - null
       type:
         type: string
         description: "Data type"

--- a/tests/resources/model_parameters/mirror_list.json
+++ b/tests/resources/model_parameters/mirror_list.json
@@ -1,5 +1,6 @@
 {
     "schema_version": "0.2.0",
+    "parameter": "mirror_list",
     "instrument": "LSTN-01",
     "site": "North",
     "parameter_version": "2.0.0",


### PR DESCRIPTION
**Important: this PR merges into db-simulation-model-refactoring**

This PR addresses the following points for `simtools-validate-file-using-schema`

- raise 'FileNotFoundError" when no files are found using the command line option `--file_directory` (which tells the code to validate all json files in this directory)
- allow for 'None' for entries 'site' and 'instrument' (e.g., most `configuration_corsika` parameters are site and instrument independent)
- fix missing name in test file for `mirror_list`