### PR TITLE
Correct branch to main for simulation model upload

### DIFF
--- a/database_scripts/upload_from_model_repository_to_db.sh
+++ b/database_scripts/upload_from_model_repository_to_db.sh
@@ -6,7 +6,7 @@
 # shellcheck disable=SC1091
 
 DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models.git"
-DB_SIMULATION_MODEL_BRANCH="prod5-prod6-corrections"
+DB_SIMULATION_MODEL_BRANCH="main"
 
 # Check that this script is not sourced but executed
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then


### PR DESCRIPTION
The 'developer' script to upload the simulation model to the database is first cloning the [Simulation Models](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models) repository. 

I forgot to change the branch to 'main' after the merge of prod5/prod6 corrections into main.