### PR TITLE
Remove prototype from description of simtools in citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,9 +3,7 @@
 
 cff-version: 1.2.0
 title: >-
-  simtools - a prototype implementation of
-  tools for the Simulation System of the CTA
-  Observatory
+  simtools - Simulation tools and applications for the Cherenkov Telescope Array (CTAO)
 message: Please cite this software using these metadata.
 type: software
 authors:


### PR DESCRIPTION
Simtools is beyond the 'prototype' stage. We have removed the word `prototype` from all READMEs and documentation, but forgot the CITATION.cff file.

This is the file defining the Title of the e.g., the zenodo entry: https://zenodo.org/records/15148544