### PR TITLE
Add sim_telarray random seed for instrument configuration to metadata (and metadata tests).

### DIFF
--- a/docs/changes/1515.feature.md
+++ b/docs/changes/1515.feature.md
@@ -1,0 +1,1 @@
+Add sim_telarray random seed for instrument configuration to metadata (and metadata tests).

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -33,7 +33,7 @@ def sim_telarray_random_seeds(seed, number):
     """
     rng = np.random.default_rng(seed)
     max_int32 = np.iinfo(np.int32).max  # sim_telarray requires 32 bit integers
-    return list(rng.integers(low=1, high=max_int32 + 1, size=number, dtype=np.int32))
+    return list(rng.integers(low=1, high=max_int32, size=number, dtype=np.int32))
 
 
 class SimtelConfigWriter:

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -117,7 +117,9 @@ class SimtelConfigWriter:
             value = gen.convert_list_to_string(value, shorten_list=True)
         return value
 
-    def _get_sim_telarray_metadata(self, config_type, model_parameters, telescope_model_name):
+    def _get_sim_telarray_metadata(
+        self, config_type, model_parameters, telescope_model_name, sim_telarray_seeds=None
+    ):
         """
         Return sim_telarray metadata.
 
@@ -129,6 +131,8 @@ class SimtelConfigWriter:
             Model parameters dictionary.
         telescope_model_name: str
             Name of the telescope model
+        sim_telarray_seeds: dict
+            Dictionary with configuration for sim_telarray random instrument setup.
 
         Returns
         -------
@@ -178,6 +182,8 @@ class SimtelConfigWriter:
                 )
                 if simtel_name and value.get("meta_parameter"):
                     meta_parameters.append(f"{prefix} set {simtel_name}={value['value']}")
+        if sim_telarray_seeds and sim_telarray_seeds.get("random_instances"):
+            meta_parameters.append(f"{prefix} set sim_telarray_seeds={sim_telarray_seeds['seed']}")
 
         return meta_parameters
 
@@ -215,7 +221,11 @@ class SimtelConfigWriter:
             file.write(self.TAB + "echo *****************************\n\n")
 
             self._write_site_parameters(
-                file, site_model.parameters, config_file_directory, telescope_model
+                file,
+                site_model.parameters,
+                config_file_directory,
+                telescope_model,
+                sim_telarray_seeds,
             )
 
             file.write(self.TAB + f"maximum_telescopes = {len(telescope_model)}\n\n")
@@ -349,7 +359,9 @@ class SimtelConfigWriter:
         header += f"{comment_char}\n"
         file.write(header)
 
-    def _write_site_parameters(self, file, site_parameters, model_path, telescope_model):
+    def _write_site_parameters(
+        self, file, site_parameters, model_path, telescope_model, sim_telarray_seeds=None
+    ):
         """
         Write site parameters.
 
@@ -363,6 +375,8 @@ class SimtelConfigWriter:
             Path to the model for writing of additional files.
         telescope_model: dict of TelescopeModel
             Telescope models.
+        sim_telarray_seeds: dict
+            Dictionary with configuration for sim_telarray random instrument setup.
         """
         file.write(self.TAB + "% Site parameters\n")
         for par, value in site_parameters.items():
