### PR TITLE
Run check for changelog entry only on PRs ready for review

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,9 +16,7 @@ env:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: >
-      github.event.pull_request.draft == false &&
-      contains(github.event.pull_request.labels.*.name, 'ready for review')
+    if: github.event.pull_request.draft == false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ name: Changelog
 on:
   pull_request:
     # should also be re-run when changing labels
-    types: [opened, reopened, labeled, unlabeled, synchronize]
+    types: [opened, reopened, labeled, unlabeled, synchronize, edited]
     branches:
       - 'main'
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'ready for review')
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,7 +6,7 @@ name: Changelog
 on:
   pull_request:
     # should also be re-run when changing labels
-    types: [opened, reopened, labeled, unlabeled, synchronize, edited]
+    types: [opened, reopened, labeled, unlabeled, synchronize, ready_for_review]
     branches:
       - 'main'
 

--- a/docs/changes/1416.feature.md
+++ b/docs/changes/1416.feature.md
@@ -1,0 +1,1 @@
+Run check for changelog entry only on PRs ready for review.


### PR DESCRIPTION
This fixes the problem that the changelog entries in `docs/changes` require the pull request ID - which is not available until one actually defines a pull request. This PR changes the CI to run only when the PR is labeled 'ready for review' .