### PR TITLE
Remove error message duplication in general.collect_data_from_file

### DIFF
--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -190,7 +190,6 @@ def collect_data_from_file(file_name, yaml_document=None):
                 return _collect_data_from_yaml_file(file, file_name, yaml_document)
     # broad exception to catch all possible errors in reading the file
     except Exception as exc:  # pylint: disable=broad-except
-        _logger.error(f"Failed to read file {file_name}: {exc}")
         raise type(exc)(f"Failed to read file {file_name}: {exc}") from exc
     return None
 

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -25,7 +25,7 @@ url_simtools = "https://raw.githubusercontent.com/gammasim/simtools/main/"
 test_data = "Test data"
 
 
-def test_collect_dict_data(io_handler, caplog) -> None:
+def test_collect_dict_data(io_handler) -> None:
     dict_for_yaml = {"k3": {"kk3": 4, "kk4": 3.0}, "k4": ["bla", 2]}
     test_yaml_file = io_handler.get_output_file(file_name="test_collect_dict_data.yml")
     if not Path(test_yaml_file).exists():
@@ -76,7 +76,6 @@ def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
     # Test with invalid YAML file
     with pytest.raises(Exception, match=r"^Failed to read file"):
         gen.collect_data_from_file(test_file)
-    assert "Failed to read file" in caplog.text
 
     # Test with invalid JSON file
     test_json = io_handler.get_output_file(file_name="invalid.json")
@@ -85,7 +84,6 @@ def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
 
     with pytest.raises(Exception, match=r"^JSONDecodeError"):
         gen.collect_data_from_file(test_json)
-    assert "Failed to read file" in caplog.text
 
     # Test with unsupported file extension
     test_unsupported = io_handler.get_output_file(file_name="test.xyz")


### PR DESCRIPTION
I had been very confused by the large number of error messages when running schema validation in the simulation models repository (e.g., see [this job](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/307059)) - error messages without job failure was unexpected.

Reason was that with both used `logger.error` and `raise FileNotFoundError(...)` to issue the same error message. The catching of the error in another class did not prevent logger from issuing the error. This has been fixed by removing the logger.error statement.