### PR TITLE
Add schema for fake mirror list

### DIFF
--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -322,6 +322,7 @@ definitions:
       - ValidateArrayElementCoordinates
       - ValidateAtmosphericModel
       - ValidateCameraChargeResponse
+      - ValidateCameraEfficiency
       - ValidateCameraGainsAndEfficiency
       - ValidateCameraGeometry
       - ValidateCameraLinearity

--- a/src/simtools/schemas/model_parameters/fake_mirror_list.schema.yml
+++ b/src/simtools/schemas/model_parameters/fake_mirror_list.schema.yml
@@ -1,0 +1,33 @@
+%YAML 1.2
+---
+title: Schema for fake_mirror_list model parameter
+version: 0.1.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+developer_note: To be replaced by a data table
+name: fake_mirror_list
+short_description: Fake mirror list to be used for camera efficiency calculations ('testeff' program).
+description: |-
+  Fake mirror list to be used for camera efficiency calculations ('testeff' program).
+  Allows to obtain realistic distributions of the photon incidence angles on the camera plan.
+  Not to be used for actual simulations.
+data:
+  - type: file
+    unit: dimensionless
+    default: None
+instrument:
+  class: Structure
+  type:
+    - SSTS
+    - SCTS
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+    - ValidateCameraEfficiency
+source:
+  - Initial instrument setup
+simulation_software:
+  - name: sim_telarray

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -73,7 +73,6 @@ def test_exporting_config_files(db_config, io_handler, model_version):
         "CTA-North-LSTN-01-" + model_version + test_cfg,
         "CTA-North-MSTN-01-" + model_version + test_cfg,
         "CTA-test_layout-North-" + model_version + test_cfg,
-        "array_coordinates_LaPalma_alpha.dat",
         "NectarCAM_lightguide_efficiency_POP_131019.dat",
         "Pulse_template_nectarCam_17042020-noshift.dat",
         "array_triggers.dat",


### PR DESCRIPTION
Add model parameter schema for the `fake mirror list` (see also Simulation-ModelParameters merge request: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/5

Addresses partly #1155 (missing is the change of the testeff call.