### PR TITLE
Missing sphinx documentation

### DIFF
--- a/.github/workflows/CI-docs.yml
+++ b/.github/workflows/CI-docs.yml
@@ -52,15 +52,16 @@ jobs:
       - name: Check for complete API documentation
         run: |-
           MODULES=$(find src/simtools -type f -name "*.py" \
-            ! -path "src/simtools/applications/*" \
-            ! -name "__init__.py" ! -name "version.py" \
-            ! -path "src/simtools/_*" -prune)
-          FULLY_DOCUMENTED="TRUE"
-          for M in "${MODULES[@]}"; do
+          ! -path "src/simtools/applications/*" \
+          ! -name "__init__.py" \
+          ! -name "version.py" \
+          ! -path "src/simtools/_*" -prune)
+
+          for M in $MODULES; do
               module=$(basename "$M" .py)
               if ! grep -q "$module" docs/source/api-reference/*.md; then
-                echo "Undocumented module: $module"
-                FULLY_DOCUMENTED="FALSE"
+                  echo "Undocumented module: $module"
+                  FULLY_DOCUMENTED="FALSE"
               fi
           done
           if [[ "$FULLY_DOCUMENTED" = "FALSE" ]]; then

--- a/docs/source/api-reference/index.md
+++ b/docs/source/api-reference/index.md
@@ -17,6 +17,7 @@ io_operations
 job_execution
 array_layout
 mc_model
+production_configuration
 ray_tracing
 runners
 sim_telarray

--- a/docs/source/api-reference/io_operations.md
+++ b/docs/source/api-reference/io_operations.md
@@ -21,3 +21,12 @@ This module include I/O related functionality.
 .. automodule:: io_operations.hdf5_handler
    :members:
 ```
+
+(legacy-data-handler)-
+
+## legacy_data_handler
+
+```{eval-rst}
+.. automodule:: io_operations.legacy_data_handler
+   :members:
+```

--- a/docs/source/api-reference/production_configuration.md
+++ b/docs/source/api-reference/production_configuration.md
@@ -1,0 +1,43 @@
+(productionconfiguration)=
+
+# Production Configuration
+
+Modules provide functionality to configure a simulation production.
+This includes the derivation of energy, viewcone radius, and core scatter ranges and
+the calculation of the number of events to be simulated given a pre-determined metric.
+
+(calculate-statistical-errors-grid-point)=
+
+## calculate_statistical_errors_grid_point
+
+```{eval-rst}
+.. automodule:: production_configuration.calculate_statistical_errors_grid_point
+   :members:
+```
+
+(event-scaler)=
+
+## event_scaler
+
+```{eval-rst}
+.. automodule:: production_configuration.event_scaler
+   :members:
+```
+
+(generate-simulation-config)=
+
+## generate_simulation_config
+
+```{eval-rst}
+.. automodule:: production_configuration.generate_simulation_config
+   :members:
+```
+
+(interpolation-handler)=
+
+## interpolation_handler
+
+```{eval-rst}
+.. automodule:: production_configuration.interpolation_handler
+   :members:
+```

--- a/docs/source/api-reference/sim_telarray.md
+++ b/docs/source/api-reference/sim_telarray.md
@@ -22,6 +22,15 @@ Support modules for running sim_telarray.
    :members:
 ```
 
+## simtel_table_reader
+
+(simtel-table-reader-1)=
+
+```{eval-rst}
+.. automodule:: simtel.simtel_table_reader
+   :members:
+```
+
 ## simtel_io_events
 
 (simtel-io-events-1)=

--- a/docs/source/api-reference/visualization.md
+++ b/docs/source/api-reference/visualization.md
@@ -31,3 +31,13 @@ the visualization module.
 ```{eval-rst}
 .. automodule:: visualization.plot_camera
    :members:
+```
+
+(plot-tables)=
+
+## plot_tables
+
+```{eval-rst}
+.. automodule:: visualization.plot_tables
+   :members:
+```

--- a/src/simtools/production_configuration/calculate_statistical_errors_grid_point.py
+++ b/src/simtools/production_configuration/calculate_statistical_errors_grid_point.py
@@ -1,19 +1,12 @@
-"""
-Provides functionality to evaluate statistical uncertainties from DL2 MC event files.
-
-Classes
--------
-StatisticalErrorEvaluator
-    Handles error calculation for given DL2 MC event files and specified metrics.
-
-
-"""
+"""Evaluate statistical uncertainties from DL2 MC event files."""
 
 import logging
 
 import numpy as np
 from astropy import units as u
 from astropy.io import fits
+
+__all__ = ["StatisticalErrorEvaluator"]
 
 
 class StatisticalErrorEvaluator:
@@ -39,20 +32,7 @@ class StatisticalErrorEvaluator:
         metrics: dict[str, float],
         grid_point: tuple[float, float, float, float, float] | None = None,
     ):
-        """
-        Init the evaluator with a DL2 MC event file, its type, and metrics to calculate.
-
-        Parameters
-        ----------
-        file_path : str
-            The path to the DL2 MC event file.
-        file_type : str
-            The type of the file ('point-like' or 'cone').
-        metrics : dict, optional
-            Dictionary specifying which metrics to compute and their reference values.
-        grid_point : tuple, optional
-            Tuple specifying the grid point (energy, azimuth, zenith, NSB, offset).
-        """
+        """Init the evaluator with a DL2 MC event file, its type, and metrics to calculate."""
         self._logger = logging.getLogger(__name__)
         self.file_type = file_type
         self.metrics = metrics

--- a/src/simtools/production_configuration/event_scaler.py
+++ b/src/simtools/production_configuration/event_scaler.py
@@ -9,9 +9,7 @@ Scaling factors are calculated using error metrics and the evaluator's results.
 import astropy.units as u
 import numpy as np
 
-from simtools.production_configuration.calculate_statistical_errors_grid_point import (
-    StatisticalErrorEvaluator,
-)
+__all__ = ["EventScaler"]
 
 
 class EventScaler:
@@ -21,7 +19,7 @@ class EventScaler:
     Supports scaling both the entire dataset and specific grid points like energy values.
     """
 
-    def __init__(self, evaluator: StatisticalErrorEvaluator, science_case: str, metrics: dict):
+    def __init__(self, evaluator, science_case: str, metrics: dict):
         """
         Initialize the EventScaler with the evaluator, science case, and metrics.
 
@@ -45,15 +43,15 @@ class EventScaler:
         Parameters
         ----------
         return_sum : bool, optional
-            If `True`, returns the sum of scaled events for the entire set of MC events. If `False`,
-            returns the scaled events for each grid point along the energy axis. Default is `True`.
+            If True, returns the sum of scaled events for the entire set of MC events. If False,
+            returns the scaled events for each grid point along the energy axis. Default is True.
 
         Returns
         -------
         u.Quantity
-            If `return_sum` is `True`, returns the total scaled number of events as a `u.Quantity`.
-            If `return_sum` is `False`, returns an array of scaled events along the energy axis as
-            a `u.Quantity`.
+            If 'return_sum' is True, returns the total scaled number of events as a u.Quantity.
+            If 'return_sum' is False, returns an array of scaled events along the energy axis as
+            a u.Quantity.
         """
         scaling_factor = self._compute_scaling_factor()
 

--- a/src/simtools/production_configuration/generate_simulation_config.py
+++ b/src/simtools/production_configuration/generate_simulation_config.py
@@ -1,24 +1,11 @@
-"""
-Derives simulation configuration parameters for a specific grid point based on several metrics.
-
-Key Components:
----------------
-- `SimulationConfig`: Main class to handle simulation configuration for a grid point.
-  - Attributes:
-    - `grid_point` (dict): Contains azimuth, elevation, and night sky background.
-    - `ctao_data_level` (str): The data level for the simulation (e.g., 'A', 'B', 'C').
-    - `science_case` (str): The science case for the simulation.
-    - `file_path` (str): Path to the DL2 MC event file
-       used for statistical error evaluation.
-    - `file_type` (str): Type of the DL2 MC event file ('point-like' or 'cone').
-    - `metrics` (dict, optional): Dictionary of metrics to evaluate.
-
-"""
+"""Derives simulation configuration parameters for a grid point based on several metrics."""
 
 from simtools.production_configuration.calculate_statistical_errors_grid_point import (
     StatisticalErrorEvaluator,
 )
 from simtools.production_configuration.event_scaler import EventScaler
+
+__all__ = ["SimulationConfig"]
 
 
 class SimulationConfig:

--- a/src/simtools/production_configuration/interpolation_handler.py
+++ b/src/simtools/production_configuration/interpolation_handler.py
@@ -4,18 +4,15 @@ import astropy.units as u
 import numpy as np
 from scipy.interpolate import griddata
 
-from simtools.production_configuration.calculate_statistical_errors_grid_point import (
-    StatisticalErrorEvaluator,
-)
 from simtools.production_configuration.event_scaler import EventScaler
+
+__all__ = ["InterpolationHandler"]
 
 
 class InterpolationHandler:
     """Handle interpolation between multiple StatisticalErrorEvaluator instances."""
 
-    def __init__(
-        self, evaluators: list["StatisticalErrorEvaluator"], science_case: str, metrics: dict
-    ):
+    def __init__(self, evaluators, science_case: str, metrics: dict):
         self.evaluators = evaluators
         self.science_case = science_case
         self.metrics = metrics
@@ -157,7 +154,7 @@ class InterpolationHandler:
 
         return interpolated_threshold.item()
 
-    def plot_comparison(self, evaluator: "StatisticalErrorEvaluator"):
+    def plot_comparison(self, evaluator):
         """
         Plot a comparison between the simulated, scaled, and reconstructed events.
 


### PR DESCRIPTION
Any new module requires a corresponding markdown file in `docs/source/api-reference` and an entry in `docs/source/api-reference/index.md` (I realize that https://gammasim.github.io/simtools/developer-guide/documentation.html requires updates). We have a test that this is the case and e.g. [this one](https://github.com/gammasim/simtools/actions/runs/13284864252) is failing due to undocumented modules.

This PR adds missing documentation for some modules module (especially for production_configuration). I don't understand why tests didn't fail before (!?!) - I've checked the pull request and the tests where successful at this point. However, there seems to be a bug in the bash-style shell commands for the test; this is fixed in this PR.
 
These are the changes for this PR:

- introduction production configuration markdown file
- fix errors in docstrings to get sphinx compile without errors and warnings (note! This required to remove some type declaration from some of the functions in production_configuration modules. I've spent some time on trying to solve this, but sphinx does not accept these)
- removed duplication in module and class documentation
- added entries for legacy_data, plot_table, and simtel_table_reader
