### PR TITLE
Add additional queries to db handler to retrieve model versions etc.

### DIFF
--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -238,7 +238,9 @@ class DatabaseHandler:
         -------
         dict containing the parameters
         """
-        model_versions = [model_version] or self.get_model_versions(collection)
+        model_versions = (
+            self.get_model_versions(collection) if model_version is None else [model_version]
+        )
 
         pars = {}
         for _model_version in model_versions:

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -449,6 +449,45 @@ class DatabaseHandler:
             "entry_date": ObjectId(post["_id"]).generation_time,
         }
 
+    def get_model_versions(self, collection_name="telescopes"):
+        """
+        Get list of model versions from the DB.
+
+        Parameters
+        ----------
+        collection_name: str
+            Name of the collection.
+
+        Returns
+        -------
+        list
+            List of model versions
+        """
+        collection = self.get_collection(self._get_db_name(), "production_tables")
+        return sorted(
+            [post["model_version"] for post in collection.find({"collection": collection_name})]
+        )
+
+    def get_array_elements(self, model_version, collection="telescopes"):
+        """
+        Get list array elements for a given model version and collection from the DB.
+
+        Parameters
+        ----------
+        model_version: str
+            Version of the model.
+        collection: str
+            Which collection to get the array elements from:
+            i.e. telescopes, calibration_devices.
+
+        Returns
+        -------
+        list
+            Sorted list of all array elements found in collection
+        """
+        production_table = self._read_production_table_from_mongo_db(collection, model_version)
+        return sorted([entry for entry in production_table["parameters"] if "-design" not in entry])
+
     def get_array_elements_of_type(self, array_element_type, model_version, collection):
         """
         Get array elements of a certain type (e.g. 'LSTN') for a DB collection.

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -215,8 +215,8 @@ class DatabaseHandler:
         self,
         site,
         array_element_name,
-        model_version,
         collection,
+        model_version=None,
     ):
         """
         Get model parameters using the model version.
@@ -229,8 +229,8 @@ class DatabaseHandler:
             Site name.
         array_element_name: str
             Name of the array element model (e.g. LSTN-01, MSTS-design, ILLN-01).
-        model_version: str
-            Version of the model.
+        model_version: str, list
+            Version(s) of the model.
         collection: str
             Collection of array element (e.g. telescopes, calibration_devices).
 
@@ -238,39 +238,48 @@ class DatabaseHandler:
         -------
         dict containing the parameters
         """
-        production_table = self._read_production_table_from_mongo_db(collection, model_version)
-        array_element_list = self._get_array_element_list(
-            array_element_name, site, production_table, collection
-        )
+        model_versions = [model_version] or self.get_model_versions(collection)
 
         pars = {}
