### PR TITLE
Change checks for software updates from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"

--- a/.github/workflows/CI-software-update.yml
+++ b/.github/workflows/CI-software-update.yml
@@ -2,9 +2,9 @@ name: Software updates
 # Run regularly to update software dependencies
 
 on:
-  # every Monday at midnight
+   # Run on the first day of each month at midnight
   schedule:
-    - cron: "0 0 * * 1"
+    - cron: "0 0 1 * *"
   workflow_dispatch:
 
 jobs:

--- a/docs/changes/1394.maintenance.md
+++ b/docs/changes/1394.maintenance.md
@@ -1,0 +1,1 @@
+Change checks for software updates from weekly to monthly.


### PR DESCRIPTION
Two workflows are checking regularly for software updates:

- dependabot for github workflow actions
- CI-software-updatess for updates of pre-commit hooks.

Change interval from weekly to monthly with this PR. Weekly is too short and picks up too many minor / patch release. Try to avoid a bit of noise by moving to monthly.