### PR TITLE
Add site parameter reporting

### DIFF
--- a/src/simtools/applications/docs_produce_array_element_report.py
+++ b/src/simtools/applications/docs_produce_array_element_report.py
@@ -41,6 +41,12 @@ def _parse(label):
         "--all_sites", action="store_true", help="Produce reports for all sites."
     )
 
+    config.parser.add_argument(
+        "--observatory",
+        action="store_true",
+        help="Produce reports for an observatory at a given site.",
+    )
+
     return config.initialize(
         db_config=True, simulation_model=["site", "telescope", "model_version"]
     )


### PR DESCRIPTION
This PR adds reporting functionality for OBS-North and OBS-South parameters.

It can be run using the --all flags like this:

`python src/simtools/applications/docs_produce_array_element_report.py --observatory --all_sites --all_model_versions`

or individually like this:

`python src/simtools/applications/docs_produce_array_element_report.py --observatory --site North --model_version 5.0.0`