### PR TITLE
Primary degraded map is a parameter applied for all telescope types.

### DIFF
--- a/docs/changes/1475.bugfix.md
+++ b/docs/changes/1475.bugfix.md
@@ -1,0 +1,1 @@
+Primary degraded map is a parameter applied for all telescope types.

--- a/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
@@ -9,16 +9,16 @@ developer_note: |-
   To be replaced by a data table. Accepted range is 0 to 1
 name: primary_mirror_degraded_map
 description: |-
-  Position-dependent map of degradation factors for the primary mirror.
+  Position-dependent map of degradation factors for the (primary) mirror.
   This degradation gets applied on top of mirror_degraded_reflection.
-  Note that the impact of it on the nightsky background is not automatically
+  Note that the impact of it on the night-sky background is not automatically
   accounted for and must be evaluated separately and included in the
   configured NSB pixel p.e. rates. It is recommended to use a map with an
   average efficiency of 1.0 and use mirror_degraded_reflection
   for the overall degradation.  Tables with equidistant spacing in both x and
   y are highly recommended because the interpolation is faster.
 short_description: |-
-  Position-dependent map of degradation factors for the primary mirror.
+  Position-dependent map of degradation factors for the (primary) mirror.
 data:
   - type: file
     unit: dimensionless
@@ -26,6 +26,10 @@ data:
 instrument:
   class: Structure
   type:
+    - LSTN
+    - LSTS
+    - MSTN
+    - MSTS
     - SSTS
     - SCTS
 activity:


### PR DESCRIPTION
This was on oversight before - primary degraded map can also be used for single-mirror telescopes, see the screenshot below from the sim_telarray manual:

<img width="553" alt="Screenshot 2025-04-01 at 10 14 11" src="https://github.com/user-attachments/assets/c114dca6-eca7-43d7-8b42-aaa2fa693f29" />
