### PR TITLE
Fix licence definition in pyproject.toml

### DIFF
--- a/docs/changes/1493.maintenance.md
+++ b/docs/changes/1493.maintenance.md
@@ -1,0 +1,1 @@
+Fix licence definition in pyproject.toml to follow PEP 639.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,14 @@ requires = [
 name = "gammasimtools"
 description = "Tools for the Simulation System of the CTA Observatory"
 readme = "README.md"
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
+license-files = [ "LICENSE" ]
 authors = [
   { name = "simtools developers", email = "simtools-developer@desy.de" },
 ]
 requires-python = ">=3.11"
 classifiers = [
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Implementing [PEP 639 – Improving License Clarity with Better Package Metadata](https://peps.python.org/pep-0639/). See also [packing documentation](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license).

Fixes warnings in https://github.com/gammasim/simtools/actions/runs/14242163976/job/39914371448

Closes #1487