### PR TITLE
Add random seeds from file for instrument configuration.

### DIFF
--- a/docs/changes/1511.feature.md
+++ b/docs/changes/1511.feature.md
@@ -1,0 +1,1 @@
+Add random seeds from file for instrument configuration.

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -129,7 +129,8 @@ def _parse(description=None):
         "--sim_telarray_instrument_seeds",
         help=(
             "Random seed used for sim_telarray instrument setup. "
-            "If '--sim_telarray_random_instrument_instances is not set: use as sim_telarray seed. "
+            "If '--sim_telarray_random_instrument_instances is not set: use as sim_telarray seed "
+            " ('random_seed' parameter). "
             "Otherwise: use as base seed for the generation of random instrument instance seeds."
         ),
         type=str,

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -122,13 +122,23 @@ def _parse(description=None):
         required=False,
         default=False,
     )
-    config.parser.add_argument(
-        "--sim_telarray_seeds",
+    sim_telarray_seed_group = config.parser.add_argument_group(
+        title="Random seeds for sim_telarray instrument setup",
+    )
+    sim_telarray_seed_group.add_argument(
+        "--sim_telarray_instrument_seeds",
         help=(
-            "Use the provided random seed for sim_telarray instrument setup."
-            "Used only for testing purposes for now."
+            "Random seed used for sim_telarray instrument setup. "
+            "If '--sim_telarray_random_instrument_instances is not set: use as sim_telarray seed. "
+            "Otherwise: use as base seed for the generation of random instrument instance seeds."
         ),
         type=str,
+        required=False,
+    )
+    sim_telarray_seed_group.add_argument(
+        "--sim_telarray_random_instrument_instances",
+        help="Number of random instrument instances initialized in sim_telarray.",
+        type=int,
         required=False,
     )
     return config.initialize(

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -36,6 +36,8 @@ class ArrayModel:
     array_elements: Union[str, Path, List[str]], optional
         Array element definitions (list of array element or path to file with
         the array element positions).
+    sim_telarray_seeds : dict, optional
+        Dictionary with configuration for sim_telarray random instrument setup.
     """
 
     def __init__(
@@ -46,6 +48,7 @@ class ArrayModel:
         site: str | None = None,
         layout_name: str | None = None,
         array_elements: str | Path | list[str] | None = None,
+        sim_telarray_seeds: dict | None = None,
     ):
         """Initialize ArrayModel."""
         self._logger = logging.getLogger(__name__)
@@ -65,6 +68,7 @@ class ArrayModel:
 
         self._telescope_model_files_exported = False
         self._array_model_file_exported = False
+        self.sim_telarray_seeds = sim_telarray_seeds
 
     def _initialize(self, site: str, array_elements_config: str | Path | list[str]):
         """
@@ -259,6 +263,7 @@ class ArrayModel:
             config_file_path=self.config_file_path,
             telescope_model=self.telescope_model,
             site_model=self.site_model,
+            sim_telarray_seeds=self.sim_telarray_seeds,
         )
         self._array_model_file_exported = True
 

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -31,6 +31,8 @@ class CorsikaSimtelRunner:
         Use seeds based on run number and primary particle. If False, use sim_telarray seeds.
     use_multipipe : bool
         Use multipipe to run CORSIKA and sim_telarray.
+    sim_telarray_seeds : dict
+        Dictionary with configuration for sim_telarray random instrument setup.
     """
 
     def __init__(
@@ -201,8 +203,17 @@ class CorsikaSimtelRunner:
             ),
         )
         command += simulator_array.get_config_option("random_state", "none")
-        if self.sim_telarray_seeds:
-            command += simulator_array.get_config_option("random_seed", self.sim_telarray_seeds)
+
+        if self.sim_telarray_seeds.get("random_instances"):
+            config_dir = Path(corsika_config.array_model.config_file_path).parent
+            command += simulator_array.get_config_option(
+                "random_seed",
+                f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file_name']},auto",
+            )
+        elif self.sim_telarray_seeds.get("seed"):
+            command += simulator_array.get_config_option(
+                "random_seed", self.sim_telarray_seeds["seed"]
+            )
         command += simulator_array.get_config_option("show", "all")
         command += simulator_array.get_config_option(
             "output_file",

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -204,13 +204,13 @@ class CorsikaSimtelRunner:
         )
         command += simulator_array.get_config_option("random_state", "none")
 
-        if self.sim_telarray_seeds.get("random_instances"):
+        if self.sim_telarray_seeds and self.sim_telarray_seeds.get("random_instances"):
             config_dir = Path(corsika_config.array_model.config_file_path).parent
             command += simulator_array.get_config_option(
                 "random_seed",
                 f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file_name']},auto",
             )
-        elif self.sim_telarray_seeds.get("seed"):
+        elif self.sim_telarray_seeds and self.sim_telarray_seeds.get("seed"):
             command += simulator_array.get_config_option(
                 "random_seed", self.sim_telarray_seeds["seed"]
             )

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -174,6 +174,7 @@ class CorsikaSimtelRunner:
         str:
             Command to run sim_telarray.
         """
+        config_dir = corsika_config.array_model.get_config_directory()
         try:
             weak_pointing = any(pointing in self.label for pointing in ["divergent", "convergent"])
         except TypeError:  # allow for self.label to be None
@@ -183,7 +184,7 @@ class CorsikaSimtelRunner:
 
         command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {corsika_config.array_model.config_file_path}"
-        command += f" -I{corsika_config.array_model.get_config_directory()}"
+        command += f" -I{config_dir}"
         command += simulator_array.get_config_option(
             "telescope_theta", corsika_config.zenith_angle, weak_option=weak_pointing
         )
@@ -205,7 +206,6 @@ class CorsikaSimtelRunner:
         command += simulator_array.get_config_option("random_state", "none")
 
         if self.sim_telarray_seeds and self.sim_telarray_seeds.get("random_instances"):
-            config_dir = Path(corsika_config.array_model.config_file_path).parent
             command += simulator_array.get_config_option(
                 "random_seed",
                 f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file_name']},auto",

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -221,7 +221,7 @@ class SimtelConfigWriter:
                 file.write(f"# include <{tel_config_file}>\n\n")
             file.write("#endif \n\n")  # configuration files need to end with \n\n
 
-        if sim_telarray_seeds:
+        if sim_telarray_seeds and sim_telarray_seeds.get("random_instances"):
             self._write_random_seeds_file(sim_telarray_seeds, Path(config_file_path).parent)
 
     def _write_random_seeds_file(self, sim_telarray_seeds, config_file_directory):

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -2,6 +2,7 @@
 """Configuration file writer for sim_telarray."""
 
 import logging
+import random
 from pathlib import Path
 
 import astropy.units as u
@@ -170,7 +171,9 @@ class SimtelConfigWriter:
 
         return meta_parameters
 
-    def write_array_config_file(self, config_file_path, telescope_model, site_model):
+    def write_array_config_file(
+        self, config_file_path, telescope_model, site_model, sim_telarray_seeds=None
+    ):
         """
         Write the sim_telarray config file for an array of telescopes.
 
@@ -182,6 +185,8 @@ class SimtelConfigWriter:
             Dictionary of TelescopeModel's instances as used by the ArrayModel instance.
         site_model: Site model
             Site model.
+        sim_telarray_seeds: dict
+            Dictionary with configuration for sim_telarray random instrument setup.
         """
         with open(config_file_path, "w", encoding="utf-8") as file:
             self._write_header(file, "ARRAY CONFIGURATION FILE")
@@ -215,6 +220,33 @@ class SimtelConfigWriter:
                 file.write(f"#elif TELESCOPE == {count + 1}\n\n")
                 file.write(f"# include <{tel_config_file}>\n\n")
             file.write("#endif \n\n")  # configuration files need to end with \n\n
+
+        if sim_telarray_seeds:
+            self._write_random_seeds_file(sim_telarray_seeds, Path(config_file_path).parent)
+
+    def _write_random_seeds_file(self, sim_telarray_seeds, config_file_directory):
+        """
+        Write list of random number used to generate random instances of instrument.
+
+        Parameters
+        ----------
+        random_instances_of_instrument: int
+            Number of random instances of the instrument.
+        """
+        random.seed(sim_telarray_seeds["seed"])
+        self._logger.info(
+            "Writing random seed file "
+            f"{config_file_directory}/{sim_telarray_seeds['seed_file_name']}"
+            f" (global seed {sim_telarray_seeds['seed']})"
+        )
+        random_integers = [
+            random.randint(0, 2**32 - 1) for _ in range(sim_telarray_seeds["random_instances"])
+        ]
+        with open(
+            config_file_directory / sim_telarray_seeds["seed_file_name"], "w", encoding="utf-8"
+        ) as file:
+            for number in random_integers:
+                file.write(f"{number}\n")
 
     def write_single_mirror_list_file(
         self, mirror_number, mirrors, single_mirror_list_file, set_focal_length_to_zero=False

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -245,6 +245,11 @@ class SimtelConfigWriter:
         with open(
             config_file_directory / sim_telarray_seeds["seed_file_name"], "w", encoding="utf-8"
         ) as file:
+            file.write(
+                "# Random seeds for instrument configuration generated with seed "
+                f"{sim_telarray_seeds['seed']}"
+                f" (model version {self._model_version}, site {self._site})\n"
+            )
             for number in random_integers:
                 file.write(f"{number}\n")
 

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -188,6 +188,7 @@ class SimtelConfigWriter:
         sim_telarray_seeds: dict
             Dictionary with configuration for sim_telarray random instrument setup.
         """
+        config_file_directory = Path(config_file_path).parent
         with open(config_file_path, "w", encoding="utf-8") as file:
             self._write_header(file, "ARRAY CONFIGURATION FILE")
 
@@ -204,7 +205,7 @@ class SimtelConfigWriter:
             file.write(self.TAB + "echo *****************************\n\n")
 
             self._write_site_parameters(
-                file, site_model.parameters, Path(config_file_path).parent, telescope_model
+                file, site_model.parameters, config_file_directory, telescope_model
             )
 
             file.write(self.TAB + f"maximum_telescopes = {len(telescope_model)}\n\n")
@@ -222,7 +223,7 @@ class SimtelConfigWriter:
             file.write("#endif \n\n")  # configuration files need to end with \n\n
 
         if sim_telarray_seeds and sim_telarray_seeds.get("random_instances"):
-            self._write_random_seeds_file(sim_telarray_seeds, Path(config_file_path).parent)
+            self._write_random_seeds_file(sim_telarray_seeds, config_file_directory)
 
     def _write_random_seeds_file(self, sim_telarray_seeds, config_file_directory):
         """

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -85,13 +85,13 @@ class SimulatorArray(SimtelRunner):
         command += super().get_config_option("histogram_file", histogram_file)
         command += super().get_config_option("output_file", output_file)
         command += super().get_config_option("random_state", "none")
-        if self.sim_telarray_seeds.get("random_instrument_instances"):
+        if self.sim_telarray_seeds and self.sim_telarray_seeds.get("random_instrument_instances"):
             config_dir = Path(self.corsika_config.array_model.config_file_path).parent
             command += super().get_config_option(
                 "random_seed",
                 f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file']},auto",
             )
-        elif self.sim_telarray_seeds.get("seed"):
+        elif self.sim_telarray_seeds and self.sim_telarray_seeds.get("seed"):
             command += super().get_config_option("random_seed", self.sim_telarray_seeds["seed"])
         command += super().get_config_option("show", "all")
         command += f" {input_file}"

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -67,12 +67,13 @@ class SimulatorArray(SimtelRunner):
         str
             Command to run sim_telarray.
         """
+        config_file_path = self.corsika_config.array_model.config_file_path
         self._log_file = self.get_file_name(file_type="log", run_number=run_number)
         histogram_file = self.get_file_name(file_type="histogram", run_number=run_number)
         output_file = self.get_file_name(file_type="output", run_number=run_number)
 
         command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
-        command += f" -c {self.corsika_config.array_model.config_file_path}"
+        command += f" -c {config_file_path}"
         command += f" -I{self.corsika_config.array_model.get_config_directory()}"
         command += super().get_config_option("telescope_theta", self.corsika_config.zenith_angle)
         command += super().get_config_option("telescope_phi", self.corsika_config.azimuth_angle)
@@ -86,7 +87,7 @@ class SimulatorArray(SimtelRunner):
         command += super().get_config_option("output_file", output_file)
         command += super().get_config_option("random_state", "none")
         if self.sim_telarray_seeds and self.sim_telarray_seeds.get("random_instrument_instances"):
-            config_dir = Path(self.corsika_config.array_model.config_file_path).parent
+            config_dir = Path(config_file_path).parent
             command += super().get_config_option(
                 "random_seed",
                 f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file']},auto",

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -1,7 +1,6 @@
 """Simulation runner for array simulations."""
 
 import logging
-from pathlib import Path
 
 from simtools.io_operations import io_handler
 from simtools.runners.simtel_runner import InvalidOutputFileError, SimtelRunner
@@ -67,6 +66,7 @@ class SimulatorArray(SimtelRunner):
         str
             Command to run sim_telarray.
         """
+        config_dir = self.corsika_config.array_model.get_config_directory()
         config_file_path = self.corsika_config.array_model.config_file_path
         self._log_file = self.get_file_name(file_type="log", run_number=run_number)
         histogram_file = self.get_file_name(file_type="histogram", run_number=run_number)
@@ -74,7 +74,7 @@ class SimulatorArray(SimtelRunner):
 
         command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
         command += f" -c {config_file_path}"
-        command += f" -I{self.corsika_config.array_model.get_config_directory()}"
+        command += f" -I{config_dir}"
         command += super().get_config_option("telescope_theta", self.corsika_config.zenith_angle)
         command += super().get_config_option("telescope_phi", self.corsika_config.azimuth_angle)
         command += super().get_config_option(
@@ -87,7 +87,6 @@ class SimulatorArray(SimtelRunner):
         command += super().get_config_option("output_file", output_file)
         command += super().get_config_option("random_state", "none")
         if self.sim_telarray_seeds and self.sim_telarray_seeds.get("random_instrument_instances"):
-            config_dir = Path(config_file_path).parent
             command += super().get_config_option(
                 "random_seed",
                 f"file-by-run:{config_dir}/{self.sim_telarray_seeds['seed_file']},auto",

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -67,13 +67,12 @@ class SimulatorArray(SimtelRunner):
             Command to run sim_telarray.
         """
         config_dir = self.corsika_config.array_model.get_config_directory()
-        config_file_path = self.corsika_config.array_model.config_file_path
         self._log_file = self.get_file_name(file_type="log", run_number=run_number)
         histogram_file = self.get_file_name(file_type="histogram", run_number=run_number)
         output_file = self.get_file_name(file_type="output", run_number=run_number)
 
         command = str(self._simtel_path.joinpath("sim_telarray/bin/sim_telarray"))
-        command += f" -c {config_file_path}"
+        command += f" -c {self.corsika_config.array_model.config_file_path}"
         command += f" -I{config_dir}"
         command += super().get_config_option("telescope_theta", self.corsika_config.zenith_angle)
         command += super().get_config_option("telescope_phi", self.corsika_config.azimuth_angle)

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -78,7 +78,7 @@ class Simulator:
         self.sim_telarray_seeds = {
             "seed": self.args_dict.get("sim_telarray_instrument_seeds"),
             "random_instances": self.args_dict.get("sim_telarray_random_instrument_instances"),
-            "seed_file_name": "random_seeds.txt",  # name only; will be place in config dir
+            "seed_file_name": "sim_telarray_instrument_seeds.txt",  # name only; no directory
         }
         self.array_models = self._initialize_array_models(mongo_db_config)
         self._simulation_runner = self._initialize_simulation_runner(mongo_db_config)

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -169,8 +169,8 @@ class Simulator:
 
         seed = semver_to_int(model_version) * 10000000
         seed = seed + 1000000 if self.args_dict.get("site") != "North" else seed + 2000000
-        seed = seed + self.args_dict["zenith_angle"].value * 1000
-        return seed + self.args_dict["azimuth_angle"].value
+        seed = seed + (int)(self.args_dict["zenith_angle"].value) * 1000
+        return seed + (int)(self.args_dict["azimuth_angle"].value)
 
     def _initialize_run_list(self):
         """

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
@@ -21,6 +21,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
+      SIM_TELARRAY_RANDOM_INSTRUMENT_INSTANCES: 100
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG
       SUBMIT_ENGINE: local

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_RANDOM_INSTRUMENT_INSTANCES: 100
+      SIM_TELARRAY_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_RANDOM_INSTRUMENT_INSTANCES: 100
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 700 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_az0deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_az0deg_South_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 700 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 600 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 840 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_North_check_output.yml
@@ -20,7 +20,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 20 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_South_check_output.yml
@@ -20,7 +20,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 20 700 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
@@ -20,7 +20,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 20 500 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
@@ -20,7 +20,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 20 700 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -141,7 +141,11 @@ def test_make_run_command(corsika_simtel_runner, simtel_command, show_all, model
     )
     assert "-W" not in command
 
-    corsika_simtel_runner.sim_telarray_seeds = "12345"
+    corsika_simtel_runner.sim_telarray_seeds = {
+        "seed": "12345",
+        "random_instances": None,
+        "seed_file_name": None,
+    }
     command = corsika_simtel_runner._make_run_command(
         input_file="-",
         run_number=1,

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -155,6 +155,21 @@ def test_make_run_command(corsika_simtel_runner, simtel_command, show_all, model
     assert "random_seed" in command
     assert "12345" in command
 
+    corsika_simtel_runner.sim_telarray_seeds = {
+        "seed": "None",
+        "random_instances": 100,
+        "seed_file_name": "test_seed_file.txt",
+    }
+    command = corsika_simtel_runner._make_run_command(
+        input_file="-",
+        run_number=1,
+        corsika_config=corsika_simtel_runner.base_corsika_config,
+        simulator_array=corsika_simtel_runner.simulator_array[0],
+    )
+    assert "random_seed" in command
+    assert "file-by-run" in command
+    assert "test_seed_file.txt" in command
+
 
 def test_make_run_command_divergent(corsika_simtel_runner, simtel_command, show_all, model_version):
     corsika_simtel_runner.label = "test-corsika-simtel-runner-divergent-pointing"

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -55,7 +55,7 @@ def test_write_array_config_file(
             site_model=site_model_north,
             sim_telarray_seeds={
                 "seed": 12345,
-                "seed_file_name": "random_seeds.txt",
+                "seed_file_name": "sim_telarray_instrument_seeds.txt",
                 "random_instances": 5,
             },
         )
@@ -190,11 +190,11 @@ def test_get_sim_telarray_metadata_without_model_parameters(simtel_config_writer
 
 
 def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
-    config_file_directory = Path(tmp_test_directory) / "config"
+    config_file_directory = Path(tmp_test_directory) / "model"
     config_file_directory.mkdir(exist_ok=True)
     sim_telarray_seeds = {
         "seed": 12345,
-        "seed_file_name": "random_seeds.txt",
+        "seed_file_name": "sim_telarray_instrument_seeds.txt",
         "random_instances": 5,
     }
 

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -45,6 +45,22 @@ def test_write_array_config_file(
         assert lines[-2].endswith("\n")
         assert lines[-1] == "\n"
 
+    with mock.patch.object(
+        SimtelConfigWriter,
+        "_write_random_seeds_file",
+    ) as write_random_seeds_file_mock:
+        simtel_config_writer.write_array_config_file(
+            config_file_path=file,
+            telescope_model=telescope_model,
+            site_model=site_model_north,
+            sim_telarray_seeds={
+                "seed": 12345,
+                "seed_file_name": "random_seeds.txt",
+                "random_instances": 5,
+            },
+        )
+        write_random_seeds_file_mock.assert_called_once()
+
 
 def test_write_tel_config_file(simtel_config_writer, io_handler, file_has_text):
     file = io_handler.get_output_file(file_name="simtel-config-writer_telescope.txt")
@@ -171,3 +187,24 @@ def test_get_sim_telarray_metadata_without_model_parameters(simtel_config_writer
 
     with pytest.raises(ValueError, match=r"^Unknown metadata type"):
         simtel_config_writer._get_sim_telarray_metadata("unknown", None)
+
+
+def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
+    config_file_directory = Path(tmp_test_directory) / "config"
+    config_file_directory.mkdir(exist_ok=True)
+    sim_telarray_seeds = {
+        "seed": 12345,
+        "seed_file_name": "random_seeds.txt",
+        "random_instances": 5,
+    }
+
+    simtel_config_writer._write_random_seeds_file(sim_telarray_seeds, config_file_directory)
+
+    seed_file_path = config_file_directory / sim_telarray_seeds["seed_file_name"]
+    assert seed_file_path.exists()
+
+    with open(seed_file_path, encoding="utf-8") as file:
+        lines = file.readlines()
+        assert len(lines) == sim_telarray_seeds["random_instances"]
+        for line in lines:
+            assert line.strip().isdigit()

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -205,6 +205,8 @@ def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
 
     with open(seed_file_path, encoding="utf-8") as file:
         lines = file.readlines()
-        assert len(lines) == sim_telarray_seeds["random_instances"]
+        assert len(lines) == sim_telarray_seeds["random_instances"] + 1
         for line in lines:
+            if line[0] == "#":
+                continue
             assert line.strip().isdigit()

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -29,14 +29,42 @@ def test_simtel_runner(simtel_runner):
 
 
 def test_make_run_command(simtel_runner):
+    input_file = "test_make_run_command.inp"
     run_command = simtel_runner._make_run_command(
-        run_number=3, input_file="test_make_run_command.inp"
+        run_number=3,
+        input_file=input_file,
     )
     assert "sim_telarray" in run_command
     assert "-run" in run_command
     assert "3" in run_command
     assert "test-simtel-runner.zst" in run_command
     assert "test_make_run_command.inp" in run_command
+    assert "random_seed" not in run_command
+
+    simtel_runner.sim_telarray_seeds = {
+        "seed": 12345,
+        "random_instrument_instances": None,
+        "seed_file": None,
+    }
+    run_command = simtel_runner._make_run_command(
+        run_number=3,
+        input_file=input_file,
+    )
+    assert "random_seed" in run_command
+    assert "12345" in run_command
+
+    simtel_runner.sim_telarray_seeds = {
+        "seed": None,
+        "random_instrument_instances": 10,
+        "seed_file": "test_file_with_seeds.txt",
+    }
+    run_command = simtel_runner._make_run_command(
+        run_number=3,
+        input_file=input_file,
+    )
+    assert "random_seed" in run_command
+    assert "file-by-run" in run_command
+    assert "test_file_with_seeds.txt" in run_command
 
 
 def test_check_run_result(simtel_runner):


### PR DESCRIPTION
Add option to write a list of random seeds and pass them on to `sim_telarray` to be used for generating the same instrument settings (optics, camera, ...) for multiple runs.

Changes:

- change command line option `SIM_TELARRAY_SEEDS` to `SIM_TELARRAY_INSTRUMENT_SEEDS` (for consistent naming)
- add command line option `SIM_TELARRAY_RANDOM_INSTRUMENT_INSTANCES` to set the number of instrument instances 
   - if this parameter is not set; nothing changes compared to previous versions of simtools
   - if this is set: write for each model version into the sim_telarray configuration file a file called `random_seeds.txt` with seeds generated in `simtel_config_writer` 

