### PR TITLE
ignoring url line length

### DIFF
--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -43,9 +43,8 @@ CTA:
       MODEL:
         NAME: simpipe-schema
         VERSION: 0.1.0
-        URL: >
-         "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/"
-         "schemas/input/MST_mirror_2f_measurements.schema.yml"
+        # yamllint disable rule:line-length
+        URL: "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/input/MST_mirror_2f_measurements.schema.yml"
   CONTEXT:
     ASSOCIATED_ELEMENTS:
       - SITE: South
@@ -65,9 +64,8 @@ CTA:
         CREATION_TIME: null
         TITLE: null
       - TYPE: Presentation
-        URL: |
-          https://indico.cta-observatory.org/login/
-          ?next=%2Fevent%2F2680%2Fcontributions%2F23371%2Fattachments%2F17190%2F22730%2F200320_MST_optics.pdf
+        # yamllint disable rule:line-length
+        URL: "https://indico.cta-observatory.org/login/?next=%2Fevent%2F2680%2Fcontributions%2F23371%2Fattachments%2F17190%2F22730%2F200320_MST_optics.pdf"
         CREATION_TIME: null
         TITLE: null
         ID: null


### PR DESCRIPTION
Setting the url in one line and asking yamllint to ignore line length.
All the integration tests now pass for me locally too.