### PR TITLE
Add fixed database version for testing

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -6,7 +6,7 @@ SIMTOOLS_DB_SERVER='cta-simpipe-protodb.zeuthen.desy.de' # MongoDB server
 SIMTOOLS_DB_API_USER=YOUR_USERNAME # username for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible person
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
-SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-ModelParameters-LATEST'
+SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-ModelParameters-v0-2-0'
 SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
 
 # The dashboards to monitor the MongoDB instance are in (accessible only from within DESY)

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -7,7 +7,6 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "CTAO-Simulation-ModelParameters-LATEST"
   SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:
@@ -19,7 +18,7 @@ on:
 
 jobs:
 
-  testbuilding:
+  test_building:
     # Build the package and check if it is installable
     # (tests among others that all components are there)
     runs-on: ubuntu-latest
@@ -39,8 +38,7 @@ jobs:
           python -m pip install --upgrade build
           python -m build
 
-  integrationtests:
-    # Run integration tests
+  integration_tests:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gammasim/simtools-dev:latest
@@ -63,8 +61,16 @@ jobs:
         run: |
           echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
 
+      - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
+        run: |
+          SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')
+          SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
+
       - name: Run integration tests
         shell: bash -l {0}
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
           source /workdir/env/bin/activate
           pip install -e '.[tests,dev,doc]'

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -97,7 +97,8 @@ jobs:
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |
           SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')
-          echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> $GITHUB_ENV
+          SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
       - name: Unit tests
         shell: bash -l {0}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Unit tests
         shell: bash -l {0}
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
           pytest --durations=10 --color=yes -n auto --dist loadscope \
             --cov=simtools --cov-report=xml
@@ -112,6 +114,8 @@ jobs:
       - name: Random order
         if: github.event_name == 'schedule' && contains(matrix.extra-args, 'random-order')
         shell: bash -l {0}
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
           pytest --color=yes -n auto --dist loadscope --count 5 --random-order
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -97,17 +97,13 @@ jobs:
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: echo "SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')" >> "$GITHUB_ENV"
 
-      - name: testing env
-        env:
-          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
-        run:
-          env
-
       - name: Unit tests
         shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=${SIMTOOLS_DB_SIMULATION_MODEL}"
+          export SIMTOOLS_DB_SIMULATION_MODEL
           pytest --durations=10 --color=yes -n auto --dist loadscope \
             --cov=simtools --cov-report=xml
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -105,7 +105,6 @@ jobs:
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
-          echo "SIMTOOLS_DB_SIMULATION_MODEL=${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}"
           pytest --durations=10 --color=yes -n auto --dist loadscope \
             --cov=simtools --cov-report=xml
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -95,15 +95,16 @@ jobs:
           pip install -e '.[tests,dev,doc]'
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
-        run: echo "SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')" >> "$GITHUB_ENV"
+        run: |
+          SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> $GITHUB_ENV
 
       - name: Unit tests
         shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
-          echo "SIMTOOLS_DB_SIMULATION_MODEL=${SIMTOOLS_DB_SIMULATION_MODEL}"
-          export SIMTOOLS_DB_SIMULATION_MODEL
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}"
           pytest --durations=10 --color=yes -n auto --dist loadscope \
             --cov=simtools --cov-report=xml
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -7,7 +7,6 @@ env:
   SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
   SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
   SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_DB_SIMULATION_MODEL: "CTAO-Simulation-ModelParameters-LATEST"
   SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
 on:
@@ -94,6 +93,9 @@ jobs:
         if: matrix.install-method == 'mamba'
         run: |
           pip install -e '.[tests,dev,doc]'
+
+      - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
+        run: echo "SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')" >> "$GITHUB_ENV"
 
       - name: Unit tests
         shell: bash -l {0}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -97,6 +97,12 @@ jobs:
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: echo "SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')" >> "$GITHUB_ENV"
 
+      - name: testing env
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+        run:
+          env
+
       - name: Unit tests
         shell: bash -l {0}
         env:


### PR DESCRIPTION
Fix database version to be used in unit and integration testing.

Add this to `.en_update` instead of "LATEST" and add steps to read this value in the unit and integration tests.

This is a temporary solution until we implemented a more consistent way of setting versions for databases and software. 

Closes #1364