@@ -377,7 +391,7 @@ class SimtelConfigWriter:
             if simtel_name is not None:
                 file.write(f"{self.TAB}{simtel_name} = {value}\n")
         for meta in self._get_sim_telarray_metadata(
-            "site", site_parameters, self._telescope_model_name
+            "site", site_parameters, self._telescope_model_name, sim_telarray_seeds
         ):
             file.write(f"{self.TAB}{meta}\n")
         file.write("\n")

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -33,7 +33,7 @@ def sim_telarray_random_seeds(seed, number):
     """
     rng = np.random.default_rng(seed)
     max_int32 = np.iinfo(np.int32).max  # sim_telarray requires 32 bit integers
-    return list(rng.integers(low=0, high=max_int32 + 1, size=number, dtype=np.int32))
+    return list(rng.integers(low=1, high=max_int32 + 1, size=number, dtype=np.int32))
 
 
 class SimtelConfigWriter:

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -167,6 +167,7 @@ class SimtelConfigWriter:
                 ]
             )
             prefix = "metaparam global"
+            meta_parameters.append("metaparam global add random_seed")
         else:
             raise ValueError(f"Unknown metadata type {config_type}")
 
@@ -183,7 +184,10 @@ class SimtelConfigWriter:
                 if simtel_name and value.get("meta_parameter"):
                     meta_parameters.append(f"{prefix} set {simtel_name}={value['value']}")
         if sim_telarray_seeds and sim_telarray_seeds.get("random_instances"):
-            meta_parameters.append(f"{prefix} set sim_telarray_seeds={sim_telarray_seeds['seed']}")
+            meta_parameters.append(f"{prefix} set instrument_seed={sim_telarray_seeds['seed']}")
+            meta_parameters.append(
+                f"{prefix} set instrument_instances={sim_telarray_seeds['random_instances']}"
+            )
 
         return meta_parameters
 

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -191,18 +191,8 @@ class SimtelConfigWriter:
         else:
             raise ValueError(f"Unknown metadata type {config_type}")
 
-        if model_parameters:
-            for key, value in model_parameters.items():
-                simtel_name = names.get_simulation_software_name_from_parameter_name(
-                    key, software_name="sim_telarray", set_meta_parameter=False
-                )
-                if simtel_name and value.get("meta_parameter"):
-                    meta_parameters.append(f"{prefix} add {simtel_name}")
-                simtel_name = names.get_simulation_software_name_from_parameter_name(
-                    key, software_name="sim_telarray", set_meta_parameter=True
-                )
-                if simtel_name and value.get("meta_parameter"):
-                    meta_parameters.append(f"{prefix} set {simtel_name}={value['value']}")
+        self._add_model_parameters_to_metadata(model_parameters, meta_parameters, prefix)
+
         if sim_telarray_seeds and sim_telarray_seeds.get("random_instances"):
             meta_parameters.append(f"{prefix} set instrument_seed={sim_telarray_seeds['seed']}")
             meta_parameters.append(
@@ -210,6 +200,23 @@ class SimtelConfigWriter:
             )
 
         return meta_parameters
+
+    def _add_model_parameters_to_metadata(self, model_parameters, meta_parameters, prefix):
+        """Add model parameters to metadata."""
+        if not model_parameters:
+            return
+
+        for key, value in model_parameters.items():
+            simtel_name = names.get_simulation_software_name_from_parameter_name(
+                key, software_name="sim_telarray", set_meta_parameter=False
+            )
+            if simtel_name and value.get("meta_parameter"):
+                meta_parameters.append(f"{prefix} add {simtel_name}")
+            simtel_name = names.get_simulation_software_name_from_parameter_name(
+                key, software_name="sim_telarray", set_meta_parameter=True
+            )
+            if simtel_name and value.get("meta_parameter"):
+                meta_parameters.append(f"{prefix} set {simtel_name}={value['value']}")
 
     def write_array_config_file(
         self, config_file_path, telescope_model, site_model, sim_telarray_seeds=None

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -4,7 +4,7 @@
 from functools import cache
 
 from eventio import EventIOFile
-from eventio.simtel import HistoryMeta
+from eventio.simtel import HistoryMeta, RunHeader
 
 
 @cache
@@ -89,3 +89,32 @@ def get_sim_telarray_telescope_id(telescope_name, file):
             telescope_name_to_sim_telarray_id[telescope_name] = tel_id
 
     return telescope_name_to_sim_telarray_id.get(telescope_name, None)
+
+
+def get_corsika_run_number(file):
+    """
+    Return the CORSIKA run number from a sim_telarray file.
+
+    Parameters
+    ----------
+    file: str
+        Path to the sim_telarray file.
+
+    Returns
+    -------
+    int, None
+        CORSIKA run number. Returns None if not found.
+    """
+    run_header = None
+    with EventIOFile(file) as f:
+        found_run_header = False
+        for o in f:
+            if isinstance(o, RunHeader):
+                found_run_header = True
+            else:
+                if found_run_header:
+                    break
+                continue
+            run_header = o.parse()
+
+    return run_header.get("run") if run_header else None

--- a/src/simtools/testing/sim_telarray_metadata.py
+++ b/src/simtools/testing/sim_telarray_metadata.py
@@ -101,7 +101,7 @@ def _assert_model_parameters(metadata, model):
     return invalid_parameter_list
 
 
-def _assert_sim_telarray_seed(metadata, sim_telarray_seeds, file):
+def _assert_sim_telarray_seed(metadata, sim_telarray_seeds, file=None):
     """
     Assert that sim_telarray seed matches the values in the sim_telarray metadata.
 
