### PR TITLE
First PR for support multiple model versions

### DIFF
--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -50,7 +50,7 @@ class CommandLineParser(argparse.ArgumentParser):
             Add output file configuration to list of args.
         simulation_model: list
             List of simulation model configuration parameters to add to list of args
-            (use: 'version', 'telescope', 'site')
+            (use: 'model_version', 'telescope', 'site')
         simulation_configuration: dict
             Dict of simulation software configuration parameters to add to list of args.
         db_config: bool
@@ -271,6 +271,7 @@ class CommandLineParser(argparse.ArgumentParser):
                 help="production model version",
                 type=str,
                 default=None,
+                nargs="+",
             )
         if "parameter_version" in model_options:
             _job_group.add_argument(

--- a/src/simtools/corsika/corsika_config.py
+++ b/src/simtools/corsika/corsika_config.py
@@ -124,9 +124,12 @@ class CorsikaConfig:
         if db_config is None:  # all following parameter require DB
             return config
 
-        db_model_parameters = ModelParameter(
-            mongo_db_config=db_config, model_version=args_dict["model_version"]
-        )
+        model_version = args_dict.get("model_version", None)
+        # If the user provided multiple model versions, we take the first one
+        # because for CORSIKA config we need only one and it doesn't matter which
+        if isinstance(model_version, list):
+            model_version = model_version[0]
+        db_model_parameters = ModelParameter(mongo_db_config=db_config, model_version=model_version)
         parameters_from_db = db_model_parameters.get_simulation_software_parameters("corsika")
 
         config["INTERACTION_FLAGS"] = self._corsika_configuration_interaction_flags(

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -122,9 +122,11 @@ class DatabaseHandler:
             port=self.mongo_db_config["db_api_port"],
             username=self.mongo_db_config["db_api_user"],
             password=self.mongo_db_config["db_api_pw"],
-            authSource=self.mongo_db_config.get("db_api_authentication_database")
-            if self.mongo_db_config.get("db_api_authentication_database")
-            else "admin",
+            authSource=(
+                self.mongo_db_config.get("db_api_authentication_database")
+                if self.mongo_db_config.get("db_api_authentication_database")
+                else "admin"
+            ),
             directConnection=direct_connection,
             ssl=not direct_connection,
             tlsallowinvalidhostnames=True,
@@ -211,8 +213,13 @@ class DatabaseHandler:
         """
         collection_name = names.get_collection_name_from_parameter_name(parameter)
         if model_version:
+            model_version_to_read = model_version
+            if isinstance(model_version, list):
+                if len(model_version) != 1:
+                    raise ValueError("Only one model version can be passed to get_model_parameter.")
+                model_version_to_read = model_version[0]
             production_table = self._read_production_table_from_mongo_db(
-                collection_name, model_version
+                collection_name, model_version_to_read
             )
             array_element_list = self._get_array_element_list(
                 array_element_name, site, production_table, collection_name

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -140,6 +140,35 @@ class ArrayModel:
         """
         return self.site_model.site
 
+    @property
+    def model_version(self):
+        """Model version."""
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, model_version):
+        """
+        Set model version.
+
+        Parameters
+        ----------
+        _model_version: str or list
+            Model version (e.g., "6.0.0").
+            If a list is passed, it must contain exactly one element,
+            and only that element will be used.
+
+        Raises
+        ------
+        ValueError
+            If more than one model version is passed.
+        """
+        if isinstance(model_version, list):
+            if len(model_version) != 1:
+                raise ValueError("Only one model version can be passed to the ArrayModel.")
+            self._model_version = model_version[0]
+        else:
+            self._model_version = model_version
+
     def _build_telescope_models(self, site_model: SiteModel, array_elements: dict) -> dict:
         """
         Build the the telescope models for all telescopes of this array.

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -257,7 +257,9 @@ class ArrayModel:
             Path of the config directory path for sim_telarray.
         """
         if self._config_file_directory is None:
-            self._config_file_directory = self.io_handler.get_output_directory(self.label, "model")
+            self._config_file_directory = self.io_handler.get_output_directory(
+                self.label, f"model/{self.model_version}"
+            )
         return self._config_file_directory
 
     def _load_array_element_positions_from_file(

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -87,6 +87,32 @@ class ModelParameter:
         self._is_exported_model_files_up_to_date = False
 
     @property
+    def model_version(self):
+        """Model version."""
+        return self._model_version
+
+    @model_version.setter
+    def model_version(self, _model_version):
+        """
+        Set model version.
+
+        Parameters
+        ----------
+        _model_version: str or list
+            Model version (ex. 6.0.0).
+            If a list is passed, only the first element will be used.
+
+        Raises
+        ------
+        ValueError
+            If more than one model version is passed.
+        """
+        if isinstance(_model_version, list):
+            if len(_model_version) != 1:
+                raise ValueError("Only one model version can be passed to the ModelParameter.")
+            self._model_version = _model_version[0]
+
+    @property
     def parameters(self):
         """
         Model parameters dictionary.

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -92,25 +92,28 @@ class ModelParameter:
         return self._model_version
 
     @model_version.setter
-    def model_version(self, _model_version):
+    def model_version(self, model_version):
         """
         Set model version.
 
         Parameters
         ----------
         _model_version: str or list
-            Model version (ex. 6.0.0).
-            If a list is passed, only the first element will be used.
+            Model version (e.g., "6.0.0").
+            If a list is passed, it must contain exactly one element,
+            and only that element will be used.
 
         Raises
         ------
         ValueError
             If more than one model version is passed.
         """
-        if isinstance(_model_version, list):
-            if len(_model_version) != 1:
+        if isinstance(model_version, list):
+            if len(model_version) != 1:
                 raise ValueError("Only one model version can be passed to the ModelParameter.")
-            self._model_version = _model_version[0]
+            self._model_version = model_version[0]
+        else:
+            self._model_version = model_version
 
     @property
     def parameters(self):

--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -279,7 +279,7 @@ class ModelParameter:
             return
 
         self._config_file_directory = self.io_handler.get_output_directory(
-            label=self.label, sub_dir="model"
+            label=self.label, sub_dir=f"model/{self.model_version}"
         )
 
         # Setting file name and the location

--- a/src/simtools/model/site_model.py
+++ b/src/simtools/model/site_model.py
@@ -19,8 +19,8 @@ class SiteModel(ModelParameter):
         Site name (e.g., South or North).
     mongo_db_config: dict
         MongoDB configuration.
-    model_version: str
-        Model version.
+    model_version: str or list
+        Model version or list of model versions (in which case only the first one is used).
     label: str, optional
         Instance label. Important for output file naming.
     """

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -20,7 +20,7 @@ class CorsikaSimtelRunner:
 
     Parameters
     ----------
-    corsika_config : list
+    corsika_config : CorsikaConfig or list of CorsikaConfig
         A list of "CorsikaConfig" instances which
         contain the CORSIKA configuration parameters.
     simtel_path : str or Path
@@ -43,8 +43,10 @@ class CorsikaSimtelRunner:
         sim_telarray_seeds=None,
     ):
         self._logger = logging.getLogger(__name__)
+        if not isinstance(corsika_config, list):
+            corsika_config = [corsika_config]
         self.corsika_config = corsika_config
-        # the main corsika config is the one used to define the CORSIKA specific configuration.
+        # the main corsika config is the one used to define the CORSIKA specific parameters.
         # The others are used for the array configurations. The name "main" is a bit misleading.
         self.main_corsika_config = corsika_config[0]
         self._simtel_path = simtel_path
@@ -162,9 +164,9 @@ class CorsikaSimtelRunner:
         input_file: str
             Full path of the input CORSIKA file.
             Use '-' to tell sim_telarray to read from standard output
-        corsika_config: CorsikaConfig
+        corsika_config: CorsikaConfig, optional
             CORSIKA configuration.
-        simulator_array: SimulatorArray
+        simulator_array: SimulatorArray, optional
             SimulatorArray instance.
 
         Returns

--- a/src/simtools/runners/runner_services.py
+++ b/src/simtools/runners/runner_services.py
@@ -52,6 +52,7 @@ class RunnerServices:
             "array_name": self.corsika_config.array_model.layout_name,
             "site": self.corsika_config.array_model.site,
             "label": self.label,
+            "model_version": self.corsika_config.array_model.model_version,
             "zenith": self.corsika_config.zenith_angle,
             "azimuth": self.corsika_config.azimuth_angle,
         }
