### PR TITLE
Change MST naming in schemas to FlashCam and NectarCam

### DIFF
--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -203,6 +203,11 @@ def _add_array_elements(key, schema):
 
     """
     _list_of_array_elements = sorted(names.array_elements().keys())
+    for array_element in names.array_elements().keys():
+        design_types = names.array_element_design_types(array_element)
+        for design_type in design_types:
+            _list_of_array_elements.append(f"{array_element}-{design_type}")
+    _list_of_array_elements = sorted(set(_list_of_array_elements))
 
     def recursive_search(sub_schema, key):
         if key in sub_schema:

--- a/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
@@ -21,8 +21,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/array_window.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_window.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/asum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_offset.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
+++ b/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
@@ -37,8 +37,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_depth.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_depth.schema.yml
@@ -23,8 +23,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_filter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_filter.schema.yml
@@ -28,8 +28,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/default_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/default_trigger.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/design_model.schema.yml
+++ b/src/simtools/schemas/model_parameters/design_model.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/disc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_bins.schema.yml
@@ -23,8 +23,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/disc_start.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_start.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
@@ -28,8 +28,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
@@ -29,8 +29,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
@@ -22,8 +22,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
@@ -22,8 +22,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
@@ -21,8 +21,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
@@ -18,8 +18,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
@@ -23,8 +23,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
@@ -28,8 +28,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
@@ -22,8 +22,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
@@ -29,8 +29,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
@@ -28,8 +28,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
@@ -16,8 +16,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -12,7 +12,7 @@ description: |-
   Note that, like for discriminator/comparator and analog sum, the signal
   must exceed (\'>\') the threshold here before we declare the telescope
   triggered. The assigned threshold value would have to be one count lower
-  than in a camera-internal trigger implementation (like MSTS) where
+  than in a camera-internal trigger implementation (like MSTx-FlashCam) where
   reaching (\'>=\') the threshold is enough.
 short_description: Amplitude level above which a digital sum leads to a telescope
   trigger.
@@ -26,8 +26,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
@@ -26,8 +26,8 @@ data:
 instrument:
   class: Camera
   type:
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -74,8 +74,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -32,8 +32,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
@@ -34,8 +34,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -33,8 +33,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
@@ -34,8 +34,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
@@ -30,8 +30,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
@@ -30,8 +30,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/flatfielding.schema.yml
+++ b/src/simtools/schemas/model_parameters/flatfielding.schema.yml
@@ -18,8 +18,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 data:

--- a/src/simtools/schemas/model_parameters/focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_length.schema.yml
@@ -29,8 +29,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/focus_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/focus_offset.schema.yml
@@ -50,8 +50,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/gain_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/gain_variation.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
@@ -23,8 +23,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/min_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photons.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetMirrorPanelAlignment

--- a/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
@@ -45,8 +45,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
@@ -45,8 +45,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
@@ -35,8 +35,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_list.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_list.schema.yml
@@ -17,8 +17,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
@@ -42,8 +42,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
@@ -30,8 +30,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/muon_mono_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/muon_mono_threshold.schema.yml
@@ -29,8 +29,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
@@ -36,8 +36,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
@@ -63,8 +63,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/num_gains.schema.yml
+++ b/src/simtools/schemas/model_parameters/num_gains.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
+++ b/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
@@ -18,8 +18,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/optics_properties.schema.yml
+++ b/src/simtools/schemas/model_parameters/optics_properties.schema.yml
@@ -18,8 +18,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/photon_delay.schema.yml
+++ b/src/simtools/schemas/model_parameters/photon_delay.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
@@ -27,8 +27,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -49,8 +49,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTS
-    - MSTN
+    - MSTx-FlashCam
+    - MSTx-NectarCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
@@ -28,8 +28,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/qe_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/qe_variation.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
@@ -23,8 +23,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -31,8 +31,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/random_generator.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_generator.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/random_mono_probability.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_mono_probability.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/sampled_output.schema.yml
+++ b/src/simtools/schemas/model_parameters/sampled_output.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
@@ -26,8 +26,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
@@ -23,8 +23,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
@@ -15,8 +15,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
@@ -19,8 +19,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
@@ -92,8 +92,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
@@ -25,8 +25,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
@@ -21,8 +21,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
@@ -22,8 +22,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
@@ -29,8 +29,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
@@ -20,8 +20,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
@@ -16,8 +16,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
@@ -37,8 +37,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:

--- a/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
@@ -24,8 +24,8 @@ instrument:
   type:
     - LSTN
     - LSTS
-    - MSTN
-    - MSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
     - SSTS
     - SCTS
 activity:


### PR DESCRIPTION
Design types for MSTs have changed in the past months from `MSTN` and `MSTS` to `MSTx-FlashCam` and `MSTx-NectarCam` - this allows to have different camera definitions on the same site.

This PR propagates this changes into the `instrument:type` definition of the schema files:

- use sed to replace `MSTN` by `MSTx-NectarCam` and `MSTS` by `MSTx-FlashCam`
- small change in the schema module to add the design types to the list of allowed array elements.

This PR does not look into the model parameters and checks if e.g. certain trigger parameter definitions should be defined for on MST camera.

Close #1480 