### PR TITLE
Improvements to production docker images: arm compatibility; run integration tests

### DIFF
--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -210,7 +210,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-prod-opt
       - name: set image tag
-        run: echo "image_tag=${{ steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
+        run: |
+            TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep 'latest' | head -n1)
+            echo "image_tag=$TAG" >> "$GITHUB_ENV"
         id: set-image-tag
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -189,7 +189,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value={{date 'YYYYMMDD-HHmmss'}}
-          images: ${{ env.REGISTRY }}/gammasim/simtools-prod-opt-${{ env.LABELS }}
+          images: ${{ env.REGISTRY }}/gammasim/simtools-prod-${{ env.LABELS }}
           flavor: latest=true
 
       - name: Build and push optimized image
@@ -207,9 +207,9 @@ jobs:
             BUILD_BRANCH=${{ env.BUILD_BRANCH }}
           push:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
-          file: ./docker/Dockerfile-prod-opt
+          file: ./docker/Dockerfile-prod
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}-prod-opt
+          labels: ${{ steps.meta.outputs.labels }}-prod
       - name: set image tag
         run: |
             echo "image_tag=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)" >> "$GITHUB_ENV"
@@ -231,7 +231,7 @@ jobs:
           - {build_opt: 'prod6-baseline', extra_def: ''}
         avx_instruction: ['no_opt']
     container:
-      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}
@@ -244,7 +244,7 @@ jobs:
 
       - name: Set sim_telarray path
         run: |
-          echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
+          echo "PATH=\$PATH:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -255,5 +255,6 @@ jobs:
       - name: Run test
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
-        run: >
+        run: |
+          source /workdir/env/bin/activate
           simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -211,8 +211,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}-prod-opt
       - name: set image tag
         run: |
-            TAG=$(echo "${{ steps.meta.outputs.tags }}" | grep 'latest' | head -n1)
-            echo "image_tag=$TAG" >> "$GITHUB_ENV"
+            echo "image_tag=$(echo '${{ steps.meta.outputs.tags }}' | head -n1)" >> "$GITHUB_ENV"
         id: set-image-tag
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
@@ -231,6 +230,7 @@ jobs:
         avx_instruction: ['noOpt']
 
     steps:
+
       # test the no-opt image with one application using the database,
       # CORSIKA, sim_telarray, and simtools
       - name: Test image

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -231,8 +231,7 @@ jobs:
           - {build_opt: 'prod6-baseline', extra_def: ''}
         avx_instruction: ['no_opt']
     container:
-      image: >
-        ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -139,7 +139,7 @@ jobs:
           # - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+#          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
           - {build_opt: 'prod6-baseline', extra_def: ''}
           # - {build_opt: 'prod5', extra_def: ''}
           # - {build_opt: 'prod5-sc', extra_def: ''}
@@ -223,25 +223,25 @@ jobs:
       matrix:
         version:
           - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
+#          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+#          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
           - {build_opt: 'prod6-baseline', extra_def: ''}
         avx_instruction: ['noOpt']
-
+    container:
+      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      env:
+        SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
+        SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}
+        SIMTOOLS_DB_API_USER: ${{ env.SIMTOOLS_DB_API_USER }}
+        SIMTOOLS_DB_API_PW: ${{ env.SIMTOOLS_DB_API_PW }}
+        SIMTOOLS_DB_SERVER: ${{ env.SIMTOOLS_DB_SERVER }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # test the no-opt image with one application using the database,
-      # CORSIKA, sim_telarray, and simtools
-      - name: Test image
-        if: ${{ matrix.avx_instruction == 'noOpt' }}
+      - name: Run test
         run: >
-          docker run --rm
-          -e "SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'"
-          -e "SIMTOOLS_DB_API_PORT=${{ env.SIMTOOLS_DB_API_PORT }}"
-          -e "SIMTOOLS_DB_API_USER=${{ env.SIMTOOLS_DB_API_USER }}"
-          -e "SIMTOOLS_DB_API_PW=${{ env.SIMTOOLS_DB_API_PW }}"
-          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}"
-          -v "$(pwd):/workdir/external" ${{ needs.build-production-images-optimized.outputs.image_tag }}
-          bash -c "cd /workdir/external && simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml"
-        shell: /usr/bin/bash -e {0}
+          cd /workdir/external &&
+          simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -255,8 +255,9 @@ jobs:
       - name: Run test
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+          PYTEST_ADDOPTS: ""
         run: |
           source /workdir/env/bin/activate
           # simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
