### PR TITLE
Run scheduled nightly tests on production DB

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -68,8 +68,8 @@ jobs:
         run: |
           echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
 
-      - name: Set DB Environment Variables (workflow_dispatch only)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Create environment file (remote DB; schedule only)
+        if: ${{ github.event_name == 'schedule' }}
         run: |
           {
             echo "SIMTOOLS_DB_SERVER=${{ secrets.DB_SERVER }}"
@@ -86,7 +86,7 @@ jobs:
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
       - name: Create environment file (local DB)
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'schedule'
         run: |
           {
             echo "SIMTOOLS_DB_SERVER=mongodb"
@@ -98,7 +98,7 @@ jobs:
           } > .env
 
       - name: Upload data to MongoDB
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'schedule'
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'
@@ -109,7 +109,7 @@ jobs:
         shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
-          SIMTOOLS_DB_SERVER: ${{ github.event_name == 'workflow_dispatch' && secrets.DB_SERVER || 'mongodb' }}
+          SIMTOOLS_DB_SERVER: ${{ github.event_name == 'schedule' && secrets.DB_SERVER || 'mongodb' }}
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -76,7 +76,8 @@ jobs:
             echo "SIMTOOLS_DB_API_USER=${{ secrets.DB_API_USER }}"
             echo "SIMTOOLS_DB_API_PW=${{ secrets.DB_API_PW }}"
             echo "SIMTOOLS_DB_API_PORT=${{ secrets.DB_API_PORT }}"
-          } >> "$GITHUB_ENV"
+            echo "SIMTOOLS_SIMTEL_PATH=/workdir/sim_telarray/"
+          } > .env
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |
@@ -93,6 +94,7 @@ jobs:
             echo "SIMTOOLS_DB_API_PW=password"
             echo "SIMTOOLS_DB_API_PORT=27017"
             echo "SIMTOOLS_DB_SIMULATION_MODEL=${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}"
+            echo "SIMTOOLS_SIMTEL_PATH=/workdir/sim_telarray/"
           } > .env
 
       - name: Upload data to MongoDB

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -71,10 +71,12 @@ jobs:
       - name: Set DB Environment Variables (workflow_dispatch only)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          echo "SIMTOOLS_DB_SERVER=${{ secrets.DB_SERVER }}" >> "$GITHUB_ENV"
-          echo "SIMTOOLS_DB_API_USER=${{ secrets.DB_API_USER }}" >> "$GITHUB_ENV"
-          echo "SIMTOOLS_DB_API_PW=${{ secrets.DB_API_PW }}" >> "$GITHUB_ENV"
-          echo "SIMTOOLS_DB_API_PORT=${{ secrets.DB_API_PORT }}" >> "$GITHUB_ENV"
+          {
+            echo "SIMTOOLS_DB_SERVER=${{ secrets.DB_SERVER }}"
+            echo "SIMTOOLS_DB_API_USER=${{ secrets.DB_API_USER }}"
+            echo "SIMTOOLS_DB_API_PW=${{ secrets.DB_API_PW }}"
+            echo "SIMTOOLS_DB_API_PORT=${{ secrets.DB_API_PORT }}"
+          } >> "$GITHUB_ENV"
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |
@@ -105,6 +107,7 @@ jobs:
         shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+          SIMTOOLS_DB_SERVER: ${{ github.event_name == 'workflow_dispatch' && secrets.DB_SERVER || 'mongodb' }}
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -2,13 +2,6 @@
 name: CI-integrationtests
 # Integration tests for applications
 
-env:
-  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
-  SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
-  SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
-  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
-  SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
-
 on:
   workflow_dispatch:
   pull_request:
@@ -74,6 +67,14 @@ jobs:
       - name: Set PATH
         run: |
           echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
+
+      - name: Set DB Environment Variables (workflow_dispatch only)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "SIMTOOLS_DB_SERVER=${{ secrets.DB_SERVER }}" >> "$GITHUB_ENV"
+          echo "SIMTOOLS_DB_API_USER=${{ secrets.DB_API_USER }}" >> "$GITHUB_ENV"
+          echo "SIMTOOLS_DB_API_PW=${{ secrets.DB_API_PW }}" >> "$GITHUB_ENV"
+          echo "SIMTOOLS_DB_API_PORT=${{ secrets.DB_API_PORT }}" >> "$GITHUB_ENV"
 
       - name: Extract SIMTOOLS_DB_SIMULATION_MODEL
         run: |

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -3,6 +3,10 @@ name: CI-integrationtests
 # Integration tests for applications
 
 env:
+  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
+  SIMTOOLS_DB_API_USER: ${{ secrets.DB_API_USER }}
+  SIMTOOLS_DB_API_PW: ${{ secrets.DB_API_PW }}
+  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
   SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray/"
 
 on:
@@ -62,9 +66,10 @@ jobs:
         shell: bash -leo pipefail {0}
 
     steps:
