### PR TITLE
Use consistently numpy dtypes for model parameters

### DIFF
--- a/docs/changes/1451.maintenance.md
+++ b/docs/changes/1451.maintenance.md
@@ -1,0 +1,1 @@
+Use consistently numpy dtypes for model parameters.

--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -362,8 +362,10 @@ definitions:
       - double
       - float64
       - int
+      - int64
       - string
       - uint
+      - uint64
       - file
     title: TableColumnType
   Unit:

--- a/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Gain adjustment for amplitudes and PMT gain.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/altitude.schema.yml
@@ -12,7 +12,7 @@ description: |-
   (taking `telescope_axes_height` into account).
 short_description: Altitude above sea level of site centre.
 data:
-  - type: double
+  - type: float64
     unit: m
     default: 1800.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
@@ -28,7 +28,7 @@ data:
       - name: utm_east
         description: |-
           UTM East coordinate of the array element.
-        type: double
+        type: float64
         required: true
         unit: m
         input_processing:
@@ -36,7 +36,7 @@ data:
       - name: utm_north
         description: |-
           UTM North coordinate of the array element.
-        type: double
+        type: float64
         required: true
         unit: m
         input_processing:
@@ -45,7 +45,7 @@ data:
         description: |-
           Altitude of the array element.
         required: true
-        type: double
+        type: float64
         unit: m
         allowed_range:
           min: 0.

--- a/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
@@ -10,13 +10,13 @@ description: |-
   Position of an array element (e.g., a telescope) in ground coordinates.
 short_description: Ground coordinate position of an array element.
 data:
-  - type: double
+  - type: float64
     unit: m
     description: Array element position in x-direction (towards North)
-  - type: double
+  - type: float64
     unit: m
     description: Array element position in y-direction (towards West)
-  - type: double
+  - type: float64
     unit: m
     description: Array element altitude above reference_point_altitude
 instrument:

--- a/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
@@ -10,13 +10,13 @@ description: |-
   Position and altitude of an array element (e.g., a telescope) in UTM coordinates.
 short_description: UTM coordinate position of an array element.
 data:
-  - type: double
+  - type: float64
     unit: m
     description: Array element position in UTM East.
-  - type: double
+  - type: float64
     unit: m
     description: Array element position in UTM North.
-  - type: double
+  - type: float64
     unit: m
     description: Array element altitude above sea level.
 instrument:

--- a/src/simtools/schemas/model_parameters/array_window.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_window.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Length of a coincidence window of the default stereo trigger.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 1000.
 instrument:

--- a/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
@@ -11,7 +11,7 @@ description: |-
   (after optional shaping) is clipped for its contribution
   to the analog sum trigger.
 data:
-  - type: double
+  - type: float64
     default: 0.0
     unit: mV
     allowed_range:

--- a/src/simtools/schemas/model_parameters/asum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_offset.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: asum_offset
 description: Offset in time where shaping convolution is done.
 data:
-  - type: double
+  - type: float64
     default: 0.0
     unit: ns
     allowed_range:

--- a/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
@@ -10,7 +10,7 @@ description: |-
   The amplitude level above which an analog sum leads to a telescope
   trigger.
 data:
-  - type: double
+  - type: float64
     default: 0.0
     unit: mV
     allowed_range:

--- a/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
+++ b/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
@@ -16,7 +16,7 @@ short_description: |-
   Geometric offsets to be used in case that the azimuth, altitude,
   and optical axes do not intersect at the reference point.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 0.
     description: |-
@@ -24,7 +24,7 @@ data:
       (horizontal) altitude rotation axis. A positive value corresponds
       to an altitude axis towards the reflector. Altitude axis is on
       the optical axis, if the second parameter is zero.
-  - type: double
+  - type: float64
     unit: cm
     default: 0.
     description: |-

--- a/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Diameter of camera body (used to account for effects of shadowing).
   Flat-to-flat for square and hexagonal shapes.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 160.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
@@ -16,7 +16,7 @@ description: |-
   This shape is used only for the estimation of the shadowing.
 short_description: Camera body shape parameter (used to account for effects of shadowing).
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
@@ -12,7 +12,7 @@ description: |-
   the given angle.
 short_description: Camera rotation angle.
 data:
-  - type: double
+  - type: float64
     unit: deg
 instrument:
   class: Camera

--- a/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
@@ -15,7 +15,7 @@ description: |-
 short_description: |-
   Camera efficiency degradation factor (wavelength independent).
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/camera_depth.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_depth.schema.yml
@@ -12,7 +12,7 @@ description: |-
   and the camera depth.
 short_description: Depth of the camera body (used to account for effects of shadowing).
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 0.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
@@ -10,7 +10,7 @@ description: Number of pixels in the camera.
 developer_note: |-
   Max limit depend on sim_telarray pre-compiler settings
 data:
-  - type: uint
+  - type: uint64
     default: 1
     allowed_range:
       min: 1

--- a/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
@@ -14,7 +14,7 @@ short_description: |-
   Global wavelength-independent transmission factor of the camera,
   including any plexiglass window.
 data:
-  - type: double
+  - type: float64
     default: 1.0
     allowed_range:
       min: 0.01

--- a/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -11,7 +11,7 @@ description: |-
   Potentially useful for cross-talk calculations.
 short_description: Number of channels per readout chip.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 4
     allowed_range:

--- a/src/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_io_buffer.schema.yml
@@ -11,7 +11,7 @@ description: |-
 instrument:
   class: configuration_corsika
 data:
-  - type: int
+  - type: int64
     unit: MB
     default: 1000
 activity:

--- a/src/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_max_bunches.schema.yml
@@ -15,7 +15,7 @@ description: |-
 instrument:
   class: configuration_corsika
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 1000000
 activity:

--- a/src/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_iact_split_auto.schema.yml
@@ -16,7 +16,7 @@ description: |-
 instrument:
   class: configuration_corsika
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 15000000
 activity:

