### PR TITLE
Adapt docker files and building workflows to CORSIKA 7.8000

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: ['6.0.0', '5.0.0', '6.0.0,5.0.0']
+        model_version: ['6.0.0', '5.0.0', '6.0.0,5.0.0']
 
     defaults:
       run:
@@ -66,7 +66,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set PATH
+      - name: Set sim_telarray path
         run: |
           echo "PATH=\$PATH:/usr/bin:/usr/local/bin:$SIMTOOLS_SIMTEL_PATH" >> "$GITHUB_ENV"
 
@@ -115,4 +115,4 @@ jobs:
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'
-          pytest --model_version=${{ matrix.type }} --color=yes --durations=20 -n 4 --dist loadscope --no-cov tests/integration_tests/
+          pytest --model_version=${{ matrix.model_version }} --color=yes --durations=20 -n 4 --dist loadscope --no-cov tests/integration_tests/

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -229,17 +229,27 @@ jobs:
           # list of productions build options: 'prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc'
           - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
+        model_version:
+          - "6.0.0"
     container:
       image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}
-      env:
-        SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
-        SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}
-        SIMTOOLS_DB_API_USER: ${{ env.SIMTOOLS_DB_API_USER }}
-        SIMTOOLS_DB_API_PW: ${{ env.SIMTOOLS_DB_API_PW }}
-        SIMTOOLS_DB_SERVER: ${{ env.SIMTOOLS_DB_SERVER }}
+
+    services:
+      mongodb:
+        image: mongo:latest
+        env:
+          MONGO_INITDB_ROOT_USERNAME: api
+          MONGO_INITDB_ROOT_PASSWORD: password
+        options: >-
+          --health-cmd "mongosh --host localhost --port 27017 -u api -p password --authenticationDatabase admin --eval 'db.runCommand({ ping: 1 })'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
-      - name: Checkout repository
+      - name: checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set sim_telarray path
         run: |
@@ -251,10 +261,30 @@ jobs:
           SIMTOOLS_DB_SIMULATION_MODEL="${SIMTOOLS_DB_SIMULATION_MODEL//\'/}"
           echo "SIMTOOLS_DB_SIMULATION_MODEL=$SIMTOOLS_DB_SIMULATION_MODEL" >> "$GITHUB_ENV"
 
-      - name: Run integration tests
-        env:
-          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+      - name: Create environment file (local DB)
+        run: |
+          {
+            echo "SIMTOOLS_DB_SERVER=mongodb"
+            echo "SIMTOOLS_DB_API_USER=api"
+            echo "SIMTOOLS_DB_API_PW=password"
+            echo "SIMTOOLS_DB_API_PORT=27017"
+            echo "SIMTOOLS_DB_SIMULATION_MODEL=${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}"
+            echo "SIMTOOLS_SIMTEL_PATH=/workdir/sim_telarray/"
+          } > .env
+
+      - name: Upload data to MongoDB
         run: |
           source /workdir/env/bin/activate
-          pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist
-          pytest --no-cov --color=yes -n auto tests/integration_tests/test_applications_from_config.py
+          pip install --no-cache-dir -e '.[tests,dev,doc]'
+          cd database_scripts/
+          ./upload_from_model_repository_to_db.sh ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+
+      - name: Integration tests
+        shell: bash -l {0}
+        env:
+          SIMTOOLS_DB_SIMULATION_MODEL: ${{ env.SIMTOOLS_DB_SIMULATION_MODEL }}
+          SIMTOOLS_DB_SERVER: 'mongodb'
+        run: |
+          source /workdir/env/bin/activate
+          pip install --no-cache-dir -e '.[tests,dev,doc]'
+          pytest -model_version=${{ matrix.model_version}} --durations=20 -n 4 --dist loadscope --no-cov tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -233,6 +233,7 @@ jobs:
           - "6.0.0"
     container:
       image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}
+      options: --user 0
 
     services:
       mongodb:
@@ -245,6 +246,10 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -287,4 +292,4 @@ jobs:
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'
-          pytest -model_version=${{ matrix.model_version}} --durations=20 -n 4 --dist loadscope --no-cov tests/integration_tests/test_applications_from_config.py
+          pytest -model_version=${{ matrix.model_version}} -n 4 --dist loadscope --no-cov tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        simtel_version: ['240205', '240927']
+        simtel_version: ['240205', '240927', '250403']
 
     steps:
       - name: Checkout repository
