### PR TITLE
Fix bug in config reading from APPLICATIONS dict

### DIFF
--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -287,16 +287,14 @@ class Configurator:
             )
             # yaml parser adds \n in multiline strings, remove them
             _config_dict = gen.remove_substring_recursively_from_dict(_config_dict, substring="\n")
-            if "CTA_SIMPIPE" in _config_dict:
-                try:
-                    self._fill_from_config_dict(
-                        input_dict=gen.change_dict_keys_case(
-                            _config_dict["CTA_SIMPIPE"]["CONFIGURATION"],
-                        ),
-                        overwrite=True,
-                    )
-                except KeyError:
-                    self._logger.info(f"No CTA_SIMPIPE:CONFIGURATION dict found in {config_file}.")
+            # read configuration for first application
+            if "CONFIGURATION" in _config_dict.get("CTA_SIMPIPE", {}).get("APPLICATIONS", [{}])[0]:
+                self._fill_from_config_dict(
+                    input_dict=gen.change_dict_keys_case(
+                        _config_dict["CTA_SIMPIPE"]["APPLICATIONS"][0]["CONFIGURATION"],
+                    ),
+                    overwrite=True,
+                )
             else:
                 self._fill_from_config_dict(
                     input_dict=gen.change_dict_keys_case(_config_dict), overwrite=True

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -108,7 +108,9 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
         "output_path": "./abc/",
         "test": True,
     }
-    _tmp_dict_workflow = {"CTA_SIMPIPE": {"CONFIGURATION": _tmp_dict}}
+    _tmp_dict_workflow = {
+        "CTA_SIMPIPE": {"APPLICATIONS": [{"APPLICATION": "test", "CONFIGURATION": _tmp_dict}]}
+    }
     _workflow_file = tmp_test_directory / "configuration-test.yml"
     with open(_workflow_file, "w") as output:
         yaml.safe_dump(_tmp_dict_workflow, output, sort_keys=False)
@@ -124,17 +126,6 @@ def test_fill_from_workflow_config_file(configurator, args_dict, tmp_test_direct
             else:
                 _tmp_config[key] = value
     assert _tmp_config == configurator.config
-
-    # test that no KeyError is raised for "CTA_SIMPIPE:NO_CONFIGURATION"
-    _tmp_dict_workflow = {"CTA_SIMPIPE": {"NO_CONFIGURATION": _tmp_dict}}
-    _workflow_file = tmp_test_directory / "configuration-test-2.yml"
-    with open(_workflow_file, "w") as output:
-        yaml.safe_dump(_tmp_dict_workflow, output, sort_keys=False)
-    configurator.config["config"] = str(_workflow_file)
-    _tmp_config["config"] = str(_workflow_file)
-    configurator.config["output_path"] = None
-    # no KeyError
-    configurator._fill_from_config_file(_workflow_file)
 
 
 def test_initialize_io_handler(configurator, tmp_test_directory):


### PR DESCRIPTION
PR #1389 introduced an additional level in the definition of application config files (`APPLICATIONS`). There is a bug in the implementation which is fixed with this PR: the possibility to run any simtools using a config file instead specifying all command line options was broken (meaning e.g., `simtools-derive-photon-electron-spectrum --config my_config.yml`). 

Code was also simplified - no KEYERROR is now issued and therefore the unit test can be shortened.

Note that this expect that there is only one application config defined in the configuration files (there is another PR open #1379 , which introduces the possibility to run several applications). An example of a configuration file is:

```
CTA_SIMPIPE:
  APPLICATIONS:
  - APPLICATION: simtools-derive-photon-electron-spectrum
    TEST_NAME: LST_legacy_format
    CONFIGURATION:
      INPUT_SPECTRUM: ./tests/resources/SinglePhe_spectrum_totalfit_19pixel-average_20200601.csv
      AFTERPULSE_SPECTRUM: ./tests/resources/LST_afterpulses.dat
      STEP_SIZE: 0.02
      USE_NORM_SPE: true
      OUTPUT_PATH: simtools-output
      OUTPUT_FILE: test_single_pe_lst.ecsv
      USE_PLAIN_OUTPUT_PATH: true
      LOG_LEVEL: DEBUG
```

