### PR TITLE
Run unit and integration tests on release

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -11,6 +11,8 @@ on:
     types: [opened, synchronize]
   schedule:
     - cron: "0 0 * * *"
+  release:
+    types: [published]
 
 jobs:
 

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -15,6 +15,8 @@ on:
     types: [opened, synchronize]
   schedule:
     - cron: "0 0 * * *"
+  release:
+    types: [published]
 
 jobs:
   unittests:


### PR DESCRIPTION
CTAO AIV requires to have a sonar report for tagged releases. This PR enables to unit and integration tests to run also on release - publish.