-
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set PATH
         run: |
@@ -76,7 +81,8 @@ jobs:
           SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
-      - name: Create environment file
+      - name: Create environment file (local DB)
+        if: github.event_name != 'workflow_dispatch'
         run: |
           {
             echo "SIMTOOLS_DB_SERVER=mongodb"
@@ -87,17 +93,17 @@ jobs:
           } > .env
 
       - name: Upload data to MongoDB
+        if: github.event_name != 'workflow_dispatch'
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'
           cd database_scripts/
           ./upload_from_model_repository_to_db.sh ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
 
-      - name: Run integration tests
+      - name: Integration tests
         shell: bash -l {0}
         env:
           SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
-          SIMTOOLS_DB_SERVER: mongodb
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -2,12 +2,6 @@
 name: CI-unittests
 # Execute unit tests
 # (includes CTAO-DPPS-SonarQube)
-env:
-  SIMTOOLS_DB_SERVER: localhost
-  SIMTOOLS_DB_API_USER: api
-  SIMTOOLS_DB_API_PW: password
-  SIMTOOLS_DB_API_PORT: 27017
-  SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
 on:
   workflow_dispatch:
@@ -18,6 +12,12 @@ on:
 
 jobs:
   unittests:
+    env:
+      # For pull_request and workflow_dispatch: use local MongoDB
+      SIMTOOLS_DB_SERVER: ${{ github.event_name != 'workflow_dispatch' && 'localhost' || secrets.DB_SERVER }}
+      SIMTOOLS_DB_API_USER: ${{ github.event_name != 'workflow_dispatch' && 'api' || secrets.DB_API_USER }}
+      SIMTOOLS_DB_API_PW: ${{ github.event_name != 'workflow_dispatch' && 'password' || secrets.DB_API_PW }}
+      SIMTOOLS_DB_API_PORT: ${{ github.event_name != 'workflow_dispatch' && '27017' || secrets.DB_API_PORT }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -106,6 +106,14 @@ jobs:
           SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
+      - name: Print DB connection variables
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "DB Server: $SIMTOOLS_DB_SERVER"
+          echo "DB API User: $SIMTOOLS_DB_API_USER"
+          echo "DB API Port: $SIMTOOLS_DB_API_PORT"
+          echo "DB Simulation Model: $SIMTOOLS_DB_SIMULATION_MODEL"
+
       - name: Upload data to MongoDB
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
         run: |

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -11,13 +11,13 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  unittests:
+  unit_tests:
     env:
-      # For pull_request and workflow_dispatch: use local MongoDB
-      SIMTOOLS_DB_SERVER: ${{ github.event_name != 'workflow_dispatch' && 'localhost' || secrets.DB_SERVER }}
-      SIMTOOLS_DB_API_USER: ${{ github.event_name != 'workflow_dispatch' && 'api' || secrets.DB_API_USER }}
-      SIMTOOLS_DB_API_PW: ${{ github.event_name != 'workflow_dispatch' && 'password' || secrets.DB_API_PW }}
-      SIMTOOLS_DB_API_PORT: ${{ github.event_name != 'workflow_dispatch' && '27017' || secrets.DB_API_PORT }}
+      # For scheduled runs, use production DB
+      SIMTOOLS_DB_SERVER: ${{ github.event_name != 'schedule' && 'localhost' || secrets.DB_SERVER }}
+      SIMTOOLS_DB_API_USER: ${{ github.event_name != 'schedule' && 'api' || secrets.DB_API_USER }}
+      SIMTOOLS_DB_API_PW: ${{ github.event_name != 'schedule' && 'password' || secrets.DB_API_PW }}
+      SIMTOOLS_DB_API_PORT: ${{ github.event_name != 'schedule' && '27017' || secrets.DB_API_PORT }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -115,7 +115,7 @@ jobs:
           echo "DB Simulation Model: $SIMTOOLS_DB_SIMULATION_MODEL"
 
       - name: Upload data to MongoDB
-        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+        if: github.event_name != 'schedule'
         run: |
           cd database_scripts/
           ./upload_from_model_repository_to_db.sh ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -107,6 +107,7 @@ jobs:
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
       - name: Upload data to MongoDB
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
         run: |
           cd database_scripts/
           ./upload_from_model_repository_to_db.sh ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}

--- a/docs/changes/1454.feature.md
+++ b/docs/changes/1454.feature.md
@@ -1,0 +1,1 @@
+Run scheduled nightly integration and unit tests on production DB.


### PR DESCRIPTION
This has been tested by excluding not `schedule` but `workflow_dispatch` and run the unit in the usually PR CI plus triggered by hand:

- usually CI uploads to local DB https://github.com/gammasim/simtools/actions/runs/13987110547/job/39162743143
- by hand: no upload to local DB https://github.com/gammasim/simtools/actions/runs/13987145563/job/39162849793

Note that the mongoDB service is running in both cases - although not used for when using the production DB. 

Closes #1434