### PR TITLE
Skip testing of DB upload for simpipe integration tests.

### DIFF
--- a/docs/changes/1488.maintenance.md
+++ b/docs/changes/1488.maintenance.md
@@ -1,0 +1,1 @@
+Skip testing of DB upload for simpipe integration tests.

--- a/src/simtools/testing/configuration.py
+++ b/src/simtools/testing/configuration.py
@@ -138,12 +138,13 @@ def _skip_test_for_model_version(config, model_version_requested):
 
 def _skip_test_for_production_db(config):
     """Skip test if production db is used."""
-    simtools_db_server = os.environ.get("SIMTOOLS_DB_SERVER")
-    if (
-        simtools_db_server
-        and config.get("SKIP_FOR_PRODUCTION_DB")
-        and "db.zeuthen.desy.de" in simtools_db_server
-    ):
+    if not config.get("SKIP_FOR_PRODUCTION_DB"):
+        return
+
+    if "db.zeuthen.desy.de" in os.getenv("SIMTOOLS_DB_SERVER", ""):
+        raise ProductionDBError("Production database used for this test")
+
+    if "simpipe" in os.getenv("SIMTOOLS_DB_API_USER", ""):
         raise ProductionDBError("Production database used for this test")
 
 

--- a/tests/unit_tests/testing/test_configuration.py
+++ b/tests/unit_tests/testing/test_configuration.py
@@ -315,3 +315,30 @@ def test_skip_test_for_production_db_skip(monkeypatch):
         configuration.ProductionDBError, match="Production database used for this test"
     ):
         configuration._skip_test_for_production_db(config)
+
+
+def test_skip_test_for_production_db_no_db_api_user(monkeypatch):
+    config = {"SKIP_FOR_PRODUCTION_DB": True}
+    monkeypatch.delenv("SIMTOOLS_DB_API_USER", raising=False)
+    configuration._skip_test_for_production_db(config)
+
+
+def test_skip_test_for_production_db_not_simpipe(monkeypatch):
+    config = {"SKIP_FOR_PRODUCTION_DB": True}
+    monkeypatch.setenv("SIMTOOLS_DB_API_USER", "simtools")
+    configuration._skip_test_for_production_db(config)
+
+
+def test_skip_test_for_production_db_no_skip_flag_for_user(monkeypatch):
+    config = {}
+    monkeypatch.setenv("SIMTOOLS_DB_API_USER", "simpipe")
+    configuration._skip_test_for_production_db(config)
+
+
+def test_skip_test_for_production_db_skip_for_user(monkeypatch):
+    config = {"SKIP_FOR_PRODUCTION_DB": True}
+    monkeypatch.setenv("SIMTOOLS_DB_API_USER", "simpipe")
+    with pytest.raises(
+        configuration.ProductionDBError, match="Production database used for this test"
+    ):
+        configuration._skip_test_for_production_db(config)


### PR DESCRIPTION
Simpipe doesn't allow to open a sandbox database (or any new database). We therefore skip the integration tests uploading to the DB (these are anyway applications for developers, and not for users).