### PR TITLE
Improve reading of single parameter and files from DB

### DIFF
--- a/docs/changes/1426.feature.md
+++ b/docs/changes/1426.feature.md
@@ -1,0 +1,1 @@
+Improve reading of single parameter and files from database. Add plotting of tabular data using `parameter_version`.

--- a/src/simtools/applications/db_get_parameter_from_db.py
+++ b/src/simtools/applications/db_get_parameter_from_db.py
@@ -3,13 +3,21 @@
 r"""
     Get a parameter entry from DB for a specific telescope or a site.
 
-    The application receives a parameter name, a site, a telescope (if applicable) and \
-    a version. It then prints out the parameter entry.
+    The application receives a parameter name, a site, a telescope (if applicable) and
+    a version. Allow to print the parameter entry to screen or save it to a file.
+    Parameter describing a table file can be written to disk or exported as an astropy table
+    (if available).
 
     Command line arguments
     ----------------------
     parameter (str, required)
         Parameter name
+
+    parameter_version (str, optional)
+        Parameter version
+
+    model_version (str, required)
+        Model version
 
     site (str, required)
         South or North.
@@ -17,8 +25,14 @@ r"""
     telescope (str, optional)
         Telescope model name (e.g. LST-1, SST-D, ...)
 
-    log_level (str, optional)
-        Log level to print.
+    output_file (str, optional)
+        Output file name. If not given, print to stdout.
+
+    export_model_file (bool, optional)
+        Export model file (if parameter describes a file).
+
+    export_model_file_as_table (bool, optional)
+        Export model file as astropy table (if parameter describes a file).
 
     Raises
     ------
@@ -35,12 +49,14 @@ r"""
                 --model_version 5.0.0
 
     Get the mirror_list parameter using the parameter_version from the DB.
+    Write the mirror list to disk.
 
     .. code-block:: console
 
         simtools-db-get-parameter-from-db --parameter mirror_list \\
                 --site North --telescope LSTN-01 \\
-                --parameter_version 1.0.0
+                --parameter_version 1.0.0 \\
+                --export_model_file
 
 """
 
@@ -104,7 +120,7 @@ def main():  # noqa: D103
         parameter_version=args_dict.get("parameter_version"),
         model_version=args_dict.get("model_version"),
     )
