### PR TITLE
Remove sandboxes

### DIFF
--- a/src/simtools/applications/db_add_file_to_db.py
+++ b/src/simtools/applications/db_add_file_to_db.py
@@ -18,8 +18,7 @@
         A directory with files to upload to the DB. \
         All files in the directory with a predefined list of extensions will be uploaded.
     db (str)
-        The DB to insert the files to. \
-        The choices are either the default CTA simulation DB or a sandbox for testing.
+        The DB to insert the files to.
 
     Example
     -------

--- a/src/simtools/applications/db_add_value_from_json_to_db.py
+++ b/src/simtools/applications/db_add_value_from_json_to_db.py
@@ -10,8 +10,7 @@ r"""
     db_collection (str, required)
         The DB collection to which to add the file.
     db (str)
-        The DB to insert the files to. \
-        The choices are either the default CTA simulation DB or a sandbox for testing.
+        The DB to insert the files to.
 
     Example
     -------

--- a/src/simtools/applications/db_get_file_from_db.py
+++ b/src/simtools/applications/db_get_file_from_db.py
@@ -67,7 +67,6 @@ def main():  # noqa: D103
     db = db_handler.DatabaseHandler(mongo_db_config=db_config)
     available_dbs = [
         db_config["db_simulation_model"],
-        "sandbox",
     ]
     file_id = {}
     for db_name in available_dbs:

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -700,6 +700,7 @@ class DatabaseHandler:
             return file_system.find_one(  # pylint: disable=protected-access
                 {"filename": kwargs["filename"]}
             )._id
+        self._logger.debug(f"Writing file to DB: {file_name}")
         with open(file_name, "rb") as data_file:
             return file_system.put(data_file, **kwargs)
 

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -2,7 +2,6 @@
 
 import copy
 import logging
-import uuid
 from pathlib import Path
 from unittest.mock import call
 
@@ -16,24 +15,13 @@ logger = logging.getLogger()
 
 
 @pytest.fixture(autouse=True)
-def reset_db_client(random_id):
+def reset_db_client():
     """Reset db_client before each test."""
     # If using the class-level db_client:
     db_handler.DatabaseHandler.db_client = None
     yield  # allows the test to run
-    logger.info(f"dropping sandbox_{random_id} collections")
-    if db_handler.DatabaseHandler.db_client is not None:
-        db_handler.DatabaseHandler.db_client[f"sandbox_{random_id}"]["telescopes"].drop()
-        db_handler.DatabaseHandler.db_client[f"sandbox_{random_id}"]["calibration_devices"].drop()
-        db_handler.DatabaseHandler.db_client[f"sandbox_{random_id}"]["sites"].drop()
-
     # After the test, reset any side-effects (if necessary):
     db_handler.DatabaseHandler.db_client = None
-
-
-@pytest.fixture
-def random_id():
-    return uuid.uuid4().hex
 
 
 @pytest.fixture
@@ -80,15 +68,6 @@ def validate_model_parameter():
 @pytest.fixture
 def mock_gridfs(mocker):
     return mocker.patch("simtools.db.db_handler.gridfs.GridFS")
-
-
-@pytest.fixture
-def _db_cleanup_file_sandbox(db_no_config_file, random_id, fs_files):
-    yield
-    # Cleanup
-    logger.info("Dropping the temporary files in the sandbox")
-    db_no_config_file.db_client[f"sandbox_{random_id}"]["fs.chunks"].drop()
-    db_no_config_file.db_client[f"sandbox_{random_id}"][fs_files].drop()
 
 
 def test_set_up_connection_no_config():


### PR DESCRIPTION
**Note: merges into [db-simulation-model-refactoring](https://github.com/gammasim/simtools/tree/db-simulation-model-refactoring) branch - the 3 integration tests fails until PR #1319 is reviewed an merged**

I have carefully looked through the tests for db_handler and we don't use any sandboxes anymore. I therefore remove all related code.