### PR TITLE
Add module for dependency management

### DIFF
--- a/docs/changes/1383.feature.md
+++ b/docs/changes/1383.feature.md
@@ -1,0 +1,1 @@
+Add module for simtools dependency management. Allows to retrieve e.g. sim_telarray and CORSIKA versions.

--- a/docs/source/api-reference/dependencies.md
+++ b/docs/source/api-reference/dependencies.md
@@ -1,0 +1,21 @@
+(dependencymanagement)=
+
+# Dependency and version management.
+
+(dependencies)=
+
+## dependencies
+
+```{eval-rst}
+.. automodule:: dependencies
+   :members:
+```
+
+(version)=
+
+## version
+
+```{eval-rst}
+.. automodule:: version
+   :members:
+```

--- a/docs/source/api-reference/index.md
+++ b/docs/source/api-reference/index.md
@@ -12,6 +12,7 @@ camera
 configuration_module
 corsika
 data_model
+dependencies
 db_handler
 io_operations
 job_execution

--- a/src/simtools/dependencies.py
+++ b/src/simtools/dependencies.py
@@ -109,4 +109,4 @@ def get_build_options():
     except FileNotFoundError as exc:
         raise FileNotFoundError("No build_opts.yml file found.") from exc
     except TypeError as exc:
-        raise TypeError("SIMTEL_PATH not defined.") from exc
+        raise TypeError("SIMTOOLS_SIMTEL_PATH not defined.") from exc

