### PR TITLE
Minor improvements to dev docs and conda

### DIFF
--- a/docs/source/developer-guide/maintainer_documentation.md
+++ b/docs/source/developer-guide/maintainer_documentation.md
@@ -30,3 +30,6 @@ To prepare a release, the following steps are required:
 ## Conda feedstock
 
 The conda feedstock for gammasimtools is [this repository](https://github.com/conda-forge/gammasimtools-feedstock).
+A new merge request is automatically created for new releases on pypi.
+
+New, updated, or removed command lines tools require manual modifications in the `recipe/meta.yaml` file.


### PR DESCRIPTION
Forgot this a couple of time, see the problem outlined in issue #1373.

Added one sentence to remind me that one actually has to modify the meta.yml file manually for any changes in the command line tools.

Closes #1373 (plus the fixes in the [gammasimtools-feedstock](https://github.com/conda-forge/gammasimtools-feedstock/pull/8) pull request).