### PR TITLE
Fix setting of db_api_authentication_database through env variable.

### DIFF
--- a/docs/changes/1425.bugfix.md
+++ b/docs/changes/1425.bugfix.md
@@ -1,0 +1,1 @@
+Fix setting of `db_api_authentication_database` through env variable.

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -218,7 +218,7 @@ class CommandLineParser(argparse.ArgumentParser):
             help="database  with user info (optional)",
             type=str,
             required=False,
-            default="admin",
+            default=None,
         )
         _job_group.add_argument(
             "--db_simulation_model",

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -40,7 +40,7 @@ jsonschema_db_dict = {
         "db_api_user": {"type": "string", "description": "API username"},
         "db_api_pw": {"type": "string", "description": "Password for the API user"},
         "db_api_authentication_database": {
-            "type": "string",
+            "type": ["string", "null"],
             "default": "admin",
             "description": "DB with user info (optional)",
         },
@@ -119,7 +119,9 @@ class DatabaseHandler:
             port=self.mongo_db_config["db_api_port"],
             username=self.mongo_db_config["db_api_user"],
             password=self.mongo_db_config["db_api_pw"],
-            authSource=self.mongo_db_config.get("db_api_authentication_database", "admin"),
+            authSource=self.mongo_db_config.get("db_api_authentication_database")
+            if self.mongo_db_config.get("db_api_authentication_database")
+            else "admin",
             directConnection=direct_connection,
             ssl=not direct_connection,
             tlsallowinvalidhostnames=True,

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -207,7 +207,7 @@ def test_get_db_parameters_from_env(configurator, args_dict):
     args_dict["db_api_pw"] = "12345"
     args_dict["db_api_port"] = 42
     args_dict["db_server"] = "abc@def.de"
-    args_dict["db_api_authentication_database"] = "admin"
+    args_dict["db_api_authentication_database"] = None
     args_dict["db_simulation_model"] = "sim_model"
 
     # remove user defined parameters from comparison (depends on environment)

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -329,7 +329,7 @@ def test_get_db_parameters():
     configurator.default_config(add_db_config=True)
     db_params = configurator._get_db_parameters()
     assert db_params == {
-        "db_api_authentication_database": "admin",
+        "db_api_authentication_database": None,
         "db_api_port": None,
         "db_api_pw": None,
         "db_api_user": None,


### PR DESCRIPTION
Setting of `db_api_authentication_database` was not working due to an incorrect default configuration (always set to `admin`). This PR fixes this issue.

Closes #1422 