### PR TITLE
Refactor this function to reduce its Cognitive Complexity in `simtools.testing.validate_output`

### DIFF
--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -37,17 +37,7 @@ def validate_application_output(config, from_command_line=None, from_config_file
         _logger.info(f"Testing application output: {integration_test}")
 
         if from_command_line == from_config_file:
-            if "REFERENCE_OUTPUT_FILE" in integration_test:
-                _validate_reference_output_file(config, integration_test)
-
-            if "TEST_OUTPUT_FILES" in integration_test:
-                _validate_output_path_and_file(config, integration_test["TEST_OUTPUT_FILES"])
-
-            if "OUTPUT_FILE" in integration_test:
-                _validate_output_path_and_file(
-                    config,
-                    [{"PATH_DESCRIPTOR": "OUTPUT_PATH", "FILE": integration_test["OUTPUT_FILE"]}],
-                )
+            _validate_output_files(config, integration_test)
 
             if "FILE_TYPE" in integration_test:
                 assert assertions.assert_file_type(
@@ -57,6 +47,19 @@ def validate_application_output(config, from_command_line=None, from_config_file
                     ),
                 )
         _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file)
+
+
+def _validate_output_files(config, integration_test):
+    """Validate output files."""
+    if "REFERENCE_OUTPUT_FILE" in integration_test:
+        _validate_reference_output_file(config, integration_test)
+    if "TEST_OUTPUT_FILES" in integration_test:
+        _validate_output_path_and_file(config, integration_test["TEST_OUTPUT_FILES"])
+    if "OUTPUT_FILE" in integration_test:
+        _validate_output_path_and_file(
+            config,
+            [{"PATH_DESCRIPTOR": "OUTPUT_PATH", "FILE": integration_test["OUTPUT_FILE"]}],
+        )
 
 
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):


### PR DESCRIPTION
Address sonar complaint on code complexity, see [here](https://sonar-cta-dpps.zeuthen.desy.de/project/issues?files=src%2Fsimtools%2Ftesting%2Fvalidate_output.py&open=AZSqYadpGE3VkZNQVSCl&resolved=false&why=1&id=gammasim_simtools_AY_ssha9WiFxsX-2oy_w). This is a trivial fix and moved simply some code into a separate function for improved readability.