-          pip install --no-cache-dir pytest pytest-requirements
+          pip install --no-cache-dir pytest pytest-requirements pytest-xdist 
           pytest --no-cov -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -253,7 +253,6 @@ jobs:
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
       - name: Run test
-        shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: >

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -50,6 +50,7 @@ jobs:
   build-corsika-simtelarray:
     runs-on: ubuntu-latest
     needs: download-corsika
+    if: false
     permissions:
       contents: read
       packages: write
@@ -243,4 +244,4 @@ jobs:
 
       - name: Run test
         run: >
-          simtools-simulate-prod --config ./tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml
+          simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Set sim_telarray path
         run: |
-          echo "PATH=\$PATH:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
+          echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -242,6 +242,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set sim_telarray path
+        run: |
+          echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
+
+      - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
+        run: |
+          SIMTOOLS_DB_SIMULATION_MODEL=$(grep 'SIMTOOLS_DB_SIMULATION_MODEL=' .env_template | cut -d '=' -f2- | tr -d '"')
+          SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
+          echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
+
       - name: Run test
+        shell: bash -l {0}
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: >
           simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -243,5 +243,4 @@ jobs:
 
       - name: Run test
         run: >
-          cd /workdir/external &&
-          simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml
+          simtools-simulate-prod --config ./tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -143,7 +143,7 @@ jobs:
           - {build_opt: 'prod6-baseline', extra_def: ''}
           # - {build_opt: 'prod5', extra_def: ''}
           # - {build_opt: 'prod5-sc', extra_def: ''}
-        avx_instruction: ['avx2', 'noOpt']
+        avx_instruction: ['avx2', 'noopt']
         # avx_instruction: ['avx2', 'avx512f', 'sse4', 'avx']
 
     env:
@@ -228,15 +228,9 @@ jobs:
         production:
 #          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
           - {build_opt: 'prod6-baseline', extra_def: ''}
-        avx_instruction: ['noOpt']
+        avx_instruction: ['noopt']
     container:
-      image: ${{ format('ghcr.io/gammasim/simtools-prod-opt-{0}-corsika-{1}-bernlohr-{2}-{3}-{4}-{5}', 
-                  toLowerCase(matrix.version.simtel_version), 
-                  toLowerCase(matrix.version.corsika_version), 
-                  toLowerCase(matrix.version.bernlohr_version), 
-                  toLowerCase(matrix.production.build_opt), 
-                  toLowerCase(matrix.hadronic_model), 
-                  toLowerCase(matrix.avx_instruction)) }}
+      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -255,9 +255,8 @@ jobs:
       - name: Run test
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
-          PYTEST_ADDOPTS: ""
         run: |
           source /workdir/env/bin/activate
           # simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
