### PR TITLE
Validate meta_schema_url

### DIFF
--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -120,9 +120,8 @@ def validate_dict_using_schema(data, schema_file=None, json_schema=None):
     except jsonschema.exceptions.ValidationError as exc:
         _logger.error(f"Validation failed using schema: {json_schema}")
         raise exc
-    if data.get("meta_schema_url"):
-        if not gen.url_exists(data["meta_schema_url"]):
-            raise FileNotFoundError(f"Schema file not found: {data['meta_schema_url']}")
+    if data.get("meta_schema_url") and not gen.url_exists(data["meta_schema_url"]):
+        raise FileNotFoundError(f"Schema file not found: {data['meta_schema_url']}")
 
     _logger.debug(f"Successful validation of data using schema ({json_schema.get('name')})")
 

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -120,6 +120,10 @@ def validate_dict_using_schema(data, schema_file=None, json_schema=None):
     except jsonschema.exceptions.ValidationError as exc:
         _logger.error(f"Validation failed using schema: {json_schema}")
         raise exc
+    if data.get("meta_schema_url"):
+        if not gen.url_exists(data["meta_schema_url"]):
+            raise FileNotFoundError(f"Schema file not found: {data['meta_schema_url']}")
+
     _logger.debug(f"Successful validation of data using schema ({json_schema.get('name')})")
 
 

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -121,7 +121,7 @@ def validate_dict_using_schema(data, schema_file=None, json_schema=None):
         _logger.error(f"Validation failed using schema: {json_schema}")
         raise exc
     if data.get("meta_schema_url") and not gen.url_exists(data["meta_schema_url"]):
-        raise FileNotFoundError(f"Schema file not found: {data['meta_schema_url']}")
+        raise FileNotFoundError(f"Meta schema URL does not exist: {data['meta_schema_url']}")
 
     _logger.debug(f"Successful validation of data using schema ({json_schema.get('name')})")
 

--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -25,6 +25,7 @@ definitions:
         description: "name of meta schema (e.g. simpipe-schema)"
       meta_schema_url:
         type: string
+        format: uri
         description: "url to meta schema definition"
       meta_schema_version:
         type: string

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -99,9 +99,8 @@ def url_exists(url):
     try:
         with urllib.request.urlopen(url, timeout=5) as response:
             return response.status == 200
-    except urllib.error.HTTPError as e:
-        return e.status == 200
-    except Exception:  # pylint: disable=broad-except
+    except (urllib.error.URLError, AttributeError) as e:
+        _logger.error(f"URL {url} does not exist: {e}")
         return False
 
 

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -82,6 +82,29 @@ def is_url(url):
         return False
 
 
+def url_exists(url):
+    """
+    Check if a URL exists.
+
+    Parameters
+    ----------
+    url: str
+        URL to be checked.
+
+    Returns
+    -------
+    bool
+        True if URL exists.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            return response.status == 200
+    except urllib.error.HTTPError as e:
+        return e.status == 200
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
 def collect_data_from_http(url):
     """
     Download yaml or json file from url and return it contents as dict.

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -85,7 +85,7 @@ def test_validate_dict_using_schema(tmp_test_directory, caplog):
     schema.validate_dict_using_schema(data, schema_file)
 
     data["meta_schema_url"] = "https://invalid_url"
-    with pytest.raises(FileNotFoundError, match=r"^Schema file not found:"):
+    with pytest.raises(FileNotFoundError, match=r"^Meta schema URL does not exist:"):
         schema.validate_dict_using_schema(data, schema_file)
 
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -17,6 +17,7 @@ import simtools.utils.general as gen
 from simtools.constants import MODEL_PARAMETER_METASCHEMA
 
 url_desy = "https://www.desy.de"
+url_simtools_main = "https://github.com/gammasim/simtools/"
 url_simtools = "https://raw.githubusercontent.com/gammasim/simtools/main/"
 
 
@@ -364,6 +365,11 @@ def test_is_url():
     assert gen.is_url(url) is False
 
     assert gen.is_url(5.0) is False
+
+
+def test_url_exists():
+    assert gen.url_exists(url_simtools_main)
+    assert not gen.url_exists(url_simtools)  # raw ULR does not exist
 
 
 def test_collect_data_dict_from_json():

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -367,10 +367,14 @@ def test_is_url():
     assert gen.is_url(5.0) is False
 
 
-def test_url_exists():
+def test_url_exists(caplog):
     assert gen.url_exists(url_simtools_main)
-    assert not gen.url_exists(url_simtools)  # raw ULR does not exist
-    assert not gen.url_exists(None)
+    with caplog.at_level(logging.ERROR):
+        assert not gen.url_exists(url_simtools)  # raw ULR does not exist
+    assert "does not exist" in caplog.text
+    with caplog.at_level(logging.ERROR):
+        assert not gen.url_exists(None)
+    assert "URL None" in caplog.text
 
 
 def test_collect_data_dict_from_json():

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -370,6 +370,7 @@ def test_is_url():
 def test_url_exists():
     assert gen.url_exists(url_simtools_main)
     assert not gen.url_exists(url_simtools)  # raw ULR does not exist
+    assert not gen.url_exists(None)
 
 
 def test_collect_data_dict_from_json():


### PR DESCRIPTION
Some of the metaschema urls have been incorrect in the past (especially after changes in names or directory structure). Add here a simple check to validate that the ULR of the metaschema ulr exists.

Closes #1269