@@ -135,17 +135,18 @@ def _assert_sim_telarray_seed(metadata, sim_telarray_seeds, file):
             f"sim_telarray_seed in sim_telarray file: {metadata['instrument_seed']}, "
             f"and model: {sim_telarray_seeds.get('seed')}"
         )
-        run_number_modified = get_corsika_run_number(file) - 1
-        test_seeds = sim_telarray_random_seeds(
-            int(metadata["instrument_seed"]), int(metadata["instrument_instances"])
-        )
-        # no +1 as in sim_telarray (as we count from 0)
-        seed_used = run_number_modified % int(metadata["instrument_instances"])
-        if str(metadata.get("rng_select_seed")) != str(test_seeds[seed_used]):
-            return (
-                "Parameter rng_select_seed mismatch between sim_telarray file: "
-                f"{metadata['rng_select_seed']}, and model: {test_seeds[seed_used]}"
+        if file:
+            run_number_modified = get_corsika_run_number(file) - 1
+            test_seeds = sim_telarray_random_seeds(
+                int(metadata["instrument_seed"]), int(metadata["instrument_instances"])
             )
+            # no +1 as in sim_telarray (as we count from 0)
+            seed_used = run_number_modified % int(metadata["instrument_instances"])
+            if str(metadata.get("rng_select_seed")) != str(test_seeds[seed_used]):
+                return (
+                    "Parameter rng_select_seed mismatch between sim_telarray file: "
+                    f"{metadata['rng_select_seed']}, and model: {test_seeds[seed_used]}"
+                )
 
     return None
 

--- a/src/simtools/testing/sim_telarray_metadata.py
+++ b/src/simtools/testing/sim_telarray_metadata.py
@@ -27,6 +27,11 @@ def assert_sim_telarray_metadata(file, array_model):
     global_meta, telescope_meta = read_sim_telarray_metadata(file)
     _logger.info(f"Found metadata in sim_telarray file for {len(telescope_meta)} telescopes")
     site_parameter_mismatch = _assert_model_parameters(global_meta, array_model.site_model)
+    sim_telarray_seed_mismatch = _assert_sim_telarray_seed(
+        global_meta, array_model.sim_telarray_seeds
+    )
+    if sim_telarray_seed_mismatch:
+        site_parameter_mismatch.append(sim_telarray_seed_mismatch)
 
     if len(telescope_meta) != len(array_model.telescope_model):
         raise ValueError(
@@ -96,6 +101,36 @@ def _assert_model_parameters(metadata, model):
                 )
 
     return invalid_parameter_list
+
+
+def _assert_sim_telarray_seed(metadata, sim_telarray_seeds):
+    """
+    Assert that sim_telarray seed matches the values in the sim_telarray metadata.
+
+    Parameters
+    ----------
+    metadata: dict
+        Metadata dictionary.
+    sim_telarray_seeds: dict
+        Dictionary of sim_telarray seeds.
+
+    Returns
+    -------
+    invalid_parameter_list: list
+        Error message if sim_telarray seeds do not match.
+
+    """
+    if sim_telarray_seeds is not None:
+        if int(metadata.get("sim_telarray_seeds")) != int(sim_telarray_seeds.get("seed")):
+            return (
+                "Parameter sim_telarray_seeds mismatch between sim_telarray file: "
+                f"{metadata['sim_telarray_seeds']}, and model: {sim_telarray_seeds.get('seed')}"
+            )
+        _logger.info(
+            f"sim_telarray_seeds in sim_telarray file: {metadata['sim_telarray_seeds']}, "
+            f"and model: {sim_telarray_seeds.get('seed')}"
+        )
+    return None
 
 
 def _sim_telarray_name_from_parameter_name(parameter_name):

--- a/src/simtools/testing/sim_telarray_metadata.py
+++ b/src/simtools/testing/sim_telarray_metadata.py
@@ -120,8 +120,8 @@ def _assert_sim_telarray_seed(metadata, sim_telarray_seeds):
         Error message if sim_telarray seeds do not match.
 
     """
-    if sim_telarray_seeds is not None:
-        if int(metadata.get("sim_telarray_seeds")) != int(sim_telarray_seeds.get("seed")):
+    if sim_telarray_seeds and metadata and "sim_telarray_seeds" in metadata.keys():
+        if str(metadata.get("sim_telarray_seeds")) != str(sim_telarray_seeds.get("seed")):
             return (
                 "Parameter sim_telarray_seeds mismatch between sim_telarray file: "
                 f"{metadata['sim_telarray_seeds']}, and model: {sim_telarray_seeds.get('seed')}"

--- a/src/simtools/testing/sim_telarray_metadata.py
+++ b/src/simtools/testing/sim_telarray_metadata.py
@@ -120,14 +120,14 @@ def _assert_sim_telarray_seed(metadata, sim_telarray_seeds):
         Error message if sim_telarray seeds do not match.
 
     """
-    if sim_telarray_seeds and metadata and "sim_telarray_seeds" in metadata.keys():
-        if str(metadata.get("sim_telarray_seeds")) != str(sim_telarray_seeds.get("seed")):
+    if sim_telarray_seeds and metadata and "instrument_seed" in metadata.keys():
+        if str(metadata.get("instrument_seed")) != str(sim_telarray_seeds.get("seed")):
             return (
-                "Parameter sim_telarray_seeds mismatch between sim_telarray file: "
-                f"{metadata['sim_telarray_seeds']}, and model: {sim_telarray_seeds.get('seed')}"
+                "Parameter instrument_seed mismatch between sim_telarray file: "
+                f"{metadata['instrument_seed']}, and model: {sim_telarray_seeds.get('seed')}"
             )
         _logger.info(
-            f"sim_telarray_seeds in sim_telarray file: {metadata['sim_telarray_seeds']}, "
+            f"sim_telarray_seed in sim_telarray file: {metadata['instrument_seed']}, "
             f"and model: {sim_telarray_seeds.get('seed')}"
         )
     return None

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -7,7 +7,7 @@ from unittest import mock
 import numpy as np
 import pytest
 
-from simtools.simtel.simtel_config_writer import SimtelConfigWriter
+from simtools.simtel.simtel_config_writer import SimtelConfigWriter, sim_telarray_random_seeds
 
 logger = logging.getLogger()
 
@@ -278,3 +278,33 @@ def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
             if line[0] == "#":
                 continue
             assert line.strip().isdigit()
+
+    sim_telarray_seeds = {
+        "seed": 12345,
+        "seed_file_name": "sim_telarray_instrument_seeds.txt",
+        "random_instances": 1025,
+    }
+    with pytest.raises(
+        ValueError, match="Number of random instances of instrument must be less than 1024"
+    ):
+        simtel_config_writer._write_random_seeds_file(sim_telarray_seeds, config_file_directory)
+
+
+def test_sim_telarray_random_seeds():
+    seed = 12345
+    number = 5
+    seeds = sim_telarray_random_seeds(seed, number)
+    assert len(seeds) == number
+    assert all(isinstance(s, np.int32) for s in seeds)
+
+    seed = 54321
+    number = 10
+    seeds = sim_telarray_random_seeds(seed, number)
+    assert len(seeds) == number
+    assert all(isinstance(s, np.int32) for s in seeds)
+
+    # Test with zero number of seeds
+    seed = 12345
+    number = 0
+    seeds = sim_telarray_random_seeds(seed, number)
+    assert len(seeds) == number

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -296,6 +296,7 @@ def test_sim_telarray_random_seeds():
     seeds = sim_telarray_random_seeds(seed, number)
     assert len(seeds) == number
     assert all(isinstance(s, np.int32) for s in seeds)
+    assert all(s >= 1 for s in seeds)  # sim_telarray seeds needs to be >0
 
     seed = 54321
     number = 10

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -258,11 +258,12 @@ def test_write_dummy_telescope_configuration_file(
 
 
 def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
+    seed_file_name = "sim_telarray_instrument_seeds.txt"
     config_file_directory = Path(tmp_test_directory) / "model"
     config_file_directory.mkdir(exist_ok=True)
     sim_telarray_seeds = {
         "seed": 12345,
-        "seed_file_name": "sim_telarray_instrument_seeds.txt",
+        "seed_file_name": seed_file_name,
         "random_instances": 5,
     }
 
@@ -281,7 +282,7 @@ def test_write_random_seeds_file(simtel_config_writer, tmp_test_directory):
 
     sim_telarray_seeds = {
         "seed": 12345,
-        "seed_file_name": "sim_telarray_instrument_seeds.txt",
+        "seed_file_name": seed_file_name,
         "random_instances": 1025,
     }
     with pytest.raises(

--- a/tests/unit_tests/simtel/test_simtel_io_metdata.py
+++ b/tests/unit_tests/simtel/test_simtel_io_metdata.py
@@ -1,8 +1,11 @@
 #!/usr/bin/python3
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from simtools.simtel.simtel_io_metadata import (
+    get_corsika_run_number,
     get_sim_telarray_telescope_id,
     read_sim_telarray_metadata,
 )
@@ -38,3 +41,17 @@ def test_get_sim_telarray_telescope_id(test_sim_telarray_file):
     assert get_sim_telarray_telescope_id("LSTN-01", test_sim_telarray_file) == 1
     assert get_sim_telarray_telescope_id("MSTN-01", test_sim_telarray_file) == 5
     assert get_sim_telarray_telescope_id("MSTS-01", test_sim_telarray_file) is None
+
+
+def test_get_corsika_run_number_with_run_header():
+    assert get_corsika_run_number("tests/resources/xyzls_layout.simtel.gz") == 1
+
+
+def test_get_corsika_run_number_without_run_header():
+    mock_eventio_file = MagicMock()
+    mock_eventio_file.__enter__.return_value = []
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("simtools.simtel.simtel_io_metadata.EventIOFile", lambda x: mock_eventio_file)
+        run_number = get_corsika_run_number("test_file.simtel.gz")
+        assert run_number is None

--- a/tests/unit_tests/simtel/test_simtel_io_metdata.py
+++ b/tests/unit_tests/simtel/test_simtel_io_metdata.py
@@ -44,10 +44,29 @@ def test_get_sim_telarray_telescope_id(test_sim_telarray_file):
 
 
 def test_get_corsika_run_number_with_run_header():
+    assert (
+        get_corsika_run_number(
+            "tests/resources/run000010_gamma_za20deg_azm000deg_North_test_layout_"
+            "6.0.0_test-production-North.simtel.zst"
+        )
+        == 10
+    )
+    # The following file was actually created with the LightEmission package,
+    # but it should still return the run number correctly.
     assert get_corsika_run_number("tests/resources/xyzls_layout.simtel.gz") == 1
 
 
-def test_get_corsika_run_number_without_run_header():
+def test_get_corsika_run_number_without_run_header_real_file():
+    assert (
+        get_corsika_run_number(
+            "tests/resources/gamma_20deg_0deg_run1___cta-prod5-lapalma_"
+            "desert-2158m-LaPalma-dark.hdata.zst"
+        )
+        is None
+    )
+
+
+def test_get_corsika_run_number_without_run_header_mocking():
     mock_eventio_file = MagicMock()
     mock_eventio_file.__enter__.return_value = []
 

--- a/tests/unit_tests/testing/test_sim_telarray_metadata.py
+++ b/tests/unit_tests/testing/test_sim_telarray_metadata.py
@@ -2,7 +2,7 @@
 
 import copy
 import re
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -160,3 +160,18 @@ def test_assert_sim_telarray_seed(caplog):
 
     # Test with sim_telarray_seeds is None
     assert _assert_sim_telarray_seed(metadata, None) is None
+
+
+def test_assert_sim_telarray_metadata_seed_mismatch(test_metadata_file, array_model_north):
+    """Test assert_sim_telarray_metadata with mismatched seeds."""
+    array_model_mismatched_seed = copy.deepcopy(array_model_north)
+    array_model_mismatched_seed.sim_telarray_seeds = {"seed": "54321"}
+
+    with patch(
+        "simtools.testing.sim_telarray_metadata._assert_sim_telarray_seed",
+        return_value="Parameter sim_telarray_seeds mismatch",
+    ):
+        with pytest.raises(
+            ValueError, match=r"^Telescope or site model parameters do not match sim_telarray "
+        ):
+            assert_sim_telarray_metadata(test_metadata_file, array_model_mismatched_seed)

--- a/tests/unit_tests/testing/test_sim_telarray_metadata.py
+++ b/tests/unit_tests/testing/test_sim_telarray_metadata.py
@@ -93,9 +93,8 @@ def test_assert_sim_telarray_metadata_with_mismatched_parameters(
         "wrong_file.dat"
     )
 
-    with pytest.raises(
-        ValueError, match=r"^Telescope or site model parameters do not match sim_telarray "
-    ):
+    mismatch_message = r"^Telescope or site model parameters do not match sim_telarray "
+    with pytest.raises(ValueError, match=mismatch_message):
         assert_sim_telarray_metadata(test_metadata_file, array_model_mismatched_site)
 
     array_model_mismatched_telescope = copy.deepcopy(array_model_north)
@@ -103,9 +102,7 @@ def test_assert_sim_telarray_metadata_with_mismatched_parameters(
         "random_mono_probability"
     ]["value"] = 0.99
 
-    with pytest.raises(
-        ValueError, match=r"^Telescope or site model parameters do not match sim_telarray "
-    ):
+    with pytest.raises(ValueError, match=mismatch_message):
         assert_sim_telarray_metadata(test_metadata_file, array_model_mismatched_telescope)
 
 

--- a/tests/unit_tests/testing/test_sim_telarray_metadata.py
+++ b/tests/unit_tests/testing/test_sim_telarray_metadata.py
@@ -176,3 +176,22 @@ def test_assert_sim_telarray_metadata_seed_mismatch(test_metadata_file, array_mo
             ValueError, match=r"^Telescope or site model parameters do not match sim_telarray "
         ):
             assert_sim_telarray_metadata(test_metadata_file, array_model_mismatched_seed)
+
+
+def test_assert_sim_telarray_seed_with_rng_select_seed(caplog):
+    """Test _assert_sim_telarray_seed with rng_select_seed."""
+    metadata = {
+        "instrument_seed": "12345",
+        "instrument_instances": 100,
+        "rng_select_seed": "12394",
+    }
+    sim_telarray_seeds = {"seed": "12345", "instrument_instances": 100}
+
+    with patch(
+        "simtools.testing.sim_telarray_metadata.get_corsika_run_number", return_value=10
+    ) as get_corsika_run_number_mock:
+        with caplog.at_level(logging.INFO):
+            result = _assert_sim_telarray_seed(metadata, sim_telarray_seeds, "test_file")
+            assert "Parameter rng_select_seed mismatch between sim_telarray file" in result
+            assert "sim_telarray_seed in sim_telarray file: 12345, and model: 12345" in caplog.text
+            get_corsika_run_number_mock.assert_called_once_with("test_file")

--- a/tests/unit_tests/testing/test_sim_telarray_metadata.py
+++ b/tests/unit_tests/testing/test_sim_telarray_metadata.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import copy
+import logging
 import re
 from unittest.mock import MagicMock, patch
 
@@ -142,20 +143,20 @@ def test_is_equal():
 def test_assert_sim_telarray_seed(caplog):
     """Test _assert_sim_telarray_seed."""
 
-    metadata = {"sim_telarray_seeds": "12345"}
-    sim_telarray_seeds = {"seed": "12345"}
+    metadata = {"instrument_seed": "12345", "instrument_instances": 100}
+    sim_telarray_seeds = {"seed": "12345", "instrument_instances": 100}
 
     # Test with matching seeds
-    with caplog.at_level(level=10):
+    with caplog.at_level(logging.INFO):
         assert _assert_sim_telarray_seed(metadata, sim_telarray_seeds) is None
-        assert "sim_telarray_seeds in sim_telarray file: 12345, and model: 12345" in caplog.text
+        assert "sim_telarray_seed in sim_telarray file: 12345, and model: 12345" in caplog.text
 
     # Test with mismatched seeds
-    metadata = {"sim_telarray_seeds": "12345"}
-    sim_telarray_seeds = {"seed": "54321"}
+    metadata = {"instrument_seed": "12345", "instrument_instances": 100}
+    sim_telarray_seeds = {"seed": "54321", "instrument_instances": 100}
     assert (
         _assert_sim_telarray_seed(metadata, sim_telarray_seeds)
-        == "Parameter sim_telarray_seeds mismatch between sim_telarray file: 12345, and model: 54321"
+        == "Parameter instrument_seed mismatch between sim_telarray file: 12345, and model: 54321"
     )
 
     # Test with sim_telarray_seeds is None

--- a/tests/unit_tests/testing/test_sim_telarray_metadata.py
+++ b/tests/unit_tests/testing/test_sim_telarray_metadata.py
@@ -9,6 +9,7 @@ import pytest
 
 from simtools.simtel.simtel_io_metadata import read_sim_telarray_metadata
 from simtools.testing.sim_telarray_metadata import (
+    _assert_sim_telarray_seed,
     _sim_telarray_name_from_parameter_name,
     assert_sim_telarray_metadata,
     is_equal,
@@ -136,3 +137,26 @@ def test_is_equal():
     assert is_equal(None, None, "any") is True
     assert is_equal("none", None, "any") is True
     assert is_equal(None, "none", "any") is True
+
+
+def test_assert_sim_telarray_seed(caplog):
+    """Test _assert_sim_telarray_seed."""
+
+    metadata = {"sim_telarray_seeds": "12345"}
+    sim_telarray_seeds = {"seed": "12345"}
+
+    # Test with matching seeds
+    with caplog.at_level(level=10):
+        assert _assert_sim_telarray_seed(metadata, sim_telarray_seeds) is None
+        assert "sim_telarray_seeds in sim_telarray file: 12345, and model: 12345" in caplog.text
+
+    # Test with mismatched seeds
+    metadata = {"sim_telarray_seeds": "12345"}
+    sim_telarray_seeds = {"seed": "54321"}
+    assert (
+        _assert_sim_telarray_seed(metadata, sim_telarray_seeds)
+        == "Parameter sim_telarray_seeds mismatch between sim_telarray file: 12345, and model: 54321"
+    )
+
+    # Test with sim_telarray_seeds is None
+    assert _assert_sim_telarray_seed(metadata, None) is None


### PR DESCRIPTION
Add sim_telarray random seed for instrument configuration to metadata.

In the array configuration files, this looks e.g. like:

```
metaparam global set sim_telarray_seeds=600002020000
```

Add a test that this seed in the metadata of the generated sim_telarray output file is the expected one.

Add test that sim_telarray is using the correct random seed from the list of generated seeds.

Closes #1513 

