### PR TITLE
Update schema for production tables to allow tables for SCTs

### DIFF
--- a/src/simtools/schemas/production_tables.schema.yml
+++ b/src/simtools/schemas/production_tables.schema.yml
@@ -29,7 +29,7 @@ definitions:
             pattern: '^\d+\.\d+\.\d+$'
         propertyNames:
           description: Allowed parameter name patterns.
-          pattern: '^([A-Za-z](ST|LL)[N,S,x]-\d{2,3}|[A-Za-z](ST|LL)[N,S,x]-(design|FlashCam|NectarCam)|OBS-(North|South)|Dummy-Telescope)$'
+          pattern: '^([A-Za-z](ST|LL|CT)[N,S,x]-\d{2,3}|[A-Za-z](ST|LL|CT)[N,S,x]-(design|FlashCam|NectarCam)|OBS-(North|South)|Dummy-Telescope)$'
       design_model:
         type: object
         description: Design models.


### PR DESCRIPTION
The schema does at this point not allow for SCTs, see e.g. https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/301059

This PR fixes the allow pattern to allow for `SCTS-design` and `SCTS-<number>`.