--- a/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
@@ -11,7 +11,7 @@ description: |-
   This should be lower than the lowest altitude of any telescope.
 short_description: Observation altitude above see level assumed in the air-shower code.
 data:
-  - type: double
+  - type: float64
     unit: m
     allowed_range:
       min: 0.0

--- a/src/simtools/schemas/model_parameters/dark_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/dark_events.schema.yml
@@ -11,7 +11,7 @@ description: |-
 short_description: |-
   Pedestal events at start of run closed lid.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/disc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_bins.schema.yml
@@ -12,7 +12,7 @@ description: |-
   FADC signals.
 short_description: Number of time bins used for the discriminator simulation.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 20
     allowed_range:

--- a/src/simtools/schemas/model_parameters/disc_start.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_start.schema.yml
@@ -14,7 +14,7 @@ short_description: |-
   Number of time bins by which the discriminator simulation is ahead of
   the FADC readout.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
@@ -24,7 +24,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: mV
     default: 1.0
     condition: default_trigger==AnalogSum or default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
@@ -22,7 +22,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 1.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
@@ -22,7 +22,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 2.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
@@ -21,7 +21,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: mV
     default: 0.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
@@ -22,7 +22,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: mV
     default: 42.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
@@ -22,7 +22,7 @@ instrument:
     - SSTS
     - SCTS
 data:
-  - type: double
+  - type: float64
     unit: pct
     default: 10.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
@@ -14,7 +14,7 @@ short_description: |-
   Rise time of the discriminator output. The output signal rises linearly
   within time frame.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 1.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
@@ -11,7 +11,7 @@ description: |-
   and its variations.
 short_description: Discriminator/comparator threshold scale factor.
 data:
-  - type: double
+  - type: float64
     default: 1.0
     unit: dimensionless
     allowed_range:

--- a/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
@@ -17,7 +17,7 @@ description: |-
   accordingly.
 short_description: Integrated signal required over threshold.
 data:
-  - type: double
+  - type: float64
     unit: mV * ns
     condition: default_trigger==Majority
     default: 0.0

--- a/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: discriminator_threshold
 description: Discriminator/comparator threshold.
 data:
-  - type: double
+  - type: float64
     unit: mV
     default: 4.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
@@ -17,7 +17,7 @@ description: |-
 short_description: Time over threshold required before logic response switches to
   true.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 1.5
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
@@ -12,7 +12,7 @@ description: |-
   discriminator_var_time_over_threshold.
 short_description: Variation of gate length (Gaussian r.m.s).
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.1
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
@@ -14,7 +14,7 @@ description: |-
   Gaussian r.m.s. spread of discriminator_sigsum_over_threshold
   (Pixel-to-pixel variation).
 data:
-  - type: double
+  - type: float64
     unit: mV * ns
     default: 0.0
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
@@ -11,7 +11,7 @@ description: |-
   discriminator/comparator threshold.
 short_description: Channel-to-channel variation of discriminator threshold.
 data:
-  - type: double
+  - type: float64
     unit: mV
     default: 0.2
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Pixel-to-pixel variation of the time over threshold required before logic
   response switches to true.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.1
     condition: default_trigger==Majority

--- a/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
@@ -15,7 +15,7 @@ description: |-
   intermediate shapes between parabolic and Davies-Cotton.
 short_description: Dish curvature length, best equal to focal length.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: Amplitude level at which the digitized signal from each pixel is
   clipped.
 data:
-  - type: int
+  - type: int64
     default: 0
     unit: count
     allowed_range:

--- a/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
@@ -13,7 +13,7 @@ description: |-
   gets applied.
 short_description: FADC signal minimum contribution to digital signal sum.
 data:
-  - type: uint
+  - type: uint64
     unit: count
     default: 0
     condition: default_trigger==DigitalSum

--- a/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
@@ -12,7 +12,7 @@ description: |-
   shaping of missing outside signals are not used for trigger evaluation.
 short_description: Time offset applied before signal processing.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
@@ -14,7 +14,7 @@ description: |-
   Any such clipping is usually not a good idea, with FADC maximum
   value defined by fadc_max_signal anyway.
 data:
-  - type: uint
+  - type: uint64
     unit: count
     default: 0
     condition: default_trigger==DigitalSum

--- a/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
@@ -15,12 +15,12 @@ description: |-
   No such scaling is applied if first and second value are equal.
 short_description: Scaling of shaped signals.
 data:
-  - type: uint
+  - type: uint64
     description: multiplier
     default: 0
     unit: dimensionless
     condition: default_trigger==DigitalSum
-  - type: uint
+  - type: uint64
     description: divider
     default: 0
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
@@ -13,7 +13,7 @@ description: |-
   A value of zero implies no maximum to be applied.
 short_description: Maximum of pre-sum in available number of bits.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     condition: default_trigger==DigitalSum

--- a/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
@@ -19,7 +19,7 @@ short_description: |-
   After a patch-wise pre-summation, the resulting sum may be
   right-shifted to reduce the significant number of bits.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -17,7 +17,7 @@ description: |-
 short_description: Amplitude level above which a digital sum leads to a telescope
   trigger.
 data:
-  - type: double
+  - type: float64
     unit: count
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
@@ -16,7 +16,7 @@ description: |-
   for the final digital sum.
 short_description: Clipping of negative shaped signals.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -35,7 +35,7 @@ short_description: |-
 data:
   - description: |-
       Mean effective length for all directions of incidence.
-    type: double
+    type: float64
     unit: cm
     default: 0.0
     allowed_range:
@@ -44,7 +44,7 @@ data:
   - description: |-
       Effective length for incidence directions in mirror/camera x-z plane
       (if non-zero).
-    type: double
+    type: float64
     unit: cm
     default: 0.0
     allowed_range:
@@ -53,7 +53,7 @@ data:
   - description: |-
       Effective length for incidence directions in mirror/camera y-z plane
       (if non-zero).
