### PR TITLE
Disallow additional properties for model parameter data dictionaries

### DIFF
--- a/docs/changes/1470.bugfix.md
+++ b/docs/changes/1470.bugfix.md
@@ -1,0 +1,1 @@
+Add missing `parameter` definition in model parameter schema.

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -14,6 +14,7 @@ definitions:
   SimtoolsModelParameters:
     description: ""
     type: object
+    additionalProperties: false
     properties:
       _id:
         type: string

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -30,6 +30,9 @@ definitions:
           - string
           - "null"
         description: "Associated instrument."
+      parameter:
+        type: string
+        description: "Parameter name."
       site:
         anyOf:
           - type: string
@@ -93,6 +96,7 @@ definitions:
     required:
       - file
       - instrument
+      - parameter
       - parameter_version
       - schema_version
       - site


### PR DESCRIPTION
This [merge request CI pipeline](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/308174) should have failed as a new entry to the data dict for model parameters has been added (entry `meta_parameter`. It didn't, as a `additionalProperties: false` was missing in the schema definition. This PR fixes this.

Realized after adding this that we don't have a definition for the `parameter` entry in the model parameter dictionaries. Added it.