-    if args_dict["export_model_file"]:
+    if args_dict["export_model_file"] or args_dict["export_model_file_as_table"]:
         table = db.export_model_file(
             parameter=args_dict["parameter"],
             site=args_dict["site"],

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -210,20 +210,24 @@ class DatabaseHandler:
             production_table = self._read_production_table_from_mongo_db(
                 collection_name, model_version
             )
-            try:
-                parameter_version = production_table["parameters"][array_element_name][parameter]
-            except KeyError as exc:
-                raise ValueError(
-                    f"Parameter {parameter} not found for {array_element_name} in {model_version}"
-                ) from exc
+            array_element_list = self._get_array_element_list(
+                array_element_name, site, production_table, collection_name
+            )
+            for array_element in reversed(array_element_list):
+                parameter_version = (
+                    production_table["parameters"].get(array_element, {}).get(parameter)
+                )
+                if parameter_version:
+                    array_element_name = array_element
+                    break
 
         query = {
             "parameter_version": parameter_version,
             "parameter": parameter,
         }
-        if array_element_name is not None:
+        if array_element_name:
             query["instrument"] = array_element_name
-        if site is not None:
+        if site:
             query["site"] = site
         return self._read_mongo_db(
             query=query,

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -194,7 +194,7 @@ class DatabaseHandler:
         site: str
             Site name.
         array_element_name: str
-            Name of the array element model (e.g. MSTN, SSTS).
+            Name of the array element model.
         parameter_version: str
             Version of the parameter.
         model_version: str
@@ -229,10 +229,7 @@ class DatabaseHandler:
             query["instrument"] = array_element_name
         if site:
             query["site"] = site
-        return self._read_mongo_db(
-            query=query,
-            collection_name=collection_name,
-        )
+        return self._read_mongo_db(query=query, collection_name=collection_name)
 
     def get_model_parameters(
         self,

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -6,12 +6,10 @@ import shutil
 from copy import copy
 
 import astropy.units as u
-from astropy.table import Table
 
 import simtools.utils.general as gen
 from simtools.db import db_handler
 from simtools.io_operations import io_handler
-from simtools.simtel import simtel_table_reader
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
 from simtools.utils import names
 
@@ -516,35 +514,6 @@ class ModelParameter:
 
         self.db.export_model_files(parameters=pars_from_db, dest=self.config_file_directory)
         self._is_exported_model_files_up_to_date = True
-
-    def get_model_file_as_table(self, par_name):
-        """
-        Return tabular data from file as astropy table.
-
-        Parameters
-        ----------
-        par_name: str
-            Name of the parameter.
-
-        Returns
-        -------
-        Table
-            Astropy table.
-        """
-        _par_entry = {}
-        try:
-            _par_entry[par_name] = self._parameters[par_name]
-        except KeyError as exc:
-            raise ValueError(f"Parameter {par_name} not found in the model.") from exc
-        self.db.export_model_files(parameters=_par_entry, dest=self.config_file_directory)
-        if _par_entry[par_name]["value"].endswith("ecsv"):
-            return Table.read(
-                self.config_file_directory.joinpath(_par_entry[par_name]["value"]),
-                format="ascii.ecsv",
-            )
-        return simtel_table_reader.read_simtel_table(
-            par_name, self.config_file_directory.joinpath(_par_entry[par_name]["value"])
-        )
 
     def export_config_file(self):
         """Export the config file used by sim_telarray."""

--- a/src/simtools/simtel/simtel_table_reader.py
+++ b/src/simtools/simtel/simtel_table_reader.py
@@ -253,6 +253,9 @@ def read_simtel_table(parameter_name, file_path):
     Table
         Astropy table.
     """
+    if file_path.suffix == ".ecsv":  # table is already in correct format
+        return Table.read(file_path, format="ascii.ecsv")
+
     if parameter_name == "atmospheric_transmission":
         return _read_simtel_data_for_atmospheric_transmission(file_path)
 

--- a/src/simtools/simtel/simtel_table_reader.py
+++ b/src/simtools/simtel/simtel_table_reader.py
@@ -3,6 +3,7 @@
 
 import logging
 import re
+from pathlib import Path
 
 import astropy.units as u
 from astropy.table import Table
@@ -253,7 +254,7 @@ def read_simtel_table(parameter_name, file_path):
     Table
         Astropy table.
     """
-    if file_path.suffix == ".ecsv":  # table is already in correct format
+    if Path(file_path).suffix == ".ecsv":  # table is already in correct format
         return Table.read(file_path, format="ascii.ecsv")
 
     if parameter_name == "atmospheric_transmission":

--- a/src/simtools/visualization/plot_tables.py
+++ b/src/simtools/visualization/plot_tables.py
@@ -4,9 +4,8 @@
 import numpy as np
 
 import simtools.utils.general as gen
+from simtools.db import db_handler
 from simtools.io_operations import legacy_data_handler
-from simtools.model.site_model import SiteModel
-from simtools.model.telescope_model import TelescopeModel
 from simtools.visualization import visualize
 
 
@@ -85,20 +84,15 @@ def _read_table_from_model_database(table_config, db_config):
     Table
         Astropy table.
     """
-    if "telescope" in table_config:
-        model = TelescopeModel(
-            site=table_config["site"],
-            telescope_name=table_config["telescope"],
-            model_version=table_config["model_version"],
-            mongo_db_config=db_config,
-        )
-    else:
-        model = SiteModel(
-            site=table_config["site"],
-            model_version=table_config["model_version"],
-            mongo_db_config=db_config,
-        )
-    return model.get_model_file_as_table(table_config["parameter"])
+    db = db_handler.DatabaseHandler(mongo_db_config=db_config)
+    return db.export_model_file(
+        parameter=table_config["parameter"],
+        site=table_config["site"],
+        array_element_name=table_config.get("telescope"),
+        parameter_version=table_config.get("parameter_version"),
+        model_version=table_config.get("model_version"),
+        export_file_as_table=True,
+    )
 
 
 def _select_values_from_table(table, column_name, value):

--- a/tests/integration_tests/config/db_get_parameter_from_db_telescope_model_version.yml
+++ b/tests/integration_tests/config/db_get_parameter_from_db_telescope_model_version.yml
@@ -10,8 +10,9 @@ CTA_SIMPIPE:
       MODEL_VERSION: 6.0.0
       EXPORT_MODEL_FILE: true
       EXPORT_MODEL_FILE_AS_TABLE: true
+      OUTPUT_PATH: simtools-output
     INTEGRATION_TESTS:
-    - OUTPUT_FILE: ref_LST2_2022_04_01.dat
-    - OUTPUT_FILE: ref_LST2_2022_04_01.ecsv
+    - OUTPUT_FILE: ref_LST1_2022_04_01.dat
+    - OUTPUT_FILE: ref_LST1_2022_04_01.ecsv
 SCHEMA_NAME: application_workflow.metaschema
 SCHEMA_VERSION: 0.3.0

--- a/tests/integration_tests/config/db_get_parameter_from_db_telescope_model_version.yml
+++ b/tests/integration_tests/config/db_get_parameter_from_db_telescope_model_version.yml
@@ -6,7 +6,12 @@ CTA_SIMPIPE:
     CONFIGURATION:
       SITE: North
       TELESCOPE: LSTN-01
-      PARAMETER: mirror_list
+      PARAMETER: mirror_reflectivity
       MODEL_VERSION: 6.0.0
+      EXPORT_MODEL_FILE: true
+      EXPORT_MODEL_FILE_AS_TABLE: true
+    INTEGRATION_TESTS:
+    - OUTPUT_FILE: ref_LST2_2022_04_01.dat
+    - OUTPUT_FILE: ref_LST2_2022_04_01.ecsv
 SCHEMA_NAME: application_workflow.metaschema
 SCHEMA_VERSION: 0.3.0

--- a/tests/resources/plot_table_data/plot_single_pe_config_parameter.yml
+++ b/tests/resources/plot_table_data/plot_single_pe_config_parameter.yml
@@ -12,23 +12,23 @@ CTA_SIMPIPE:
     NO_MARKERS: true
     TABLES:
       - PARAMETER: pm_photoelectron_spectrum
-        TELESCOPE: LSTN-01
+        TELESCOPE: LSTN-design
         SITE: North
-        MODEL_VERSION: 6.0.0
+        PARAMETER_VERSION: 1.0.0
         LABEL: 'LSTN (prompt)'
         COLUMN_X: 'amplitude'
         COLUMN_Y: 'response'
       - PARAMETER: pm_photoelectron_spectrum
-        TELESCOPE: LSTN-01
+        TELESCOPE: LSTN-design
         SITE: North
-        MODEL_VERSION: 6.0.0
+        PARAMETER_VERSION: 1.0.0
         LABEL: 'LSTN (prompt + afterpulsing)'
         COLUMN_X: 'amplitude'
         COLUMN_Y: 'response_with_ap'
       - PARAMETER: pm_photoelectron_spectrum
         TELESCOPE: MSTx-FlashCam
         SITE: South
-        MODEL_VERSION: 6.0.0
+        PARAMETER_VERSION: 1.0.0
         LABEL: 'MSTS (prompt + afterpulsing)'
         COLUMN_X: 'amplitude'
         COLUMN_Y: 'response_with_ap'

--- a/tests/resources/plot_table_data/plot_single_pe_config_parameter.yml
+++ b/tests/resources/plot_table_data/plot_single_pe_config_parameter.yml
@@ -13,14 +13,14 @@ CTA_SIMPIPE:
     TABLES:
       - PARAMETER: pm_photoelectron_spectrum
         TELESCOPE: LSTN-01
-        SITE: NORTH
+        SITE: North
         MODEL_VERSION: 6.0.0
         LABEL: 'LSTN (prompt)'
         COLUMN_X: 'amplitude'
         COLUMN_Y: 'response'
       - PARAMETER: pm_photoelectron_spectrum
         TELESCOPE: LSTN-01
-        SITE: NORTH
+        SITE: North
         MODEL_VERSION: 6.0.0
         LABEL: 'LSTN (prompt + afterpulsing)'
         COLUMN_X: 'amplitude'

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -207,12 +207,12 @@ def test_get_db_parameters_from_env(configurator, args_dict):
     args_dict["db_api_pw"] = "12345"
     args_dict["db_api_port"] = 42
     args_dict["db_server"] = "abc@def.de"
-    args_dict["db_api_authentication_database"] = None
     args_dict["db_simulation_model"] = "sim_model"
 
     # remove user defined parameters from comparison (depends on environment)
     expected_config = {k: v for k, v in args_dict.items() if not k.startswith("user_")}
     actual_config = {k: v for k, v in configurator.config.items() if not k.startswith("user_")}
+    actual_config.pop("db_api_authentication_database")  # depends on user setup; ignore here
 
     assert expected_config == actual_config
 

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -691,7 +691,7 @@ def test_get_array_elements_of_type(db, mocker):
 
     # Test with different array element type
     array_element_type = "MSTS"
-    mock_get_production_table = mocker.patch.object(
+    mocker.patch.object(
         db,
         "_read_production_table_from_mongo_db",
         return_value={

--- a/tests/unit_tests/db/test_db_handler.py
+++ b/tests/unit_tests/db/test_db_handler.py
@@ -86,6 +86,87 @@ def mock_gridfs(mocker):
     return mocker.patch("simtools.db.db_handler.gridfs.GridFS")
 
 
+@pytest.fixture
+def standard_test_params():
+    """Common test parameters used across multiple tests."""
+    return {
+        "site": "North",
+        "array_element_name": "LSTN-01",
+        "model_version": "1.0.0",
+        "parameter_version": "1.0.0",
+        "collection": "telescopes",
+        "parameter": "test_param",
+    }
+
+
+@pytest.fixture
+def mock_db_name(mocker, db, test_db):
+    """Common fixture for mocking _get_db_name."""
+    return mocker.patch.object(db, "_get_db_name", return_value=test_db)
+
+
+@pytest.fixture
+def mock_collection_setup(mocker, db):
+    """Common fixture for mocking collection operations."""
+    mock_collection = mocker.Mock()
+    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mock_collection)
+    return {"collection": mock_collection, "get_collection": mock_get_collection}
+
+
+@pytest.fixture
+def mock_db_client(mocker, db, test_db):
+    """Common fixture for mocking db_client."""
+    mock_client = {test_db: mocker.Mock()}
+    return mocker.patch.object(db_handler.DatabaseHandler, "db_client", mock_client)
+
+
+@pytest.fixture
+def mock_file_system(mocker, mock_gridfs):
+    """Setup mock file system objects."""
+    mock_fs = mock_gridfs.return_value
+    mock_file_instance = mocker.Mock(_id="file_id")
+    mock_fs.find_one.return_value = mock_file_instance
+    return {"fs": mock_fs, "instance": mock_file_instance}
+
+
+@pytest.fixture
+def export_files_setup(db, mock_db_name, mocker):
+    """Common setup for export_model_files tests."""
+    mock_get_file_mongo_db = mocker.patch.object(
+        db, "_get_file_mongo_db", return_value=mocker.Mock(_id="file_id")
+    )
+    mock_write_file = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
+    return {"get_file_mongo_db": mock_get_file_mongo_db, "write_file": mock_write_file}
+
+
+@pytest.fixture
+def add_parameter_mocks(db, mocker, test_db, value_unit_type, validate_model_parameter):
+    """Common setup for add_new_parameter tests."""
+    mock_validate = mocker.patch(
+        validate_model_parameter,
+        return_value={"parameter": "param1", "value": "value1", "file": False},
+    )
+    mock_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
+    mock_coll = mocker.Mock()
+    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mock_coll)
+    mock_insert_one = mocker.patch.object(mock_coll, "insert_one")
+    mock_value_unit = mocker.patch(
+        value_unit_type,
+        return_value=("value1", "unit1", None),
+    )
+    mock_reset_cache = mocker.patch.object(db, "_reset_parameter_cache")
+
+    return {
+        "validate": mock_validate,
+        "db_name": mock_db_name,
+        "collection": mock_coll,
+        "get_collection": mock_get_collection,
+        "insert_one": mock_insert_one,
+        "value_unit": mock_value_unit,
+        "reset_cache": mock_reset_cache,
+    }
+
+
 def test_set_up_connection_no_config():
     """Test _set_up_connection with no configuration."""
     db = db_handler.DatabaseHandler(mongo_db_config=None)
@@ -167,8 +248,13 @@ def test_find_latest_simulation_model_db(db, db_no_config_file, mocker):
     )
 
 
-def test_get_model_parameters(db, mocker):
+def test_get_model_parameters(db, mocker, standard_test_params):
     """Test get_model_parameters method."""
+    site = standard_test_params["site"]
+    array_element_name = standard_test_params["array_element_name"]
+    model_version = standard_test_params["model_version"]
+    collection = standard_test_params["collection"]
+
     mock_get_production_table = mocker.patch.object(
         db,
         "_read_production_table_from_mongo_db",
@@ -181,11 +267,6 @@ def test_get_model_parameters(db, mocker):
     mock_read_mongo_db = mocker.patch.object(
         db, "_read_mongo_db", return_value={"param1": {"value": "value1"}}
     )
-
-    site = "North"
-    array_element_name = "LSTN-01"
-    model_version = "1.0.0"
-    collection = "telescopes"
 
     result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
@@ -222,8 +303,13 @@ def test_get_model_parameters(db, mocker):
     assert result == {"param1": {"value": "value1"}}
 
 
-def test_get_model_parameters_with_cache(db, mocker):
+def test_get_model_parameters_with_cache(db, mocker, standard_test_params):
     """Test get_model_parameters method with cache."""
+    site = standard_test_params["site"]
+    array_element_name = standard_test_params["array_element_name"]
+    model_version = standard_test_params["model_version"]
+    collection = standard_test_params["collection"]
+
     mock_get_production_table = mocker.patch.object(
         db,
         "_read_production_table_from_mongo_db",
@@ -235,11 +321,6 @@ def test_get_model_parameters_with_cache(db, mocker):
     mock_read_cache = mocker.patch.object(
         db, "_read_cache", return_value=("cache_key", {"param1": {"value": "cached_value"}})
     )
-
-    site = "North"
-    array_element_name = "LSTN-01"
-    model_version = "1.0.0"
-    collection = "telescopes"
 
     result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
@@ -257,8 +338,13 @@ def test_get_model_parameters_with_cache(db, mocker):
     assert result == {"param1": {"value": "cached_value"}}
 
 
-def test_get_model_parameters_no_parameters(db, mocker):
+def test_get_model_parameters_no_parameters(db, mocker, standard_test_params):
     """Test get_model_parameters method with no parameters."""
+    site = standard_test_params["site"]
+    array_element_name = standard_test_params["array_element_name"]
+    model_version = standard_test_params["model_version"]
+    collection = standard_test_params["collection"]
+
     mock_get_production_table = mocker.patch.object(
         db, "_read_production_table_from_mongo_db", return_value={"parameters": {}}
     )
@@ -266,11 +352,6 @@ def test_get_model_parameters_no_parameters(db, mocker):
         db, "_get_array_element_list", return_value=["LSTN-01"]
     )
     mock_read_cache = mocker.patch.object(db, "_read_cache", return_value=("cache_key", None))
-
-    site = "North"
-    array_element_name = "LSTN-01"
-    model_version = "1.0.0"
-    collection = "telescopes"
 
     result = db.get_model_parameters(site, array_element_name, collection, model_version)
 
@@ -288,9 +369,8 @@ def test_get_model_parameters_no_parameters(db, mocker):
     assert result == {}
 
 
-def test_get_collection(db, mocker, test_db):
+def test_get_collection(db, mock_db_name, test_db, mocker):
     """Test get_collection method."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
     mocker.patch.object(
         db_handler.DatabaseHandler, "db_client", {test_db: {"test_collection": "mock_collection"}}
     )
@@ -298,7 +378,7 @@ def test_get_collection(db, mocker, test_db):
 
     result = db.get_collection(test_db, collection_name)
 
-    mock_get_db_name.assert_called_once_with(test_db)
+    mock_db_name.assert_called_once_with(test_db)
     assert result == "mock_collection"
 
 
@@ -320,40 +400,32 @@ def test_get_collections(db, db_config, fs_files):
 
 
 def test_export_model_files_with_file_names(
-    db, mocker, tmp_test_directory, test_db, test_file, test_file_2
+    db, export_files_setup, mock_db_name, tmp_test_directory, test_db, test_file, test_file_2
 ):
     """Test export_model_files method with file names."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
-    mock_get_file_mongo_db = mocker.patch.object(
-        db, "_get_file_mongo_db", return_value=mocker.Mock(_id="file_id")
-    )
-    mock_write_file_from_mongo_to_disk = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
-
+    mocks = export_files_setup
     file_names = [test_file, test_file_2]
 
     result = db.export_model_files(file_names=file_names, dest=tmp_test_directory)
 
-    mock_get_db_name.assert_called()
-    mock_get_file_mongo_db.assert_has_calls([call(test_db, test_file), call(test_db, test_file_2)])
-    mock_write_file_from_mongo_to_disk.assert_has_calls(
+    mock_db_name.assert_called()
+    mocks["get_file_mongo_db"].assert_has_calls(
+        [call(test_db, test_file), call(test_db, test_file_2)]
+    )
+    mocks["write_file"].assert_has_calls(
         [
-            call(test_db, tmp_test_directory, mock_get_file_mongo_db.return_value),
-            call(test_db, tmp_test_directory, mock_get_file_mongo_db.return_value),
+            call(test_db, tmp_test_directory, mocks["get_file_mongo_db"].return_value),
+            call(test_db, tmp_test_directory, mocks["get_file_mongo_db"].return_value),
         ]
     )
     assert result == {test_file: "file_id", test_file_2: "file_id"}
 
 
 def test_export_model_files_with_parameters(
-    db, mocker, tmp_test_directory, test_db, test_file, test_file_2
+    db, export_files_setup, mock_db_name, tmp_test_directory, test_db, test_file, test_file_2
 ):
     """Test export_model_files method with parameters."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
-    mock_get_file_mongo_db = mocker.patch.object(
-        db, "_get_file_mongo_db", return_value=mocker.Mock(_id="file_id")
-    )
-    mock_write_file_from_mongo_to_disk = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
-
+    mocks = export_files_setup
     parameters = {
         "param1": {"file": True, "value": test_file},
         "param2": {"file": True, "value": test_file_2},
@@ -361,53 +433,54 @@ def test_export_model_files_with_parameters(
 
     result = db.export_model_files(parameters=parameters, dest=tmp_test_directory)
 
-    mock_get_db_name.assert_called()
-    mock_get_file_mongo_db.assert_has_calls([call(test_db, test_file), call(test_db, test_file_2)])
-    mock_write_file_from_mongo_to_disk.assert_has_calls(
+    mock_db_name.assert_called()
+    mocks["get_file_mongo_db"].assert_has_calls(
+        [call(test_db, test_file), call(test_db, test_file_2)]
+    )
+    mocks["write_file"].assert_has_calls(
         [
-            call(test_db, tmp_test_directory, mock_get_file_mongo_db.return_value),
-            call(test_db, tmp_test_directory, mock_get_file_mongo_db.return_value),
+            call(test_db, tmp_test_directory, mocks["get_file_mongo_db"].return_value),
+            call(test_db, tmp_test_directory, mocks["get_file_mongo_db"].return_value),
         ]
     )
     assert result == {test_file: "file_id", test_file_2: "file_id"}
 
 
-def test_export_model_files_file_exists(db, mocker, tmp_test_directory, test_db, test_file):
+def test_export_model_files_file_exists(
+    db, mock_db_name, mocker, tmp_test_directory, test_db, test_file
+):
     """Test export_model_files method when file already exists."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
     mock_get_file_mongo_db = mocker.patch.object(db, "_get_file_mongo_db")
-    mock_write_file_from_mongo_to_disk = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
+    mock_write_file = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
     mock_path_exists = mocker.patch("pathlib.Path.exists", return_value=True)
 
     file_names = [test_file]
-
     result = db.export_model_files(file_names=file_names, dest=tmp_test_directory)
 
-    mock_get_db_name.assert_called()
+    mock_db_name.assert_called()
     mock_get_file_mongo_db.assert_not_called()
-    mock_write_file_from_mongo_to_disk.assert_not_called()
+    mock_write_file.assert_not_called()
     mock_path_exists.assert_called_once()
     assert result == {test_file: "file exists"}
 
 
-def test_export_model_files_file_not_found(db, mocker, tmp_test_directory, test_db, test_file):
+def test_export_model_files_file_not_found(
+    db, mock_db_name, mocker, tmp_test_directory, test_db, test_file
+):
     """Test export_model_files method when file is not found in parameters."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
     mock_get_file_mongo_db = mocker.patch.object(
         db, "_get_file_mongo_db", side_effect=FileNotFoundError
     )
-    mock_write_file_from_mongo_to_disk = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
+    mock_write_file = mocker.patch.object(db, "_write_file_from_mongo_to_disk")
 
-    parameters = {
-        "param1": {"file": True, "value": test_file},
-    }
+    parameters = {"param1": {"file": True, "value": test_file}}
 
     with pytest.raises(FileNotFoundError):
         db.export_model_files(parameters=parameters, dest=tmp_test_directory)
 
-    mock_get_db_name.assert_called()
+    mock_db_name.assert_called()
     mock_get_file_mongo_db.assert_called_once_with(test_db, test_file)
-    mock_write_file_from_mongo_to_disk.assert_not_called()
+    mock_write_file.assert_not_called()
 
 
 def test_get_query_from_parameter_version_table(db):
@@ -420,87 +493,27 @@ def test_get_query_from_parameter_version_table(db):
         "param1": "v1",
         "param2": "v2",
     }
-    array_element_name = "LSTN-01"
-    site = "North"
 
-    result = db._get_query_from_parameter_version_table(
-        parameter_version_table, array_element_name, site
-    )
+    test_cases = [
+        # (array_element_name, site, expected_result)
+        ("LSTN-01", "North", {"$or": or_list, "instrument": "LSTN-01", "site": "North"}),
+        ("LSTN-01", None, {"$or": or_list, "instrument": "LSTN-01"}),
+        (None, "North", {"$or": or_list, "site": "North"}),
+        (None, None, {"$or": or_list}),
+        ("xSTx-design", "North", {"$or": or_list, "site": "North"}),
+    ]
 
-    expected_query = {
-        "$or": or_list,
-        "instrument": array_element_name,
-        "site": site,
-    }
-
-    assert result == expected_query
-
-    # _get_query_from_parameter_version_table method without site.
-    array_element_name = "LSTN-01"
-    site = None
-
-    result = db._get_query_from_parameter_version_table(
-        parameter_version_table, array_element_name, site
-    )
-
-    expected_query = {
-        "$or": or_list,
-        "instrument": array_element_name,
-    }
-
-    assert result == expected_query
-
-    #  _get_query_from_parameter_version_table method without array element name.
-    array_element_name = None
-    site = "North"
-
-    result = db._get_query_from_parameter_version_table(
-        parameter_version_table, array_element_name, site
-    )
-
-    expected_query = {
-        "$or": or_list,
-        "site": site,
-    }
-
-    assert result == expected_query
-
-    # _get_query_from_parameter_version_table method without site and array element name.
-    array_element_name = None
-    site = None
-
-    result = db._get_query_from_parameter_version_table(
-        parameter_version_table, array_element_name, site
-    )
-
-    expected_query = {
-        "$or": or_list,
-    }
-
-    assert result == expected_query
-
-    # _get_query_from_parameter_version_table method with array element name 'xSTx-design'.
-    array_element_name = "xSTx-design"
-    site = "North"
-
-    result = db._get_query_from_parameter_version_table(
-        parameter_version_table, array_element_name, site
-    )
-
-    expected_query = {
-        "$or": or_list,
-        "site": site,
-    }
-
-    assert result == expected_query
+    for array_element_name, site, expected in test_cases:
+        result = db._get_query_from_parameter_version_table(
+            parameter_version_table, array_element_name, site
+        )
+        assert result == expected
 
 
-def test_read_mongo_db(db, mocker, test_db):
+def test_read_mongo_db(db, mock_db_name, mock_collection_setup, mocker, test_db):
     """Test read_mongo_db method."""
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value=test_db)
-    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mocker.Mock())
     mock_find = mocker.patch.object(
-        db.get_collection.return_value,
+        mock_collection_setup["collection"],
         "find",
         return_value=[
             {"_id": ObjectId(), "parameter": "param1", "value": "value1"},
@@ -513,8 +526,8 @@ def test_read_mongo_db(db, mocker, test_db):
 
     result = db._read_mongo_db(query, collection_name)
 
-    mock_get_db_name.assert_called_once_with()
-    mock_get_collection.assert_called_once_with(test_db, collection_name)
+    mock_db_name.assert_called_once_with()
+    mock_collection_setup["get_collection"].assert_called_once_with(test_db, collection_name)
     mock_find.assert_called_once_with(query)
     assert result == {
         "param1": {
@@ -531,7 +544,8 @@ def test_read_mongo_db(db, mocker, test_db):
         },
     }
 
-    mocker.patch.object(db.get_collection.return_value, "find", return_value=[])
+    # Test with no results
+    mocker.patch.object(mock_collection_setup["collection"], "find", return_value=[])
     with pytest.raises(
         ValueError,
         match=r"The following query for test_collection returned zero results: "
@@ -540,30 +554,38 @@ def test_read_mongo_db(db, mocker, test_db):
         db._read_mongo_db(query, collection_name)
 
 
-def test__read_production_table_from_mongo_db_with_cache(db, mocker, test_db):
-    """Test _read_production_table_from_mongo_db method with cache."""
-    collection_name = "telescopes"
-    model_version = "1.0.0"
-    param = {"param1": "value1"}
-    mock_cache_key = mocker.patch.object(db, "_cache_key", return_value="cache_key")
-    db_handler.DatabaseHandler.production_table_cached["cache_key"] = {
+def setup_production_table_cached(cache_key, model_version, param):
+    """Helper to set up production table cache."""
+    db_handler.DatabaseHandler.production_table_cached[cache_key] = {
         "collection": model_version,
         "model_version": model_version,
         "parameters": param,
         "design_model": {},
         "entry_date": ObjectId().generation_time,
     }
+    return db_handler.DatabaseHandler.production_table_cached[cache_key]
+
+
+def test_read_production_table_from_mongo_db_with_cache(db, mocker, test_db, mock_collection_setup):
+    """Test _read_production_table_from_mongo_db method with cache."""
+    collection_name = "telescopes"
+    model_version = "1.0.0"
+    param = {"param1": "value1"}
+
+    # Test with cache hit
+    mock_cache_key = mocker.patch.object(db, "_cache_key", return_value="cache_key")
+    cached_result = setup_production_table_cached("cache_key", model_version, param)
 
     result = db._read_production_table_from_mongo_db(collection_name, model_version)
 
     mock_cache_key.assert_called_once_with(None, None, model_version, collection_name)
-    assert result == db_handler.DatabaseHandler.production_table_cached["cache_key"]
+    assert result == cached_result
 
+    # Test with cache miss
     mock_cache_key = mocker.patch.object(db, "_cache_key", return_value="no_cache_key")
-    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mocker.Mock())
     mocker.patch.object(db, "_get_db_name", return_value=test_db)
     mock_find_one = mocker.patch.object(
-        db.get_collection.return_value,
+        mock_collection_setup["collection"],
         "find_one",
         return_value={
             "_id": ObjectId(),
@@ -577,20 +599,18 @@ def test__read_production_table_from_mongo_db_with_cache(db, mocker, test_db):
     result = db._read_production_table_from_mongo_db(collection_name, model_version)
 
     mock_cache_key.assert_called_once_with(None, None, model_version, collection_name)
-    mock_get_collection.assert_called_once_with(test_db, "production_tables")
+    mock_collection_setup["get_collection"].assert_called_once_with(test_db, "production_tables")
     mock_find_one.assert_called_once_with(
         {"model_version": model_version, "collection": collection_name}
     )
-    assert result == {
-        "collection": collection_name,
-        "model_version": model_version,
-        "parameters": param,
-        "design_model": {},
-        "entry_date": mock_find_one.return_value["_id"].generation_time,
-    }
+    assert result["collection"] == collection_name
+    assert result["model_version"] == model_version
+    assert result["parameters"] == param
+    assert result["design_model"] == {}
+    assert "entry_date" in result
 
-    # test with no results
-    mocker.patch.object(db.get_collection.return_value, "find_one", return_value=None)
+    # Test with no results
+    mocker.patch.object(mock_collection_setup["collection"], "find_one", return_value=None)
     with pytest.raises(
         ValueError,
         match=r"The following query returned zero results: "
@@ -601,40 +621,37 @@ def test__read_production_table_from_mongo_db_with_cache(db, mocker, test_db):
 
 def test_get_array_elements_of_type(db, mocker):
     """Test get_array_elements_of_type method."""
-    mock_get_production_table = mocker.patch.object(
-        db,
-        "_read_production_table_from_mongo_db",
-        return_value={
-            "parameters": {"LSTN-01": "value1", "LSTN-02": "value2", "MSTS-01": "value3"}
-        },
-    )
-
     array_element_type = "LSTN"
     model_version = "1.0.0"
     collection = "telescopes"
 
-    result = db.get_array_elements_of_type(array_element_type, model_version, collection)
+    test_cases = [
+        # Production table, expected result
+        (
+            {"parameters": {"LSTN-01": "value1", "LSTN-02": "value2", "MSTS-01": "value3"}},
+            ["LSTN-01", "LSTN-02"],
+        ),
+        ({"parameters": {"MSTS-01": "value3"}}, []),
+        ({"parameters": {"LSTN-01": "value1", "LSTN-design": "value2"}}, ["LSTN-01"]),
+    ]
 
-    mock_get_production_table.assert_called_once_with(collection, model_version)
-    assert result == ["LSTN-01", "LSTN-02"]
-
-    # Test with no matching array elements
-    mock_get_production_table.return_value = {"parameters": {"MSTS-01": "value3"}}
-    result = db.get_array_elements_of_type(array_element_type, model_version, collection)
-    assert result == []
-
-    # Test with array elements containing '-design'
-    mock_get_production_table.return_value = {
-        "parameters": {"LSTN-01": "value1", "LSTN-design": "value2"}
-    }
-    result = db.get_array_elements_of_type(array_element_type, model_version, collection)
-    assert result == ["LSTN-01"]
+    for prod_table, expected in test_cases:
+        mock_get_production_table = mocker.patch.object(
+            db, "_read_production_table_from_mongo_db", return_value=prod_table
+        )
+        result = db.get_array_elements_of_type(array_element_type, model_version, collection)
+        mock_get_production_table.assert_called_once_with(collection, model_version)
+        assert result == expected
 
     # Test with different array element type
     array_element_type = "MSTS"
-    mock_get_production_table.return_value = {
-        "parameters": {"LSTN-01": "value1", "MSTS-01": "value3", "MSTS-02": "value4"}
-    }
+    mock_get_production_table = mocker.patch.object(
+        db,
+        "_read_production_table_from_mongo_db",
+        return_value={
+            "parameters": {"LSTN-01": "value1", "MSTS-01": "value3", "MSTS-02": "value4"}
+        },
+    )
     result = db.get_array_elements_of_type(array_element_type, model_version, collection)
     assert result == ["MSTS-01", "MSTS-02"]
 
@@ -667,24 +684,18 @@ def test_get_simulation_configuration_parameters(db, mocker):
         db.get_simulation_configuration_parameters("wrong", "North", "LSTN-design", "6.0.0")
 
 
-def test_get_file_mongo_db_file(db, mocker, test_db, test_file, mock_gridfs):
+def test_get_file_mongo_db_file(db, test_db, test_file, mock_file_system, mock_db_client):
     """Test _get_file_mongo_db method when file exists."""
-    mock_db_client = mocker.patch.object(
-        db_handler.DatabaseHandler, "db_client", {test_db: mocker.Mock()}
-    )
-    mock_file_system = mock_gridfs.return_value
-    mock_file_system.exists.return_value = True
-    mock_file_instance = mocker.Mock()
-    mock_file_system.find_one.return_value = mock_file_instance
+    mock_file_system["fs"].exists.return_value = True
 
     result = db._get_file_mongo_db(test_db, test_file)
 
-    mock_gridfs.assert_called_once_with(mock_db_client[test_db])
-    mock_file_system.exists.assert_called_once_with({"filename": test_file})
-    mock_file_system.find_one.assert_called_once_with({"filename": test_file})
-    assert result == mock_file_instance
+    mock_file_system["fs"].exists.assert_called_once_with({"filename": test_file})
+    mock_file_system["fs"].find_one.assert_called_once_with({"filename": test_file})
+    assert result == mock_file_system["instance"]
 
-    mock_file_system.exists.return_value = False
+    # Test when file does not exist
+    mock_file_system["fs"].exists.return_value = False
     with pytest.raises(
         FileNotFoundError, match=f"The file {test_file} does not exist in the database {test_db}"
     ):
@@ -730,86 +741,51 @@ def test_add_production_table(db, mocker, test_db):
     mock_insert_one.assert_called_once_with(production_table)
 
 
-def test_add_new_parameter(db, mocker, value_unit_type, validate_model_parameter, test_db):
+def test_add_new_parameter(db, add_parameter_mocks, test_db):
     """Test add_new_parameter method."""
-    mock_validate_model_parameter = mocker.patch(
-        validate_model_parameter,
-        return_value={"parameter": "param1", "value": "value1", "file": False},
-    )
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value="test_db")
-    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mocker.Mock())
-    mock_insert_one = mocker.patch.object(db.get_collection.return_value, "insert_one")
-    mock_get_value_unit_type = mocker.patch(
-        value_unit_type,
-        return_value=("value1", "unit1", None),
-    )
-    mock_reset_parameter_cache = mocker.patch.object(db, "_reset_parameter_cache")
-
+    mocks = add_parameter_mocks
     par_dict = {"parameter": "param1", "value": "value1", "file": False}
     collection_name = "telescopes"
     file_prefix = None
 
     db.add_new_parameter(test_db, par_dict, collection_name, file_prefix)
 
-    mock_validate_model_parameter.assert_called_once_with(par_dict)
-    mock_get_db_name.assert_called_once_with(test_db)
-    mock_get_collection.assert_called_once_with("test_db", collection_name)
-    mock_get_value_unit_type.assert_called_once_with(value="value1", unit_str=None)
-    mock_insert_one.assert_called_once_with(
+    mocks["validate"].assert_called_once_with(par_dict)
+    mocks["db_name"].assert_called_once_with(test_db)
+    mocks["get_collection"].assert_called_once_with(test_db, collection_name)
+    mocks["value_unit"].assert_called_once_with(value="value1", unit_str=None)
+    mocks["insert_one"].assert_called_once_with(
         {"parameter": "param1", "value": "value1", "file": False, "unit": "unit1"}
     )
-    mock_reset_parameter_cache.assert_called_once()
+    mocks["reset_cache"].assert_called_once()
 
 
-def test_add_new_parameter_with_file(
-    db, mocker, tmp_test_directory, value_unit_type, validate_model_parameter, test_db
-):
+def test_add_new_parameter_with_file(db, add_parameter_mocks, tmp_test_directory, test_db, mocker):
     """Test add_new_parameter method with file."""
-    mock_validate_model_parameter = mocker.patch(
-        validate_model_parameter,
-        return_value={"parameter": "param1", "value": "value1", "file": True},
-    )
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value="test_db")
-    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mocker.Mock())
-    mock_insert_one = mocker.patch.object(db.get_collection.return_value, "insert_one")
-    mock_get_value_unit_type = mocker.patch(
-        value_unit_type,
-        return_value=("value1", "unit1", None),
-    )
+    mocks = add_parameter_mocks
+    mocks["validate"].return_value = {"parameter": "param1", "value": "value1", "file": True}
     mock_insert_file_to_db = mocker.patch.object(db, "insert_file_to_db")
-    mock_reset_parameter_cache = mocker.patch.object(db, "_reset_parameter_cache")
 
     par_dict = {"parameter": "param1", "value": "value1", "file": True}
     collection_name = "telescopes"
 
     db.add_new_parameter(test_db, par_dict, collection_name, tmp_test_directory)
 
-    mock_validate_model_parameter.assert_called_once_with(par_dict)
-    mock_get_db_name.assert_called_once_with(test_db)
-    mock_get_collection.assert_called_once_with("test_db", collection_name)
-    mock_get_value_unit_type.assert_called_once_with(value="value1", unit_str=None)
-    mock_insert_one.assert_called_once_with(
+    mocks["validate"].assert_called_once_with(par_dict)
+    mocks["db_name"].assert_called_once_with(test_db)
+    mocks["get_collection"].assert_called_once_with(test_db, collection_name)
+    mocks["value_unit"].assert_called_once_with(value="value1", unit_str=None)
+    mocks["insert_one"].assert_called_once_with(
         {"parameter": "param1", "value": "value1", "file": True, "unit": "unit1"}
     )
-    mock_insert_file_to_db.assert_called_once_with(f"{tmp_test_directory!s}/value1", "test_db")
-    mock_reset_parameter_cache.assert_called_once()
+    mock_insert_file_to_db.assert_called_once_with(f"{tmp_test_directory!s}/value1", test_db)
+    mocks["reset_cache"].assert_called_once()
 
 
-def test_add_new_parameter_with_file_no_prefix(
-    db, mocker, value_unit_type, validate_model_parameter, test_db
-):
+def test_add_new_parameter_with_file_no_prefix(db, add_parameter_mocks, test_db):
     """Test add_new_parameter method with file but no file_prefix."""
-    mock_validate_model_parameter = mocker.patch(
-        validate_model_parameter,
-        return_value={"parameter": "param1", "value": "value1", "file": True},
-    )
-    mock_get_db_name = mocker.patch.object(db, "_get_db_name", return_value="test_db")
-    mock_get_collection = mocker.patch.object(db, "get_collection", return_value=mocker.Mock())
-    mock_get_value_unit_type = mocker.patch(
-        value_unit_type,
-        return_value=("value1", "unit1", None),
-    )
-    mock_reset_parameter_cache = mocker.patch.object(db, "_reset_parameter_cache")
+    mocks = add_parameter_mocks
+    mocks["validate"].return_value = {"parameter": "param1", "value": "value1", "file": True}
 
     par_dict = {"parameter": "param1", "value": "value1", "file": True}
     collection_name = "telescopes"
@@ -822,11 +798,11 @@ def test_add_new_parameter_with_file_no_prefix(
     ):
         db.add_new_parameter(test_db, par_dict, collection_name, file_prefix)
 
-    mock_validate_model_parameter.assert_called_once_with(par_dict)
-    mock_get_db_name.assert_called_once_with(test_db)
-    mock_get_collection.assert_called_once_with("test_db", collection_name)
-    mock_get_value_unit_type.assert_called_once_with(value="value1", unit_str=None)
-    mock_reset_parameter_cache.assert_not_called()
+    mocks["validate"].assert_called_once_with(par_dict)
+    mocks["db_name"].assert_called_once_with(test_db)
+    mocks["get_collection"].assert_called_once_with(test_db, collection_name)
+    mocks["value_unit"].assert_called_once_with(value="value1", unit_str=None)
+    mocks["reset_cache"].assert_not_called()
 
 
 def test_insert_file_to_db_file_exists(db, mocker, test_db, test_file, mock_gridfs):

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -367,30 +367,3 @@ def test_export_nsb_spectrum_to_telescope_altitude_correction_file(telescope_mod
         },
         dest=model_directory,
     )
-
-
-def test_get_model_file_as_table(telescope_model_lst, mocker):
-    telescope_copy = copy.deepcopy(telescope_model_lst)
-
-    with pytest.raises(ValueError, match="Parameter not_a_parameter not found in the model"):
-        telescope_copy.get_model_file_as_table("not_a_parameter")
-
-    mock_db_export = mocker.patch.object(DatabaseHandler, "export_model_files")
-    mock_simtel_table_reader = mocker.patch("simtools.simtel.simtel_table_reader.read_simtel_table")
-    telescope_copy.get_model_file_as_table("pm_photoelectron_spectrum")
-
-    assert mock_db_export.call_count == 1
-    assert mock_simtel_table_reader.call_count == 1
-
-
-def test_get_model_file_as_ecsv_table(telescope_model_sst, mocker):
-    telescope_copy = copy.deepcopy(telescope_model_sst)
-
-    mock_db_export = mocker.patch.object(DatabaseHandler, "export_model_files")
-    mock_simtel_table_reader = mocker.patch("simtools.simtel.simtel_table_reader.read_simtel_table")
-    mock_astropy_table_reader = mocker.patch("astropy.table.Table.read")
-    telescope_copy.get_model_file_as_table("secondary_mirror_incidence_angle")
-
-    assert mock_db_export.call_count == 1
-    assert mock_simtel_table_reader.call_count == 0
-    assert mock_astropy_table_reader.call_count == 1

--- a/tests/unit_tests/visualization/test_plot_tables.py
+++ b/tests/unit_tests/visualization/test_plot_tables.py
@@ -36,9 +36,9 @@ def test_plot(mock_read_table_data, mock_visualize):
 
 @mock.patch("simtools.visualization.plot_tables.gen.get_structure_array_from_table")
 @mock.patch("simtools.visualization.plot_tables.legacy_data_handler.read_legacy_data_as_table")
-@mock.patch("simtools.visualization.plot_tables._read_table_from_model_database")
+@mock.patch("simtools.visualization.plot_tables.db_handler.DatabaseHandler")
 def test_read_table_data_from_file(
-    mock_read_table_from_model_database,
+    mock_db_handler_class,
     mock_read_legacy_data_as_table,
     mock_get_structure_array_from_table,
 ):
@@ -61,6 +61,7 @@ def test_read_table_data_from_file(
 
     result = plot_tables.read_table_data(config, db_config)
 
+    mock_db_handler_class.assert_not_called()
     mock_read_legacy_data_as_table.assert_called_once_with("test_file", "csv")
     mock_get_structure_array_from_table.assert_called_once_with(mock_table, ["x", "y"])
     assert result == {"test_table": mock_structure_array}
@@ -68,9 +69,9 @@ def test_read_table_data_from_file(
 
 @mock.patch("simtools.visualization.plot_tables.gen.get_structure_array_from_table")
 @mock.patch("simtools.visualization.plot_tables.legacy_data_handler.read_legacy_data_as_table")
-@mock.patch("simtools.visualization.plot_tables._read_table_from_model_database")
+@mock.patch("simtools.visualization.plot_tables.db_handler.DatabaseHandler")
 def test_read_table_data_from_model_database(
-    mock_read_table_from_model_database,
+    mock_db_handler_class,
     mock_read_legacy_data_as_table,
     mock_get_structure_array_from_table,
 ):
@@ -88,14 +89,23 @@ def test_read_table_data_from_model_database(
         ]
     }
     db_config = None
+    mock_db_handler = mock_db_handler_class.return_value
     mock_table = mock.MagicMock()
-    mock_read_table_from_model_database.return_value = mock_table
+    mock_db_handler.export_model_file.return_value = mock_table
     mock_structure_array = mock.MagicMock()
     mock_get_structure_array_from_table.return_value = mock_structure_array
 
     result = plot_tables.read_table_data(config, db_config)
 
-    mock_read_table_from_model_database.assert_called_once_with(config["tables"][0], db_config)
+    mock_db_handler_class.assert_called_once_with(mongo_db_config=db_config)
+    mock_db_handler.export_model_file.assert_called_once_with(
+        parameter="test_parameter",
+        site="test_site",
+        array_element_name="test_telescope",
+        parameter_version=None,
+        model_version="test_version",
+        export_file_as_table=True,
+    )
     mock_get_structure_array_from_table.assert_called_once_with(mock_table, ["x", "y"])
     assert result == {"test_table": mock_structure_array}
 
@@ -108,8 +118,8 @@ def test_read_table_data_no_table_data_defined():
         plot_tables.read_table_data(config, db_config)
 
 
-@mock.patch("simtools.visualization.plot_tables.TelescopeModel")
-def test_read_table_from_model_database(mock_telescope_model_class):
+@mock.patch("simtools.visualization.plot_tables.db_handler.DatabaseHandler")
+def test_export_model_file(mock_db_handler_class):
     table_config = {
         "site": "test_site",
         "telescope": "test_telescope",
@@ -117,40 +127,59 @@ def test_read_table_from_model_database(mock_telescope_model_class):
         "parameter": "test_parameter",
     }
     db_config = None
-    mock_telescope_model = mock_telescope_model_class.return_value
+    mock_db_handler = mock_db_handler_class.return_value
     mock_table = mock.MagicMock()
-    mock_telescope_model.get_model_file_as_table.return_value = mock_table
+    mock_db_handler.export_model_file.return_value = mock_table
 
-    result = plot_tables._read_table_from_model_database(table_config, db_config)
+    # This test replaces test_read_table_from_model_database
+    # We'll directly test the export_model_file functionality by calling read_table_data
+    config = {"tables": [table_config]}
+    table_config["label"] = "test_label"
+    table_config["column_x"] = "x"
+    table_config["column_y"] = "y"
 
-    mock_telescope_model_class.assert_called_once_with(
+    plot_tables.read_table_data(config, db_config)
+
+    mock_db_handler_class.assert_called_once_with(mongo_db_config=db_config)
+    mock_db_handler.export_model_file.assert_called_once_with(
+        parameter="test_parameter",
         site="test_site",
-        telescope_name="test_telescope",
+        array_element_name="test_telescope",
+        parameter_version=None,
         model_version="test_version",
-        mongo_db_config=db_config,
+        export_file_as_table=True,
     )
-    mock_telescope_model.get_model_file_as_table.assert_called_once_with("test_parameter")
-    assert result == mock_table
 
 
-@mock.patch("simtools.visualization.plot_tables.SiteModel")
-def test_read_table_from_model_database_site(mock_site_model_class):
+@mock.patch("simtools.visualization.plot_tables.db_handler.DatabaseHandler")
+def test_export_model_file_site_only(mock_db_handler_class):
     table_config = {
         "site": "test_site",
         "model_version": "test_version",
         "parameter": "test_parameter",
     }
     db_config = None
-    mock_site_model = mock_site_model_class.return_value
+    mock_db_handler = mock_db_handler_class.return_value
     mock_table = mock.MagicMock()
-    mock_site_model.get_model_file_as_table.return_value = mock_table
+    mock_db_handler.export_model_file.return_value = mock_table
 
-    plot_tables._read_table_from_model_database(table_config, db_config)
+    # This test replaces test_read_table_from_model_database_site
+    # We'll directly test the export_model_file functionality by calling read_table_data
+    config = {"tables": [table_config]}
+    table_config["label"] = "test_label"
+    table_config["column_x"] = "x"
+    table_config["column_y"] = "y"
 
-    mock_site_model_class.assert_called_once_with(
+    plot_tables.read_table_data(config, db_config)
+
+    mock_db_handler_class.assert_called_once_with(mongo_db_config=db_config)
+    mock_db_handler.export_model_file.assert_called_once_with(
+        parameter="test_parameter",
         site="test_site",
+        array_element_name=None,
+        parameter_version=None,
         model_version="test_version",
-        mongo_db_config=db_config,
+        export_file_as_table=True,
     )
 
 

--- a/tests/unit_tests/visualization/test_plot_tables.py
+++ b/tests/unit_tests/visualization/test_plot_tables.py
@@ -131,8 +131,6 @@ def test_export_model_file(mock_db_handler_class):
     mock_table = mock.MagicMock()
     mock_db_handler.export_model_file.return_value = mock_table
 
-    # This test replaces test_read_table_from_model_database
-    # We'll directly test the export_model_file functionality by calling read_table_data
     config = {"tables": [table_config]}
     table_config["label"] = "test_label"
     table_config["column_x"] = "x"
@@ -163,8 +161,6 @@ def test_export_model_file_site_only(mock_db_handler_class):
     mock_table = mock.MagicMock()
     mock_db_handler.export_model_file.return_value = mock_table
 
-    # This test replaces test_read_table_from_model_database_site
-    # We'll directly test the export_model_file functionality by calling read_table_data
     config = {"tables": [table_config]}
     table_config["label"] = "test_label"
     table_config["column_x"] = "x"


### PR DESCRIPTION
Simplify and improve reading of a single parameter entry and exporting from model parameter files:

- allow to retrieve model parameter dict using `DBHandler.get_model_parameter` for a given `parameter_version` or `model_version`  (before: only for a `parameter_version`); tried to generalize the reading of parameter with the choice of both version types.
- allow to export using the same function tables files
- allow to export (if applicable) tables files in astropy ecsv files.

Adjusted the application `simtools-db-get-parameter` for these changes with additional options.

This approach simplified especially the plotting routes. Plotting of parameter tables is now possible using the `parameter_version`, see example in [tests/resources/plot_table_data/plot_single_pe_config_parameter.yml](tests/resources/plot_table_data/plot_single_pe_config_parameter.yml).

Improved testing and added missing unit tests.

Addresses partly #1403.