### PR TITLE
Fix failing test of production images - set consistent date

### DIFF
--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -136,8 +136,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-          # - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
+          # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
           - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
@@ -223,8 +223,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-          # - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
+          # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
           - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}


### PR DESCRIPTION
Fix of failing tests of production images, see e.g., https://github.com/gammasim/simtools/actions/runs/14013865711/job/39252381358 

Underlying issue that we define the build matrix three times in the workflow file (didn't find a more elegant solution) - and all three have to be identical. We have commented out different versions at different steps; this is fixed now.

(they are commented out as right now there is no need to build all possible combinations of versions and build args).

Fixed pipeline: https://github.com/gammasim/simtools/actions/runs/14030126370/job/39276114170