### PR TITLE
Set user in docker images and add possibility to add user information from env/command line

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -8,6 +8,10 @@ SIMTOOLS_DB_API_PW=YOUR_PASSWORD # Password for MongoDB: ask the responsible per
 SIMTOOLS_DB_API_AUTHENTICATION_DATABASE='admin'
 SIMTOOLS_DB_SIMULATION_MODEL='CTAO-Simulation-ModelParameters-v0-4-0'
 SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'
+SIMTOOLS_USER_NAME='simtools-user'
+SIMTOOLS_USER_ORGANIZATION='CTAO'
+SIMTOOLS_USER_EMAIL="default@email.org"
+SIMTOOLS_USER_ORCID='0000-0000-0000-0000'
 
 # The dashboards to monitor the MongoDB instance are in (accessible only from within DESY)
 # https://statspub.zeuthen.desy.de/d/4vXnWwMGz/mongodb?orgId=1&refresh=30s

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -24,4 +24,7 @@ ENV SIMTEL_PATH="/workdir/sim_telarray/"
 ENV PATH="/workdir/simtools/env/bin/:$PATH"
 SHELL ["/bin/bash", "-c"]
 
+RUN useradd --create-home --system --user-group ctao
+USER ctao
+
 WORKDIR /workdir/external

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -20,6 +20,9 @@ RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \
     pip install --no-cache-dir ./simtools && \
     rm -rf simtools
 
+RUN useradd --create-home --system --user-group ctao
+USER ctao
+
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 ENV PATH="/workdir/env/bin/:$PATH"
 SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -98,6 +98,9 @@ RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \
     pip install --no-cache-dir ./simtools && \
     rm -rf simtools
 
+RUN useradd --create-home --system --user-group ctao
+USER ctao
+
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 ENV PATH="/workdir/env/bin/:$PATH"
 SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -49,4 +49,7 @@ RUN cprog=$(/bin/ls /workdir/sim_telarray/corsika-run/corsika*$(uname)_* 2>/dev/
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 
+RUN useradd --create-home --system --user-group ctao
+USER ctao
+
 SHELL ["/bin/bash", "-c"]

--- a/docs/changes/1400.feature.md
+++ b/docs/changes/1400.feature.md
@@ -1,0 +1,1 @@
+Set user in docker images and add possibility to add user information from env/command line.

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -70,6 +70,7 @@ class CommandLineParser(argparse.ArgumentParser):
             self.initialize_output_arguments()
         self.initialize_config_files()
         self.initialize_application_execution_arguments()
+        self.initialize_user_arguments()
 
     def initialize_config_files(self):
         """Initialize configuration files."""
@@ -173,6 +174,34 @@ class CommandLineParser(argparse.ArgumentParser):
         )
         _job_group.add_argument(
             "--version", action="version", version=f"%(prog)s {simtools.version.__version__}"
+        )
+
+    def initialize_user_arguments(self):
+        """Initialize user arguments."""
+        _job_group = self.add_argument_group("user")
+        _job_group.add_argument(
+            "--user_name",
+            help="user name",
+            type=str,
+            required=False,
+        )
+        _job_group.add_argument(
+            "--user_organization",
+            help="user organization",
+            type=str,
+            required=False,
+        )
+        _job_group.add_argument(
+            "--user_email",
+            help="user email",
+            type=str,
+            required=False,
+        )
+        _job_group.add_argument(
+            "--user_orcid",
+            help="user ORCID",
+            type=str,
+            required=False,
         )
 
     def initialize_db_config_arguments(self):

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -199,9 +199,10 @@ class MetadataCollector:
         contact_dict: dict
             Dictionary for contact metadata fields.
         """
-        contact_dict["name"] = (
-            contact_dict.get("name") or self.args_dict.get("user_name") or getpass.getuser()
-        )
+        contact_dict["name"] = contact_dict.get("name") or self.args_dict.get("user_name")
+        if contact_dict["name"] is None:
+            self._logger.warning("No user name provided, take user info from system level.")
+            contact_dict["name"] = getpass.getuser()
         meta_dict = {
             "email": "user_mail",
             "orcid": "user_orcid",

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -199,8 +199,16 @@ class MetadataCollector:
         contact_dict: dict
             Dictionary for contact metadata fields.
         """
-        if contact_dict.get("name", None) is None:
-            contact_dict["name"] = getpass.getuser()
+        contact_dict["name"] = (
+            contact_dict.get("name") or self.args_dict.get("user_name") or getpass.getuser()
+        )
+        meta_dict = {
+            "email": "user_mail",
+            "orcid": "user_orcid",
+            "organization": "user_organization",
+        }
+        for key, value in meta_dict.items():
+            contact_dict[key] = contact_dict.get(key) or self.args_dict.get(value)
 
     def _fill_context_meta(self, context_dict):
         """

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -154,6 +154,7 @@ def test_initialize_default_arguments():
             "paths",
             "configuration",
             "execution",
+            "user",
         ]
 
     _parser_2 = parser.CommandLineParser()

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -210,7 +210,11 @@ def test_get_db_parameters_from_env(configurator, args_dict):
     args_dict["db_api_authentication_database"] = "admin"
     args_dict["db_simulation_model"] = "sim_model"
 
-    assert configurator.config == args_dict
+    # remove user defined parameters from comparison (depends on environment)
+    expected_config = {k: v for k, v in args_dict.items() if not k.startswith("user_")}
+    actual_config = {k: v for k, v in configurator.config.items() if not k.startswith("user_")}
+
+    assert expected_config == actual_config
 
 
 def test_initialize_output(configurator):

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -90,10 +90,13 @@ def test_get_top_level_metadata(args_dict_site):
     assert top_level_meta["cta"]["activity"]["end"] > top_level_meta["cta"]["activity"]["start"]
 
 
-def test_fill_contact_meta(args_dict_site):
+def test_fill_contact_meta(args_dict_site, caplog):
     contact_dict = {}
     collector = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     collector._fill_contact_meta(contact_dict)
+    with caplog.at_level(logging.WARNING):
+        collector._fill_contact_meta(contact_dict)
+    assert "No user name provided, take user info from system level." in caplog.text
     assert contact_dict["name"] == getpass.getuser()
 
 


### PR DESCRIPTION
Add two related items:

- default user in all docker containers is now `ctao` and not `root`
- add possibility to add user information, which is used for a more complete collection of the metadata information:

```
user:
  --user_name USER_NAME
                        user name (default: None)
  --user_organization USER_ORGANIZATION
                        user organization (default: None)
  --user_email USER_EMAIL
                        user email (default: None)
  --user_orcid USER_ORCID
                        user ORCID (default: None)
```

These values can also be specified in your `.env` file:

```
SIMTOOLS_USER_NAME='G.Maier'
SIMTOOLS_USER_ORCID='0000-0001-9868-4700'
```