-    type: double
+    type: float64
     unit: cm
     default: 0.0
     allowed_range:
@@ -61,12 +61,12 @@ data:
       max: 10000.0
   - description: |-
       Any displacement along x in the focal plane from asymmetric PSF behavior.
-    type: double
+    type: float64
     unit: cm
     default: 0.0
   - description: |-
       Any displacement along y in the focal plane from asymmetric PSF behavior.
-    type: double
+    type: float64
     unit: cm
     default: 0.0
 instrument:

--- a/src/simtools/schemas/model_parameters/epsg_code.schema.yml
+++ b/src/simtools/schemas/model_parameters/epsg_code.schema.yml
@@ -14,7 +14,7 @@ description: |-
   system, and Earth ellipsoids at the site.
 short_description: Site EPSG code
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     allowed_range:
       min: 1024

--- a/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -15,7 +15,7 @@ description: |-
 short_description: Peak amplitude above pedestal for a photo electron with average
   signal.
 data:
-  - type: double
+  - type: float64
     description: FADC amplitude (for high-gain channel in case of dual-readout chain).
     unit: count
     default: 14.0

--- a/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
@@ -14,7 +14,7 @@ description: |-
   FADC bins read out.
 short_description: Number of FADC bins to be simulated.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 20
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -22,7 +22,7 @@ description: |-
   they are clipped at zero.
 short_description: Emulation of FADC pedestal compensation.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: -1
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
@@ -14,7 +14,7 @@ description: |-
   Deviation of (F)ADCs pedestals in a single channel.
   (for high-gain channel in case of dual-readout chain).
 data:
-  - type: double
+  - type: float64
     description: |-
       Deviation of (F)ADCs pedestals
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
@@ -14,7 +14,7 @@ description: |-
   Used only when fadc_compensate_pedestal is activated.
 short_description: R.M.S. error on the pedestal evaluation for the compensation step.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
@@ -21,7 +21,7 @@ short_description: |-
   Assumed error in initial calibration of pedestal
   (affects only the reported pedestal).
 data:
-  - type: double
+  - type: float64
     default: 0.08
     description: |-
       Error in pedestal calibration

