### PR TITLE
Update testeff command for SSTs/SCTs to use fake mirror list

### DIFF
--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -78,7 +78,7 @@ class SimtelConfigWriter:
             file.write("#endif\n\n")
 
             for _simtel_name, value in parameters.items():
-                if _simtel_name.startswith("array_trigger"):
+                if _simtel_name.startswith("array_trigger") or _simtel_name == "fake_mirror_list":
                     continue  # array trigger is a site parameter, not a telescope parameter
                 if _simtel_name:
                     file.write(f"{_simtel_name} = {self._get_value_string_for_simtel(value)}\n")

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -78,8 +78,10 @@ class SimtelConfigWriter:
             file.write("#endif\n\n")
 
             for _simtel_name, value in parameters.items():
+                # array trigger is a site parameter, not a telescope parameter
+                # fake_mirror_list is not a sim_telarray parameter (used for testeff only)
                 if _simtel_name.startswith("array_trigger") or _simtel_name == "fake_mirror_list":
-                    continue  # array trigger is a site parameter, not a telescope parameter
+                    continue
                 if _simtel_name:
                     file.write(f"{_simtel_name} = {self._get_value_string_for_simtel(value)}\n")
             _config_meta = self._get_simtel_metadata("telescope")

--- a/src/simtools/simtel/simulator_camera_efficiency.py
+++ b/src/simtools/simtel/simulator_camera_efficiency.py
@@ -135,6 +135,8 @@ class SimulatorCameraEfficiency(SimtelRunner):
         command += f" {pixel_shape_cmd} {pixel_diameter}"
         if mirror_class == 0:
             command += f" -fmir {self._telescope_model.get_parameter_value('mirror_list')}"
+        if mirror_class == 2:
+            command += f" -fmir {self._telescope_model.get_parameter_value('fake_mirror_list')}"
         command += f" -fref {mirror_reflectivity}"
         if mirror_class == 2:
             command += " -m2"

--- a/src/simtools/testing/helpers.py
+++ b/src/simtools/testing/helpers.py
@@ -6,19 +6,12 @@ from pathlib import Path
 
 def skip_camera_efficiency(config):
     """Skip camera efficiency tests if the old version of testeff is used."""
-    if "camera-efficiency" in config["APPLICATION"]:
-        if not _new_testeff_version():
-            return (
-                "Any applications calling the old version of testeff are skipped "
-                "due to a limitation of the old testeff not allowing to specify "
-                "the include directory. Please update your sim_telarray tarball."
-            )
-        full_test_name = f"{config['APPLICATION']}_{config['TEST_NAME']}"
-        if "simtools-validate-camera-efficiency_SSTS" == full_test_name:
-            return (
-                "The test simtools-validate-camera-efficiency_SSTS is skipped "
-                "since the fake SST mirrors are not yet implemented (#1155)"
-            )
+    if "camera-efficiency" in config["APPLICATION"] and not _new_testeff_version():
+        return (
+            "Any applications calling the old version of testeff are skipped "
+            "due to a limitation of the old testeff not allowing to specify "
+            "the include directory. Please update your sim_telarray tarball."
+        )
     return None
 
 

--- a/tests/integration_tests/config/validate_camera_efficiency_ssts.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_ssts.yml
@@ -1,7 +1,6 @@
 CTA_SIMPIPE:
   APPLICATION: simtools-validate-camera-efficiency
   TEST_NAME: SSTS
-  MODEL_VERSION_USE_CURRENT: true
   CONFIGURATION:
     SITE: South
     TELESCOPE: SSTS-design

--- a/tests/unit_tests/testing/test_helpers.py
+++ b/tests/unit_tests/testing/test_helpers.py
@@ -55,16 +55,6 @@ def test_skip_camera_efficiency_new_testeff(new_testeff_version):
         helpers.skip_camera_efficiency(config)
 
 
-def test_skip_camera_efficiency_specific_test(new_testeff_version):
-    config = {
-        "APPLICATION": "simtools-validate-camera-efficiency",
-        "TEST_NAME": "SSTS",
-    }
-    with mock.patch(new_testeff_version, return_value=True):
-        skip_string = helpers.skip_camera_efficiency(config)
-        assert "fake SST mirrors" in skip_string
-
-
 def test_skip_camera_efficiency_not_camera_efficiency():
     config = {"APPLICATION": "other-application", "TEST_NAME": "some_test"}
     helpers.skip_camera_efficiency(config)


### PR DESCRIPTION
Fake mirror lists have been introduced with the new database structure. Adapt here the testeff command to use these for SCTs/SSTs/.

Note #1340, which fill make sure that the list of parameters to ignore in simtel_config_writer will not increase in future...

Closes #1155 