### PR TITLE
Remove black from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,4 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
-        args: ["--line-length=100"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff
     rev: v0.9.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,6 @@ exclude = [ "simtools._dev_version.*" ]
 [tool.setuptools_scm]
 write_to = "src/simtools/_version.py"
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 line-length = 100
 indent-width = 4


### PR DESCRIPTION
 Duplication with ruff, not needed. Also possibly introduces issues, then two code formatting tools are applied (and they disagree).