-          pip install --no-cache-dir pytest pytest-requirements pytest-xdist 
+          pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist 
           pytest --no-cov -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -207,7 +207,7 @@ jobs:
             BUILD_BRANCH=${{ env.BUILD_BRANCH }}
           push:
             ${{ github.event_name == 'release' || github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch' }}
-          file: ./docker/Dockerfile-prod
+          file: ./docker/Dockerfile-prod-opt
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-prod
       - name: set image tag

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -258,3 +258,5 @@ jobs:
         run: |
           source /workdir/env/bin/activate
           simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
+          pip install pytest pytest-requirements
+          pytest --no-cov -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -257,6 +257,6 @@ jobs:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
           source /workdir/env/bin/activate
-          simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
-          pip install pytest pytest-requirements
+          # simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
+          pip install --no-cache-dir pytest pytest-requirements
           pytest --no-cov -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -230,7 +230,13 @@ jobs:
           - {build_opt: 'prod6-baseline', extra_def: ''}
         avx_instruction: ['noOpt']
     container:
-      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      image: ${{ format('ghcr.io/gammasim/simtools-prod-opt-{0}-corsika-{1}-bernlohr-{2}-{3}-{4}-{5}', 
+                  toLowerCase(matrix.version.simtel_version), 
+                  toLowerCase(matrix.version.corsika_version), 
+                  toLowerCase(matrix.version.bernlohr_version), 
+                  toLowerCase(matrix.production.build_opt), 
+                  toLowerCase(matrix.hadronic_model), 
+                  toLowerCase(matrix.avx_instruction)) }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -14,6 +14,10 @@ on:
     - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC (build only)
 
 env:
+  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
+  SIMTOOLS_DB_API_USER: ${{ secrets.DB_READ_USER }}
+  SIMTOOLS_DB_API_PW: ${{ secrets.DB_READ_PW }}
+  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   CLOUD_URL: "https://syncandshare.desy.de/index.php/s/"
@@ -205,3 +209,37 @@ jobs:
           file: ./docker/Dockerfile-prod-opt
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}-prod-opt
+      - name: set image tag
+        run: echo "image_tag=${{ steps.meta.outputs.tags }}" >> $GITHUB_OUTPUT
+        id: set-image-tag
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tags }}
+
+  test-images:
+    runs-on: ubuntu-latest
+    needs: build-production-images-optimized
+    strategy:
+      matrix:
+        version:
+          - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
+        hadronic_model: ['qgs2']
+        production:
+          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-baseline', extra_def: ''}
+        avx_instruction: ['noOpt']
+
+    steps:
+      # test the no-opt image with one application using the database,
+      # CORSIKA, sim_telarray, and simtools
+      - name: Test image
+        if: ${{ matrix.avx_instruction == 'noOpt' }}
+        run: >
+          docker run --rm
+          -e "SIMTOOLS_SIMTEL_PATH='/workdir/sim_telarray'"
+          -e "SIMTOOLS_DB_API_PORT=${{ env.SIMTOOLS_DB_API_PORT }}"
+          -e "SIMTOOLS_DB_API_USER=${{ env.SIMTOOLS_DB_API_USER }}"
+          -e "SIMTOOLS_DB_API_PW=${{ env.SIMTOOLS_DB_API_PW }}"
+          -e "SIMTOOLS_DB_SERVER=${{ env.SIMTOOLS_DB_SERVER }}"
+          -v "$(pwd):/workdir/external" ${{ needs.build-production-images-optimized.outputs.image_tag }}
+          bash -c "cd /workdir/external && simtools-simulate-prod --config /workdir/external/tests/integration_tests/config/simulate_prod_gamma_20_deg_pack_for_grid.yml"
+        shell: /usr/bin/bash -e {0}

--- a/.github/workflows/build-docker-corsika-simtelarray-image.yml
+++ b/.github/workflows/build-docker-corsika-simtelarray-image.yml
@@ -1,6 +1,7 @@
 ---
 name: docker-corsika-simtelarray
 # Build and push vanilla CORSIKA / sim_telarray image and simtools-prod images for different CPU architectures.
+# Integration tests are running on the non-optimized ('no_opt') image.
 
 on:
   workflow_dispatch:
@@ -50,7 +51,6 @@ jobs:
   build-corsika-simtelarray:
     runs-on: ubuntu-latest
     needs: download-corsika
-    if: false
     permissions:
       contents: read
       packages: write
@@ -140,11 +140,11 @@ jobs:
           # - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-#          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
           - {build_opt: 'prod6-baseline', extra_def: ''}
           # - {build_opt: 'prod5', extra_def: ''}
           # - {build_opt: 'prod5-sc', extra_def: ''}
-        avx_instruction: ['avx2', 'noopt']
+        avx_instruction: ['avx2', 'no_opt']
         # avx_instruction: ['avx2', 'avx512f', 'sse4', 'avx']
 
     env:
@@ -224,14 +224,15 @@ jobs:
       matrix:
         version:
           - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-#          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
+          # - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-#          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
           - {build_opt: 'prod6-baseline', extra_def: ''}
-        avx_instruction: ['noopt']
+        avx_instruction: ['no_opt']
     container:
-      image: ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      image: >
+        ghcr.io/gammasim/simtools-prod-opt-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}
@@ -252,11 +253,10 @@ jobs:
           SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
