### PR TITLE
Fix unit tests for skipping tests when using production DB

### DIFF
--- a/tests/unit_tests/testing/test_configuration.py
+++ b/tests/unit_tests/testing/test_configuration.py
@@ -320,12 +320,14 @@ def test_skip_test_for_production_db_skip(monkeypatch):
 def test_skip_test_for_production_db_no_db_api_user(monkeypatch):
     config = {"SKIP_FOR_PRODUCTION_DB": True}
     monkeypatch.delenv("SIMTOOLS_DB_API_USER", raising=False)
+    monkeypatch.delenv("SIMTOOLS_DB_SERVER", raising=False)
     configuration._skip_test_for_production_db(config)
 
 
 def test_skip_test_for_production_db_not_simpipe(monkeypatch):
     config = {"SKIP_FOR_PRODUCTION_DB": True}
     monkeypatch.setenv("SIMTOOLS_DB_API_USER", "simtools")
+    monkeypatch.delenv("SIMTOOLS_DB_SERVER", raising=False)
     configuration._skip_test_for_production_db(config)
 
 


### PR DESCRIPTION
Possibly fixes unit tests in testing routines which allows to skip integration tests depending on certain DB configurations (see #1488).

Nightly tests fail: https://github.com/gammasim/simtools/actions/runs/14287388882/job/40044146465#step:13:2013

I think this fixes the issues, although I did not manage to get a failing test with my local setup (tried different DB configurations; random execution of tests).