@@ -57,17 +57,17 @@ jobs:
     strategy:
       matrix:
         production:
-          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
-          - {build_opt: 'prod5', extra_def: ''}
-          - {build_opt: 'prod5-sc', extra_def: ''}
+          # - {build_opt: 'prod5', extra_def: ''}
+          # - {build_opt: 'prod5-sc', extra_def: ''}
         version:
           # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
-        hadronic_model: ['qgs2']
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2'}
+          - {simtel_version: '250403', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3'}
 
     env:
-      LABELS: '${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}'
+      LABELS: '${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}'
 
     steps:
       - name: Checkout repository
@@ -117,7 +117,7 @@ jobs:
           build-args: |
            BUILD_OPT=${{ matrix.production.build_opt }}
            EXTRA_DEF=${{ matrix.production.extra_def }}
-           HADRONIC_MODEL=${{ matrix.hadronic_model }}
+           HADRONIC_MODEL=${{ matrix.version.hadronic_model }}
            SIMTEL_VERSION=${{ matrix.version.simtel_version }}
            CORSIKA_VERSION=${{ matrix.version.corsika_version }}
            BERNLOHR_VERSION=${{ matrix.version.bernlohr_version }}
@@ -140,7 +140,7 @@ jobs:
           - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
           # - {build_opt: 'prod5', extra_def: ''}
           # - {build_opt: 'prod5-sc', extra_def: ''}
@@ -227,7 +227,7 @@ jobs:
           - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
         hadronic_model: ['qgs2']
         production:
-          - {build_opt: 'prod6-sc', extra_def: '-DMAXIMUM_TELESCOPES=128'}
+          - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
         avx_instruction: ['no_opt']
     container:

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -15,10 +15,6 @@ on:
     - cron: '0 0 * * 0'  # Every Sunday at 00:00 UTC (build only)
 
 env:
-  SIMTOOLS_DB_SERVER: ${{ secrets.DB_SERVER }}
-  SIMTOOLS_DB_API_USER: ${{ secrets.DB_READ_USER }}
-  SIMTOOLS_DB_API_PW: ${{ secrets.DB_READ_PW }}
-  SIMTOOLS_DB_API_PORT: ${{ secrets.DB_API_PORT }}
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   CLOUD_URL: "https://syncandshare.desy.de/index.php/s/"

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -291,5 +291,6 @@ jobs:
           SIMTOOLS_DB_SERVER: 'mongodb'
         run: |
           source /workdir/env/bin/activate
-          pip install --no-cache-dir -e '.[tests,dev,doc]'
-          pytest -model_version=${{ matrix.model_version}} -n auto --no-cov tests/integration_tests/test_applications_from_config.py
+          pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist
+          # TODO - add model_version
+          pytest --no-cov --color=yes -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -288,5 +288,4 @@ jobs:
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir pytest pytest-cov pytest-requirements pytest-xdist
-          # TODO - add model_version
-          pytest --no-cov --color=yes -n auto tests/integration_tests/test_applications_from_config.py
+          pytest --model_version=${{ matrix.model_version }} --no-cov --color=yes -n auto tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -292,4 +292,4 @@ jobs:
         run: |
           source /workdir/env/bin/activate
           pip install --no-cache-dir -e '.[tests,dev,doc]'
-          pytest -model_version=${{ matrix.model_version}} -n 4 --dist loadscope --no-cov tests/integration_tests/test_applications_from_config.py
+          pytest -model_version=${{ matrix.model_version}} -n auto --no-cov tests/integration_tests/test_applications_from_config.py

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        simtel_version: ['240205', '240927', '250403']
+        simtel_version: ['240205', '240927', '250304']
 
     steps:
       - name: Checkout repository
@@ -64,7 +64,7 @@ jobs:
         version:
           # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
           - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2'}
-          - {simtel_version: '250403', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3'}
+          - {simtel_version: '250304', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3'}
 
     env:
       LABELS: '${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}'
@@ -136,19 +136,17 @@ jobs:
     strategy:
       matrix:
         version:
-          # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
-        hadronic_model: ['qgs2']
+          # list of avx instructions: 'avx2', 'avx512f', 'sse4', 'avx'
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2', avx_instruction: 'no_opt'}
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2', avx_instruction: 'avx2'}
+          - {simtel_version: '250304', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3', avx_instruction: 'no_opt'}
         production:
+          # list of productions build options: 'prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc'
           - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
-          # - {build_opt: 'prod5', extra_def: ''}
-          # - {build_opt: 'prod5-sc', extra_def: ''}
-        avx_instruction: ['avx2', 'no_opt']
-        # avx_instruction: ['avx2', 'avx512f', 'sse4', 'avx']
 
     env:
-      LABELS: "${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}"
+      LABELS: "${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}"
 
     steps:
       - name: Checkout repository
@@ -200,8 +198,8 @@ jobs:
           build-args: |
             BUILD_OPT=${{ matrix.production.build_opt }}
             EXTRA_DEF=${{ matrix.production.extra_def }}
-            HADRONIC_MODEL=${{ matrix.hadronic_model }}
-            AVX_FLAG=${{ matrix.avx_instruction }}
+            HADRONIC_MODEL=${{ matrix.version.hadronic_model }}
+            AVX_FLAG=${{ matrix.version.avx_instruction }}
             CORSIKA_VERSION=${{ matrix.version.corsika_version }}
             BERNLOHR_VERSION=${{ matrix.version.bernlohr_version }}
             BUILD_BRANCH=${{ env.BUILD_BRANCH }}
@@ -223,15 +221,16 @@ jobs:
     strategy:
       matrix:
         version:
-          # - {simtel_version: '240205', corsika_version: '77500', bernlohr_version: '1.67'}
-          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68'}
-        hadronic_model: ['qgs2']
+          # list of avx instructions: 'avx2', 'avx512f', 'sse4', 'avx'
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2', avx_instruction: 'no_opt'}
+          - {simtel_version: '240927', corsika_version: '77550', bernlohr_version: '1.68', hadronic_model: 'qgs2', avx_instruction: 'avx2'}
+          - {simtel_version: '250304', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3', avx_instruction: 'no_opt'}
         production:
+          # list of productions build options: 'prod6-sc', 'prod6-baseline', 'prod5', 'prod5-sc'
           - {build_opt: 'prod6-sc', extra_def: ''}
           - {build_opt: 'prod6-baseline', extra_def: ''}
-        avx_instruction: ['no_opt']
     container:
-      image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.hadronic_model }}-${{ matrix.avx_instruction }}
+      image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}
       env:
         SIMTOOLS_SIMTEL_PATH: "/workdir/sim_telarray"
         SIMTOOLS_DB_API_PORT: ${{ env.SIMTOOLS_DB_API_PORT }}

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -2,7 +2,7 @@ FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ENV GCC_PATH="/usr/bin/"
 ARG BUILD_OPT="prod6-sc"
-ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
+ARG EXTRA_DEF=""
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="avx2"
 ARG CORSIKA_VERSION="77550"
@@ -44,7 +44,7 @@ RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
     if [[ "$AVX_FLAG" == "no_opt" ]]; then \
         CFLAGS="-g  -std=c99 -O3"; \
         CXXFLAGS="-g  -std=c99 -O3"; \
-        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -std=c99 -O3"; \
+        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -O3"; \
     else \
         CFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
         CXXFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
@@ -63,16 +63,25 @@ RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
 # Rename executable to 'corsika'
 RUN mv -f corsika-$CORSIKA_VERSION/run/corsika$CORSIKA_VERSIONLinux_* corsika-$CORSIKA_VERSION/run/corsika
 # Build sim_telarray
-RUN export NO_CORSIKA=1 EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
+RUN touch corsika-$CORSIKA_VERSION.tar.gz && \
+    export NO_CORSIKA=1 EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
 # CORSIKA source code is removed to follow
 # the CORSIKA non-distribution policy.
-RUN mv ./corsika-77*/run corsika-run && \
+RUN mv ./corsika-7*/run corsika-run && \
     rm -rf ./corsika-7[0-9]* && \
     find . -name "*.tar.gz" -delete && \
     find . -name "doc*" -type d -exec rm -rf {} + 2>/dev/null && \
     find . -name "*.o" -delete && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
+
+# remove unnecessary large QGSJet tables (e.g. remove qgs3 tables when using qgs2)
+RUN if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
+        find . -name "qgsdat-II-04.bz2" -exec rm -fv {} \; ; \
+    fi && \
+    if [[ "$HADRONIC_MODEL" == "qgs2" ]]; then \
+        find . -name "qgsdat-III.bz2" -exec rm -fv {} \; ; \
+    fi
 
 # create a yml file in workdir with the build options
 RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
@@ -90,8 +99,16 @@ ARG PYTHON_VERSION=3.12
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
 RUN microdnf update -y && microdnf install -y \
-    bc findutils gcc-c++ git gsl-devel gcc-fortran libgfortran \
-    procps python${PYTHON_VERSION}-devel zstd && \
+    bc \
+    zstd \
+    gsl-devel \
+    gcc-fortran \
+    procps \
+    findutils \
+    gcc-c++ \
+    git \
+    libgfortran \
+    python${PYTHON_VERSION}-devel && \
     microdnf clean all
 
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
@@ -101,6 +118,5 @@ RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
   && pip install -U pip \
   && pip install --no-cache-dir "git+${SIMTOOLS_REQUIREMENT}@${BUILD_BRANCH}"
 
-ENV SIMTEL_PATH="/workdir/sim_telarray/"
+ENV SIMTEL_PATH="/workdir/sim_telarray"
 ENV PATH="/workdir/env/bin/:$PATH"
-SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -13,7 +13,7 @@ ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
 
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
-    autoconf automake csh patch perl which && \
+    autoconf automake csh patch perl which bzip2 && \
     yum clean all
 
 ADD corsika_simtelarray.tar.gz .
@@ -75,12 +75,19 @@ RUN mv ./corsika-7*/run corsika-run && \
     find . -name "*.o" -delete && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
-# remove unnecessary large QGSJet tables (e.g. remove qgs3 tables when using qgs2)
-RUN if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
-        find . -name "qgsdat-II-04.bz2" -exec rm -fv {} \; ; \
+# Unzip QGSJet tables; remove tables not needed (e.g. remove qgs3 tables when using qgs2)
+RUN cd corsika-run && \
+    if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
+        if [ -f qgsdat-III.bz2 ]; then \
+            bzip2 -dq qgsdat-III.bz2; \
+        fi; \
+        rm -f -v qgsdat-II-04.bz2; \
     fi && \
     if [[ "$HADRONIC_MODEL" == "qgs2" ]]; then \
-        find . -name "qgsdat-III.bz2" -exec rm -fv {} \; ; \
+        if [ -f qgsdat-II-04.bz2 ]; then \
+            bzip2 -dq qgsdat-II-04.bz2; \
+        fi; \
+        rm -f -v qgsdat-III.bz2; \
     fi
 
 # create a yml file in workdir with the build options
@@ -116,7 +123,9 @@ RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
   && python${PYTHON_VERSION} -m venv env \
   && source env/bin/activate \
   && pip install -U pip \
-  && pip install --no-cache-dir "git+${SIMTOOLS_REQUIREMENT}@${BUILD_BRANCH}"
+  && pip install --no-cache-dir "git+${SIMTOOLS_REQUIREMENT}@${BUILD_BRANCH}" \
+  && echo ". /workdir/env/bin/activate" >> ~/.bashrc t
 
 ENV SIMTEL_PATH="/workdir/sim_telarray"
 ENV PATH="/workdir/env/bin/:$PATH"
+SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -2,7 +2,7 @@ FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ENV GCC_PATH="/usr/bin/"
 ARG BUILD_OPT="prod6-sc"
-ARG EXTRA_DEF=""
+ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="avx2"
 ARG CORSIKA_VERSION="77550"

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,7 +1,6 @@
 FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ARG BUILD_OPT="prod6-sc"
-ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="no_opt"
 ARG CORSIKA_VERSION="77550"
@@ -15,17 +14,16 @@ RUN yum update -y && yum install -y \
 ADD corsika_simtelarray.tar.gz .
 RUN rm -f examples-with-data.tar.gz && \
     rm -f sim_telarray_config.tar.gz && \
-    export EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
+    ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
 # corsika source code is removed to follow
 # the corsika non-distribution policy.
-RUN mv ./corsika-77*/run corsika-run && \
+RUN mv ./corsika-7*/run corsika-run && \
     rm -rf ./corsika-7[0-9]* && \
     find . -name "*.tar.gz" -delete
 
 # create a yml file in workdir with the build options
 RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
-    echo "extra_def: $EXTRA_DEF" >> /workdir/sim_telarray/build_opts.yml && \
     echo "hadronic_model: $HADRONIC_MODEL" >> /workdir/sim_telarray/build_opts.yml && \
     echo "avx_flag: $AVX_FLAG" >> /workdir/sim_telarray/build_opts.yml && \
     echo "corsika_version: $CORSIKA_VERSION" >> /workdir/sim_telarray/build_opts.yml && \

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,7 +1,7 @@
 FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ARG BUILD_OPT="prod6-sc"
-ARG EXTRA_DEF=""
+ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="no_opt"
 ARG CORSIKA_VERSION="77550"

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,6 +1,7 @@
 FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ARG BUILD_OPT="prod6-sc"
+ARG EXTRA_DEF=""
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="no_opt"
 ARG CORSIKA_VERSION="77550"
@@ -14,16 +15,26 @@ RUN yum update -y && yum install -y \
 ADD corsika_simtelarray.tar.gz .
 RUN rm -f examples-with-data.tar.gz && \
     rm -f sim_telarray_config.tar.gz && \
-    ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
+    export EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
 # corsika source code is removed to follow
 # the corsika non-distribution policy.
 RUN mv ./corsika-7*/run corsika-run && \
     rm -rf ./corsika-7[0-9]* && \
-    find . -name "*.tar.gz" -delete
+    find . -name "*.tar.gz" -delete && \
+    rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
+
+# remove unnecessary large QGSJet tables (e.g. remove qgs3 tables when using qgs2)
+RUN if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
+        find . -name "qgsdat-II-04.bz2" -exec rm -fv {} \; ; \
+    fi && \
+    if [[ "$HADRONIC_MODEL" == "qgs2" ]]; then \
+        find . -name "qgsdat-III.bz2" -exec rm -fv {} \; ; \
+    fi
 
 # create a yml file in workdir with the build options
 RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
+    echo "extra_def: $EXTRA_DEF" >> /workdir/sim_telarray/build_opts.yml && \
     echo "hadronic_model: $HADRONIC_MODEL" >> /workdir/sim_telarray/build_opts.yml && \
     echo "avx_flag: $AVX_FLAG" >> /workdir/sim_telarray/build_opts.yml && \
     echo "corsika_version: $CORSIKA_VERSION" >> /workdir/sim_telarray/build_opts.yml && \
@@ -45,6 +56,4 @@ RUN microdnf update -y && microdnf install -y \
 RUN cprog=$(/bin/ls /workdir/sim_telarray/corsika-run/corsika*$(uname)_* 2>/dev/null | tail -1) && \
     ln -sf $cprog /workdir/sim_telarray/corsika-run/corsika
 
-ENV SIMTEL_PATH="/workdir/sim_telarray/"
-
-SHELL ["/bin/bash", "-c"]
+ENV SIMTEL_PATH="/workdir/sim_telarray"

--- a/docs/changes/1512.feature.md
+++ b/docs/changes/1512.feature.md
@@ -1,0 +1,1 @@
+Adapt docker files and building workflows to CORSIKA 7.8000.


### PR DESCRIPTION
Several changes related to the introduction of CORSIKA 7.8000, bernlohr package version 1.69 and qgs3.

In details, this means

- make corsika 7.8 sim_telarray package available through cloud storage with the data `20250304` (used also as secret identifier)
- re-arrange matrix logic in `.github/workflows/build-simtools-production-image.yml` to allow release-dependent hadronic interaction models and optimization statement (as qgs3 is only available in 7.8; optimized compilation is not working yet for 7.8)
- cosmetics: try to make `Dockerfile-prod-opt` and `Dockerfile-simtelarray` as similar as possible (the latter is used as base image for the development environment)
- remove `-std=c99` for fortran compilation (removes lots of warnings)
- adaption to updated build scripts from sim_telarray to distinguish between 7.7 and 7.8
- remove qgs2 tables when using qgs3 and vice versa (safes disk space in the image)
- remove `DMAXIMUM_TELESCOPES` extra define statements for prod6-sc (as it is defined with `DMAXIMUM_TELESCOPES`).
- update integration tests using newly build container images in `build-simtools-production-image` to use a local DB (instead of remote in Zeuthen). Tried to synchronize as much with the identical approach in `CI-integrationtests.yml` (not ideal that this is duplicated)

This means we have in future also images with CORSIKA 7.8, bernlohr package 1.69, and qgs3 available.

Compilation of optimized images for 7.8 (needs feedback from experts) needs to be fixed in a separate PR, see issue #1532 