-      - name: Run test
+      - name: Run integration tests
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
         run: |
           source /workdir/env/bin/activate
-          # simtools-simulate-prod --config tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
-          pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist 
-          pytest --no-cov -n auto tests/integration_tests/test_applications_from_config.py
+          pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist
+          pytest --no-cov --color=yes -n auto tests/integration_tests/test_applications_from_config.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       [
         "--strict",
         "-d",
-        '{extends: default, rules: {line-length: {max: 250}, indentation: {spaces: 2, indent-sequences: consistent}, truthy: {allowed-values: ["true", "false", "on", "off"]}}}'
+        '{extends: default, rules: {line-length: {max: 300}, indentation: {spaces: 2, indent-sequences: consistent}, truthy: {allowed-values: ["true", "false", "on", "off"]}}}'
       ]
 # towncrier
 - repo: https://github.com/twisted/towncrier

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -28,7 +28,7 @@ RUN cd corsika-$CORSIKA_VERSION && \
     if [[ $CORSIKA_VERSION -eq 77550 ]]; then \
         (cd src && patch -b -p0 corsika.F < "../../corsika-77550.patch"); \
     fi && \
-    if [[ "$AVX_FLAG" == "noOpt" ]]; then \
+    if [[ "$AVX_FLAG" == "noopt" ]]; then \
         ../corsika_build_script $HADRONIC_MODEL generic; \
     else \
         ./corsika_opt_patching.sh && \
@@ -40,7 +40,7 @@ RUN cd corsika-$CORSIKA_VERSION && \
 RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
     AVX_EXTRA_FLAG=$([ "$AVX_FLAG" = "avx512f" ] && echo "-ffp-contract=off" || echo "") && \
     CFLAGS="" && CXXFLAGS="" && FFLAGS="" && \
-    if [[ "$AVX_FLAG" == "noOpt" ]]; then \
+    if [[ "$AVX_FLAG" == "noopt" ]]; then \
         CFLAGS="-g  -std=c99 -O3"; \
         CXXFLAGS="-g  -std=c99 -O3"; \
         FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -std=c99 -O3"; \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -28,7 +28,7 @@ RUN cd corsika-$CORSIKA_VERSION && \
     if [[ $CORSIKA_VERSION -eq 77550 ]]; then \
         (cd src && patch -b -p0 corsika.F < "../../corsika-77550.patch"); \
     fi && \
-    if [[ "$AVX_FLAG" == "noopt" ]]; then \
+    if [[ "$AVX_FLAG" == "no_opt" ]]; then \
         ../corsika_build_script $HADRONIC_MODEL generic; \
     else \
         ./corsika_opt_patching.sh && \
@@ -40,7 +40,7 @@ RUN cd corsika-$CORSIKA_VERSION && \
 RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
     AVX_EXTRA_FLAG=$([ "$AVX_FLAG" = "avx512f" ] && echo "-ffp-contract=off" || echo "") && \
     CFLAGS="" && CXXFLAGS="" && FFLAGS="" && \
-    if [[ "$AVX_FLAG" == "noopt" ]]; then \
+    if [[ "$AVX_FLAG" == "no_opt" ]]; then \
         CFLAGS="-g  -std=c99 -O3"; \
         CXXFLAGS="-g  -std=c99 -O3"; \
         FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -std=c99 -O3"; \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -40,9 +40,9 @@ RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
     AVX_EXTRA_FLAG=$([ "$AVX_FLAG" = "avx512f" ] && echo "-ffp-contract=off" || echo "") && \
     CFLAGS="" && CXXFLAGS="" && FFLAGS="" && \
     if [[ "$AVX_FLAG" == "noOpt" ]]; then \
-        CFLAGS="-g  -std=c99 -O3 -mavx2"; \
-        CXXFLAGS="-g  -std=c99 -O3 -mavx2"; \
-        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -std=c99 -O3 -mavx2"; \
+        CFLAGS="-g  -std=c99 -O3"; \
+        CXXFLAGS="-g  -std=c99 -O3"; \
+        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -std=c99 -O3"; \
     else \
         CFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
         CXXFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -8,6 +8,7 @@ ARG AVX_FLAG="avx2"
 ARG CORSIKA_VERSION="77550"
 ARG BERNLOHR_VERSION="1.68"
 ARG BUILD_BRANCH=main
