### PR TITLE
Store arrays in model parameters as arrays and not as strings. 

### DIFF
--- a/database_scripts/upload_from_model_repository_to_db.sh
+++ b/database_scripts/upload_from_model_repository_to_db.sh
@@ -7,7 +7,7 @@
 set -e
 
 DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models.git"
-DB_SIMULATION_MODEL_BRANCH="strings-to-arrays"
+DB_SIMULATION_MODEL_BRANCH="main"
 
 # Check that this script is not sourced but executed
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then

--- a/database_scripts/upload_from_model_repository_to_db.sh
+++ b/database_scripts/upload_from_model_repository_to_db.sh
@@ -7,7 +7,7 @@
 set -e
 
 DB_SIMULATION_MODEL_URL="https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models.git"
-DB_SIMULATION_MODEL_BRANCH="main"
+DB_SIMULATION_MODEL_BRANCH="strings-to-arrays"
 
 # Check that this script is not sourced but executed
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then

--- a/docs/changes/1466.maintenance.md
+++ b/docs/changes/1466.maintenance.md
@@ -1,0 +1,1 @@
+Store arrays in model parameters as arrays and not as strings.

--- a/src/simtools/data_model/model_data_writer.py
+++ b/src/simtools/data_model/model_data_writer.py
@@ -441,13 +441,13 @@ class ModelDataWriter:
 
         """
         try:
-            data_dict["value"] = gen.convert_list_to_string(data_dict["value"])
-            data_dict["unit"] = gen.convert_list_to_string(data_dict["unit"], comma_separated=True)
-            data_dict["type"] = gen.convert_list_to_string(
-                data_dict["type"], comma_separated=True, collapse_list=True
-            )
             if isinstance(data_dict["unit"], str):
                 data_dict["unit"] = data_dict["unit"].replace("None", "null")
+            elif isinstance(data_dict["unit"], list):
+                data_dict["unit"] = [
+                    unit.replace("None", "null") if isinstance(unit, str) else unit
+                    for unit in data_dict["unit"]
+                ]
         except KeyError:
             pass
         return data_dict

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -12,7 +12,7 @@ from simtools.io_operations import io_handler
 from simtools.model.site_model import SiteModel
 from simtools.model.telescope_model import TelescopeModel
 from simtools.simtel.simtel_config_writer import SimtelConfigWriter
-from simtools.utils import general, names
+from simtools.utils import names
 
 __all__ = ["ArrayModel"]
 
@@ -326,9 +326,7 @@ class ArrayModel:
             "site": site,
             "parameter_version": parameter_version,
             "unique_id": None,
-            "value": general.convert_list_to_string(
-                [x.to("m").value, y.to("m").value, z.to("m").value]
-            ),
+            "value": [x.to("m").value, y.to("m").value, z.to("m").value],
             "unit": "m",
             "type": "float64",
             "file": False,

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -62,6 +62,11 @@ definitions:
         anyOf:
           - type: string
           - type: "null"
+          - type: array
+            items:
+              type:
+                - string
+                - "null"
         description: "Unit of the parameter."
       value:
         anyOf:

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -221,10 +221,9 @@ def test_dump_model_parameter(tmp_test_directory, db_config):
     )
     assert Path(tmp_test_directory / "array_element_position_utm.json").is_file()
     assert isinstance(position_dict, dict)
-    value_list = [float(value) for value in position_dict["value"].split()]
-    assert pytest.approx(value_list[0]) == 217659.6
-    assert pytest.approx(value_list[1]) == 3184995.1
-    assert pytest.approx(value_list[2]) == 2185.0
+    assert pytest.approx(position_dict["value"][0]) == 217659.6
+    assert pytest.approx(position_dict["value"][1]) == 3184995.1
+    assert pytest.approx(position_dict["value"][2]) == 2185.0
     assert Path(tmp_test_directory / "array_element_position_utm.meta.yml").is_file()
 
     position_dict = writer.ModelDataWriter.dump_model_parameter(
@@ -236,11 +235,10 @@ def test_dump_model_parameter(tmp_test_directory, db_config):
         output_path=tmp_test_directory,
         use_plain_output_path=True,
     )
-    value_list = [float(value) for value in position_dict["value"].split()]
-    assert pytest.approx(value_list[0]) == 6.55
-    assert pytest.approx(value_list[1]) == 0.0
-    assert pytest.approx(value_list[2]) == 0.0
-    assert pytest.approx(value_list[3]) == 0.0
+    assert pytest.approx(position_dict["value"][0]) == 6.55
+    assert pytest.approx(position_dict["value"][1]) == 0.0
+    assert pytest.approx(position_dict["value"][2]) == 0.0
+    assert pytest.approx(position_dict["value"][3]) == 0.0
 
     with patch(
         "simtools.data_model.model_data_writer.ModelDataWriter.check_db_for_existing_parameter"
@@ -315,42 +313,14 @@ def test_get_validated_parameter_dict():
 
 
 def test_prepare_data_dict_for_writing():
-    data_dict_1 = {}
-    assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_1) == {}
-    data_dict_2 = {
-        "value": 5.5,
-        "unit": "m",
-        "type": "float64",
-    }
-    assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_2) == data_dict_2
-    data_dict_3 = {
-        "value": [5.5, 6.6],
-        "unit": "m",
-        "type": "float64",
-    }
-    assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_3) == {
-        "value": "5.5 6.6",
-        "unit": "m",
-        "type": "float64",
-    }
-    data_dict_4 = {
-        "value": [5.5, 6.6],
-        "unit": ["m", "l"],
-        "type": ["float64", "float64"],
-    }
-    assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_4) == {
-        "value": "5.5 6.6",
-        "unit": "m, l",
-        "type": "float64",
-    }
     data_dict_5 = {
         "value": [5.5, 6.6],
         "unit": ["None", "None"],
         "type": "float64",
     }
     assert writer.ModelDataWriter.prepare_data_dict_for_writing(data_dict_5) == {
-        "value": "5.5 6.6",
-        "unit": "null, null",
+        "value": [5.5, 6.6],
+        "unit": ["null", "null"],
         "type": "float64",
     }
 

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -115,7 +115,7 @@ def test_get_telescope_position_parameter(array_model, io_handler):
         "site": "North",
         "parameter_version": "2.0.0",
         "unique_id": None,
-        "value": "10.0 2.0 30.0",
+        "value": [10.0, 2.0, 30.0],
         "unit": "m",
         "type": "float64",
         "file": False,


### PR DESCRIPTION
Consistently write lists/arrays as such and not as simtel-style strings.

- remove all conversions to strings with the exception simtel_config_writer (there it is needed, as sim_telarray requires strings)
- kept the string-to-list conversion on the "reading side" - this ensures backwards compatibility
- updated model parameter schema to allow list of strings (or list of Nones) for the unit field

Related to [MR 23 in SimulationModels](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/23).

Closes #1317.