### PR TITLE
Remove duplication in converting strings to lists

### DIFF
--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -766,18 +766,10 @@ class DataValidator:
         Converts strings to numerical values or lists of values, if required.
 
         """
-        value = self.data_dict["value"]
-        if not isinstance(value, str):
-            return
-
-        # assume float value if type is not defined
-        _is_float = self.data_dict.get("type", "float").startswith(("float", "double"))
-
-        if value.isnumeric():
-            self.data_dict["value"] = float(value) if _is_float else int(value)
-        else:
-            self.data_dict["value"] = gen.convert_string_to_list(value, is_float=_is_float)
-
+        self.data_dict["value"], _ = value_conversion.split_value_and_unit(
+            self.data_dict["value"],
+            "int" in self.data_dict.get("type", "float"),
+        )
         if self.data_dict["unit"] is not None:
             self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])
 

--- a/src/simtools/utils/value_conversion.py
+++ b/src/simtools/utils/value_conversion.py
@@ -87,7 +87,7 @@ def get_value_unit_type(value, unit_str=None):
     return base_value, _unit_as_string(base_unit), base_type
 
 
-def split_value_and_unit(value):
+def split_value_and_unit(value, is_integer=False):
     """
     Split a value into its value and unit.
 
@@ -98,6 +98,10 @@ def split_value_and_unit(value):
     ----------
     value: str, int, float, bool, u.Quantity
         Value to be parsed.
+    is_integer: bool
+        Flag to indicate if the value is an integer.
+
+    # TODO unit tests for is_integer
 
     Returns
     -------
@@ -107,9 +111,9 @@ def split_value_and_unit(value):
     if isinstance(value, u.Quantity):
         return _split_value_is_quantity(value)
     if isinstance(value, str):
-        return _split_value_is_string(value)
+        return _split_value_is_string(value, is_integer)
     if isinstance(value, list | np.ndarray):
-        return _split_value_is_list(value)
+        return _split_value_is_list(value, is_integer)
     return value, None
 
 
@@ -120,25 +124,27 @@ def _split_value_is_quantity(value):
     return value.value, str(value.unit)
 
 
-def _split_value_is_string(value):
+def _split_value_is_string(value, is_integer=False):
     """Split vale and unit for a string."""
     if value.isdigit():  # single integer value
         return int(value), None
     try:  # single value with/without unit
-        return u.Quantity(value).value, str(u.Quantity(value).unit)
+        return int(u.Quantity(value).value) if is_integer else u.Quantity(value).value, str(
+            u.Quantity(value).unit
+        )
     except ValueError:
-        return _split_value_is_list(gen.convert_string_to_list(value))
+        return _split_value_is_list(gen.convert_string_to_list(value), is_integer)
     except TypeError:  # string value (not numerical)
         return value, None
 
 
-def _split_value_is_list(value):
+def _split_value_is_list(value, is_integer=False):
     """Split value and unit for a list."""
     value_list = []
     unit_list = []
     for item in value:
         _value, _unit = split_value_and_unit(item)
-        value_list.append(_value)
+        value_list.append(int(_value) if is_integer else _value)
         if isinstance(_unit, str):
             unit_list.append(_unit)
         else:


### PR DESCRIPTION
Maintenance PR to remove duplication of how strings / units are converted to lists for sim_telarray string lists.

This code has been almost exactly duplicated in validate_data and value_conversion. Remove this duplication.