### PR TITLE
Bug fix in DB-upload related string to list conversion

### DIFF
--- a/docs/changes/1423.bugfix.md
+++ b/docs/changes/1423.bugfix.md
@@ -1,1 +1,1 @@
-Bug fix in database-upload related string to list conversion.
+Bugfix in database-upload related string to list conversion.

--- a/docs/changes/1423.bugfix.md
+++ b/docs/changes/1423.bugfix.md
@@ -1,0 +1,1 @@
+Bug fix in database-upload related string to list conversion.

--- a/src/simtools/utils/value_conversion.py
+++ b/src/simtools/utils/value_conversion.py
@@ -123,13 +123,16 @@ def _split_value_is_quantity(value, is_integer=False):
 
 
 def _split_value_is_string(value, is_integer=False):
-    """Split vale and unit for a string."""
+    """Split value and unit for a string."""
     if value.isdigit():  # single integer value
         return int(value), None
     try:  # single value with/without unit
-        return int(u.Quantity(value).value) if is_integer else u.Quantity(value).value, str(
-            u.Quantity(value).unit
-        )
+        if is_integer:
+            return int(int(u.Quantity(value).value))
+        quantity = u.Quantity(value)
+        if str(quantity.unit).isdigit():  # cases where numbers are wrongly identified as units
+            raise ValueError
+        return quantity.value, str(quantity.unit)
     except ValueError:
         return _split_value_is_list(gen.convert_string_to_list(value), is_integer)
     except TypeError:  # string value (not numerical)

--- a/src/simtools/utils/value_conversion.py
+++ b/src/simtools/utils/value_conversion.py
@@ -127,12 +127,11 @@ def _split_value_is_string(value, is_integer=False):
     if value.isdigit():  # single integer value
         return int(value), None
     try:  # single value with/without unit
-        if is_integer:
-            return int(int(u.Quantity(value).value))
         quantity = u.Quantity(value)
-        if str(quantity.unit).isdigit():  # cases where numbers are wrongly identified as units
+        unit = str(quantity.unit)
+        if unit.isdigit():  # cases where numbers are wrongly identified as units
             raise ValueError
-        return quantity.value, str(quantity.unit)
+        return (int(quantity.value), unit) if is_integer else (quantity.value, unit)
     except ValueError:
         return _split_value_is_list(gen.convert_string_to_list(value), is_integer)
     except TypeError:  # string value (not numerical)

--- a/tests/unit_tests/utils/test_value_conversion.py
+++ b/tests/unit_tests/utils/test_value_conversion.py
@@ -149,6 +149,7 @@ def test_split_value_is_string():
     assert value_conversion._split_value_is_string("100 m") == (100, "m")
     assert value_conversion._split_value_is_string("hello") == ("hello", None)
     assert value_conversion._split_value_is_string("100 cm, 200 cm") == ([100, 200], ["cm", "cm"])
+    assert value_conversion._split_value_is_string("100 200") == ([100, 200], [None, None])
 
 
 def test_split_value_is_list():

--- a/tests/unit_tests/utils/test_value_conversion.py
+++ b/tests/unit_tests/utils/test_value_conversion.py
@@ -150,6 +150,10 @@ def test_split_value_is_string():
     assert value_conversion._split_value_is_string("hello") == ("hello", None)
     assert value_conversion._split_value_is_string("100 cm, 200 cm") == ([100, 200], ["cm", "cm"])
     assert value_conversion._split_value_is_string("100 200") == ([100, 200], [None, None])
+    test_int = value_conversion._split_value_is_string("100", True)
+    assert isinstance(test_int[0], int)
+    assert test_int[1] is None
+    assert test_int[0] == 100
 
 
 def test_split_value_is_list():


### PR DESCRIPTION
This is a bug fix to another issue (seems to be a weekly thing) of the string to list conversion needed for the DB upload (really should address this, see #1317).

This address a bug where a two number array as `240 1000.` is interpreted as `240.` and unit `Unit(dimensionless with a scale of 700)`.

Added a fix assuming the we don't use dimensionless units with a scale. Added also a test.

(as mentioned, this will all go away when addressing #1317).