### PR TITLE
Fix date writing to ensure ISO date format

### DIFF
--- a/docs/changes/1411.bugfix.md
+++ b/docs/changes/1411.bugfix.md
@@ -1,0 +1,1 @@
+Fix date writing to ensure ISO-conform date format.

--- a/docs/changes/1411.bugfix.md
+++ b/docs/changes/1411.bugfix.md
@@ -1,1 +1,1 @@
-Fix date writing to ensure ISO-conform date format.
+Fix date writing to ensure  RFC 3339-conform date format.

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -98,7 +98,7 @@ class MetadataCollector:
         try:
             self.top_level_meta[self.observatory]["activity"][
                 "end"
-            ] = gen.now_in_date_time_isoformat()
+            ] = gen.now_date_time_in_isoformat()
         except KeyError:
             pass
         return self.top_level_meta
@@ -335,7 +335,7 @@ class MetadataCollector:
         self.schema_dict = self.get_data_model_schema_dict()
 
         product_dict["id"] = str(uuid.uuid4())
-        product_dict["creation_time"] = gen.now_in_date_time_isoformat()
+        product_dict["creation_time"] = gen.now_date_time_in_isoformat()
         product_dict["description"] = self.schema_dict.get("description", None)
 
         # DATA:CATEGORY
@@ -403,7 +403,7 @@ class MetadataCollector:
         activity_dict["name"] = self.args_dict.get("label", None)
         activity_dict["type"] = "software"
         activity_dict["id"] = self.args_dict.get("activity_id", "UNDEFINED_ACTIVITY_ID")