+ARG PYTHON_VERSION=3.12
 ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
 
 RUN yum update -y && yum install -y \
@@ -85,16 +86,17 @@ FROM almalinux:9.5-minimal
 WORKDIR /workdir
 ARG BUILD_BRANCH=main
 ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
+ARG PYTHON_VERSION=3.12
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN microdnf update -y && microdnf install -y \
     bc findutils gcc-c++ git gsl-devel gcc-fortran libgfortran \
-    procps python3.12-devel zstd && \
+    procps python${PYTHON_VERSION}-devel zstd && \
     microdnf clean all
 
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
   && git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1 \
-  && python3.12 -m venv env \
+  && python${PYTHON_VERSION} -m venv env \
   && source env/bin/activate \
   && pip install -U pip \
   && pip install --no-cache-dir ${SIMTOOLS_REQUIREMENT}

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -87,7 +87,7 @@ COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN microdnf update -y && microdnf install -y \
     bc findutils gcc-c++ git gsl-devel gcc-fortran libgfortran \
-    procps python3.11-pip zstd && \
+    procps python3.11-dev zstd && \
     microdnf clean all
 
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -8,6 +8,7 @@ ARG AVX_FLAG="avx2"
 ARG CORSIKA_VERSION="77550"
 ARG BERNLOHR_VERSION="1.68"
 ARG BUILD_BRANCH=main
+ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
 
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
@@ -83,20 +84,21 @@ RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
 FROM almalinux:9.5-minimal
 WORKDIR /workdir
 ARG BUILD_BRANCH=main
+ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN microdnf update -y && microdnf install -y \
     bc findutils gcc-c++ git gsl-devel gcc-fortran libgfortran \
-    procps python3.11-pip zstd && \
+    procps python3.12-devel zstd && \
     microdnf clean all
 
-RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \
-    git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1 && \
-    python3.11 -m venv env && \
-    source env/bin/activate && \
-    pip install -U pip && \
-    pip install --no-cache-dir ./simtools && \
-    rm -rf simtools
+RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
+  && git clone -b $BUILD_BRANCH https://github.com/gammasim/simtools.git --depth 1 \
+  && python3.12 -m venv env \
+  && source env/bin/activate \
+  && pip install -U pip \
+  && pip install --no-cache-dir ${SIMTOOLS_REQUIREMENT}
+#  && pip install --no-cache-dir ./simtools
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 ENV PATH="/workdir/env/bin/:$PATH"

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -87,7 +87,7 @@ COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN microdnf update -y && microdnf install -y \
     bc findutils gcc-c++ git gsl-devel gcc-fortran libgfortran \
-    procps python3.11-dev zstd && \
+    procps python3.11-pip zstd && \
     microdnf clean all
 
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') && \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -98,7 +98,6 @@ RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
   && source env/bin/activate \
   && pip install -U pip \
   && pip install --no-cache-dir ${SIMTOOLS_REQUIREMENT}
-#  && pip install --no-cache-dir ./simtools
 
 ENV SIMTEL_PATH="/workdir/sim_telarray/"
 ENV PATH="/workdir/env/bin/:$PATH"

--- a/docs/changes/1420.feature.md
+++ b/docs/changes/1420.feature.md
@@ -1,0 +1,1 @@
+Add integration tests to production image generation.


### PR DESCRIPTION
Two improvements regarding the production images:

- remove `avx2` flag for non-optimized images to allow to run them on arm-based CPUs (still need to use `podman run --arch amd64 ...` to execute)
- add integration test to run on the production images with non-optimized CORSIKA; this was noted recently that we need to test these images. 

Note that this is in some sense a duplication of what has been / will be added in the SimPipe gitlab repository. However, for it is easier to develop these steps here.

Minor changes: 

- docker image tags are call small caps. Changed there the name for non-optimized images from `noOpt` to `no-opt`.
- increased the allowed line length in yaml files in the pre-commit section to 300 characters (from 250). Reason is that I simple cannot get the CI running without having the `image` file in one single line.