### PR TITLE
Exclude tests directory (and test files) from pypi package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,11 @@ package-dir = { "" = "src" }
 
 [tool.setuptools.packages.find]
 where = [ "src" ]
-exclude = [ "simtools._dev_version.*" ]
+exclude = [
+  "simtools._dev_version.*",
+  "./tests",
+  "./tests/*",
+]
 
 [tool.setuptools_scm]
 write_to = "src/simtools/_version.py"


### PR DESCRIPTION
simtools releases trigger deployment to pypi. Currently the `./tests` directory including all test files are included in the package, leading to an unnecessary large package (~10 MB). 

Exclude with this PR the tests directory from the pypi package.