-        for array_element in array_element_list:
-            cache_key, cache_dict = self._read_cache(
-                DatabaseHandler.model_parameters_cached,
-                names.validate_site_name(site) if site else None,
-                array_element,
-                model_version,
-                collection,
+        for _model_version in model_versions:
+            production_table = self._read_production_table_from_mongo_db(collection, _model_version)
+            array_element_list = self._get_array_element_list(
+                array_element_name, site, production_table, collection
             )
-            if cache_dict:
-                self._logger.debug(f"Found {array_element} in cache (key: {cache_key})")
-                pars.update(cache_dict)
-                continue
-            self._logger.debug(f"Did not find {array_element} in cache (key: {cache_key})")
-
-            try:
-                parameter_version_table = production_table["parameters"][array_element]
-            except KeyError:  # allow missing array elements (parameter dict is checked later)
-                continue
-            DatabaseHandler.model_parameters_cached[cache_key] = self._read_mongo_db(
-                query=self._get_query_from_parameter_version_table(
-                    parameter_version_table, array_element, site
-                ),
-                collection_name=collection,
-            )
-            pars.update(DatabaseHandler.model_parameters_cached[cache_key])
-
+            for array_element in array_element_list:
+                pars.update(
+                    self._get_parameter_for_model_version(
+                        array_element, _model_version, site, collection, production_table
+                    )
+                )
         return pars
+
+    def _get_parameter_for_model_version(
+        self, array_element, model_version, site, collection, production_table
+    ):
+        cache_key, cache_dict = self._read_cache(
+            DatabaseHandler.model_parameters_cached,
+            names.validate_site_name(site) if site else None,
+            array_element,
+            model_version,
+            collection,
+        )
+        if cache_dict:
+            self._logger.debug(f"Found {array_element} in cache (key: {cache_key})")
+            return cache_dict
+        self._logger.debug(f"Did not find {array_element} in cache (key: {cache_key})")
+
+        try:
+            parameter_version_table = production_table["parameters"][array_element]
+        except KeyError:  # allow missing array elements (parameter dict is checked later)
+            return {}
+        DatabaseHandler.model_parameters_cached[cache_key] = self._read_mongo_db(
+            query=self._get_query_from_parameter_version_table(
+                parameter_version_table, array_element, site
+            ),
+            collection_name=collection,
+        )
+        return DatabaseHandler.model_parameters_cached[cache_key]
 
     def get_collection(self, db_name, collection_name):
         """
@@ -549,7 +558,7 @@ class DatabaseHandler:
             return self.get_model_parameters(
                 None,
                 None,
-                model_version,
+                model_version=model_version,
                 collection="configuration_corsika",
             )
         if simulation_software == "simtel":
@@ -557,7 +566,7 @@ class DatabaseHandler:
                 self.get_model_parameters(
                     site,
                     array_element_name,
-                    model_version,
+                    model_version=model_version,
                     collection="configuration_sim_telarray",
                 )
                 if site and array_element_name

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -307,7 +307,7 @@ class ModelParameter:
 
         if self.name is not None:
             self._parameters = self.db.get_model_parameters(
-                self.site, self.name, self.model_version, self.collection
+                self.site, self.name, self.collection, self.model_version
             )
 
         if self.site is not None:
@@ -315,8 +315,8 @@ class ModelParameter:
                 self.db.get_model_parameters(
                     self.site,
                     None,
-                    self.model_version,
                     "sites",
+                    self.model_version,
                 )
             )
         self._load_simulation_software_parameter()

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -251,7 +251,7 @@ def test_get_model_parameters(db, mocker):
     model_version = "1.0.0"
     collection = "telescopes"
 
-    result = db.get_model_parameters(site, array_element_name, model_version, collection)
+    result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
     mock_get_production_table.assert_called_once_with(collection, model_version)
     mock_get_array_element_list.assert_called_once_with(
@@ -305,7 +305,7 @@ def test_get_model_parameters_with_cache(db, mocker):
     model_version = "1.0.0"
     collection = "telescopes"
 
-    result = db.get_model_parameters(site, array_element_name, model_version, collection)
+    result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
     mock_get_production_table.assert_called_once_with(collection, model_version)
     mock_get_array_element_list.assert_called_once_with(
@@ -336,7 +336,7 @@ def test_get_model_parameters_no_parameters(db, mocker):
     model_version = "1.0.0"
     collection = "telescopes"
 
-    result = db.get_model_parameters(site, array_element_name, model_version, collection)
+    result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
     mock_get_production_table.assert_called_once_with(collection, model_version)
     mock_get_array_element_list.assert_called_once_with(

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -1142,3 +1142,23 @@ def test_get_array_element_list_without_design_model_in_production_table(db, moc
 
     mock_get_array_element_type_from_name.assert_called_once_with(array_element_name)
     assert result == ["LSTN-design", "LSTN-01"]
+
+
+def test_get_model_versions(db):
+
+    model_versions = db.get_model_versions()
+    assert len(model_versions) > 0
+    assert "5.0.0" in model_versions
+    assert "6.0.0" in model_versions
+
+
+def test_get_array_elements(db):
+
+    prod5_elements = db.get_array_elements("5.0.0", "telescopes")
+    assert len(prod5_elements) > 0
+    assert "LSTN-01" in prod5_elements
+    assert "MSTN-101" not in prod5_elements
+    prod6_elements = db.get_array_elements("6.0.0", "telescopes")
+    assert "MSTN-101" in prod6_elements
+    prod6_calibration_devices = db.get_array_elements("6.0.0", "calibration_devices")
+    assert "ILLN-02" in prod6_calibration_devices


### PR DESCRIPTION
Additional database queries are required to generate the model parameter reports, see issue #1344 👍 

- return list of all available model versions in the DB: new `db_handler.get_model_versions()`
- return list of array elements / site for a given model version: new `db_handler.get_array_elements()` (default collection is `telescopes`, but can also be e.g. `calibration_devices`
- return all model parameters (all parameter versions) for a given array element: updated `db_handler.get_model_parameters()` and allow `model_version` to be `None` (or a list of model versions). If `None`, the parameters for all available model versions is returned.

Closes #1344 