### PR TITLE
Change warnings on missing parameters to debug statements

### DIFF
--- a/src/simtools/model/model_parameter.py
+++ b/src/simtools/model/model_parameter.py
@@ -351,12 +351,8 @@ class ModelParameter:
                         simulation_software=simulation_software,
                     )
                 )
-            except ValueError as exc:
-                self._logger.warning(
-                    f"No {simulation_software} parameters found for "
-                    f"{self.site}, {self.name} (model version {self.model_version}). "
-                    f" (Query {exc})"
-                )
+            except ValueError:
+                pass
 
     def _load_parameters_from_db(self):
         """Read parameters from DB and store them in _parameters."""

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -153,7 +153,8 @@ def test_load_simulation_software_parameter(telescope_model_lst, caplog):
     telescope_copy._simulation_config_parameters = {"not_corsika": {}, "not_simtel": {}}
     with caplog.at_level(logging.WARNING):
         telescope_copy._load_simulation_software_parameter()
-    assert "No not_corsika parameters found for North" in caplog.text
+
+    assert len(caplog.records) == 0
 
 
 def test_load_parameters_from_db(telescope_model_lst, mocker):


### PR DESCRIPTION
Pull #1494 introduced reading the list of simulation softwares from the schema files (to avoid hardwired lists). A now noticed side effect is when reading model parameters are the following warning messages:

```
WARNING::model_parameter(l355)::_load_simulation_software_parameter::No testeff parameters found for North, LSTN-03 (model version 6.0.0).  (Query Unknown simulation software: testeff)
WARNING::model_parameter(l355)::_load_simulation_software_parameter::No simtools parameters found for North, LSTN-04 (model version 6.0.0).  (Query Unknown simulation software: simtools)
```

The software packages `testeff` and `simtools` do not have configuration entries in the model data base (as e.g., `configuration_sim_telarray` and `configuration_corsika`).

Removed the log.WARNING statement, as a ValueError is ok in this case (thought adding a log.DEBUG statement - but there would be a lot printout not helping debugging).