--- a/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -15,7 +15,7 @@ description: |-
 short_description: Peak amplitude above pedestal for a photo electron with average
   signal (low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: FADC amplitude (for low-gain channel in case of dual-readout chain).
     unit: count
     condition: num_gains==2

--- a/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -22,7 +22,7 @@ description: |-
   they are clipped at zero.
 short_description: Emulation of FADC pedestal compensation.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: -1
     condition: num_gains==2

--- a/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
@@ -13,7 +13,7 @@ developer_note: |-
 description: |-
   Deviation of (F)ADCs pedestals in a single channel (low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       Deviation of (F)ADCs pedestals (for low-gain channels).
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
@@ -14,7 +14,7 @@ description: |-
   Used only when fadc_compensate_pedestal is activated.
 short_description: R.M.S. error on the pedestal evaluation for the compensation step.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: -1.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
@@ -20,7 +20,7 @@ short_description: |-
   Assumed error in initial calibration of pedestal
   (low-gain channels; affects only the reported pedestal).
 data:
-  - type: double
+  - type: float64
     description: |-
       Error in pedestal calibration
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
@@ -11,7 +11,7 @@ description: |-
   For a typical 12-bit ADC this would be 4095.
 short_description: Maximum value of digitized signal per sample (low-gain channels).
 data:
-  - type: int
+  - type: int64
     description: |-
       Maximum FADC signal
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
@@ -15,7 +15,7 @@ short_description: |-
   The maximum value of a pulse sum produced by hardware pulse summation,
   in sum mode rather than recording pulse samples (low-gain channels).
 data:
-  - type: int
+  - type: int64
     description: |-
       Maximum value of a pulse sum
       (for low-gain channel in case of dual-readout chain)

--- a/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
@@ -11,7 +11,7 @@ description: |-
   (for low-gain channel, if different gains are used).
 short_description: Gaussian r.m.s. spread of white noise per time bin in digitisation (low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       Gaussian r.m.s. spread of white noise per time bin in digitisation
       (for low-gain channel in case of dual-readout chain)

--- a/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: fadc_lg_pedestal
 description: (F)ADC pedestal value per time slice (low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       (F)ADC pedestal value per time slice
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
@@ -16,7 +16,7 @@ description: |-
   amplitude of a single photo-electron.
 short_description: FADC counts per mV voltage (for low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       FADC counts per mV voltage.
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
@@ -12,7 +12,7 @@ description: |-
   (random) amount. Parameter determines the Gaussian r.m.s.
 short_description: Systematic common variations of pedestals (low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       Systematic common variations of pedestals.
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
@@ -11,7 +11,7 @@ description: |-
   time slice (low-gain channels). Value is the r.m.s. of the randomly chosen pedestal values
   around the FADC pedestal.
 data:
-  - type: double
+  - type: float64
     description: |-
       Pedestal variations
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: fadc_lg_var_sensitivity
 description: Relative variations in sensitivity (even for FADCs of the same channel; low-gain channels).
 data:
-  - type: double
+  - type: float64
     description: |-
       Relative variations in sensitivity
       (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
@@ -12,7 +12,7 @@ description: |-
   For a typical 12-bit ADC this would be 4095.
 short_description: Maximum value of digitized signal per sample.
 data:
-  - type: uint
+  - type: uint64
     description: |-
       Maximum FADC signal
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
@@ -16,7 +16,7 @@ short_description: |-
   The maximum value of a pulse sum produced by hardware pulse summation,
   in sum mode rather than recording pulse samples.
 data:
-  - type: uint
+  - type: uint64
     description: |-
       Maximum value of a pulse sum
       (for high-gain channel in case of dual-readout chain)

--- a/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: fadc_mhz
 description: FADC sampling rate.
 data:
-  - type: double
+  - type: float64
     default: 1000.
     unit: MHz
 instrument:

--- a/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -11,7 +11,7 @@ description: |-
   (for high-gain channel, if different gains are used).
 short_description: Gaussian r.m.s. spread of white noise per time bin in digitization.
 data:
-  - type: double
+  - type: float64
     description: |-
       Gaussian r.m.s. spread of white noise per time bin in digitization
       (for high-gain channel in case of dual-readout chain)

--- a/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
@@ -9,7 +9,7 @@ name: fadc_pedestal
 description: |-
   (F)ADC pedestal value per time slice (for high-gain channel for dual-gain readout).
 data:
-  - type: double
+  - type: float64
     description: |-
       (F)ADC pedestal value per time slice
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
@@ -17,7 +17,7 @@ description: |-
   (for high-gain channel for dual-gain readout).
 short_description: FADC counts per mV voltage.
 data:
-  - type: double
+  - type: float64
     description: |-
       FADC counts per mV voltage.
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
@@ -17,7 +17,7 @@ short_description: |-
   Number of bins read out in sampled data or summed up in ADC sum data.
   Corresponds to the experimental length of the readout window.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
@@ -16,7 +16,7 @@ short_description: |-
   Number of bins before telescope trigger where summing or reading of
   sampled data starts.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
@@ -13,7 +13,7 @@ description: |-
   (random) amount. Parameter determines the Gaussian r.m.s.
 short_description: Systematic common variations of pedestals.
 data:
-  - type: double
+  - type: float64
     description: |-
       Systematic common variations of pedestals.
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
@@ -12,7 +12,7 @@ description: |-
   around the FADC pedestal
   (for high-gain channel for dual-gain readout.
 data:
-  - type: double
+  - type: float64
     description: |-
       Pedestal variations
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
@@ -9,7 +9,7 @@ name: fadc_var_sensitivity
 description: |-
   Relative variations in sensitivity (even for FADCs of the same channel).
 data:
-  - type: double
+  - type: float64
     description: |-
       Relative variations in sensitivity
       (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_length.schema.yml
@@ -18,7 +18,7 @@ description: |-
   focal length.
 short_description: Nominal overall focal length of the entire telescope.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 1500.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
@@ -21,121 +21,121 @@ short_description: |-
   off-axis shape.
 data:
   - name: p0
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p1
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p2
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p3
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p4
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p5
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p6
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p7
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p8
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p9
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p10
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p11
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p12
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p13
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p14
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p15
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p16
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p17
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p18
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm
     default: 0.
   - name: p19
-    type: double
+    type: float64
     description: coefficient describing focal surface
     required: true
     unit: cm

--- a/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: focal_surface_ref_radius
 description: The length scale to which the focal_surface_parameters apply.
 data:
-  - type: double
+  - type: float64
     condition: mirror_class==2
     unit: cm
     default: 1.0

--- a/src/simtools/schemas/model_parameters/focus_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/focus_offset.schema.yml
@@ -24,22 +24,22 @@ short_description: |-
   Distance of the starlight focus from the camera pixels (light guides)
   entry.
 data:
-  - type: double
+  - type: float64
     name: focus_offset
     description: Constant focus offset $\Delta_0$.
     unit: cm
     default: 2.8
-  - type: double
+  - type: float64
     description: Zenith angle $\Delta_0$ at which minimum is reached.
     unit: deg
     default: 28.0
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_c$ in
       $\Delta_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
     unit: dimensionless
     default: 0.0
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_s$ in
       $\Delta_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.

--- a/src/simtools/schemas/model_parameters/gain_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/gain_variation.schema.yml
@@ -15,7 +15,7 @@ description: |-
   The parameter sets the Gaussian r.m.s. spread of random fluctuations, used
   as \texttt{amplitude *= RandGaus(1., gain_variation)}.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.02
     allowed_range:

--- a/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
@@ -11,7 +11,7 @@ description: |-
    Horizontal component in direction of magnetic North of the geomagnetic
    field at given site.
 data:
-  - type: double
+  - type: float64
     unit: uT
 instrument:
   class: Site

--- a/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
@@ -11,7 +11,7 @@ description: |-
    Rotation angle between geographic South and geomagnetic North direction
    (corresponds to CORSIKA ARRANG parameter).
 data:
-  - type: double
+  - type: float64
     unit: deg
     allowed_range:
       min: -180.0

--- a/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
@@ -11,7 +11,7 @@ description: |-
    Vertical component in downwards direction of the geomagnetic
    field at given site.
 data:
-  - type: double
+  - type: float64
     unit: uT
 instrument:
   class: Site

--- a/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Relative pixel-to-pixel variation of the ratio of high-gain to
   low-gain amplitudes.
 data:
-  - type: double
+  - type: float64
     required: false
     condition: num_gains==2
     default: 0.0

--- a/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
@@ -9,7 +9,7 @@ name: iobuf_maximum
 description: |-
   Buffer limits for input and output of eventio data.
 data:
-  - type: int
+  - type: int64
     unit: byte
     default: 200000000
     allowed_range:

--- a/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
@@ -9,7 +9,7 @@ name: iobuf_output_maximum
 description: |-
   The maximum size of the I/O buffer for output data, including raw data for all telescopes.
 data:
-  - type: int
+  - type: int64
     unit: byte
     default: 20000000
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -14,7 +14,7 @@ description: |-
 short_description: |-
   Relative variation of laser shots from shot to shot.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Use external trigger for calibration.
 data:
-  - type: int
+  - type: int64
     default: 0
     allowed_range:
       min: 0

--- a/src/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -11,7 +11,7 @@ description: |-
 short_description: |-
   Number of laser photons at each photo detector.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 500
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Exponentially decaying pulse shape time.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Shift position of the signal in the read-out window.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Gaussian pulse time width.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Top-Hat pulse time full-width.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
@@ -11,7 +11,7 @@ description: |-
 short_description: |-
   Relative variation of laser shots from shot to shot.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.05
     allowed_range:

--- a/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Wavelength of light-source.
 data:
-  - type: double
+  - type: float64
     unit: "nm"
     default: 400
     allowed_range:

--- a/src/simtools/schemas/model_parameters/led_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_events.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Additional calibration-type events.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/led_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_photons.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   LED intensity in the camera lid in front of each pixel.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 4.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
@@ -13,7 +13,7 @@ description: |-
 short_description: |-
   Shift position of the signal in the read-out window.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0.0
 instrument:

--- a/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Gaussian sigma LED pulse width.
 data:
-  - type: double
+  - type: float64
     unit: "ns"
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
@@ -12,7 +12,7 @@ description: |-
 short_description: |-
   Average amplitude variation of LED in front of each pixel.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
@@ -12,7 +12,7 @@ description: |-
   Minimum number of detected photoelectrons required in a camera before running the
   more CPU-intense electronics simulation.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: -1
 instrument:

--- a/src/simtools/schemas/model_parameters/min_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photons.schema.yml
@@ -9,7 +9,7 @@ name: min_photons
 description: |-
   Minimum number of photons required before doing simulation.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: -1
 instrument:

--- a/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Gaussian r.m.s. spread of random fluctuations in the aligned mirror
   distance from the focus.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 2.0
     condition: mirror_class==1

--- a/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
@@ -20,21 +20,21 @@ short_description: |-
   Gaussian r.m.s. spread of random fluctuations of the mirror alignment
   angle with respect to nominal alignment in the horizontal component.
 data:
-  - type: double
+  - type: float64
     description: Constant value $\sigma_0$.
     unit: deg
     default: 0.0035
-  - type: double
+  - type: float64
     description: Zenith angle $\theta_0$ at which minimum is reached.
     unit: deg
     default: 28.0
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_c$ in
       $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
     unit: dimensionless
     default: 0.023
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_s$ in
       $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.

--- a/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
@@ -20,21 +20,21 @@ short_description: |-
   Gaussian r.m.s. spread of random fluctuations of the mirror alignment
   angle with respect to nominal alignment in the vertical component.
 data:
-  - type: double
+  - type: float64
     description: Constant value $\sigma_0$.
     unit: deg
     default: 0.0034
-  - type: double
+  - type: float64
     description: Zenith angle $\theta_0$ at which minimum is reached.
     unit: deg
     default: 28.0
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_c$ in
       $\sigma_c = (\cos(\theta)-\cos(\theta_0)) / k_c$.
     unit: dimensionless
     default: 0.01
-  - type: double
+  - type: float64
     description: |-
       Scaling term $k_s$ in
       $\sigma_s = (\sin(\theta)-\sin(\theta_0)) / k_s$.

--- a/src/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -15,7 +15,7 @@ description: |-
 short_description: Parameter to control the type of mirror used (DC, parabolic or
   SC).
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
@@ -24,7 +24,7 @@ description: |-
 short_description: |-
   Mirror degradation factor (wavelength independent).
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
@@ -15,7 +15,7 @@ description: |-
   the overall focal length).
 short_description: Standard focal length of mirror tiles.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
@@ -17,7 +17,7 @@ short_description: |-
   Offset of mirror back plane from fixed point of telescope mount or
   from the altitude rotation axis, along the direction of the optical axis.
 data:
-  - type: double
+  - type: float64
     unit: cm
     default: 130.0
 instrument:

--- a/src/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_panel_2f_measurements.schema.yml
@@ -23,17 +23,17 @@ data:
           Mirror panel radius.
         required: true
         unit: cm
-        type: double
+        type: float64
       - name: psf
         description: |-
           Spot size of mirror panel PSF at nominal distance.
         required: true
         unit: cm
-        type: double
+        type: float64
       - name: psf_opt
         description: |-
           Spot size of mirror panel PSF
           (best value, not at nominal distance).
         required: false
         unit: cm
-        type: double
+        type: float64

--- a/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
@@ -16,21 +16,21 @@ short_description: |-
   Gaussian r.m.s. spread of random fluctuations of microscopic reflection
   angles due to small-scale surface deviations.
 data:
-  - type: double
+  - type: float64
     description: Projected Gaussian r.m.s. of the first component.
     unit: deg
     default: 0.0066
     allowed_range:
       min: 0.0
       max: 2.0
-  - type: double
+  - type: float64
     description: Fractional amplitude of second component.
     unit: dimensionless
     default: 0.0
     allowed_range:
       min: 0.0
       max: 1.0
-  - type: double
+  - type: float64
     description: Projected Gaussian r.m.s. of the second component.
     unit: deg
     default: 0.0

--- a/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
@@ -19,7 +19,7 @@ short_description: |-
   Actual threshold of the telescope trigger, adjusted relative to the
   number of required pixels.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: -0.5
     allowed_range:

--- a/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
@@ -11,7 +11,7 @@ description: |-
   This only takes effect if nsb_scaling_factor is exactly 1.0
 short_description: NSB scaling as function of airmass (zenith angle).
 data:
-  - type: double
+  - type: float64
     description: |-
       Zenith-level fraction of NSB resulting from airglow.
       Value should be on the order of 0.7.
@@ -20,7 +20,7 @@ data:
     allowed_range:
       min: 0.0
       max: 1.0
-  - type: double
+  - type: float64
     description: |-
       Effective extinction coefficient applicable for NSB light
       (due to scattering it should be smaller than extinction

--- a/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
@@ -15,7 +15,7 @@ short_description: |-
   Pixel p.e. rate at which the gain drops to half the nominal value due to
   bias resistance and cell capacitance (SiPM cameras).
 data:
-  - type: double
+  - type: float64
     unit: GHz
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
@@ -22,7 +22,7 @@ short_description: |-
 data:
   - name: nsb_offaxis_function
     required: false
-    type: double
+    type: float64
     description: |
       Function identifier.
     default: 0
@@ -34,28 +34,28 @@ data:
     description: |
       NSB off-axis factor $p_1$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
   - name: reference_radius_p2
     description: |
       Camera reference radius $p_2$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: cm
   - name: nsb_offaxis_p3
     description: |
       NSB off-axis factor $p_3$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
   - name: nsb_offaxis_p4
     description: |
       NSB off-axis factor $p_4$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
 instrument:

--- a/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
@@ -17,7 +17,7 @@ short_description: |-
   Number of photo-electrons per nanosecond per pixel due to nightsky
   background.
 data:
-  - type: double
+  - type: float64
     unit: GHz
     default: 0.218
     allowed_range:

--- a/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
@@ -12,7 +12,7 @@ description: |-
   night sky background level during astronomical darkness)
 short_description: Reference value for night-sky background flux.
 data:
-  - type: double
+  - type: float64
     unit: 1/(sr*ns*cm**2)
     default: 0.24
 instrument:

--- a/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
@@ -11,7 +11,7 @@ description: |-
   reference setting.
 short_description: Global NSB scaling factor.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
@@ -25,7 +25,7 @@ data:
         description: Wavelength
         required: true
         unit: nm
-        type: double
+        type: float64
         required_range:
           min: 300.0
           max: 700.0
@@ -36,7 +36,7 @@ data:
         description: Intensity of the night-sky background
         required: true
         unit: photons / arcsec**2 m**2 s** micron
-        type: double
+        type: float64
         required_range:
           min: 0.0
 activity:

--- a/src/simtools/schemas/model_parameters/num_gains.schema.yml
+++ b/src/simtools/schemas/model_parameters/num_gains.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: num_gains
 description: Number of different gains the input signal gets digitized.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 2
     allowed_range:

--- a/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -11,7 +11,7 @@ description: |-
 short_description: |-
   Number of pedestal events at start of run with camera lid open (same NSB as for normal events).
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/photon_delay.schema.yml
+++ b/src/simtools/schemas/model_parameters/photon_delay.schema.yml
@@ -13,7 +13,7 @@ description: |-
   Additional delay added to the arrival times
   of all photons at the photo sensors.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.0
 instrument:

--- a/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
+++ b/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
@@ -11,7 +11,7 @@ description: |-
 short_description: |-
   Number of photons per run.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1e10
     allowed_range:

--- a/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
@@ -13,7 +13,7 @@ description: |-
   The presence of a non-zero value does not imply any microscopic model
   of the pixel structure.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: 0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
@@ -31,7 +31,7 @@ short_description: |-
   Parameter controlling the orientation of the pixels, setting it to be
   aligned with the optical axis or the focal surface normal.
 data:
-  - type: uint
+  - type: uint64
     default: 1
     allowed_range:
       min: 0

--- a/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
@@ -14,7 +14,7 @@ description: |-
   in a real instrument are not accounted for).
 short_description: Time difference between telescope and pixel trigger recording.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Photo detector average gain. Used to determine the DC currents
   from night-sky background (NSB) pixel rates.
 data:
-  - type: double
+  - type: float64
     default: 40000.0
     allowed_range:
       min: 10000.0

--- a/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
@@ -16,7 +16,7 @@ description: |-
   photo-electrons are included in the amplitude distribution of the
   single-p.e. spectrum.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     allowed_range:
       min: 0.01

--- a/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
@@ -11,7 +11,7 @@ description: |-
   the PMT gain index p through $g \propto U^{p}$.
   Used only for PMT timing.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 4.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -9,14 +9,14 @@ name: pm_transit_time
 description: Total transit time of the photodetector at the average voltage.
 data:
   - name: pm_transit_time_at_average_voltage
-    type: double
+    type: float64
     description: Total transit time of the PMT at the average voltage.
     unit: ns
     default: 20.
     allowed_range:
       min: 0.0
   - name: pm_transit_time_to_first_dynode
-    type: double
+    type: float64
     description: |-
       Fixed transit time between cathode and first dynode, in case of
       the first dynode being stabilized. Use zero for a passive divider.
@@ -25,7 +25,7 @@ data:
     allowed_range:
       min: 0.0
   - name: fixed_voltage_first_dynode
-    type: double
+    type: float64
     description: |-
       The fixed voltage (or fraction of total nominal voltage) applied to
       a stabilized first dynode. Use zero for a passive divider.
@@ -36,7 +36,7 @@ data:
     developer_note: "This parameter can describe in sim_telarray the fraction of total\n\
       nominal voltage in case total nominal voltage is set to zero."
   - name: total_nominal_voltage
-    type: double
+    type: float64
     default: 1100.
     description: Total nominal voltage.
     unit: V

--- a/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
@@ -15,7 +15,7 @@ description: |-
   r.m.s. spread of random voltage fluctuations,
   \texttt{V = RandGaus(1., pm_voltage_variation)}.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.03
     allowed_range:

--- a/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
@@ -11,7 +11,7 @@ description: |-
   Used only in case mirror_list is not defined (i.e., mirror_list=none).
 data:
   - name: primary_mirror_diameter
-    type: double
+    type: float64
     unit: cm
     condition: mirror_list==None&&mirror_class==2
     default: 0.

--- a/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
@@ -11,7 +11,7 @@ description: |-
 data:
   - name: primary_hole_diameter
     description: Diameter of central hole in primary mirror.
-    type: double
+    type: float64
     default: 0.
     unit: cm
     condition: mirror_class==2

--- a/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
@@ -30,121 +30,121 @@ short_description: |-
   along the optical axis and its shape.
 data:
   - name: p0
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p1
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p2
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p3
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p4
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p5
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p6
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p7
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p8
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p9
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p10
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p11
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p12
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p13
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p14
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p15
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p16
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p17
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p18
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm
     default: 0.
   - name: p19
-    type: double
+    type: float64
     description: coefficient describing primary mirror
     required: true
     unit: cm

--- a/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
@@ -14,7 +14,7 @@ short_description: The length scale to which the primary_mirror_parameters apply
 data:
   - name: primary_ref_radius
     description: The length scale to which the primary_mirror_parameters apply.
-    type: double
+    type: float64
     unit: cm
     default: 1.0
     condition: mirror_class==2

--- a/src/simtools/schemas/model_parameters/qe_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/qe_variation.schema.yml
@@ -16,7 +16,7 @@ description: |-
   the average quantum or photon detection efficiency; the variation
   is applied independent of the wavelength.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 0.035
     allowed_range:

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -16,12 +16,12 @@ description: |-
   random focal length value does not get applied.
 short_description: The spread of random fluctuations in mirror focal lengths.
 data:
-  - type: double
+  - type: float64
     description: Width (r.m.s.) of Gaussian distribution for random focal lengths.
     unit: cm
     default: 7.4
     condition: mirror_class==1
-  - type: double
+  - type: float64
     description: Width of top-hat distribution for random focal lengths.
     unit: cm
     default: 0.0

--- a/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
@@ -11,7 +11,7 @@ description: |-
   This location is typically identical or close to the site center.
 short_description: Altitude above sea level of site reference point.
 data:
-  - type: double
+  - type: float64
     unit: m
     allowed_range:
       min: 0.0

--- a/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
@@ -11,7 +11,7 @@ description: |-
   Not to be used for coordinate transformations (use UTM coordinates for this).
 short_description: Latitude of site reference point.
 data:
-  - type: double
+  - type: float64
     unit: deg
     allowed_range:
       min: -90.0

--- a/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
@@ -11,7 +11,7 @@ description: |-
   Not to be used for coordinate transformations (use UTM coordinates for this).
 short_description: Longitude of site reference point.
 data:
-  - type: double
+  - type: float64
     unit: deg
     allowed_range:
       min: -180.0

--- a/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
@@ -12,7 +12,7 @@ description: |-
   position.
 short_description: UTM east of site reference point.
 data:
-  - type: double
+  - type: float64
     unit: m
     allowed_range:
       min: 0.

--- a/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
@@ -12,7 +12,7 @@ description: |-
   position.
 short_description: UTM north of site reference point.
 data:
-  - type: double
+  - type: float64
     unit: m
     allowed_range:
       min: 0.

--- a/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
@@ -21,7 +21,7 @@ data:
       primary center, which means a z value of par:secondary_ref_radius
       times the first par:secondary_mirror_parameters value is at the
       height of the center of the secondary.
-    type: double
+    type: float64
     unit: cm
     required: true
     condition: mirror_class==2
@@ -32,14 +32,14 @@ data:
       primary center, which means a z value of par:secondary_ref_radius
       times the first par:secondary_mirror_parameters value is at the
       height of the center of the secondary.
-    type: double
+    type: float64
     unit: cm
     required: true
     condition: mirror_class==2
     default: 0.
   - name: radius_r1
     description: Radius of open cylinder shape or cone shape at baffle_z1.
-    type: double
+    type: float64
     unit: cm
     required: true
     condition: mirror_class==2
@@ -48,14 +48,14 @@ data:
     description: |-
       Wall thickness of the baffle. The radius radius_r1 and radius_r2
       are the inner radii in case of finite wall thickness.
-    type: double
+    type: float64
     unit: cm
     required: false
     condition: mirror_class==2
     default: 0.
   - name: radius_r2
     description: Radius of open cylinder shape or cone shape at baffle_z2.
-    type: double
+    type: float64
     unit: cm
     required: false
     condition: mirror_class==2

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
@@ -16,7 +16,7 @@ description: |-
 short_description: |-
   Mirror degradation factor for the secondary mirror (wavelength independent).
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
@@ -11,7 +11,7 @@ description: |-
   Used only in case mirror_list is not defined (i.e., mirror_list=none).
 data:
   - name: secondary_mirror_diameter
-    type: double
+    type: float64
     unit: cm
     condition: mirror_list==None&&mirror_class==2
     default: 0.

--- a/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
@@ -14,7 +14,7 @@ description: |-
 data:
   - name: secondary_hole_diameter
     description: Diameter of any non-reflective part of the secondary mirror.
-    type: double
+    type: float64
     default: 0.
     unit: cm
     condition: mirror_class==2

--- a/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
@@ -30,121 +30,121 @@ short_description: |-
   along the optical axis and its shape.
 data:
   - name: p0
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p1
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p2
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p3
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p4
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p5
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p6
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p7
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p8
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p9
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p10
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p11
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p12
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p13
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p14
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p15
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p16
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p17
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p18
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm
     default: 0.
   - name: p19
-    type: double
+    type: float64
     description: coefficient describing secondary mirror
     required: true
     unit: cm

--- a/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
@@ -14,7 +14,7 @@ short_description: The length scale to which the secondary_mirror_parameters app
 data:
   - name: secondary_ref_radius
     description: The length scale to which the secondary_mirror_parameters apply.
-    type: double
+    type: float64
     unit: cm
     condition: mirror_class==2
     default: 1.

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
@@ -16,7 +16,7 @@ short_description: |-
   The diameter of any non-reflective but not transparent (black)
   central part of the secondary mirror in a dual-mirror telescope.
 data:
-  - type: double
+  - type: float64
     unit: cm
     condition: mirror_class==2
     default: -1.

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
@@ -16,7 +16,7 @@ short_description: |-
   The offset of the shadowing element from the level of the edge of the
   secondary mirror.
 data:
-  - type: double
+  - type: float64
     unit: cm
     condition: mirror_class==2
     default: 0.0

--- a/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
@@ -15,7 +15,7 @@ description: |-
   in fewer than the given number of photo-electrons, as no attempt is made to trace photons through the telescope
   and produce any photo-electrons if there are too few photons in the first place.
 data:
-  - type: int
+  - type: int64
     unit: dimensionless
     default: -1
     allowed_range:

--- a/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
@@ -12,7 +12,7 @@ description: |-
   for the various levels of confidence that a pixel actually belongs to the shower image.
   Instead of making them individually configurable, a common scale factor can be applied to all of them.
 data:
-  - type: double
+  - type: float64
     unit: dimensionless
     default: 1
     allowed_range:

--- a/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: telescope_axis_height
 description: Height of telescope elevation axis above ground level.
 data:
-  - type: double
+  - type: float64
     unit: m
 instrument:
   class: Structure

--- a/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
@@ -12,7 +12,7 @@ description: |-
   this misalignment are saved as telescope azimuth and altitude
   pointing directions.
 data:
-  - type: double
+  - type: float64
     unit: deg
     default: 0.001
 instrument:

--- a/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
@@ -11,7 +11,7 @@ description: |-
   (Gaussian r.m.s.). The resulting telescope pointing including
   this misalignment is not saved to the simulation output.
 data:
-  - type: double
+  - type: float64
     unit: deg
     default: 0.001
 instrument:

--- a/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
@@ -13,7 +13,7 @@ description: |-
   are fully contained.
 short_description: Telescope fiducial sphere radius.
 data:
-  - type: double
+  - type: float64
     unit: m
 instrument:
   class: Structure

--- a/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
@@ -40,7 +40,7 @@ short_description: |-
   shadowing by masts.
 data:
   - name: constant_p0
-    type: double
+    type: float64
     description: |
       Constant transmission factor $p_0$.
     required: true
@@ -51,7 +51,7 @@ data:
       max: 1.0
   - name: transmission_function
     required: false
-    type: double
+    type: float64
     description: |
       Transmission function identifier.
     default: 0
@@ -63,28 +63,28 @@ data:
     description: |
       Transmission factor $p_2$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
   - name: transmission_p3
     description: |
       Transmission factor $p_3$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
   - name: transmission_p4
     description: |
       Transmission factor $p_4$.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
   - name: transmission_p5
     description: |
       Transmission factor $p_5.
     required: false
-    type: double
+    type: float64
     default: 0.0
     unit: dimensionless
 instrument:

--- a/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
@@ -13,7 +13,7 @@ description: |-
   of these values being non-zero should be sufficient.
 short_description: Minimum signal sum at sector trigger over threshold.
 data:
-  - type: double
+  - type: float64
     unit: mV * ns
     default: 7.8
     allowed_range:

--- a/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: teltrig_min_time
 description: Minimum time of sector trigger over threshold.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 1.5
     allowed_range:

--- a/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Accuracy with which the actual signal delay due to transit
   time variation and corresponding compensation can be determined.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
@@ -11,7 +11,7 @@ description: |-
   transit time compensation can be determined before the
   compensation is applied.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
@@ -12,7 +12,7 @@ description: |-
   A value of zero means no compensation is applied.
   The same compensation is applied to all channels.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.0
     allowed_range:

--- a/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
@@ -19,7 +19,7 @@ description: |-
   compensation if used, is reported in the calibration data block, but only
   up to a random accuracy defined by par:transit-time-calib-error.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.
     allowed_range:

--- a/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
@@ -10,7 +10,7 @@ description: |-
   Time jitter (Gaussian r.m.s. spread of random fluctuations) of individual
   photo-electrons.
 data:
-  - type: double
+  - type: float64
     unit: ns
     default: 0.75
     allowed_range:

--- a/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
@@ -8,7 +8,7 @@ meta_schema_version: 0.1.0
 name: trigger_current_limit
 description: Pixels above this limit are excluded from the trigger.
 data:
-  - type: double
+  - type: float64
     unit: uA
     default: 20.0
 instrument:

--- a/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
@@ -16,19 +16,19 @@ short_description: |-
   The delay applied to the trigger output to compensate for the different
   execution times of each trigger algorithm.
 data:
-  - type: double
+  - type: float64
     description: Delay applied for majority trigger.
     unit: ns
     default: 0.0
-  - type: double
+  - type: float64
     description: Delay applied for analog sum trigger.
     unit: ns
     default: 0.0
-  - type: double
+  - type: float64
     description: Delay applied for digital sum trigger.
     unit: ns
     default: 0.0
-  - type: double
+  - type: float64
     description: Delay (TODO this value is unclear)
     unit: ns
     default: 0.0

--- a/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
@@ -14,7 +14,7 @@ description: |-
   trigger_pixels.
 short_description: Number of pixels required for single telescope trigger.
 data:
-  - type: uint
+  - type: uint64
     unit: dimensionless
     default: 4
     allowed_range:

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -273,7 +273,7 @@ def test_get_validated_parameter_dict():
         "unique_id": None,
         "value": 2,
         "unit": u.Unit(""),
-        "type": "int",
+        "type": "int64",
         "file": False,
     }
 
@@ -291,7 +291,7 @@ def test_get_validated_parameter_dict():
         "unique_id": None,
         "value": 5,
         "unit": u.Unit("ns"),
-        "type": "double",
+        "type": "float64",
         "file": False,
     }
 
@@ -309,7 +309,7 @@ def test_get_validated_parameter_dict():
         "unique_id": None,
         "value": 2700.0,
         "unit": u.Unit("m"),
-        "type": "double",
+        "type": "float64",
         "file": False,
     }
 


### PR DESCRIPTION
Model parameter data are currently defined sometimes as python and sometimes as numpy types. No obvious reason why one or the other is used.

This merge request changes the schemas to use consistently numpy types. There is a corresponding merge request for the model parameter database here: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/22

To list the define files types:

```
cd src/simtools/schemas/model_parameters
grep -h "\- type" * | sort -u
```

Closes #1216 