### PR TITLE
Fix reading of combined units from model parameter unit string

### DIFF
--- a/docs/changes/1415.bugfix.md
+++ b/docs/changes/1415.bugfix.md
@@ -1,0 +1,1 @@
+Fix reading of combined units from model parameter unit string.

--- a/src/simtools/data_model/validate_data.py
+++ b/src/simtools/data_model/validate_data.py
@@ -802,7 +802,8 @@ class DataValidator:
             "int" in self.data_dict.get("type", "float"),
         )
         if isinstance(self.data_dict["unit"], str):
-            self.data_dict["unit"] = gen.convert_string_to_list(self.data_dict["unit"])
+            self.data_dict["unit"] = gen.convert_string_to_list(
+                self.data_dict["unit"], force_comma_separation=True)
 
     def _convert_results_to_model_format(self):
         """

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -744,7 +744,7 @@ def convert_list_to_string(data, comma_separated=False, shorten_list=False, coll
     return " ".join(str(item) for item in data)
 
 
-def convert_string_to_list(data_string, is_float=True):
+def convert_string_to_list(data_string, is_float=True, force_comma_separation=False):
     """
     Convert string (as used e.g. in sim_telarray) to list.
 
@@ -754,6 +754,10 @@ def convert_string_to_list(data_string, is_float=True):
     ----------
     data_string: object
         String to be converted
+    is_float: bool
+        If True, convert to float, otherwise to int.
+    force_comma_separation: bool
+        If True, force comma separation.
 
     Returns
     -------
@@ -771,7 +775,7 @@ def convert_string_to_list(data_string, is_float=True):
     if "," in data_string:
         result = data_string.split(",")
         return [item.strip() for item in result]
-    if " " in data_string:
+    if " " in data_string and not force_comma_separation:
         return data_string.split()
     return data_string
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -525,7 +525,6 @@ def test_user_confirm_no(mock_input):
 
 
 def test_validate_data_type():
-
     test_cases = [
         # Test exact data type match
         ("int", 5, None, False, True),
@@ -570,7 +569,6 @@ def test_validate_data_type():
 
 
 def test_convert_list_to_string():
-
     assert gen.convert_list_to_string(None) is None
     assert gen.convert_list_to_string("a") == "a"
     assert gen.convert_list_to_string(5) == 5
@@ -603,7 +601,6 @@ def test_convert_list_to_string():
 
 
 def test_convert_string_to_list():
-
     t_1 = gen.convert_string_to_list("1 2 3 4")
     assert len(t_1) == 4
     assert pytest.approx(t_1[1]) == 2.0
@@ -625,7 +622,10 @@ def test_convert_string_to_list():
     assert gen.convert_string_to_list("bla bla") == ["bla", "bla"]
     assert gen.convert_string_to_list("bla,bla") == ["bla", "bla"]
     assert gen.convert_string_to_list("bla bla", force_comma_separation=True) == "bla bla"
-    assert gen.convert_string_to_list("bla bla, bla blaa", force_comma_separation=True) == ["bla bla", "bla blaa"]
+    assert gen.convert_string_to_list("bla bla, bla blaa", force_comma_separation=True) == [
+        "bla bla",
+        "bla blaa",
+    ]
     # import for list of dimensionless entries in database
     assert gen.convert_string_to_list(",") == ["", ""]
     assert gen.convert_string_to_list(" , , ") == ["", "", ""]
@@ -772,7 +772,6 @@ def test_clear_default_sim_telarray_cfg_directories():
 
 
 def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
-
     # Test with a list of file names with valid suffixes.
     file_1 = tmp_test_directory / "file1.txt"
     file_2 = tmp_test_directory / "file2.txt"
@@ -808,7 +807,6 @@ def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
 
 
 def test_now_date_time_in_isoformat():
-
     now = gen.now_date_time_in_isoformat()
     assert now is not None
     assert isinstance(now, str)

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -624,6 +624,7 @@ def test_convert_string_to_list():
     assert gen.convert_string_to_list("bla_bla") == "bla_bla"
     assert gen.convert_string_to_list("bla bla") == ["bla", "bla"]
     assert gen.convert_string_to_list("bla,bla") == ["bla", "bla"]
+    assert gen.convert_string_to_list("bla bla", force_comma_separation=True) == ["bla la"]
     # import for list of dimensionless entries in database
     assert gen.convert_string_to_list(",") == ["", ""]
     assert gen.convert_string_to_list(" , , ") == ["", "", ""]

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -618,12 +618,13 @@ def test_convert_string_to_list():
     t_3 = gen.convert_string_to_list("0.1")
     assert pytest.approx(t_3[0]) == 0.1
 
+    bla_bla = "bla bla"
     assert gen.convert_string_to_list("bla_bla") == "bla_bla"
-    assert gen.convert_string_to_list("bla bla") == ["bla", "bla"]
+    assert gen.convert_string_to_list(bla_bla) == ["bla", "bla"]
     assert gen.convert_string_to_list("bla,bla") == ["bla", "bla"]
-    assert gen.convert_string_to_list("bla bla", force_comma_separation=True) == "bla bla"
+    assert gen.convert_string_to_list(bla_bla, force_comma_separation=True) == bla_bla
     assert gen.convert_string_to_list("bla bla, bla blaa", force_comma_separation=True) == [
-        "bla bla",
+        bla_bla,
         "bla blaa",
     ]
     # import for list of dimensionless entries in database

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -624,7 +624,8 @@ def test_convert_string_to_list():
     assert gen.convert_string_to_list("bla_bla") == "bla_bla"
     assert gen.convert_string_to_list("bla bla") == ["bla", "bla"]
     assert gen.convert_string_to_list("bla,bla") == ["bla", "bla"]
-    assert gen.convert_string_to_list("bla bla", force_comma_separation=True) == ["bla la"]
+    assert gen.convert_string_to_list("bla bla", force_comma_separation=True) == "bla bla"
+    assert gen.convert_string_to_list("bla bla, bla blaa", force_comma_separation=True) == ["bla bla", "bla blaa"]
     # import for list of dimensionless entries in database
     assert gen.convert_string_to_list(",") == ["", ""]
     assert gen.convert_string_to_list(" , , ") == ["", "", ""]


### PR DESCRIPTION
Fixes a bug in reading combined units (e.g. `ct / mV`) from the model parameter json. 

Combined units should not be split into arrays - above example was split into `["ct", "mV"]`. 

This is issue connected to the storage of arrays as strings for the model parameter DB entries (to be fixed, see issue #1317), which has been noted to be error prone before. Note the inconsistency: we allow values to be space or comma separated; units must be comma separated (this has not been taken into account for now; this PR fixes it).

On a medium term, #1317 should be addressed.