### PR TITLE
Switch on ruff formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
   hooks:
   - id: ruff
     args: ["--fix"]
+  - id: ruff-format
 # pylint
 - repo: local
   hooks:

--- a/src/simtools/applications/convert_all_model_parameters_from_simtel.py
+++ b/src/simtools/applications/convert_all_model_parameters_from_simtel.py
@@ -232,7 +232,6 @@ def read_and_export_parameters(args_dict, logger):
     _parameters_not_in_simtel = []
 
     for _parameter, _schema_file in zip(_parameters, _schema_files):
-
         logger.info(f"Parameter: {_parameter} Schema file: {_schema_file}")
         simtel_config_reader = read_simtel_config_file(
             args_dict, logger, _schema_file, _camera_pixel

--- a/src/simtools/applications/convert_model_parameter_from_simtel.py
+++ b/src/simtools/applications/convert_model_parameter_from_simtel.py
@@ -82,7 +82,6 @@ def _parse(label=None, description=None):
 
 
 def main():  # noqa: D103
-
     args_dict, _ = _parse(
         label=Path(__file__).stem,
         description="Convert simulation model parameter from sim_telarray to simtools format.",

--- a/src/simtools/applications/db_add_file_to_db.py
+++ b/src/simtools/applications/db_add_file_to_db.py
@@ -46,7 +46,6 @@ from simtools.db import db_handler
 
 
 def _parse():
-
     config = configurator.Configurator(
         description="Add file to the DB.",
         usage="simtools-add-file-to-db --file_name test_application.dat --db test-data",

--- a/src/simtools/applications/derive_mirror_rnda.py
+++ b/src/simtools/applications/derive_mirror_rnda.py
@@ -194,8 +194,7 @@ def _parse(label):
     config.parser.add_argument(
         "--random_focal_length",
         help=(
-            "Value of the random focal length. "
-            "Only used if 'use_random_focal_length' is activated."
+            "Value of the random focal length. Only used if 'use_random_focal_length' is activated."
         ),
         default=None,
         type=float,

--- a/src/simtools/applications/derive_psf_parameters.py
+++ b/src/simtools/applications/derive_psf_parameters.py
@@ -81,6 +81,7 @@ r"""
         mirror_align_random_vertical = [0.005, 28.0, 0.0, 0.0]
 
 """
+
 import logging
 from collections import OrderedDict
 

--- a/src/simtools/applications/run_application.py
+++ b/src/simtools/applications/run_application.py
@@ -134,7 +134,6 @@ def read_application_configuration(configuration_file, logger):
 
 
 def main():  # noqa: D103
-
     args_dict, _ = _parse(
         Path(__file__).stem,
         description="Run simtools applications from configuration file.",

--- a/src/simtools/applications/simulate_light_emission.py
+++ b/src/simtools/applications/simulate_light_emission.py
@@ -117,7 +117,6 @@ r"""
 
 """
 
-
 import logging
 import subprocess
 from pathlib import Path
@@ -390,7 +389,6 @@ def main():
             run_script = light_source.prepare_script(generate_postscript=True, **args_dict)
             log_file = f"{light_source.output_directory}/logfile.log"
             with open(log_file, "w", encoding="utf-8") as log_file:
-
                 subprocess.run(
                     run_script,
                     shell=False,
@@ -430,7 +428,6 @@ def main():
                 )
 
     elif args_dict["light_source_setup"] == "layout":
-
         light_source = SimulatorLightEmission(
             telescope_model=telescope_model,
             calibration_model=calibration_model,
@@ -443,7 +440,6 @@ def main():
         run_script = light_source.prepare_script(generate_postscript=True, **args_dict)
         log_file = f"{light_source.output_directory}/logfile.log"
         with open(log_file, "w", encoding="utf-8") as log_file:
-
             subprocess.run(
                 run_script, shell=False, check=False, text=True, stdout=log_file, stderr=log_file
             )

--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -232,25 +232,25 @@ class CorsikaConfig:
 
     def _input_config_first_interaction_height(self, entry):
         """Return FIXHEI parameter CORSIKA format."""
-        return [f"{entry['value']*u.Unit(entry['unit']).to('cm'):.2f}", "0"]
+        return [f"{entry['value'] * u.Unit(entry['unit']).to('cm'):.2f}", "0"]
 
     def _input_config_corsika_starting_grammage(self, entry):
         """Return FIXCHI parameter CORSIKA format."""
-        return f"{entry['value']*u.Unit(entry['unit']).to('g/cm2')}"
+        return f"{entry['value'] * u.Unit(entry['unit']).to('g/cm2')}"
 
     def _input_config_corsika_particle_kinetic_energy_cutoff(self, entry):
         """Return ECUTS parameter CORSIKA format."""
         e_cuts = entry["value"]
         return [
-            f"{e_cuts[0]*u.Unit(entry['unit']).to('GeV')} "
-            f"{e_cuts[1]*u.Unit(entry['unit']).to('GeV')} "
-            f"{e_cuts[2]*u.Unit(entry['unit']).to('GeV')} "
-            f"{e_cuts[3]*u.Unit(entry['unit']).to('GeV')}"
+            f"{e_cuts[0] * u.Unit(entry['unit']).to('GeV')} "
+            f"{e_cuts[1] * u.Unit(entry['unit']).to('GeV')} "
+            f"{e_cuts[2] * u.Unit(entry['unit']).to('GeV')} "
+            f"{e_cuts[3] * u.Unit(entry['unit']).to('GeV')}"
         ]
 
     def _input_config_corsika_longitudinal_parameters(self, entry):
         """Return LONGI parameter CORSIKA format."""
-        return ["T", f"{entry['value']*u.Unit(entry['unit']).to('g/cm2')}", "F", "F"]
+        return ["T", f"{entry['value'] * u.Unit(entry['unit']).to('g/cm2')}", "F", "F"]
 
     def _corsika_configuration_cherenkov_parameters(self, parameters_from_db):
         """
@@ -279,8 +279,8 @@ class CorsikaConfig:
         """Return CWAVLG parameter CORSIKA format."""
         wavelength_range = entry["value"]
         return [
-            f"{wavelength_range[0]*u.Unit(entry['unit']).to('nm')}",
-            f"{wavelength_range[1]*u.Unit(entry['unit']).to('nm')}",
+            f"{wavelength_range[0] * u.Unit(entry['unit']).to('nm')}",
+            f"{wavelength_range[1] * u.Unit(entry['unit']).to('nm')}",
         ]
 
     def _corsika_configuration_iact_parameters(self, parameters_from_db):

--- a/src/simtools/corsika/corsika_histograms.py
+++ b/src/simtools/corsika/corsika_histograms.py
@@ -1248,8 +1248,7 @@ class CorsikaHistograms:
                     meta_data=self._meta_dict,
                 )
                 self._logger.info(
-                    f"Writing 1D histogram with name {hdf5_table_name} to "
-                    f"{self.hdf5_file_name}."
+                    f"Writing 1D histogram with name {hdf5_table_name} to {self.hdf5_file_name}."
                 )
                 # overwrite takes precedence over append
                 if overwrite is True:
@@ -1382,8 +1381,7 @@ class CorsikaHistograms:
                 )
 
                 self._logger.info(
-                    f"Writing 2D histogram with name {hdf5_table_name} to "
-                    f"{self.hdf5_file_name}."
+                    f"Writing 2D histogram with name {hdf5_table_name} to {self.hdf5_file_name}."
                 )
                 # Always appending to table due to the file previously created
                 # by self._export_1d_histograms.

--- a/src/simtools/corsika/corsika_histograms_visualize.py
+++ b/src/simtools/corsika/corsika_histograms_visualize.py
@@ -93,8 +93,7 @@ def _kernel_plot_2d_photons(histograms_instance, property_name, log_z=False):
         all_figs.append(fig)
         if histograms_instance.individual_telescopes is False:
             ax.set_title(
-                f"{histograms_instance.dict_2d_distributions[property_name]['file name']}"
-                "_all_tels"
+                f"{histograms_instance.dict_2d_distributions[property_name]['file name']}_all_tels"
             )
         else:
             ax.text(
@@ -285,8 +284,7 @@ def _kernel_plot_1d_photons(histograms_instance, property_name, log_y=True):
             ax.set_yscale("log")
         if histograms_instance.individual_telescopes is False:
             ax.set_title(
-                f"{histograms_instance.dict_1d_distributions[property_name]['file name']}"
-                "_all_tels"
+                f"{histograms_instance.dict_1d_distributions[property_name]['file name']}_all_tels"
             )
         else:
             ax.set_title(

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -96,9 +96,9 @@ class MetadataCollector:
 
         """
         try:
-            self.top_level_meta[self.observatory]["activity"][
-                "end"
-            ] = gen.now_date_time_in_isoformat()
+            self.top_level_meta[self.observatory]["activity"]["end"] = (
+                gen.now_date_time_in_isoformat()
+            )
         except KeyError:
             pass
         return self.top_level_meta

--- a/src/simtools/layout/array_layout.py
+++ b/src/simtools/layout/array_layout.py
@@ -718,8 +718,7 @@ class ArrayLayout:
                     set(_telescope_list_from_name + _telescope_list_from_type)
                 )
             self._logger.info(
-                f"Selected {len(self._telescope_list)} telescopes"
-                f" (from originally {_n_telescopes})"
+                f"Selected {len(self._telescope_list)} telescopes (from originally {_n_telescopes})"
             )
         except TypeError:
             self._logger.info("No asset list provided, keeping all telescopes")

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -443,8 +443,7 @@ class ModelParameter:
             )
 
         self._logger.debug(
-            f"Changing parameter {par_name} "
-            f"from {self.get_parameter_value(par_name)} to {value}"
+            f"Changing parameter {par_name} from {self.get_parameter_value(par_name)} to {value}"
         )
         self._parameters[par_name]["value"] = value
 

--- a/src/simtools/production_configuration/calculate_statistical_errors_grid_point.py
+++ b/src/simtools/production_configuration/calculate_statistical_errors_grid_point.py
@@ -81,8 +81,7 @@ class StatisticalErrorEvaluator:
         unique_zeniths = 90 * u.deg - np.unique(events_data["PNT_ALT"]) * u.deg
         if len(unique_azimuths) > 1 or len(unique_zeniths) > 1:
             msg = (
-                f"Multiple values found for azimuth ({unique_azimuths}) "
-                f"zenith ({unique_zeniths})."
+                f"Multiple values found for azimuth ({unique_azimuths}) zenith ({unique_zeniths})."
             )
             self._logger.error(msg)
             raise ValueError(msg)
@@ -326,15 +325,15 @@ class StatisticalErrorEvaluator:
     def calculate_metrics(self):
         """Calculate all defined metrics as specified in self.metrics and store results."""
         if "uncertainty_effective_area" in self.metrics:
-
             self.uncertainty_effective_area = self.calculate_uncertainty_effective_area()
             if self.uncertainty_effective_area:
                 energy_range = self.metrics.get("uncertainty_effective_area", {}).get(
                     "energy_range"
                 )
-                min_energy, max_energy = energy_range["value"][0] * u.Unit(
-                    energy_range["unit"]
-                ), energy_range["value"][1] * u.Unit(energy_range["unit"])
+                min_energy, max_energy = (
+                    energy_range["value"][0] * u.Unit(energy_range["unit"]),
+                    energy_range["value"][1] * u.Unit(energy_range["unit"]),
+                )
 
                 valid_errors = [
                     error

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -48,7 +48,6 @@ class ReadParameters:
                 input_file.open("r", encoding="utf-8") as infile,
                 output_file.open("w", encoding="utf-8") as outfile,
             ):
-
                 outfile.write(f"# {input_file.stem}")
                 outfile.write("\n")
                 outfile.write("```")

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -129,9 +129,7 @@ class CorsikaSimtelRunner:
         )
         with open(multipipe_script, "w", encoding="utf-8") as file:
             multipipe_command = Path(self._simtel_path).joinpath(
-                "sim_telarray/bin/multipipe_corsika "
-                f"-c {multipipe_file}"
-                " || echo 'Fan-out failed'"
+                f"sim_telarray/bin/multipipe_corsika -c {multipipe_file} || echo 'Fan-out failed'"
             )
             file.write(f"{multipipe_command}")
 

--- a/src/simtools/simtel/simtel_config_reader.py
+++ b/src/simtools/simtel/simtel_config_reader.py
@@ -153,8 +153,7 @@ class SimtelConfigReader:
 
         """
         self._logger.debug(
-            f"Reading simtel config file {simtel_config_file} "
-            f"for parameter {self.parameter_name}"
+            f"Reading simtel config file {simtel_config_file} for parameter {self.parameter_name}"
         )
         matching_lines = {}
         try:

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -72,8 +72,7 @@ class SimtelConfigWriter:
 
             file.write("#ifdef TELESCOPE\n")
             file.write(
-                f"   echo Configuration for {self._telescope_model_name}"
-                " - TELESCOPE $(TELESCOPE)\n"
+                f"   echo Configuration for {self._telescope_model_name} - TELESCOPE $(TELESCOPE)\n"
             )
             file.write("#endif\n\n")
 

--- a/src/simtools/simtel/simtel_io_histograms.py
+++ b/src/simtools/simtel/simtel_io_histograms.py
@@ -219,8 +219,8 @@ class SimtelIOHistograms:
         )
 
         stacked_num_simulated_events, stacked_num_triggered_events = self.get_stacked_num_events()
-        logging.info("Total number of simulated events: " f"{stacked_num_simulated_events} events")
-        logging.info("Total number of triggered events: " f"{stacked_num_triggered_events} events")
+        logging.info(f"Total number of simulated events: {stacked_num_simulated_events} events")
+        logging.info(f"Total number of triggered events: {stacked_num_triggered_events} events")
         obs_time = simtel_hist_instance.estimate_observation_time(stacked_num_simulated_events)
         logging.info(
             "Estimated equivalent observation time corresponding to the number of"

--- a/src/simtools/simtel/simulator_camera_efficiency.py
+++ b/src/simtools/simtel/simulator_camera_efficiency.py
@@ -72,9 +72,7 @@ class SimulatorCameraEfficiency(SimtelRunner):
                 / Path(self._telescope_model.get_parameter_value("nsb_reference_spectrum")).name
             )
 
-    def _make_run_command(
-        self, run_number=None, input_file=None
-    ):  # pylint: disable=unused-argument
+    def _make_run_command(self, run_number=None, input_file=None):  # pylint: disable=unused-argument
         """Prepare the command used to run testeff."""
         self._logger.debug("Preparing the command to run testeff")
 

--- a/src/simtools/simtel/simulator_light_emission.py
+++ b/src/simtools/simtel/simulator_light_emission.py
@@ -234,7 +234,6 @@ class SimulatorLightEmission(SimtelRunner):
         command += f"/{self.le_application[0]}"
 
         if self.light_source_type == "led":
-
             if self.le_application[1] == "variable":
                 command += f" -x {self.default_le_config['x_pos']['default'].to(u.cm).value}"
                 command += f" -y {self.default_le_config['y_pos']['default'].to(u.cm).value}"
@@ -245,7 +244,6 @@ class SimulatorLightEmission(SimtelRunner):
                 command += f" -n {self.photons_per_run}"
 
             elif self.le_application[1] == "layout":
-
                 x_origin = x_cal - x_tel
                 y_origin = y_cal - y_tel
                 z_origin = z_cal - z_tel
@@ -291,7 +289,7 @@ class SimulatorLightEmission(SimtelRunner):
 
             command += f" --telescope-theta {angle_theta}"
             command += f" --telescope-phi {angle_phi}"
-            command += f" --laser-theta {90-angles[2]}"
+            command += f" --laser-theta {90 - angles[2]}"
             command += f" --laser-phi {angles[3]}"  # convention north (x) towards east (-y)
             command += f" --atmosphere {_model_directory}/"
             command += f"{self._telescope_model.get_parameter_value('atmospheric_profile')}"
@@ -352,8 +350,7 @@ class SimulatorLightEmission(SimtelRunner):
         )
         command += super().get_config_option(
             "output_file",
-            f"{self.output_directory}/"
-            f"{self.le_application[0]}_{self.le_application[1]}.simtel.gz",
+            f"{self.output_directory}/{self.le_application[0]}_{self.le_application[1]}.simtel.gz",
         )
         command += super().get_config_option(
             "histogram_file",

--- a/src/simtools/simtel/simulator_ray_tracing.py
+++ b/src/simtools/simtel/simulator_ray_tracing.py
@@ -136,9 +136,7 @@ class SimulatorRayTracing(SimtelRunner):
             self._logger.debug("For single mirror mode, need to prepare the single pixel camera.")
             self._write_out_single_pixel_camera_file()
 
-    def _make_run_command(
-        self, run_number=None, input_file=None
-    ):  # pylint: disable=unused-argument
+    def _make_run_command(self, run_number=None, input_file=None):  # pylint: disable=unused-argument
         """Generate simtel_array run command."""
         if self.config.single_mirror_mode:
             # Note: no mirror length defined for dual-mirror telescopes

--- a/tests/integration_tests/test_ray_tracing.py
+++ b/tests/integration_tests/test_ray_tracing.py
@@ -36,7 +36,6 @@ def test_ssts(telescope_model_name, db_config, simtel_path_no_mock, io_handler, 
 
 
 def test_rx(db_config, simtel_path_no_mock, io_handler, telescope_model_lst):
-
     ray = RayTracing(
         telescope_model=telescope_model_lst,
         simtel_path=simtel_path_no_mock,

--- a/tests/unit_tests/camera/test_camera_efficiency.py
+++ b/tests/unit_tests/camera/test_camera_efficiency.py
@@ -97,7 +97,6 @@ def test_load_files(camera_efficiency_lst):
 
 
 def test_simulate(io_handler, camera_efficiency_lst, caplog, mocker):
-
     mock_run = mocker.patch.object(SimulatorCameraEfficiency, "run")
     with caplog.at_level(logging.INFO):
         camera_efficiency_lst.simulate()
@@ -132,9 +131,7 @@ def test_calc_tot_efficiency(camera_efficiency_lst, prepare_results_file):
     camera_efficiency_lst.export_model_files()
     assert camera_efficiency_lst.calc_tot_efficiency(
         camera_efficiency_lst.calc_tel_efficiency()
-    ) == pytest.approx(
-        0.48018680628175714
-    )  # Value for Prod5 LST-1
+    ) == pytest.approx(0.48018680628175714)  # Value for Prod5 LST-1
 
 
 def test_calc_reflectivity(camera_efficiency_lst, prepare_results_file):

--- a/tests/unit_tests/camera/test_single_photon_electron_spectrum.py
+++ b/tests/unit_tests/camera/test_single_photon_electron_spectrum.py
@@ -33,7 +33,6 @@ def spe_data():
 @patch("simtools.io_operations.io_handler.IOHandler")
 @patch("simtools.camera.single_photon_electron_spectrum.MetadataCollector")
 def test_init(mock_metadata_collector, mock_io_handler, spe_spectrum):
-
     mock_io_handler_instance = mock_io_handler.return_value
     mock_metadata_collector_instance = mock_metadata_collector.return_value
 
@@ -52,7 +51,6 @@ def test_init(mock_metadata_collector, mock_io_handler, spe_spectrum):
     "SinglePhotonElectronSpectrum._derive_spectrum_norm_spe"
 )
 def test_derive_single_pe_spectrum(mock_derive_spectrum_norm_spe, spe_spectrum):
-
     spe_spectrum.args_dict["use_norm_spe"] = True
     spe_spectrum.derive_single_pe_spectrum()
     mock_derive_spectrum_norm_spe.assert_called_once()

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -141,7 +141,6 @@ def test_azimuth_angle(caplog):
 
 
 def test_initialize_default_arguments():
-
     # default arguments
     _parser_1 = parser.CommandLineParser()
     _parser_1.initialize_default_arguments()

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -47,7 +47,6 @@ def test_repr(corsika_config_mock_array_model):
 
 
 def test_fill_corsika_configuration(io_handler, corsika_config_mock_array_model):
-
     empty_config = CorsikaConfig(
         array_model=None, label="test-corsika-config", args_dict=None, db_config=None
     )

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -71,7 +71,6 @@ def test_get_data_model_schema_dict(args_dict_site):
 
 
 def test_get_top_level_metadata(args_dict_site):
-
     collector = metadata_collector.MetadataCollector(args_dict=args_dict_site)
     assert (
         collector.top_level_meta["cta"]["activity"]["end"]
@@ -418,7 +417,6 @@ def test_fill_instrument_meta(args_dict_site):
 
 
 def test_clean_meta_data():
-
     pre_clean = {
         "reference": {"version": "1.0.0"},
         "contact": {"organization": "CTAO", "name": "not_me", "email": None, "orcid": None},

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -211,7 +211,6 @@ def test_json_numpy_encoder():
 
 
 def test_dump_model_parameter(tmp_test_directory, db_config):
-
     parameter_version = "1.1.0"
     instrument = "LSTN-01"
     num_gains_name = "num_gains"
@@ -283,7 +282,6 @@ def test_dump_model_parameter(tmp_test_directory, db_config):
 
 
 def test_get_validated_parameter_dict():
-
     w1 = writer.ModelDataWriter()
     assert w1.get_validated_parameter_dict(
         parameter_name="num_gains", value=2, instrument="MSTN-01", parameter_version="0.0.1"
@@ -338,7 +336,6 @@ def test_get_validated_parameter_dict():
 
 
 def test_prepare_data_dict_for_writing():
-
     data_dict_1 = {}
     assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_1) == {}
     data_dict_2 = {
@@ -380,7 +377,6 @@ def test_prepare_data_dict_for_writing():
 
 
 def test_get_unit_from_schema(num_gains_schema):
-
     w1 = writer.ModelDataWriter()
 
     assert w1._get_unit_from_schema() is None
@@ -398,7 +394,6 @@ def test_get_unit_from_schema(num_gains_schema):
 
 
 def test_parameter_is_a_file(num_gains_schema):
-
     w1 = writer.ModelDataWriter()
 
     assert not w1._parameter_is_a_file()

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -17,7 +17,6 @@ from simtools.utils import general as gen
 
 
 def test_get_get_model_parameter_schema_files(tmp_test_directory):
-
     par, files = schema.get_get_model_parameter_schema_files()
     assert len(files)
     assert files[0].is_file()
@@ -33,7 +32,6 @@ def test_get_get_model_parameter_schema_files(tmp_test_directory):
 
 
 def test_get_model_parameter_schema_file():
-
     schema_file = str(schema.get_model_parameter_schema_file("num_gains"))
 
     assert str(MODEL_PARAMETER_SCHEMA_PATH / "num_gains.schema.yml") in schema_file
@@ -43,7 +41,6 @@ def test_get_model_parameter_schema_file():
 
 
 def test_get_model_parameter_schema_version():
-
     most_recent = schema.get_model_parameter_schema_version()
     assert most_recent == "0.3.0"
 
@@ -55,7 +52,6 @@ def test_get_model_parameter_schema_version():
 
 
 def test_validate_dict_using_schema(tmp_test_directory, caplog):
-
     with caplog.at_level(logging.WARNING):
         schema.validate_dict_using_schema(None, None)
     assert "No schema provided for validation of" in caplog.text
@@ -180,7 +176,6 @@ def test_load_schema(caplog, tmp_test_directory):
 
 
 def test_add_array_elements():
-
     test_dict_1 = {"data": {"InstrumentTypeElement": {"enum": ["LSTN", "MSTN"]}}}
     test_dict_added = schema._add_array_elements("InstrumentTypeElement", test_dict_1)
     assert len(test_dict_added["data"]["InstrumentTypeElement"]["enum"]) > 2

--- a/tests/unit_tests/data_model/test_validate_data.py
+++ b/tests/unit_tests/data_model/test_validate_data.py
@@ -139,7 +139,6 @@ def test_validate_data_file(caplog):
 
 
 def test_validate_parameter_and_file_name(caplog):
-
     num_gain_file = "tests/resources/model_parameters/schema-0.2.0/num_gains-1.0.0.json"
     parameter = "num_gains"
     parameter_version = "1.0.0"
@@ -372,7 +371,6 @@ def test_check_range(reference_columns, caplog):
 
 
 def test_is_dimensionless():
-
     data_validator = validate_data.DataValidator()
 
     assert data_validator._is_dimensionless(None)
@@ -642,7 +640,6 @@ def test_read_validation_schema(tmp_test_directory):
 
 # incomplete test
 def test_validate_data_dict():
-
     # parameter with unit
     data_validator = validate_data.DataValidator(
         schema_file=schema.get_model_parameter_schema_file("reference_point_altitude")
@@ -899,7 +896,6 @@ def test_validate_model_parameter(mocker):
 
 
 def test__check_site_and_array_element_consistency():
-
     data_validator = validate_data.DataValidator()
 
     sucess_matrix = [(None, None), ("OBS-North", None), ("OBS-North", "North")]

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -118,7 +118,6 @@ def test_open_mongo_db_direct_connection(mocker, db, db_config):
 
 
 def test_find_latest_simulation_model_db(db, db_no_config_file, mocker):
-
     db_no_config_file._find_latest_simulation_model_db()
     assert db_no_config_file.mongo_db_config is None
 
@@ -1122,7 +1121,6 @@ def test_get_array_element_list_with_design_model_in_production_table(db, mocker
 
 
 def test_get_model_versions(db):
-
     model_versions = db.get_model_versions()
     assert len(model_versions) > 0
     assert "5.0.0" in model_versions
@@ -1130,7 +1128,6 @@ def test_get_model_versions(db):
 
 
 def test_get_array_elements(db):
-
     prod5_elements = db.get_array_elements("5.0.0", "telescopes")
     assert len(prod5_elements) > 0
     assert "LSTN-01" in prod5_elements
@@ -1142,7 +1139,6 @@ def test_get_array_elements(db):
 
 
 def test_get_design_model(db):
-
     assert db.get_design_model("5.0.0", "LSTN-01") == "LSTN-design"
     assert db.get_design_model("6.0.0", "LSTN-01") == "LSTN-design"
     assert db.get_design_model("5.0.0", "SSTS-03") == "SSTS-design"

--- a/tests/unit_tests/io_operations/test_hdf5_handler.py
+++ b/tests/unit_tests/io_operations/test_hdf5_handler.py
@@ -48,7 +48,6 @@ def test_fill_hdf5_table_2d(corsika_histograms_instance_set_histograms):
 
 
 def test_read_hdf5():
-
     tables = read_hdf5(
         "tests/resources/run2_gamma_za20deg_azm0deg-North-Prod5_test-production-5_reduced.hdata.hdf5"
     )

--- a/tests/unit_tests/io_operations/test_legacy_data_handler.py
+++ b/tests/unit_tests/io_operations/test_legacy_data_handler.py
@@ -12,7 +12,6 @@ def test_spe_file():
 
 
 def test_read_legacy_data_file(test_spe_file):
-
     table = legacy_data_handler.read_legacy_data_as_table(test_spe_file, "legacy_lst_single_pe")
     assert table.colnames == ["amplitude", "response"]
 
@@ -21,5 +20,4 @@ def test_read_legacy_data_file(test_spe_file):
 
 
 def test_read_legacy_lst_single_pe(test_spe_file):
-
     assert isinstance(legacy_data_handler.read_legacy_lst_single_pe(test_spe_file), Table)

--- a/tests/unit_tests/job_execution/test_job_manager.py
+++ b/tests/unit_tests/job_execution/test_job_manager.py
@@ -192,7 +192,6 @@ def test_submit_gridengine(mock_gen, job_submitter, mocker, output_log, logfile_
 
 @patch("simtools.job_execution.job_manager.subprocess.run")
 def test_execute(mock_subprocess_run, job_submitter, job_submitter_real):
-
     shell_command = "echo Hello World"
     job_submitter._execute("local", shell_command)
 

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -74,7 +74,6 @@ def array_layout_south_four_lst_instance(db_config, model_version):
 
 
 def test_initialize_site_parameters_from_db():
-
     with pytest.raises(ValueError, match="No database configuration provided"):
         ArrayLayout(site="North", mongo_db_config=None, model_version="test_model_version")
 
@@ -449,7 +448,6 @@ def test_export_telescope_list_table(
 
 
 def test_export_one_telescope_as_json(db_config, model_version, telescope_north_utm_test_file):
-
     layout = ArrayLayout(
         mongo_db_config=db_config,
         site="North",
@@ -479,7 +477,6 @@ def test_export_one_telescope_as_json(db_config, model_version, telescope_north_
 
 
 def test_read_table_from_json_file(db_config, model_version):
-
     ground_table_file = "tests/resources/model_parameters/array_element_position_ground-2.0.0.json"
     layout = ArrayLayout(
         mongo_db_config=db_config,

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -16,7 +16,6 @@ logger = logging.getLogger()
 
 
 def test_get_parameter_type(telescope_model_lst, caplog):
-
     assert telescope_model_lst.get_parameter_type("num_gains") == "int64"
     telescope_model_copy = copy.deepcopy(telescope_model_lst)
     telescope_model_copy._parameters["num_gains"].pop("type")
@@ -26,7 +25,6 @@ def test_get_parameter_type(telescope_model_lst, caplog):
 
 
 def test_get_parameter_file_flag(telescope_model_lst, caplog):
-
     assert telescope_model_lst.get_parameter_file_flag("num_gains") is False
     telescope_model_copy = copy.deepcopy(telescope_model_lst)
     telescope_model_copy._parameters["num_gains"].pop("file")
@@ -372,7 +370,6 @@ def test_export_nsb_spectrum_to_telescope_altitude_correction_file(telescope_mod
 
 
 def test_get_model_file_as_table(telescope_model_lst, mocker):
-
     telescope_copy = copy.deepcopy(telescope_model_lst)
 
     with pytest.raises(ValueError, match="Parameter not_a_parameter not found in the model"):
@@ -387,7 +384,6 @@ def test_get_model_file_as_table(telescope_model_lst, mocker):
 
 
 def test_get_model_file_as_ecsv_table(telescope_model_sst, mocker):
-
     telescope_copy = copy.deepcopy(telescope_model_sst)
 
     mock_db_export = mocker.patch.object(DatabaseHandler, "export_model_files")

--- a/tests/unit_tests/model/test_model_utils.py
+++ b/tests/unit_tests/model/test_model_utils.py
@@ -6,7 +6,6 @@ from simtools.model import model_utils
 
 
 def test_is_two_mirror_telescope():
-
     assert not model_utils.is_two_mirror_telescope("LSTN-01")
     assert not model_utils.is_two_mirror_telescope("MSTN-01")
     assert not model_utils.is_two_mirror_telescope("MSTS-01")
@@ -15,7 +14,6 @@ def test_is_two_mirror_telescope():
 
 
 def test_compute_telescope_transmission():
-
     pars = [0.8, 0, 0.0, 0.0, 0.0]
     off_axis = 0.0
     assert pytest.approx(model_utils.compute_telescope_transmission(pars, off_axis)) == pars[0]

--- a/tests/unit_tests/production_configuration/test_calculate_statistical_errors_grid.py
+++ b/tests/unit_tests/production_configuration/test_calculate_statistical_errors_grid.py
@@ -180,9 +180,9 @@ def test_calculate_overall_metric_average(test_fits_file):
     overall_metric = evaluator.calculate_overall_metric(metric="average")
     expected_metric = 0.4
 
-    assert np.isclose(
-        overall_metric, expected_metric
-    ), f"Expected {expected_metric}, got {overall_metric}"
+    assert np.isclose(overall_metric, expected_metric), (
+        f"Expected {expected_metric}, got {overall_metric}"
+    )
 
 
 def test_calculate_overall_metric_maximum(test_fits_file):
@@ -202,9 +202,9 @@ def test_calculate_overall_metric_maximum(test_fits_file):
         0.4  # max and average are the same in this case since there is only one metric
     )
 
-    assert np.isclose(
-        overall_metric, expected_metric
-    ), f"Expected {expected_metric}, got {overall_metric}"
+    assert np.isclose(overall_metric, expected_metric), (
+        f"Expected {expected_metric}, got {overall_metric}"
+    )
 
 
 def test_create_bin_edges(test_fits_file, metric):
@@ -222,9 +222,9 @@ def test_create_bin_edges(test_fits_file, metric):
     expected_bin_edges = np.array([1.0, 2.0, 3.0, 4.0])
 
     assert isinstance(bin_edges, np.ndarray)
-    assert np.array_equal(
-        bin_edges, expected_bin_edges
-    ), f"Expected {expected_bin_edges}, got {bin_edges}"
+    assert np.array_equal(bin_edges, expected_bin_edges), (
+        f"Expected {expected_bin_edges}, got {bin_edges}"
+    )
 
 
 def test_compute_efficiency_and_errors(test_fits_file, metric):
@@ -242,12 +242,12 @@ def test_compute_efficiency_and_errors(test_fits_file, metric):
     expected_efficiencies = np.array([0.1, 0.1, 0.1, 0.0]) * u.dimensionless_unscaled
     expected_relative_errors = np.array([0.3, 0.21213203, 0.42426407, 0.0])
 
-    assert np.allclose(
-        efficiencies, expected_efficiencies, atol=1e-2
-    ), f"Expected efficiencies {expected_efficiencies}, but got {efficiencies}"
-    assert np.allclose(
-        relative_errors, expected_relative_errors, atol=1e-2
-    ), f"Expected relative errors {expected_relative_errors}, but got {relative_errors}"
+    assert np.allclose(efficiencies, expected_efficiencies, atol=1e-2), (
+        f"Expected efficiencies {expected_efficiencies}, but got {efficiencies}"
+    )
+    assert np.allclose(relative_errors, expected_relative_errors, atol=1e-2), (
+        f"Expected relative errors {expected_relative_errors}, but got {relative_errors}"
+    )
 
     with pytest.raises(
         ValueError, match="Reconstructed event counts exceed simulated event counts."

--- a/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
+++ b/tests/unit_tests/ray_tracing/test_mirror_panel_psf.py
@@ -67,7 +67,6 @@ def test_define_telescope_model(mock_args_dict, mock_telescope_model_string, moc
         patch(mock_telescope_model_string) as mock_telescope_model,
         patch(mock_find_file_string) as mock_find_file,
     ):
-
         args_dict["mirror_list"] = None
         args_dict["random_focal_length"] = None
         db_config = {"db": "config"}
@@ -93,7 +92,6 @@ def test_define_telescope_model(mock_args_dict, mock_telescope_model_string, moc
         patch(mock_telescope_model_string) as mock_telescope_model,
         patch(mock_find_file_string) as mock_find_file,
     ):
-
         args_dict["mirror_list"] = "mirror_list_CTA-N-LST1_v2019-03-31_rotated.ecsv"
         args_dict["model_path"] = "tests/resources"
         args_dict["random_focal_length"] = 0.1
@@ -125,7 +123,6 @@ def test_define_telescope_model_test_errors(
         patch(mock_telescope_model_string),
         patch(mock_find_file_string),
     ):
-
         db_config = {"db": "config"}
         label = "test_label"
 
@@ -157,7 +154,6 @@ def test_write_optimization_data(mock_mirror_panel_psf):
         patch("simtools.ray_tracing.mirror_panel_psf.writer.ModelDataWriter.dump") as mock_dump,
         patch("simtools.ray_tracing.mirror_panel_psf.MetadataCollector") as mock_metadata_collector,
     ):
-
         mirror_panel_psf.write_optimization_data()
         mock_dump.assert_called_once()
         mock_metadata_collector.assert_called_once()
@@ -190,7 +186,6 @@ def test_run_simulations_and_analysis(mock_telescope_model_string, mock_find_fil
         patch(mock_find_file_string),
         patch("simtools.ray_tracing.mirror_panel_psf.RayTracing") as mock_ray_tracing,
     ):
-
         db_config = {"db": "config"}
         label = "test_label"
         mirror_panel_psf = MirrorPanelPSF(label, args_dict, db_config)
@@ -277,7 +272,6 @@ def test_derive_random_reflection_angle_no_tuning(
         mock_run_simulations_and_analysis_string,
         return_value=(0.5, 0.1),
     ) as mock_run_simulations_and_analysis:
-
         mock_run_simulations_and_analysis.start()
         mirror_psf.derive_random_reflection_angle()
 
@@ -302,7 +296,6 @@ def test_derive_random_reflection_angle_with_tuning(
             return_value=(0.5, 0.1),
         ) as mock_run_simulations,
     ):
-
         mirror_psf.derive_random_reflection_angle()
 
         mock_optimize.assert_called_once()
@@ -324,7 +317,6 @@ def test_optimize_reflection_angle(mock_mirror_panel_psf, mock_run_simulations_a
             (0.45, 0.1),  # Third call
         ],
     ) as mock_run_simulations:
-
         mirror_psf._optimize_reflection_angle()
 
         assert mirror_psf.results_rnda == pytest.approx([0.1, 0.09, 0.08])

--- a/tests/unit_tests/ray_tracing/test_psf_analysis.py
+++ b/tests/unit_tests/ray_tracing/test_psf_analysis.py
@@ -47,7 +47,6 @@ def psf_image():
 
 
 def test_init_zero_focal_length(caplog):
-
     with caplog.at_level(logging.WARNING):
         PSFImage(focal_length=0.0)
     assert "Focal length is zero; no conversion from cm to deg possible." in caplog.text

--- a/tests/unit_tests/ray_tracing/test_ray_tracing.py
+++ b/tests/unit_tests/ray_tracing/test_ray_tracing.py
@@ -84,7 +84,6 @@ def ray_tracing_lst_single_mirror_mode(telescope_model_lst_mock, simtel_path):
 
 
 def test_ray_tracing_init(simtel_path, telescope_model_lst_mock, caplog):
-
     with caplog.at_level(logging.DEBUG):
         ray = RayTracing(
             telescope_model=telescope_model_lst_mock,
@@ -203,7 +202,6 @@ def test_analyze(ray_tracing_lst, mocker, export, force, read_called, store_call
 
 
 def test_process_off_axis_and_mirror(ray_tracing_lst, mocker):
-
     mock_generate_file_name = mocker.patch.object(
         ray_tracing_lst, "_generate_file_name", return_value="photons_file"
     )

--- a/tests/unit_tests/reporting/test_docs_read_parameters.py
+++ b/tests/unit_tests/reporting/test_docs_read_parameters.py
@@ -5,7 +5,6 @@ from simtools.reporting.docs_read_parameters import ReadParameters
 
 
 def test_get_all_parameter_descriptions(telescope_model_lst, io_handler, db_config):
-
     output_path = io_handler.get_output_directory(sub_dir=f"{telescope_model_lst.model_version}")
     read_parameters = ReadParameters(
         db_config=db_config, telescope_model=telescope_model_lst, output_path=output_path
@@ -20,7 +19,6 @@ def test_get_all_parameter_descriptions(telescope_model_lst, io_handler, db_conf
 
 
 def test_get_telescope_parameter_data(telescope_model_lst, io_handler, db_config):
-
     output_path = io_handler.get_output_directory(sub_dir=f"{telescope_model_lst.model_version}")
     read_parameters = ReadParameters(
         db_config=db_config, telescope_model=telescope_model_lst, output_path=output_path

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -45,7 +45,6 @@ def corsika_simtel_runner(io_handler, corsika_config_mock_array_model, simtel_pa
 
 
 def test_corsika_simtel_runner(corsika_simtel_runner):
-
     assert isinstance(corsika_simtel_runner.corsika_runner, CorsikaRunner)
     assert isinstance(corsika_simtel_runner.simulator_array, SimulatorArray)
 
@@ -140,7 +139,6 @@ def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_
 
 
 def test_get_file_name(corsika_simtel_runner, simulation_file):
-
     assert (
         corsika_simtel_runner.get_file_name(
             simulation_software="corsika", file_type="log", run_number=1

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -164,18 +164,14 @@ def test_get_data_file_path(runner_service, corsika_runner_mock_array_model, fil
         file_type="corsika_output", file_name=file_base_name, run_number=1
     ) == corsika_runner_mock_array_model._directory["data"].joinpath(
         runner_service._get_run_number_string(1)
-    ).joinpath(
-        f"{file_base_name}.zst"
-    )
+    ).joinpath(f"{file_base_name}.zst")
 
     # simtel output
     assert runner_service._get_data_file_path(
         file_type="simtel_output", file_name=file_base_name, run_number=1
     ) == corsika_runner_mock_array_model._directory["data"].joinpath(
         runner_service._get_run_number_string(1)
-    ).joinpath(
-        f"{file_base_name}.simtel.zst"
-    )
+    ).joinpath(f"{file_base_name}.simtel.zst")
 
 
 def test_get_sub_file_path(runner_service, file_base_name, io_handler):
@@ -200,7 +196,6 @@ def test_get_sub_file_path(runner_service, file_base_name, io_handler):
 
 
 def test_get_file_name(runner_service):
-
     assert isinstance(runner_service.get_file_name("log", run_number=1), pathlib.Path)
     assert isinstance(runner_service.get_file_name("output", run_number=1), pathlib.Path)
     assert isinstance(runner_service.get_file_name("sub_log", run_number=1), pathlib.Path)

--- a/tests/unit_tests/runners/test_simtel_runner.py
+++ b/tests/unit_tests/runners/test_simtel_runner.py
@@ -58,7 +58,6 @@ def test_run(simtel_runner, caplog):
 
 
 def test_run_simtel_and_check_output(simtel_runner):
-
     with pytest.raises(SimtelExecutionError):
         simtel_runner._run_simtel_and_check_output("test-5", None, None)
     assert simtel_runner._run_simtel_and_check_output("echo test", None, None) == 0

--- a/tests/unit_tests/simtel/test_simtel_config_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_config_reader.py
@@ -67,7 +67,6 @@ def test_simtel_config_reader_num_gains(config_reader_num_gains):
 def test_simtel_config_reader_telescope_transmission(
     config_reader_telescope_transmission, simtel_config_file, schema_telescope_transmission
 ):
-
     _config = config_reader_telescope_transmission
     assert isinstance(_config.parameter_dict, dict)
     assert _config.parameter_name == "telescope_transmission"
@@ -85,7 +84,6 @@ def test_simtel_config_reader_telescope_transmission(
 def test_compare_simtel_config_with_schema(
     config_reader_num_gains, config_reader_telescope_transmission, caplog
 ):
-
     _config_ng = config_reader_num_gains
 
     # no differences; should result in no output
@@ -123,7 +121,6 @@ def test_compare_simtel_config_with_schema(
 
 
 def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, caplog):
-
     _config_ng = config_reader_num_gains
 
     with pytest.raises(FileNotFoundError):
@@ -144,7 +141,6 @@ def test_read_simtel_config_file(config_reader_num_gains, simtel_config_file, ca
 
 
 def test_get_type_and_dimension_from_simtel_cfg(config_reader_num_gains):
-
     _config = copy.deepcopy(config_reader_num_gains)
 
     assert _config._get_type_and_dimension_from_simtel_cfg(["Int", "1"]) == ("int64", 1)
@@ -161,7 +157,6 @@ def test_get_type_and_dimension_from_simtel_cfg(config_reader_num_gains):
 
 
 def test_resolve_all_in_column(config_reader_num_gains):
-
     _config = config_reader_num_gains
 
     # empty
@@ -180,7 +175,6 @@ def test_resolve_all_in_column(config_reader_num_gains):
 
 
 def test_add_value_from_simtel_cfg(config_reader_num_gains):
-
     _config = config_reader_num_gains
 
     # None
@@ -218,7 +212,6 @@ def test_add_value_from_simtel_cfg(config_reader_num_gains):
 
 
 def test_get_simtel_parameter_name(config_reader_num_gains):
-
     _config = copy.deepcopy(config_reader_num_gains)
     assert _config._get_simtel_parameter_name("num_gains") == "NUM_GAINS"
     assert _config._get_simtel_parameter_name("telescope_transmission") == "TELESCOPE_TRANSMISSION"

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -59,7 +59,6 @@ def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
 
 
 def test_get_simtel_metadata(simtel_config_writer):
-
     _tel = simtel_config_writer._get_simtel_metadata("telescope")
     assert len(_tel) == 8
     assert _tel["camera_config_name"] == simtel_config_writer._telescope_model_name
@@ -75,7 +74,6 @@ def test_get_simtel_metadata(simtel_config_writer):
 
 
 def test_get_value_string_for_simtel(simtel_config_writer):
-
     assert simtel_config_writer._get_value_string_for_simtel(None) == "none"
     assert simtel_config_writer._get_value_string_for_simtel(True) == 1
     assert simtel_config_writer._get_value_string_for_simtel(False) == 0

--- a/tests/unit_tests/simtel/test_simtel_io_histogram.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histogram.py
@@ -190,7 +190,6 @@ def test_view_cone(simtel_hist_io_instance, simtel_hist_hdata_io_instance):
 
 
 def test_compute_system_trigger_rate_and_table(simtel_hist_io_instance):
-
     assert simtel_hist_io_instance.trigger_rate is None
     assert simtel_hist_io_instance.trigger_rate_uncertainty is None
     assert simtel_hist_io_instance.trigger_rate_per_energy_bin is None
@@ -210,7 +209,6 @@ def test_compute_system_trigger_rate_and_table(simtel_hist_io_instance):
 
 
 def test_compute_system_trigger_rate_with_input(simtel_hist_io_instance):
-
     new_instance = copy.copy(simtel_hist_io_instance)
     events_histogram, triggered_events_histogram = new_instance.fill_event_histogram_dicts()
     new_events_histogram = copy.copy(events_histogram)
@@ -225,7 +223,6 @@ def test_compute_system_trigger_rate_with_input(simtel_hist_io_instance):
 
 
 def test_produce_trigger_meta_data(simtel_hist_io_instance, simtel_io_file):
-
     trigger_rate = 1000  # Hz
 
     simtel_hist_io_instance.histogram_file = simtel_io_file
@@ -280,7 +277,6 @@ def test_estimate_observation_time(simtel_hist_io_instance):
 
 
 def test_estimate_trigger_rate_uncertainty(simtel_hist_io_instance):
-
     simtel_hist_io_instance.compute_system_trigger_rate()
     _simulated, _triggered = simtel_hist_io_instance.total_number_of_events
     trigger_rate_uncertainty = simtel_hist_io_instance.estimate_trigger_rate_uncertainty(

--- a/tests/unit_tests/simtel/test_simtel_table_reader.py
+++ b/tests/unit_tests/simtel/test_simtel_table_reader.py
@@ -96,7 +96,6 @@ def test_data_simple_columns():
 
 
 def test_data_columns_mirror_reflectivity():
-
     columns, description = simtel_table_reader._data_columns_mirror_reflectivity(2, ["0", "20"])
     assert columns == [
         {"name": "wavelength", "description": "Wavelength", "unit": "nm"},

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -97,7 +97,6 @@ def test_check_run_result(simulator_camera_efficiency):
 
 @pytest.mark.xfail(reason="Test requires Derived-Values Database")
 def test_get_one_dim_distribution(io_handler, db_config, simtel_path, model_version_prod5):
-
     logger.warning(
         "Running test_get_one_dim_distribution using prod5 model "
         " (prod6 model with 1D transmission function)"

--- a/tests/unit_tests/simtel/test_simulator_light_emission.py
+++ b/tests/unit_tests/simtel/test_simulator_light_emission.py
@@ -246,7 +246,6 @@ def test_make_light_emission_script_laser(
     mock_output_path,
     io_handler,
 ):
-
     # Call the method under test
     command = mock_simulator_laser._make_light_emission_script()
 
@@ -277,7 +276,6 @@ def test_make_light_emission_script_laser(
 
 
 def test_calibration_pointing_direction(mock_simulator):
-
     # Calling calibration_pointing_direction method
     pointing_vector, angles = mock_simulator.calibration_pointing_direction()
 
@@ -307,7 +305,6 @@ def test_create_postscript(mock_simulator, simtel_path, mock_output_path):
 
 
 def test_plot_simtel_ctapipe(mock_simulator, mock_output_path):
-
     mock_simulator.output_directory = "./tests/resources/"
     cleaning_args = [5, 3, 2]
     filename = f"{mock_simulator.output_directory}/"

--- a/tests/unit_tests/test_constants.py
+++ b/tests/unit_tests/test_constants.py
@@ -6,7 +6,6 @@ import simtools.constants as constants
 
 
 def test_constants():
-
     assert isinstance(constants.METADATA_JSON_SCHEMA, Path)
     assert constants.METADATA_JSON_SCHEMA.is_file()
 

--- a/tests/unit_tests/test_dependencies.py
+++ b/tests/unit_tests/test_dependencies.py
@@ -28,7 +28,6 @@ def test_get_database_version_no_version():
 
 
 def test_get_corsika_version(caplog):
-
     # no build_opts.yml file
     with caplog.at_level(logging.WARNING):
         assert dependencies.get_corsika_version() is None

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -90,7 +90,6 @@ def shower_array_simulator(io_handler, db_config, simulations_args_dict):
 
 
 def test_init_simulator(shower_simulator, array_simulator, shower_array_simulator):
-
     assert isinstance(shower_simulator._simulation_runner, CorsikaRunner)
     assert isinstance(shower_array_simulator._simulation_runner, CorsikaSimtelRunner)
     assert isinstance(array_simulator._simulation_runner, SimulatorArray)

--- a/tests/unit_tests/testing/test_assertions.py
+++ b/tests/unit_tests/testing/test_assertions.py
@@ -45,7 +45,6 @@ def valid_sim_telarray_file_content():
 
 
 def test_assert_file_type_json(test_json_file, test_yaml_file):
-
     assert assertions.assert_file_type("json", test_json_file)
     assert not assertions.assert_file_type("json", "tests/resources/does_not_exist.json")
     assert not assertions.assert_file_type("json", test_yaml_file)
@@ -54,7 +53,6 @@ def test_assert_file_type_json(test_json_file, test_yaml_file):
 
 
 def test_assert_file_type_yaml(test_json_file, test_yaml_file, caplog):
-
     assert assertions.assert_file_type("yaml", test_yaml_file)
     assert assertions.assert_file_type("yml", test_yaml_file)
     assert not assertions.assert_file_type("yml", "tests/resources/does_not_exit.schema.yml")
@@ -65,7 +63,6 @@ def test_assert_file_type_yaml(test_json_file, test_yaml_file, caplog):
 
 
 def test_assert_file_type_others(caplog):
-
     with caplog.at_level(logging.INFO):
         assert assertions.assert_file_type(
             "ecsv", "tests/resources/telescope_positions-South-ground.ecsv"

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -414,7 +414,6 @@ def test_validate_application_output_with_file_type(
 
 
 def test_compare_simtel_cfg_files(tmp_test_directory):
-
     file1 = Path("tests/resources/sim_telarray_configurations/CTA-North-LSTN-01-6.0.0_test.cfg")
     file2 = Path("tests/resources/sim_telarray_configurations/CTA-North-LSTN-01-6.0.0_test.cfg")
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -525,7 +525,6 @@ def test_user_confirm_no(mock_input):
 
 
 def test_validate_data_type():
-
     test_cases = [
         # Test exact data type match
         ("int", 5, None, False, True),
@@ -570,7 +569,6 @@ def test_validate_data_type():
 
 
 def test_convert_list_to_string():
-
     assert gen.convert_list_to_string(None) is None
     assert gen.convert_list_to_string("a") == "a"
     assert gen.convert_list_to_string(5) == 5
@@ -603,7 +601,6 @@ def test_convert_list_to_string():
 
 
 def test_convert_string_to_list():
-
     t_1 = gen.convert_string_to_list("1 2 3 4")
     assert len(t_1) == 4
     assert pytest.approx(t_1[1]) == 2.0
@@ -770,7 +767,6 @@ def test_clear_default_sim_telarray_cfg_directories():
 
 
 def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
-
     # Test with a list of file names with valid suffixes.
     file_1 = tmp_test_directory / "file1.txt"
     file_2 = tmp_test_directory / "file2.txt"
@@ -806,7 +802,6 @@ def test_get_list_of_files_from_command_line(tmp_test_directory) -> None:
 
 
 def test_now_date_time_in_isoformat():
-
     now = gen.now_date_time_in_isoformat()
     assert now is not None
     assert isinstance(now, str)

--- a/tests/unit_tests/utils/test_names.py
+++ b/tests/unit_tests/utils/test_names.py
@@ -19,20 +19,17 @@ def invalid_name():
 
 
 def test_model_parameters():
-
     assert isinstance(names.model_parameters(), dict)
     assert isinstance(names.model_parameters("Telescope"), dict)
     assert len(names.model_parameters()) > len(names.model_parameters("Telescope"))
 
 
 def test_site_parameters():
-
     assert isinstance(names.site_parameters(), dict)
     assert "altitude" in names.site_parameters()
 
 
 def test_telescope_parameters():
-
     assert isinstance(names.telescope_parameters(), dict)
     assert "focal_length" in names.telescope_parameters()
 
@@ -207,7 +204,6 @@ def test_get_site_from_array_element_name(invalid_name):
 
 
 def test_get_collection_name_from_array_element_name():
-
     assert "telescopes" == names.get_collection_name_from_array_element_name("LSTN-01")
     assert "telescopes" == names.get_collection_name_from_array_element_name("MSTx-FlashCam")
     assert "sites" == names.get_collection_name_from_array_element_name("North", False)
@@ -261,7 +257,6 @@ def test_get_array_element_id_from_name(invalid_name):
 
 
 def test_generate_file_name_camera_efficiency():
-
     site = "South"
     telescope_model_name = "LSTS-01"
     zenith_angle = 20
@@ -562,7 +557,6 @@ def test_get_simulation_software_name_from_parameter_name():
 
 
 def test_file_name_with_version():
-
     assert names.file_name_with_version(None, None) is None
     assert names.file_name_with_version("file", None) is None
     assert names.file_name_with_version(None, ".yml") is None
@@ -575,7 +569,6 @@ def test_file_name_with_version():
 
 
 def test_db_collection_to_instrument_class_key():
-
     assert names.db_collection_to_instrument_class_key() == ["Structure", "Camera", "Telescope"]
 
     with pytest.raises(KeyError, match="Invalid collection name no_collection"):
@@ -583,7 +576,6 @@ def test_db_collection_to_instrument_class_key():
 
 
 def test_is_design_type():
-
     assert names.is_design_type("LSTN-design")
     assert names.is_design_type("MSTS-FlashCam")
     assert names.is_design_type("MSTS-NectarCam")

--- a/tests/unit_tests/utils/test_value_conversion.py
+++ b/tests/unit_tests/utils/test_value_conversion.py
@@ -164,7 +164,6 @@ def test_split_value_is_list():
 
 
 def test_unit_as_string():
-
     assert value_conversion._unit_as_string(None) is None
     assert value_conversion._unit_as_string("m") == "m"
     assert value_conversion._unit_as_string(["m"]) == "m"


### PR DESCRIPTION
Was wondering why long lines are not fixed anymore with pre-commit. Ruff formatting needs to be switched on explicitly (remember that we have removed black to avoid using several tools recently; see PR #1407.

ruff and black are nearly identical, but not exactly  (see the [ruff FAQ](https://docs.astral.sh/ruff/faq/#is-the-ruff-linter-compatible-with-black)). This means running it over all files changed 60 files. Scanning through the changes, I do think it improved the readability of the code and we should apply them.