### PR TITLE
Use full array pointings if available

### DIFF
--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -199,7 +199,7 @@ class LimitCalculator:
         z_2 = x_1 * np.cos(array_altitude_rad) + z_1 * np.sin(array_altitude_rad)
         off_angles = np.arctan2(np.sqrt(x_2**2 + y_2**2), z_2) * (180.0 / np.pi)
 
-        angle_bins = np.linspace(off_angles.min(), off_angles.max(), 400)
+        angle_bins = np.linspace(off_angles.min(), off_angles.max(), 1000)
         hist, _ = np.histogram(off_angles, bins=angle_bins)
 
         upper_bin_edge_value = self._compute_limits(
@@ -241,9 +241,11 @@ class LimitCalculator:
         core_distances_triggered = core_distances_all[shower_id_triggered_masked]
         triggered_energies = self.simulated[shower_id_triggered_masked]
 
-        core_bins = np.linspace(core_distances_triggered.min(), core_distances_triggered.max(), 400)
+        core_bins = np.linspace(
+            core_distances_triggered.min(), core_distances_triggered.max(), 1000
+        )
         energy_bins = np.logspace(
-            np.log10(triggered_energies.min()), np.log10(triggered_energies.max()), 400
+            np.log10(triggered_energies.min()), np.log10(triggered_energies.max()), 1000
         )
         plt.figure(figsize=(8, 6))
         plt.hist2d(

--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -190,6 +190,7 @@ class LimitCalculator:
         azimuth_diff = self.array_azimuth - self.shower_sim_azimuth  # * (np.pi / 180.0)
         sim_altitude_rad = self.shower_sim_altitude  # * (np.pi / 180.0)
         array_altitude_rad = self.array_altitude  # * (np.pi / 180.0)
+
         x_1 = np.cos(azimuth_diff) * np.cos(sim_altitude_rad)
         y_1 = np.sin(azimuth_diff) * np.cos(sim_altitude_rad)
         z_1 = np.sin(sim_altitude_rad)
@@ -197,6 +198,7 @@ class LimitCalculator:
         y_2 = y_1
         z_2 = x_1 * np.cos(array_altitude_rad) + z_1 * np.sin(array_altitude_rad)
         off_angles = np.arctan2(np.sqrt(x_2**2 + y_2**2), z_2) * (180.0 / np.pi)
+
         angle_bins = np.linspace(off_angles.min(), off_angles.max(), 400)
         hist, _ = np.histogram(off_angles, bins=angle_bins)
 

--- a/src/simtools/production_configuration/extract_mc_event_data.py
+++ b/src/simtools/production_configuration/extract_mc_event_data.py
@@ -184,7 +184,7 @@ class MCEventExtractor:
         if (len(alt_range) > 1 or len(az_range) > 1) and (
             not np.allclose(alt_range, alt_range[0]) or not np.allclose(az_range, az_range[0])
         ):
-            self._logger.warning(
+            self._logger.info(
                 "The alt_range or az_range values are changing throughout the file. "
                 "Using the full range as is."
             )


### PR DESCRIPTION
Small PR to include the option to add the full array pointings if present in the mc header. Also adds a log message if this is the case. Currently we have simulations with fixed pointings, so this is not used.