--- a/src/simtools/dependencies.py
+++ b/src/simtools/dependencies.py
@@ -1,0 +1,112 @@
+"""
+Simtools dependencies version management.
+
+This modules provides two main functionalities:
+
+- retrieve the versions of simtools dependencies (e.g., databases, sim_telarray, CORSIKA)
+- provide space for future implementations of version management
+
+"""
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import simtools.utils.general as gen
+from simtools.db.db_handler import DatabaseHandler
+
+_logger = logging.getLogger(__name__)
+
+
+def get_version_string(db_config=None):
+    """Print the versions of the dependencies."""
+    return (
+        f"Database version: {get_database_version(db_config)}\n"
+        f"sim_telarray version: {get_sim_telarray_version()}\n"
+        f"CORSIKA version: {get_corsika_version()}\n"
+    )
+
+
+def get_database_version(db_config):
+    """
+    Get the version of the simulation model data base used.
+
+    Parameters
+    ----------
+    db_config : dict
+        Dictionary containing the database configuration.
+
+    Returns
+    -------
+    str
+        Version of the simulation model data base used.
+
+    """
+    if db_config is None:
+        return None
+    db = DatabaseHandler(db_config)
+    return db.mongo_db_config.get("db_simulation_model")
+
+
+def get_sim_telarray_version():
+    """
+    Get the version of the sim_telarray package using 'sim_telarray --version'.
+
+    Returns
+    -------
+    str
+        Version of the sim_telarray package.
+    """
+    sim_telarray_path = os.getenv("SIMTOOLS_SIMTEL_PATH")
+    if sim_telarray_path is None:
+        _logger.warning("Environment variable SIMTOOLS_SIMTEL_PATH is not set.")
+        return None
+    sim_telarray_path = Path(sim_telarray_path) / "bin" / "sim_telarray"
+
+    # expect stdout with e.g. a line 'Release: 2024.271.0 from 2024-09-27'
+    result = subprocess.run(
+        [sim_telarray_path, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    match = re.search(r"^Release:\s+(.+)", result.stdout, re.MULTILINE)
+
+    if match:
+        return match.group(1).split()[0]
+    raise ValueError(f"sim_telarray release not found in {result.stdout}")
+
+
+def get_corsika_version():
+    """
+    Get the version of the corsika package.
+
+    Returns
+    -------
+    str
+        Version of the corsika package.
+    """
+    try:
+        build_opts = get_build_options()
+    except (FileNotFoundError, TypeError):
+        _logger.warning("CORSIKA version not implemented yet.")
+        return None
+    return build_opts.get("corsika_version")
+
+
+def get_build_options():
+    """
+    Return CORSIKA / sim_telarray build options.
+
+    Expects a build_opts.yml file in the sim_telarray directory.
+    """
+    try:
+        return gen.collect_data_from_file(
+            Path(os.getenv("SIMTOOLS_SIMTEL_PATH")) / "build_opts.yml"
+        )
+    except FileNotFoundError as exc:
+        raise FileNotFoundError("No build_opts.yml file found.") from exc
+    except TypeError as exc:
+        raise TypeError("SIMTEL_PATH not defined.") from exc

--- a/tests/unit_tests/test_dependencies.py
+++ b/tests/unit_tests/test_dependencies.py
@@ -68,7 +68,7 @@ def test_get_sim_telarray_version_no_env_var(caplog, monkeypatch):
 
 
 def test_get_sim_telarray_version_no_release(monkeypatch):
-    monkeypatch.setenv("SIMTOOLS_SIMTEL_PATH", "/fake/path")
+    monkeypatch.setenv("SIMTOOLS_SIMTEL_PATH", "/fake/path_simtel")
     mock_result = mock.Mock()
     mock_result.stdout = "Some other output"
     mock_result.stderr = ""

--- a/tests/unit_tests/test_dependencies.py
+++ b/tests/unit_tests/test_dependencies.py
@@ -7,11 +7,6 @@ import pytest
 
 from simtools import dependencies
 from simtools.db.db_handler import DatabaseHandler
-from simtools.dependencies import (
-    get_corsika_version,
-    get_database_version,
-    get_sim_telarray_version,
-)
 
 
 def test_get_database_version_success():
@@ -20,7 +15,7 @@ def test_get_database_version_success():
     mock_db_handler.mongo_db_config = {"db_simulation_model": "v1.0.0"}
 
     with mock.patch("simtools.dependencies.DatabaseHandler", return_value=mock_db_handler):
-        assert get_database_version(db_config) == "v1.0.0"
+        assert dependencies.get_database_version(db_config) == "v1.0.0"
 
 
 def test_get_database_version_no_version():
@@ -29,21 +24,21 @@ def test_get_database_version_no_version():
     mock_db_handler.mongo_db_config = {}
 
     with mock.patch("simtools.dependencies.DatabaseHandler", return_value=mock_db_handler):
-        assert get_database_version(db_config) is None
+        assert dependencies.get_database_version(db_config) is None
 
 
 def test_get_corsika_version(caplog):
 
     # no build_opts.yml file
     with caplog.at_level(logging.WARNING):
-        assert get_corsika_version() is None
+        assert dependencies.get_corsika_version() is None
     assert "CORSIKA version not implemented yet." in caplog.text
 
     # mock get_build_options to return a dict
     with mock.patch(
         "simtools.dependencies.get_build_options", return_value={"corsika_version": "7.7"}
     ):
-        assert get_corsika_version() == "7.7"
+        assert dependencies.get_corsika_version() == "7.7"
 
 
 def test_get_sim_telarray_version_success(monkeypatch):
@@ -55,7 +50,7 @@ def test_get_sim_telarray_version_success(monkeypatch):
 
     subprocess_mock = "subprocess.run"
     with mock.patch(subprocess_mock, return_value=mock_result):
-        assert get_sim_telarray_version() == expected_version
+        assert dependencies.get_sim_telarray_version() == expected_version
 
     with mock.patch(subprocess_mock, return_value=mock_result):
         version_string = dependencies.get_version_string()
@@ -67,7 +62,7 @@ def test_get_sim_telarray_version_no_env_var(caplog, monkeypatch):
     monkeypatch.delenv("SIMTOOLS_SIMTEL_PATH", raising=False)
 
     with caplog.at_level(logging.WARNING):
-        assert get_sim_telarray_version() is None
+        assert dependencies.get_sim_telarray_version() is None
 
     assert "Environment variable SIMTOOLS_SIMTEL_PATH is not set." in caplog.text
 
@@ -80,7 +75,7 @@ def test_get_sim_telarray_version_no_release(monkeypatch):
 
     with mock.patch("subprocess.run", return_value=mock_result):
         with pytest.raises(ValueError, match="sim_telarray release not found in Some other output"):
-            get_sim_telarray_version()
+            dependencies.get_sim_telarray_version()
 
 
 def test_build_options(monkeypatch):

--- a/tests/unit_tests/test_dependencies.py
+++ b/tests/unit_tests/test_dependencies.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+
+import logging
+from unittest import mock
+
+import pytest
+
+from simtools import dependencies
+from simtools.db.db_handler import DatabaseHandler
+from simtools.dependencies import (
+    get_corsika_version,
+    get_database_version,
+    get_sim_telarray_version,
+)
+
+
+def test_get_database_version_success():
+    db_config = {"host": "localhost", "port": 27017}
+    mock_db_handler = mock.MagicMock(spec=DatabaseHandler)
+    mock_db_handler.mongo_db_config = {"db_simulation_model": "v1.0.0"}
+
+    with mock.patch("simtools.dependencies.DatabaseHandler", return_value=mock_db_handler):
+        assert get_database_version(db_config) == "v1.0.0"
+
+
+def test_get_database_version_no_version():
+    db_config = {"host": "localhost", "port": 27017}
+    mock_db_handler = mock.MagicMock(spec=DatabaseHandler)
+    mock_db_handler.mongo_db_config = {}
+
+    with mock.patch("simtools.dependencies.DatabaseHandler", return_value=mock_db_handler):
+        assert get_database_version(db_config) is None
+
+
+def test_get_corsika_version(caplog):
+
+    # no build_opts.yml file
+    with caplog.at_level(logging.WARNING):
+        assert get_corsika_version() is None
+    assert "CORSIKA version not implemented yet." in caplog.text
+
+    # mock get_build_options to return a dict
+    with mock.patch(
+        "simtools.dependencies.get_build_options", return_value={"corsika_version": "7.7"}
+    ):
+        assert get_corsika_version() == "7.7"
+
+
+def test_get_sim_telarray_version_success(monkeypatch):
+    monkeypatch.setenv("SIMTOOLS_SIMTEL_PATH", "/fake/path")
+    expected_version = "2024.271.0"
+    mock_result = mock.Mock()
+    mock_result.stdout = "Release: 2024.271.0 from 2024-09-27"
+    mock_result.stderr = ""
+
+    subprocess_mock = "subprocess.run"
+    with mock.patch(subprocess_mock, return_value=mock_result):
+        assert get_sim_telarray_version() == expected_version
+
+    with mock.patch(subprocess_mock, return_value=mock_result):
+        version_string = dependencies.get_version_string()
+        assert "Database version: None" in version_string
+        assert "sim_telarray version:" in version_string
+
+
+def test_get_sim_telarray_version_no_env_var(caplog, monkeypatch):
+    monkeypatch.delenv("SIMTOOLS_SIMTEL_PATH", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        assert get_sim_telarray_version() is None
+
+    assert "Environment variable SIMTOOLS_SIMTEL_PATH is not set." in caplog.text
+
+
+def test_get_sim_telarray_version_no_release(monkeypatch):
+    monkeypatch.setenv("SIMTOOLS_SIMTEL_PATH", "/fake/path")
+    mock_result = mock.Mock()
+    mock_result.stdout = "Some other output"
+    mock_result.stderr = ""
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        with pytest.raises(ValueError, match="sim_telarray release not found in Some other output"):
+            get_sim_telarray_version()
+
+
+def test_build_options(monkeypatch):
+    # no SIMTEL_PATH defined
+    with pytest.raises(TypeError, match="SIMTEL_PATH not defined"):
+        dependencies.get_build_options()
+    # SIMTEL_PATH defined, but no build_opts.yml file
+    monkeypatch.setenv("SIMTOOLS_SIMTEL_PATH", "/fake/path")
+    with pytest.raises(FileNotFoundError, match="No build_opts.yml file found."):
+        dependencies.get_build_options()
+
+    # mock gen.collect_data_from_file to return a dict
+    with mock.patch(
+        "simtools.dependencies.gen.collect_data_from_file", return_value={"corsika_version": "7.7"}
+    ):
+        build_opts = dependencies.get_build_options()
+        assert build_opts == {"corsika_version": "7.7"}


### PR DESCRIPTION
This modules provides two main functionalities:

- retrieve the versions of simtools dependencies (e.g., databases, sim_telarray, CORSIKA)
- provide space for future implementations of version management (e.g., this simtools version works only with certain combinations of sim_telarray / CORSIKA)

Best to look first at the unit test for the review.

Note that the `build_opts.yml` file is introduced with PR #1382.