-        activity_dict["start"] = gen.now_in_date_time_isoformat()
+        activity_dict["start"] = gen.now_date_time_in_isoformat()
         activity_dict["end"] = activity_dict["start"]
         activity_dict["software"]["name"] = "simtools"
         activity_dict["software"]["version"] = simtools.version.__version__

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -6,7 +6,6 @@ implementation of the observatory metadata model.
 
 """
 
-import datetime
 import getpass
 import logging
 import uuid
@@ -99,7 +98,7 @@ class MetadataCollector:
         try:
             self.top_level_meta[self.observatory]["activity"][
                 "end"
-            ] = datetime.datetime.now().isoformat(timespec="seconds")
+            ] = gen.now_in_date_time_isoformat()
         except KeyError:
             pass
         return self.top_level_meta
@@ -336,7 +335,7 @@ class MetadataCollector:
         self.schema_dict = self.get_data_model_schema_dict()
 
         product_dict["id"] = str(uuid.uuid4())
-        product_dict["creation_time"] = datetime.datetime.now().isoformat(timespec="seconds")
+        product_dict["creation_time"] = gen.now_in_date_time_isoformat()
         product_dict["description"] = self.schema_dict.get("description", None)
 
         # DATA:CATEGORY
@@ -404,7 +403,7 @@ class MetadataCollector:
         activity_dict["name"] = self.args_dict.get("label", None)
         activity_dict["type"] = "software"
         activity_dict["id"] = self.args_dict.get("activity_id", "UNDEFINED_ACTIVITY_ID")
-        activity_dict["start"] = datetime.datetime.now().isoformat(timespec="seconds")
+        activity_dict["start"] = gen.now_in_date_time_isoformat()
         activity_dict["end"] = activity_dict["start"]
         activity_dict["software"]["name"] = "simtools"
         activity_dict["software"]["version"] = simtools.version.__version__

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -1,6 +1,7 @@
 """General functions useful across different parts of the code."""
 
 import copy
+import datetime
 import json
 import logging
 import os
@@ -922,3 +923,8 @@ def get_list_of_files_from_command_line(file_names, suffix_list):
             _logger.error(f"{one_file} is not a file.")
             raise FileNotFoundError from exc
     return _files
+
+
+def now_in_date_time_isoformat():
+    """Return date and time in isoformat and second accuracy."""
+    return datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -925,6 +925,6 @@ def get_list_of_files_from_command_line(file_names, suffix_list):
     return _files
 
 
-def now_in_date_time_isoformat():
+def now_date_time_in_isoformat():
     """Return date and time in isoformat and second accuracy."""
     return datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")

--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -29,10 +29,10 @@ CTA:
     DESCRIPTION: |-
       Mirror curvature radius and PSF measurements
       from 2f test stand
-    CREATION_TIME: '2020-03-20 12:00:00'
+    CREATION_TIME: '2020-03-20T12:00:00+00:00'
     ID: null
     VALID:
-      START: '2020-03-20 12:00:00'
+      START: '2020-03-20T12:00:00+00:00'
       END: '2024-03-20 12:00:00'
     FORMAT: ascii.ecsv
     DATA:

--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -33,7 +33,7 @@ CTA:
     ID: null
     VALID:
       START: '2020-03-20T12:00:00+00:00'
-      END: '2024-03-20 12:00:00'
+      END: '2024-03-20T12:00:00+00:00'
     FORMAT: ascii.ecsv
     DATA:
       CATEGORY: CAL

--- a/tests/resources/derive_mirror_rnda_psf_mean.ecsv
+++ b/tests/resources/derive_mirror_rnda_psf_mean.ecsv
@@ -10,11 +10,11 @@
 # meta: !!omap
 # - CTA:
 #     ACTIVITY:
-#       END: '2024-10-19T11:51:57'
+#       END: '2024-10-19T11:51:57+00:00'
 #       ID: 88e1f2fe-98ca-440b-8c68-3c45ef1560bc
 #       NAME: derive_mirror_rnda
 #       SOFTWARE: {NAME: simtools, VERSION: 0.7.1.dev608+g141ca6b22.d20241018}
-#       START: '2024-10-19T11:51:57'
+#       START: '2024-10-19T11:51:57+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: root, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -40,7 +40,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2024-10-19T11:51:57'
+#       CREATION_TIME: '2024-10-19T11:51:57+00:00'
 #       DATA:
 #         ASSOCIATION: null
 #         CATEGORY: SIM

--- a/tests/resources/derive_mirror_rnda_psf_measurement.ecsv
+++ b/tests/resources/derive_mirror_rnda_psf_measurement.ecsv
@@ -10,11 +10,11 @@
 # meta: !!omap
 # - CTA:
 #     ACTIVITY:
-#       END: '2024-10-17T15:37:20'
+#       END: '2024-10-17T15:37:20+00:00'
 #       ID: fce38520-bb31-4938-b4a9-53811ce61adb
 #       NAME: derive_mirror_rnda
 #       SOFTWARE: {NAME: simtools, VERSION: 0.7.1.dev603+gd5737230f}
-#       START: '2024-10-17T15:37:20'
+#       START: '2024-10-17T15:37:20+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: root, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -40,7 +40,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2024-10-17T15:37:20'
+#       CREATION_TIME: '2024-10-17T15:37:20+00:00'
 #       DATA:
 #         ASSOCIATION: null
 #         CATEGORY: SIM

--- a/tests/resources/derive_mirror_rnda_psf_no_tuning.ecsv
+++ b/tests/resources/derive_mirror_rnda_psf_no_tuning.ecsv
@@ -10,11 +10,11 @@
 # meta: !!omap
 # - CTA:
 #     ACTIVITY:
-#       END: '2024-10-19T11:43:08'
+#       END: '2024-10-19T11:43:08+00:00'
 #       ID: d45ad25b-dd15-40e4-93c6-cd214cbfab40
 #       NAME: derive_mirror_rnda
 #       SOFTWARE: {NAME: simtools, VERSION: 0.7.1.dev608+g141ca6b22.d20241018}
-#       START: '2024-10-19T11:43:08'
+#       START: '2024-10-19T11:43:08+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: root, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -40,7 +40,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2024-10-19T11:43:08'
+#       CREATION_TIME: '2024-10-19T11:43:08+00:00'
 #       DATA:
 #         ASSOCIATION: null
 #         CATEGORY: SIM

--- a/tests/resources/derive_mirror_rnda_psf_random_flen.ecsv
+++ b/tests/resources/derive_mirror_rnda_psf_random_flen.ecsv
@@ -10,11 +10,11 @@
 # meta: !!omap
 # - CTA:
 #     ACTIVITY:
-#       END: '2024-10-18T19:07:05'
+#       END: '2024-10-18T19:07:05+00:00'
 #       ID: dbc4200c-7cc7-4a13-9023-c1be7e0b5be6
 #       NAME: derive_mirror_rnda
 #       SOFTWARE: {NAME: simtools, VERSION: 0.7.1.dev608+g141ca6b22.d20241018}
-#       START: '2024-10-18T19:07:05'
+#       START: '2024-10-18T19:07:05+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: root, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -40,7 +40,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: null, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2024-10-18T19:07:05'
+#       CREATION_TIME: '2024-10-18T19:07:05+00:00'
 #       DATA:
 #         ASSOCIATION: null
 #         CATEGORY: SIM

--- a/tests/resources/num_gains.meta.yml
+++ b/tests/resources/num_gains.meta.yml
@@ -29,10 +29,10 @@ CTA:
   PRODUCT:
     DESCRIPTION: >
       Number of gains.
-    CREATION_TIME: '2017-05-08 12:00:00'
+    CREATION_TIME: '2017-05-08T12:00:00+00:00'
     ID: null
     VALID:
-      START: '2017-05-08 12:00:00'
+      START: '2017-05-08T12:00:00+00:00'
     FORMAT: number
     FILENAME: null
     DATA:

--- a/tests/resources/num_gains.meta.yml
+++ b/tests/resources/num_gains.meta.yml
@@ -51,7 +51,7 @@ CTA:
       - TYPE: CTAO-MC-DOC
         TITLE: "CTA Monte Carlo Model LST Appendix (last update: 04 May 2020)"
         ID: null
-        CREATION_TIME: '2020-04-20 12:00:00'
+        CREATION_TIME: '2020-04-20T12:00:00+00:00'
         URL: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/verification/verification-process/lst/-/blob/master/Appendix-LST.pdf
     # List of array elements this data product is associated with
     ASSOCIATED_ELEMENTS:

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -70,7 +70,7 @@
                         "TYPE": "CTAO-DOC",
                         "TITLE": "Layouts of the CTAO Arrays",
                         "ID": "CTA-SPE-PSC-000000-0001 1c",
-                        "CREATION_TIME": "2022-05-30 12:00:00",
+                        "CREATION_TIME": "2022-05-30T12:00:00+00:00",
                         "URL": null
                     }
                 ]

--- a/tests/resources/reference_point_altitude.json
+++ b/tests/resources/reference_point_altitude.json
@@ -16,7 +16,7 @@
             },
             "PRODUCT": {
                 "DESCRIPTION": "Reference point altitude as used in prod6",
-                "CREATION_TIME": "2024-01-11T08:16:11",
+                "CREATION_TIME": "2024-01-11T08:16:11+00:00",
                 "ID": null,
                 "DATA": {
                     "CATEGORY": null,

--- a/tests/resources/spe_LST_2022-04-27_AP2.0e-4.ecsv
+++ b/tests/resources/spe_LST_2022-04-27_AP2.0e-4.ecsv
@@ -14,16 +14,16 @@
 #       steps of size 0.020000 from 0.000000 to 42.000000.]
 # - CTA:
 #     ACTIVITY:
-#       END: '2025-01-06T13:27:47'
+#       END: '2025-01-06T13:27:47+00:00'
 #       ID: 1aa11e50-a4ec-4654-b221-08e77e93afed
 #       NAME: derive_photon_electron_spectrum
 #       SOFTWARE: {NAME: simtools, VERSION: 0.8.3.dev106+g9fc2e7f29.d20250106}
-#       START: '2025-01-06T13:27:47'
+#       START: '2025-01-06T13:27:47+00:00'
 #       TYPE: software
 #     CONTACT: {NAME: root, ORGANIZATION: CTAO}
 #     PROCESS: {TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2025-01-06T13:27:47'
+#       CREATION_TIME: '2025-01-06T13:27:47+00:00'
 #       DATA: {CATEGORY: SIM, LEVEL: R1, TYPE: Service}
 #       FILENAME: test_single_pe_lst.ecsv
 #       FORMAT: ecsv

--- a/tests/resources/telescope_positions-North-ground.ecsv
+++ b/tests/resources/telescope_positions-North-ground.ecsv
@@ -9,11 +9,11 @@
 # meta:
 #   CTA:
 #     ACTIVITY:
-#       END: '2023-12-21T12:55:11'
+#       END: '2023-12-21T12:55:11+00:00'
 #       ID: 4488a138-1384-439f-af0d-9f9a3e639481
 #       NAME: convert_geo_coordinates_of_array_elements
 #       SOFTWARE: {NAME: simtools, VERSION: 0.5.2.dev1089+gf69028b0.d20231221}
-#       START: '2023-12-21T12:55:11'
+#       START: '2023-12-21T12:55:11+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: maierg, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -37,7 +37,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: North, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2023-12-21T12:55:11'
+#       CREATION_TIME: '2023-12-21T12:55:11+00:00'
 #       DATA:
 #         ASSOCIATION: Site
 #         CATEGORY: SIM

--- a/tests/resources/telescope_positions-North-mercator.ecsv
+++ b/tests/resources/telescope_positions-North-mercator.ecsv
@@ -10,11 +10,11 @@
 # meta:
 #   CTA:
 #     ACTIVITY:
-#       END: '2024-01-17T08:18:14'
+#       END: '2024-01-17T08:18:14+00:00'
 #       ID: 2f5a2ee4-32c9-4302-bc71-9ea418f9e385
 #       NAME: convert_geo_coordinates_of_array_elements
 #       SOFTWARE: {NAME: simtools, VERSION: 0.5.2.dev1253+g8e35ba20}
-#       START: '2024-01-17T08:18:14'
+#       START: '2024-01-17T08:18:14+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: maierg, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -38,7 +38,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: North, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2024-01-17T08:18:14'
+#       CREATION_TIME: '2024-01-17T08:18:14+00:00'
 #       DATA:
 #         ASSOCIATION: Site
 #         CATEGORY: SIM

--- a/tests/resources/telescope_positions-North-utm.ecsv
+++ b/tests/resources/telescope_positions-North-utm.ecsv
@@ -15,11 +15,11 @@
 #       ASSOCIATED_ELEMENTS:
 #       - {CLASS: array, ID: null, SITE: North, TYPE: null}
 #       DOCUMENT:
-#       - {CREATION_TIME: '2022-05-30 12:00:00', ID: CTA-SPE-PSC-000000-0001 1c, TITLE: Layouts of the CTAO Arrays, TYPE: CTAO-DOC}
+#       - {CREATION_TIME: '2022-05-30T12:00:00+00:00', ID: CTA-SPE-PSC-000000-0001 1c, TITLE: Layouts of the CTAO Arrays, TYPE: CTAO-DOC}
 #     INSTRUMENT: {CLASS: null, ID: null, SITE: North, TYPE: null}
 #     PROCESS: {ID: null, TYPE: null}
 #     PRODUCT:
-#       CREATION_TIME: '2022-05-30 12:00:00'
+#       CREATION_TIME: '2022-05-30T12:00:00+00:00'
 #       DATA:
 #         ASSOCIATION: Subarray
 #         CATEGORY: CAL
@@ -33,7 +33,7 @@
 #       FILENAME: telescope_positions-North-utm.ecsv
 #       FORMAT: ascii.ecsv
 #       ID: null
-#       VALID: {START: '2022-05-30 12:00:00'}
+#       VALID: {START: '2022-05-30T12:00:00+00:00'}
 #     REFERENCE: {VERSION: 1.0.0}
 # schema: astropy-2.0
 asset_code sequence_number utm_east utm_north altitude geo_code

--- a/tests/resources/telescope_positions-North-utm.meta.yml
+++ b/tests/resources/telescope_positions-North-utm.meta.yml
@@ -29,10 +29,10 @@ CTA:
       Telescope positions for the CTAO Northern site
       (UTM coordinate system). Consistent with
       document CTA-SPE-PSC-000000-0001 1c.
-    CREATION_TIME: '2022-05-30 12:00:00'
+    CREATION_TIME: '2022-05-30T12:00:00+00:00'
     ID: null
     VALID:
-      START: '2022-05-30 12:00:00'
+      START: '2022-05-30T12:00:00+00:00'
     FORMAT: ascii.ecsv
     FILENAME: telescope_positions-North-utm.ecsv
     DATA:
@@ -49,7 +49,7 @@ CTA:
       - TYPE: CTAO-DOC
         TITLE: Layouts of the CTAO Arrays
         ID: CTA-SPE-PSC-000000-0001 1c
-        CREATION_TIME: '2022-05-30 12:00:00'
+        CREATION_TIME: '2022-05-30T12:00:00+00:00'
     ASSOCIATED_ELEMENTS:
       - SITE: North
         CLASS: array

--- a/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
+++ b/tests/resources/telescope_positions-North-with-calibration-devices-ground.ecsv
@@ -9,11 +9,11 @@
 # meta:
 #   CTA:
 #     ACTIVITY:
-#       END: '2023-12-21T12:55:11'
+#       END: '2023-12-21T12:55:11+00:00'
 #       ID: 4488a138-1384-439f-af0d-9f9a3e639481
 #       NAME: convert_geo_coordinates_of_array_elements
 #       SOFTWARE: {NAME: simtools, VERSION: 0.5.2.dev1089+gf69028b0.d20231221}
-#       START: '2023-12-21T12:55:11'
+#       START: '2023-12-21T12:55:11+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: maierg, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -37,7 +37,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: North, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2023-12-21T12:55:11'
+#       CREATION_TIME: '2023-12-21T12:55:11+00:00'
 #       DATA:
 #         ASSOCIATION: Site
 #         CATEGORY: SIM

--- a/tests/resources/telescope_positions-South-ground.ecsv
+++ b/tests/resources/telescope_positions-South-ground.ecsv
@@ -9,11 +9,11 @@
 # meta:
 #   CTA:
 #     ACTIVITY:
-#       END: '2023-12-21T12:55:11'
+#       END: '2023-12-21T12:55:11+00:00'
 #       ID: 4488a138-1384-439f-af0d-9f9a3e639481
 #       NAME: convert_geo_coordinates_of_array_elements
 #       SOFTWARE: {NAME: simtools, VERSION: 0.5.2.dev1089+gf69028b0.d20231221}
-#       START: '2023-12-21T12:55:11'
+#       START: '2023-12-21T12:55:11+00:00'
 #       TYPE: software
 #     CONTACT: {EMAIL: null, NAME: maierg, ORGANIZATION: CTAO}
 #     CONTEXT:
@@ -37,7 +37,7 @@
 #     INSTRUMENT: {CLASS: null, DESCRIPTION: null, ID: null, SITE: CTA-South, SUBTYPE: null, TYPE: null}
 #     PROCESS: {ID: null, SUBTYPE: null, TYPE: simulation}
 #     PRODUCT:
-#       CREATION_TIME: '2023-12-21T12:55:11'
+#       CREATION_TIME: '2023-12-21T12:55:11+00:00'
 #       DATA:
 #         ASSOCIATION: Site
 #         CATEGORY: SIM

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+import datetime
 import gzip
 import logging
 import os
@@ -802,3 +803,17 @@ def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
     suffix_list = [".txt"]
     with pytest.raises(FileNotFoundError):
         gen.get_list_of_files_from_command_line(file_names, suffix_list)
+
+
+def test_now_in_date_time_isoformat():
+
+    now = gen.now_in_date_time_isoformat()
+    assert now is not None
+    assert isinstance(now, str)
+    assert len(now) == 25
+    assert now[4] == "-"
+    assert now[7] == "-"
+    assert now[10] == "T"
+    assert now[13] == ":"
+    assert now[16] == ":"
+    assert datetime.datetime.fromisoformat(now) is not None

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -805,9 +805,9 @@ def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
         gen.get_list_of_files_from_command_line(file_names, suffix_list)
 
 
-def test_now_in_date_time_isoformat():
+def test_now_date_time_in_isoformat():
 
-    now = gen.now_in_date_time_isoformat()
+    now = gen.now_date_time_in_isoformat()
     assert now is not None
     assert isinstance(now, str)
     assert len(now) == 25


### PR DESCRIPTION
Noticed today with failing integration tests (schema validation issues) that `datetime.datetime.now().isoformat()` is not writing ISO time format strings (???).

Fixed this with the pull request below. To avoid repeating the required options, added a general function `simtools.gen.now_date_time_in_isoformat()`. Adjusted all files in `test/resources` to the correct format.