@@ -141,7 +142,8 @@ class RunnerServices:
         return (
             f"{run_dir}_{info_for_file_name['primary']}_"
             f"za{round(zenith):02}deg_azm{azimuth:03}deg_"
-            f"{info_for_file_name['site']}_{info_for_file_name['array_name']}{file_label}"
+            f"{info_for_file_name['site']}_{info_for_file_name['array_name']}_"
+            f"{info_for_file_name['model_version']}{file_label}"
         )
 
     def _get_log_file_path(self, file_type, file_name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,13 +355,14 @@ def corsika_config(io_handler, db_config, corsika_config_data, array_model_south
 
 
 @pytest.fixture
-def corsika_config_mock_array_model(io_handler, db_config, corsika_config_data):
+def corsika_config_mock_array_model(io_handler, db_config, corsika_config_data, model_version):
     """Corsika configuration object (using array model South)."""
     array_model = mock.MagicMock()
     array_model.layout_name = "test_layout"
     array_model.corsika_config.primary = "proton"
     array_model.site_model = mock.MagicMock()
     array_model.site_model._parameters = {"geomag_rotation": -4.533}
+    array_model.model_version = model_version
 
     # Define get_parameter_value() to behave as expected
     def mock_get_parameter_value(par_name):

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -46,7 +46,7 @@ def corsika_simtel_runner(io_handler, corsika_config_mock_array_model, simtel_pa
 
 def test_corsika_simtel_runner(corsika_simtel_runner):
     assert isinstance(corsika_simtel_runner.corsika_runner, CorsikaRunner)
-    assert isinstance(corsika_simtel_runner.simulator_array, SimulatorArray)
+    assert isinstance(corsika_simtel_runner.simulator_array[0], SimulatorArray)
 
 
 def test_prepare_run_script(corsika_simtel_runner):
@@ -83,8 +83,8 @@ def test_prepare_run_script_with_invalid_run(corsika_simtel_runner):
 
 def test_export_multipipe_script(corsika_simtel_runner, simtel_command, show_all):
     corsika_simtel_runner._export_multipipe_script(run_number=1)
-    script = Path(corsika_simtel_runner.corsika_config.config_file_path.parent).joinpath(
-        corsika_simtel_runner.corsika_config.get_corsika_config_file_name("multipipe")
+    script = Path(corsika_simtel_runner.main_corsika_config.config_file_path.parent).joinpath(
+        corsika_simtel_runner.main_corsika_config.get_corsika_config_file_name("multipipe")
     )
 
     assert script.exists()
@@ -98,11 +98,11 @@ def test_export_multipipe_script(corsika_simtel_runner, simtel_command, show_all
 
 def test_write_multipipe_script(corsika_simtel_runner):
     corsika_simtel_runner._export_multipipe_script(run_number=1)
-    multipipe_file = Path(corsika_simtel_runner.corsika_config.config_file_path.parent).joinpath(
-        corsika_simtel_runner.corsika_config.get_corsika_config_file_name("multipipe")
-    )
+    multipipe_file = Path(
+        corsika_simtel_runner.main_corsika_config.config_file_path.parent
+    ).joinpath(corsika_simtel_runner.main_corsika_config.get_corsika_config_file_name("multipipe"))
     corsika_simtel_runner._write_multipipe_script(multipipe_file)
-    script = Path(corsika_simtel_runner.corsika_config.config_file_path.parent).joinpath(
+    script = Path(corsika_simtel_runner.main_corsika_config.config_file_path.parent).joinpath(
         "run_cta_multipipe"
     )
 
@@ -115,7 +115,12 @@ def test_write_multipipe_script(corsika_simtel_runner):
 
 
 def test_make_run_command(corsika_simtel_runner, simtel_command, show_all):
-    command = corsika_simtel_runner._make_run_command(input_file="-", run_number=1)
+    command = corsika_simtel_runner._make_run_command(
+        input_file="-",
+        run_number=1,
+        corsika_config=corsika_simtel_runner.main_corsika_config,
+        simulator_array=corsika_simtel_runner.simulator_array[0],
+    )
     assert simtel_command in command
     assert "-C telescope_theta=20" in command
     assert "-C telescope_phi=0" in command
@@ -124,13 +129,23 @@ def test_make_run_command(corsika_simtel_runner, simtel_command, show_all):
 
     _test_corsika_simtel_runner = copy.deepcopy(corsika_simtel_runner)
     _test_corsika_simtel_runner.label = None
-    command = _test_corsika_simtel_runner._make_run_command(input_file="-", run_number=1)
+    command = _test_corsika_simtel_runner._make_run_command(
+        input_file="-",
+        run_number=1,
+        corsika_config=corsika_simtel_runner.main_corsika_config,
+        simulator_array=corsika_simtel_runner.simulator_array[0],
+    )
     assert "-W" not in command
 
 
 def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_all):
     corsika_simtel_runner.label = "test-corsika-simtel-runner-divergent-pointing"
-    command = corsika_simtel_runner._make_run_command(input_file="-", run_number=1)
+    command = corsika_simtel_runner._make_run_command(
+        input_file="-",
+        run_number=1,
+        corsika_config=corsika_simtel_runner.main_corsika_config,
+        simulator_array=corsika_simtel_runner.simulator_array[0],
+    )
     assert simtel_command in command
     assert "-W telescope_theta=20" in command  # -W is for pointing
     assert "-W telescope_phi=0" in command

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -28,9 +28,12 @@ def show_all():
 
 
 @pytest.fixture
-def simulation_file():
+def simulation_file(model_version):
     """Base name for simulation test file."""
-    return "run000001_proton_za20deg_azm000deg_South_test_layout_test-corsika-simtel-runner"
+    return (
+        f"run000001_proton_za20deg_azm000deg_South_test_layout_{model_version}_"
+        "test-corsika-simtel-runner"
+    )
 
 
 @pytest.fixture
@@ -114,7 +117,7 @@ def test_write_multipipe_script(corsika_simtel_runner):
         assert "'Fan-out failed'" in script_content
 
 
-def test_make_run_command(corsika_simtel_runner, simtel_command, show_all):
+def test_make_run_command(corsika_simtel_runner, simtel_command, show_all, model_version):
     command = corsika_simtel_runner._make_run_command(
         input_file="-",
         run_number=1,
@@ -125,7 +128,7 @@ def test_make_run_command(corsika_simtel_runner, simtel_command, show_all):
     assert "-C telescope_theta=20" in command
     assert "-C telescope_phi=0" in command
     assert show_all in command
-    assert "run000001_proton_za20deg_azm000deg_South_test_layout_test" in command
+    assert f"run000001_proton_za20deg_azm000deg_South_test_layout_{model_version}" in command
 
     _test_corsika_simtel_runner = copy.deepcopy(corsika_simtel_runner)
     _test_corsika_simtel_runner.label = None
@@ -138,7 +141,7 @@ def test_make_run_command(corsika_simtel_runner, simtel_command, show_all):
     assert "-W" not in command
 
 
-def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_all):
+def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_all, model_version):
     corsika_simtel_runner.label = "test-corsika-simtel-runner-divergent-pointing"
     command = corsika_simtel_runner._make_run_command(
         input_file="-",
@@ -150,7 +153,7 @@ def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_
     assert "-W telescope_theta=20" in command  # -W is for pointing
     assert "-W telescope_phi=0" in command
     assert show_all in command
-    assert "run000001_proton_za20deg_azm000deg_South_test_layout_test" in command
+    assert f"run000001_proton_za20deg_azm000deg_South_test_layout_{model_version}" in command
 
 
 def test_get_file_name(corsika_simtel_runner, simulation_file):

--- a/tests/unit_tests/runners/test_runner_services.py
+++ b/tests/unit_tests/runners/test_runner_services.py
@@ -56,9 +56,11 @@ def runner_service_config_only_diffuse_gamma(corsika_config_mock_array_model):
 
 
 @pytest.fixture
-def file_base_name():
+def file_base_name(model_version):
     """Base name for simulation test file."""
-    return "run000001_proton_za20deg_azm000deg_South_test_layout_test-corsika-runner"
+    return (
+        f"run000001_proton_za20deg_azm000deg_South_test_layout_{model_version}_test-corsika-runner"
+    )
 
 
 def test_init_runner_services(runner_service_config_only):
@@ -67,18 +69,21 @@ def test_init_runner_services(runner_service_config_only):
     assert runner_service_config_only.directory == {}
 
 
-def test_get_info_for_file_name(runner_service_config_only):
+def test_get_info_for_file_name(runner_service_config_only, model_version):
     info_for_file_name = runner_service_config_only._get_info_for_file_name(run_number=1)
     assert info_for_file_name["run_number"] == 1
     assert info_for_file_name["primary"] == "proton"
     assert info_for_file_name["array_name"] == "test_layout"
     assert info_for_file_name["site"] == "South"
     assert info_for_file_name["label"] == "test-corsika-runner"
+    assert info_for_file_name["model_version"] == model_version
     assert info_for_file_name["zenith"] == pytest.approx(20)
     assert info_for_file_name["azimuth"] == pytest.approx(0)
 
 
-def test_get_info_for_file_name_diffuse_gamma(runner_service_config_only_diffuse_gamma):
+def test_get_info_for_file_name_diffuse_gamma(
+    runner_service_config_only_diffuse_gamma, model_version
+):
     info_for_file_name = runner_service_config_only_diffuse_gamma._get_info_for_file_name(
         run_number=1
     )
@@ -87,6 +92,7 @@ def test_get_info_for_file_name_diffuse_gamma(runner_service_config_only_diffuse
     assert info_for_file_name["array_name"] == "test_layout"
     assert info_for_file_name["site"] == "South"
     assert info_for_file_name["label"] == "test-corsika-runner"
+    assert info_for_file_name["model_version"] == model_version
     assert info_for_file_name["zenith"] == pytest.approx(20)
     assert info_for_file_name["azimuth"] == pytest.approx(0)
 
@@ -110,7 +116,7 @@ def test_load_corsika_data_directories(runner_service_config_only):
         assert isinstance(item, pathlib.Path)
 
 
-def test_has_file(io_handler, runner_service):
+def test_has_file(io_handler, runner_service, file_base_name):
     corsika_file = io_handler.get_input_data_file(
         file_name="run1_proton_za20deg_azm0deg_North_1LST_test-lst-array.corsika.zst", test=True
     )
@@ -123,20 +129,18 @@ def test_has_file(io_handler, runner_service):
     output_directory.mkdir(parents=True, exist_ok=True)
     shutil.copy(
         corsika_file,
-        output_directory.joinpath(
-            "run000001_proton_za20deg_azm000deg_South_test_layout_test-corsika-runner.zst"
-        ),
+        output_directory.joinpath(f"{file_base_name}.zst"),
     )
     assert runner_service.has_file(file_type="corsika_output", run_number=1)
     assert not runner_service.has_file(file_type="log", run_number=1234)
 
 
-def test_get_file_basename(runner_service, file_base_name):
+def test_get_file_basename(runner_service, file_base_name, model_version):
     assert runner_service._get_file_basename(1) == file_base_name
     _runner_service_copy = copy.deepcopy(runner_service)
     _runner_service_copy.label = ""
     assert _runner_service_copy._get_file_basename(1) == (
-        "run000001_proton_za20deg_azm000deg_South_test_layout"
+        f"run000001_proton_za20deg_azm000deg_South_test_layout_{model_version}"
     )
 
 

--- a/tests/unit_tests/simtel/test_simulator_ray_tracing.py
+++ b/tests/unit_tests/simtel/test_simulator_ray_tracing.py
@@ -157,7 +157,7 @@ def test_make_run_command(simulator_ray_tracing_sst, model_version):
 
     assert "bin/sim_telarray" in command
     assert (
-        "model/CTA-South-SSTS-design-"
+        f"model/{model_version}/CTA-South-SSTS-design-"
         + model_version.replace("_", "-")
         + "_test-telescope-model-sst.cfg"
         in command

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -111,13 +111,6 @@ def test_simulation_software(array_simulator, shower_simulator, shower_array_sim
     assert "Invalid simulation software" in caplog.text
 
 
-def test_initialize_array_model(shower_simulator, db_config):
-    assert isinstance(
-        shower_simulator._initialize_array_model(mongo_db_config=db_config),
-        ArrayModel,
-    )
-
-
 def test_initialize_run_list(shower_simulator, caplog):
     assert shower_simulator._initialize_run_list() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     test_shower_simulator = copy.deepcopy(shower_simulator)
@@ -372,3 +365,26 @@ def test_pack_for_register(array_simulator, mocker, caplog):
     shutil.move.assert_any_call(
         Path("output_file2"), Path("directory_for_grid_upload/output_file2")
     )
+
+
+def test_initialize_array_model_with_single_version(shower_simulator, db_config, model_version):
+    # Test with a single model version
+    array_models = shower_simulator._initialize_array_model(mongo_db_config=db_config)
+    assert len(array_models) == 1
+    assert isinstance(array_models[0], ArrayModel)
+    assert array_models[0].model_version == model_version
+    assert array_models[0].site == shower_simulator.args_dict.get("site")
+    assert array_models[0].layout_name == shower_simulator.args_dict.get("array_layout_name")
+
+
+def test_initialize_array_model_with_multiple_versions(shower_simulator, db_config):
+    # Test with multiple model versions
+    model_versions = ["5.0.0", "6.0.0"]
+    shower_simulator.args_dict["model_version"] = model_versions
+    array_models = shower_simulator._initialize_array_model(mongo_db_config=db_config)
+    assert len(array_models) == 2
+    for i, model_version in enumerate(model_versions):
+        assert isinstance(array_models[i], ArrayModel)
+        assert array_models[i].model_version == model_version
+        assert array_models[i].site == shower_simulator.args_dict.get("site")
+        assert array_models[i].layout_name == shower_simulator.args_dict.get("array_layout_name")


### PR DESCRIPTION
This PR adds the possibility to write out the configuration of multiple models for sim_telarray to run in multipipe mode. That technically already works, but I am pretty sure further optimization of file names, output redirection, etc. are needed. Nevertheless, since this first step already works and the tests pass (locally at least), I think it's best to split the work to multiple PRs and start with this one.