### PR TITLE
Clipping long data files

### DIFF
--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -54,11 +54,20 @@ class ReadParameters:
                 with output_file.open("w", encoding="utf-8") as outfile:
                     outfile.write(f"# {input_file.stem}\n")
                     outfile.write(
+                        "The full file can be found in the Simulation Model repository [here]"
+                        "(https://gitlab.cta-observatory.org/cta-science/simulations/"
+                        "simulation-model/simulation-models/-/blob/main/simulation-models/"
+                        f"model_parameters/Files/{input_file.stem}.dat).\n\n"
+                    )
+                    outfile.write(
                         f"![Parameter plot.](../{IMAGE_PATH}/{self.array_element}_"
                         f"{parameter}_{self.model_version.split('.')[0]}.png)\n"
                     )
+                    outfile.write("\n\n")
+                    outfile.write("The first 30 lines of the file are:\n")
                     outfile.write("```\n")
-                    outfile.write(file_contents)
+                    first_30_lines = "\n".join(file_contents.splitlines()[:30])
+                    outfile.write(first_30_lines)
                     outfile.write("\n```")
 
         except FileNotFoundError as exc:

--- a/tests/unit_tests/reporting/test_docs_read_parameters.py
+++ b/tests/unit_tests/reporting/test_docs_read_parameters.py
@@ -152,7 +152,7 @@ def test__convert_to_md(telescope_model_lst, io_handler, db_config):
 
     code_block = match.group(1)
     line_count = len(code_block.strip().splitlines())
-    assert line_count <= 30
+    assert line_count == 30
 
     # Compare to actual first 30 lines of input file
     input_path = Path("tests/resources/spe_LST_2022-04-27_AP2.0e-4.dat")


### PR DESCRIPTION
Only include the first 30 lines of a .dat file and add a link to the Simulation Models repository.