### PR TITLE
Add SimPipe usecases to integration tests config for DPPS 0.1

### DIFF
--- a/tests/integration_tests/config/derive_photon_electron_spectrum_lst_ecsv.yml
+++ b/tests/integration_tests/config/derive_photon_electron_spectrum_lst_ecsv.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-derive-photon-electron-spectrum
     TEST_NAME: LST_ecsv
+    TEST_USE_CASE: UC-150-2.1.2
     CONFIGURATION:
       INPUT_SPECTRUM: ./tests/resources/SinglePhe_spectrum_totalfit_19pixel-average_20200601.ecsv
       AFTERPULSE_SPECTRUM: ./tests/resources/LST_afterpulses.ecsv

--- a/tests/integration_tests/config/derive_photon_electron_spectrum_lst_legacy_format.yml
+++ b/tests/integration_tests/config/derive_photon_electron_spectrum_lst_legacy_format.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-derive-photon-electron-spectrum
     TEST_NAME: LST_legacy_format
+    TEST_USE_CASE: UC-150-2.1.2
     CONFIGURATION:
       INPUT_SPECTRUM: ./tests/resources/SinglePhe_spectrum_totalfit_19pixel-average_20200601.csv
       AFTERPULSE_SPECTRUM: ./tests/resources/LST_afterpulses.dat

--- a/tests/integration_tests/config/submit_model_parameter_from_external_submit_focus_offset.yml
+++ b/tests/integration_tests/config/submit_model_parameter_from_external_submit_focus_offset.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-submit-model-parameter-from-external
     TEST_NAME: submit_focus_offset
+    TEST_USE_CASE: UC-150-2.1.1
     CONFIGURATION:
       PARAMETER: focus_offset
       VALUE: 6.55 cm, 0.0 deg, 0.0, 0.0

--- a/tests/integration_tests/config/submit_model_parameter_from_external_submit_mirror_list.yml
+++ b/tests/integration_tests/config/submit_model_parameter_from_external_submit_mirror_list.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-submit-model-parameter-from-external
     TEST_NAME: submit_mirror_list
+    TEST_USE_CASE: UC-150-2.1.1
     CONFIGURATION:
       PARAMETER: mirror_list
       VALUE: mirror_CTA-100_1.20-86-0.04.dat

--- a/tests/integration_tests/config/submit_model_parameter_from_external_submit_num_gains.yml
+++ b/tests/integration_tests/config/submit_model_parameter_from_external_submit_num_gains.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-submit-model-parameter-from-external
     TEST_NAME: submit_num_gains
+    TEST_USE_CASE: UC-150-2.1.1
     CONFIGURATION:
       PARAMETER: num_gains
       VALUE: 2

--- a/tests/integration_tests/config/submit_model_parameter_from_external_submit_reference_point_altitude.yml
+++ b/tests/integration_tests/config/submit_model_parameter_from_external_submit_reference_point_altitude.yml
@@ -3,6 +3,7 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-submit-model-parameter-from-external
     TEST_NAME: submit_reference_point_altitude
+    TEST_USE_CASE: UC-150-2.1.1
     CONFIGURATION:
       PARAMETER: reference_point_altitude
       VALUE: 2.177 km

--- a/tests/integration_tests/config/validate_file_using_schema_json_validate_schema-0.2.0.yml
+++ b/tests/integration_tests/config/validate_file_using_schema_json_validate_schema-0.2.0.yml
@@ -3,7 +3,6 @@ CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-validate-file-using-schema
     TEST_NAME: json_validate_schema-0.2.0
-    TEST_USE_CASE: UC-150-1.1
     CONFIGURATION:
       SCHEMA: src/simtools/schemas/model_parameter.metaschema.yml
       FILE_NAME: tests/resources/model_parameters/schema-0.2.0/num_gains-1.0.0.json


### PR DESCRIPTION
Add use case descriptors required for the use cases included in DPPS release 0.1:

- Setting Simulation Model Parameters via API [UC-150-2.1.1](https://gitlab.cta-observatory.org/cta-computing/dpps/dpps-project-management/dpps-use-cases/-/blob/main/SimPipe/UC-150-2.1.1--set_simulation_model_parameter-through-api.md?ref_type=heads)
- Derive Single Photoelectron Response [UC-150-2.1.2](https://gitlab.cta-observatory.org/cta-computing/dpps/dpps-project-management/dpps-use-cases/-/blob/main/SimPipe/UC-150-2.1.2--derive_single_photo_electron_response.md?ref_type=heads)

Remove the `TEST_USE_CASE` from `validate_file_using_schema_json_validate_schema-0.2.0.yml` - this was introduced for testing of the pytest marker only.