### PR TITLE
Schema typos and URL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ simtools provides:
 simtools is one part of the CTAO Simulation Pipeline, which consist of the following components:
 
 - [CORSIKA](https://www.iap.kit.edu/corsika/) air shower simulation code and the [sim_telarray](https://www.mpi-hd.mpg.de/hfm/~bernlohr/sim_telarray/) telescope simulation code
-- [simulation model parameter](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters)
+- [simulation models](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models)
 - [databases](https://gammasim.github.io/simtools/databases.html), especially the model parameter database
 
 :::{note}

--- a/docs/source/user-guide/databases.md
+++ b/docs/source/user-guide/databases.md
@@ -3,7 +3,7 @@
 The simtools package uses a prototype MongoDB database to store the simulation model parameters.
 Access to the DB is handled via a dedicated API module ([db_handler](#dbhandler)).
 
-Simulation model parameters are stored in databases (see the [Simulation Model](model_parameters.md#simulation-model) section) and synced with the [CTAO model parameter repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters).
+Simulation model parameters are stored in databases (see the [Simulation Model](model_parameters.md#simulation-model) section) and synced with the [CTAO model repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models).
 
 ## Database structure
 
@@ -53,7 +53,7 @@ The mongoDB database can be accessed via the command-line interface `mongo` or v
 
 ## Update the database
 
-Model parameters should first be reviewed and accepted in the [model parameter repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters) before they are uploaded to the database (see the following sections on how to set up a local copy of the model parameter database for testing and development).
+Model parameters should first be reviewed and accepted in the [model repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models) before they are uploaded to the database (see the following sections on how to set up a local copy of the model parameter database for testing and development).
 
 :::{Danger}
 Updating the database is for experts only.
@@ -99,7 +99,7 @@ Note that database names are hardcoded in the scripts and need to be adjusted ac
 
 #### Option 2: Fill local database from model parameter repository
 
-The script `upload_from_model_repository_to_db.sh` uses the [model parameter repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters) from the CTAO gitlab and
+The script `upload_from_model_repository_to_db.sh` uses the [model repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models) from the CTAO gitlab and
 uploads its contents to the local database instance.
 
 Note that repository branches are hardcoded in the scripts and need to be adjusted accordingly.

--- a/docs/source/user-guide/model_parameters.md
+++ b/docs/source/user-guide/model_parameters.md
@@ -26,7 +26,7 @@ The {ref}`db_handler module <DBHANDLER>` provides reading and writing interfaces
 
 Simtools includes applications to write new model parameters to the databases and the export or import model parameters from sim_telarray configuration files (see following sections).
 
-Review and revision control of the simulation models uses the [model parameters gitlab repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters/-/blob/main/README.md?ref_type=heads). Simtools provides applications to read, write, and update the databases from this repository.
+Review and revision control of the simulation models uses a [gitlab repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models). Simtools provides applications to read, write, and update the databases from this repository.
 
 :::{Note}
 The simulation model is a central part of the CTAO Simulation Pipeline. The responsibility for the values and the correctness of the simulation model parameters is with the CTAO Simulation Team.
@@ -184,7 +184,7 @@ simulation_software:
 
 ## Data structure for model parameters
 
-The model parameters are stored in json-style in the [model repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/model_parameters) and database.
+The model parameters are stored in json-style in the [model repository](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models) and database.
 A typical model parameter file looks like:
 
 ```json
@@ -193,7 +193,7 @@ A typical model parameter file looks like:
     "parameter": "num_gains",
     "instrument": "LSTN-01",
     "site": "North",
-    "parameter_version": "6.0.0",
+    "parameter_version": "1.0.0",
     "unique_id": null,
     "value": 2,
     "unit": null,

--- a/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
@@ -7,7 +7,7 @@ meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/si
 meta_schema_version: 0.1.0
 name: array_element_position_utm
 description: |-
-  Position and alitutude of an array element (e.g., a telescope) in UTM coordinates.
+  Position and altitude of an array element (e.g., a telescope) in UTM coordinates.
 short_description: UTM coordinate position of an array element.
 data:
   - type: double

--- a/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: channels_per_chip
 description: |-
   Number of channels per readout chip.
-  Potentially useful for crosstalk calculations.
+  Potentially useful for cross-talk calculations.
 short_description: Number of channels per readout chip.
 data:
   - type: uint

--- a/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: fadc_compensate_pedestal
 description: |-
   Emulate FADC pedestal compensation (as e.g., done in camera firmware using FPGAs)
-  to homogenise significant pixel-to-pixel variations of raw pedestals values
+  to homogenize significant pixel-to-pixel variations of raw pedestals values
   (for high-gain channel for dual-gain readout).
   The resulting values are still unsigned integers and no rescaling takes place
   (pure integer pedestal offset). No compensation takes place for the default value

--- a/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: fadc_lg_compensate_pedestal
 description: |-
   Emulate FADC pedestal compensation (as e.g., done in camera firmware using FPGAs)
-  to homogenise significant pixel-to-pixel variations of raw pedestals values
+  to homogenize significant pixel-to-pixel variations of raw pedestals values
   (for low-gain channel for dual-gain readout).
   The resulting values are still unsigned integers and no rescaling takes place
   (pure integer pedestal offset). No compensation takes place for the default value

--- a/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -7,13 +7,13 @@ meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/si
 meta_schema_version: 0.1.0
 name: fadc_noise
 description: |-
-  Gaussian r.m.s. spread of white noise per time bin in digitisation
+  Gaussian r.m.s. spread of white noise per time bin in digitization
   (for high-gain channel, if different gains are used).
-short_description: Gaussian r.m.s. spread of white noise per time bin in digitisation.
+short_description: Gaussian r.m.s. spread of white noise per time bin in digitization.
 data:
   - type: double
     description: |-
-      Gaussian r.m.s. spread of white noise per time bin in digitisation
+      Gaussian r.m.s. spread of white noise per time bin in digitization
       (for high-gain channel in case of dual-readout chain)
     unit: count
     default: 4.0

--- a/src/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -7,9 +7,9 @@ meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/si
 meta_schema_version: 0.1.0
 name: laser_photons
 description: |-
-  Number of laser photons at each photodetector.
+  Number of laser photons at each photo detector.
 short_description: |-
-  Number of laser photons at each photodetector.
+  Number of laser photons at each photo detector.
 data:
   - type: double
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Mirror degradation factor for the secondary mirror (wavelength independent).
   Strictly interpreted as being for reflection on the secondary mirror of a
   dual-mirror telescope, and still gets applied in simulations where only
-  the reflection on the primary mirror is bypassd (for example a
+  the reflection on the primary mirror is bypassed (for example a
   flat-fielding light source illuminating the camera via reflection on the
   secondary).
 short_description: |-


### PR DESCRIPTION
This PR fixes typos in the schema files and updates url to the new simulation model repository in the simtools documentation.

Using 'aspell' to fix the typos.