### PR TITLE
Multiple versions integration test

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: ['6.0.0', '5.0.0']
+        type: ['6.0.0', '5.0.0', '6.0.0,5.0.0']
 
     defaults:
       run:

--- a/docs/changes/1520.feature.md
+++ b/docs/changes/1520.feature.md
@@ -1,0 +1,1 @@
+Integration test with multipipe and support for packing all output files in grid productions.

--- a/src/simtools/runners/corsika_runner.py
+++ b/src/simtools/runners/corsika_runner.py
@@ -221,7 +221,12 @@ class CorsikaRunner:
         return cmd
 
     def get_file_name(
-        self, simulation_software="corsika", file_type=None, run_number=None, mode=""
+        self,
+        simulation_software="corsika",
+        file_type=None,
+        run_number=None,
+        mode="",
+        model_version_index=0,
     ):
         """
         Get the full path of a file for a given run number.
@@ -234,6 +239,10 @@ class CorsikaRunner:
             File type.
         run_number: int
             Run number.
+        model_version_index: int
+            Index of the model version.
+            This is used to select the correct simulator_array instance in case
+            multiple array models are simulated.
 
         Returns
         -------
@@ -248,4 +257,5 @@ class CorsikaRunner:
             file_type=file_type,
             run_number=run_number,
             mode=mode,
+            model_version_index=model_version_index,
         )

--- a/src/simtools/runners/runner_services.py
+++ b/src/simtools/runners/runner_services.py
@@ -222,7 +222,13 @@ class RunnerServices:
         sub_log_file_dir.mkdir(parents=True, exist_ok=True)
         return sub_log_file_dir.joinpath(f"sub_{file_name}{suffix}")
 
-    def get_file_name(self, file_type, run_number=None, mode=None):
+    def get_file_name(
+        self,
+        file_type,
+        run_number=None,
+        mode=None,
+        model_version_index=0,
+    ):  # pylint: disable=unused-argument
         """
         Get a CORSIKA/sim_telarray style file name for various log and data file types.
 
@@ -234,6 +240,11 @@ class RunnerServices:
             Run number.
         mode: str
             out or err (optional, relevant only for sub_log).
+        model_version_index: int
+            Index of the model version.
+            This is not used here, but in other implementations of this function is
+            used to select the correct simulator_array instance in case
+            multiple array models are simulated.
 
         Returns
         -------

--- a/src/simtools/runners/simtel_runner.py
+++ b/src/simtools/runners/simtel_runner.py
@@ -216,7 +216,14 @@ class SimtelRunner:
         """Return computing resources used."""
         return self.runner_service.get_resources(run_number)
 
-    def get_file_name(self, simulation_software="simtel", file_type=None, run_number=None, mode=""):
+    def get_file_name(
+        self,
+        simulation_software="simtel",
+        file_type=None,
+        run_number=None,
+        mode="",
+        model_version_index=0,
+    ):
         """
         Get the full path of a file for a given run number.
 
@@ -228,6 +235,10 @@ class SimtelRunner:
             File type.
         run_number: int
             Run number.
+        model_version_index: int
+            Index of the model version.
+            This is used to select the correct simulator_array instance in case
+            multiple array models are simulated.
 
         Returns
         -------
@@ -239,5 +250,8 @@ class SimtelRunner:
                 f"simulation_software ({simulation_software}) is not supported in SimulatorArray"
             )
         return self.runner_service.get_file_name(
-            file_type=file_type, run_number=run_number, mode=mode
+            file_type=file_type,
+            run_number=run_number,
+            mode=mode,
+            model_version_index=model_version_index,
         )

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -741,7 +741,10 @@ class Simulator:
         original_version = next(
             model.model_version
             for model in self.array_models
-            if model.model_version in original_log.name
+            if re.search(
+                rf"(?<![0-9A-Za-z]){re.escape(model.model_version)}(?![0-9A-Za-z])",
+                original_log.name,
+            )
         )
 
         for model in self.array_models:

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -1,5 +1,6 @@
 """Simulator class for managing simulations of showers and array of telescopes."""
 
+import gzip
 import logging
 import re
 import shutil
@@ -410,39 +411,66 @@ class Simulator:
 
         """
         keys = ["output", "sub_out", "log", "input", "hist", "corsika_log"]
-        defaults = dict.fromkeys(keys)
-        results = {key: defaults[key] for key in keys}
-        results["output"] = str(
-            self._simulation_runner.get_file_name(file_type="output", run_number=run_number)
-        )
-        results["sub_out"] = str(
-            self._simulation_runner.get_file_name(
-                file_type="sub_log", mode="out", run_number=run_number
-            )
-        )
+        results = {key: [] for key in keys}
 
         if "simtel" in self.simulation_software:
-            results["log"] = str(
-                self._simulation_runner.get_file_name(
-                    file_type="log", simulation_software="simtel", run_number=run_number
-                )
-            )
-            results["input"] = str(file)
-            results["hist"] = str(
-                self._simulation_runner.get_file_name(
-                    file_type="histogram", simulation_software="simtel", run_number=run_number
-                )
-            )
+            results["input"].append(str(file))
 
-        if "corsika" in self.simulation_software:
-            results["corsika_log"] = str(
+        results["sub_out"].append(
+            str(
                 self._simulation_runner.get_file_name(
-                    file_type="corsika_log", simulation_software="corsika", run_number=run_number
+                    file_type="sub_log",
+                    mode="out",
+                    run_number=run_number,
                 )
             )
+        )
+
+        for model_version_index, _ in enumerate(self.array_models):
+            results["output"].append(
+                str(
+                    self._simulation_runner.get_file_name(
+                        file_type="output",
+                        run_number=run_number,
+                        model_version_index=model_version_index,
+                    )
+                )
+            )
+            if "simtel" in self.simulation_software:
+                results["log"].append(
+                    str(
+                        self._simulation_runner.get_file_name(
+                            file_type="log",
+                            simulation_software="simtel",
+                            run_number=run_number,
+                            model_version_index=model_version_index,
+                        )
+                    )
+                )
+                results["hist"].append(
+                    str(
+                        self._simulation_runner.get_file_name(
+                            file_type="histogram",
+                            simulation_software="simtel",
+                            run_number=run_number,
+                            model_version_index=model_version_index,
+                        )
+                    )
+                )
+            if "corsika" in self.simulation_software:
+                results["corsika_log"].append(
+                    str(
+                        self._simulation_runner.get_file_name(
+                            file_type="corsika_log",
+                            simulation_software="corsika",
+                            run_number=run_number,
+                            model_version_index=model_version_index,
+                        )
+                    )
+                )
 
         for key in keys:
-            self._results[key].append(results[key])
+            self._results[key].extend(results[key])
 
     def get_file_list(self, file_type="output"):
         """
@@ -581,6 +609,8 @@ class Simulator:
         """
         Pack simulation output files for registering on the grid.
 
+        Creates separate tarballs for each model version's log files.
+
         Parameters
         ----------
         directory_for_grid_upload: str
@@ -594,7 +624,7 @@ class Simulator:
         log_files = self.get_file_list(file_type="log")
         corsika_log_files = self.get_file_list(file_type="corsika_log")
         histogram_files = self.get_file_list(file_type="hist")
-        tar_file_name = Path(log_files[0]).name.replace("log.gz", "log_hist.tar.gz")
+
         directory_for_grid_upload = (
             Path(directory_for_grid_upload)
             if directory_for_grid_upload
@@ -604,26 +634,36 @@ class Simulator:
         )
         directory_for_grid_upload.mkdir(parents=True, exist_ok=True)
 
-        tar_file_name = directory_for_grid_upload.joinpath(tar_file_name)
+        # If there are more than one model version,
+        # duplicate the corsika log file to have one for each model version with the "right name".
+        if len(self.array_models) > 1 and corsika_log_files:
+            self._copy_corsika_log_file_for_all_versions(corsika_log_files)
 
-        with tarfile.open(tar_file_name, "w:gz") as tar:
-            files_to_tar = (
-                (log_files[:1] if log_files else [])
-                + (histogram_files[:1] if histogram_files else [])
-                + (corsika_log_files[:1] if corsika_log_files else [])
-            )
-            for file_to_tar in files_to_tar:
-                tar.add(file_to_tar, arcname=Path(file_to_tar).name)
+        # Group files by model version
+        for model in self.array_models:
+            model_version = model.model_version
 
-        for file_to_move in [*output_files]:
+            # Filter files for this model version
+            model_logs = [f for f in log_files if model_version in f]
+            model_hists = [f for f in histogram_files if model_version in f]
+            model_corsika_logs = [f for f in corsika_log_files if model_version in f]
+
+            if model_logs:
+                tar_file_name = Path(model_logs[0]).name.replace("log.gz", "log_hist.tar.gz")
+                tar_file_path = directory_for_grid_upload.joinpath(tar_file_name)
+
+                with tarfile.open(tar_file_path, "w:gz") as tar:
+                    files_to_tar = model_logs + model_hists + model_corsika_logs
+                    for file_to_tar in files_to_tar:
+                        tar.add(file_to_tar, arcname=Path(file_to_tar).name)
+
+        for file_to_move in output_files:
             source_file = Path(file_to_move)
             destination_file = directory_for_grid_upload / source_file.name
             if destination_file.exists():
                 self._logger.warning(f"Overwriting existing file: {destination_file}")
-            # Note that this will overwrite previous files which exist in the directory
-            # It should be fine for normal production since each run is on a separate node
-            # so no files are expected there.
             shutil.move(source_file, destination_file)
+
         self._logger.info(f"Output files for the grid placed in {directory_for_grid_upload!s}")
 
     def validate_metadata(self):
@@ -643,3 +683,44 @@ class Simulator:
                 self._logger.warning(
                     f"No sim_telarray file found for model version {model.model_version}: {files}"
                 )
+
+    def _copy_corsika_log_file_for_all_versions(self, corsika_log_files):
+        """
+        Create copies of the CORSIKA log file for each model version.
+
+        Adds a header comment to each copy explaining its relationship to the original.
+
+        Parameters
+        ----------
+        corsika_log_files: list
+            List containing the original CORSIKA log file path.
+
+        """
+        original_log = Path(corsika_log_files[0])
+        # Find which model version the original log belongs to
+        original_version = next(
+            model.model_version
+            for model in self.array_models
+            if model.model_version in original_log.name
+        )
+
+        for model in self.array_models:
+            if model.model_version == original_version:
+                continue
+
+            new_log = original_log.parent / original_log.name.replace(
+                original_version, model.model_version
+            )
+
+            with gzip.open(new_log, "wt") as new_file:
+                new_file.write(
+                    f"###############################################################\n"
+                    f"Copy of CORSIKA log file from model version {original_version}.\n"
+                    f"Applicable also for {model.model_version} (same CORSIKA configuration,\n"
+                    f"different sim_telarray model versions in the same run).\n"
+                    f"###############################################################\n\n"
+                )
+                with gzip.open(original_log, "rt") as orig_file:
+                    shutil.copyfileobj(orig_file, new_file)
+
+            corsika_log_files.append(str(new_log))

--- a/src/simtools/testing/configuration.py
+++ b/src/simtools/testing/configuration.py
@@ -101,7 +101,10 @@ def configure(config, tmp_test_directory, request):
 
     """
     tmp_output_path = create_tmp_output_path(tmp_test_directory, config)
-    model_version_requested = request.config.getoption("--model_version")
+    model_version_requested = request.config.getoption("--model_version").split(",")
+    model_version_requested = (
+        model_version_requested[0] if len(model_version_requested) == 1 else model_version_requested
+    )
 
     if "CONFIGURATION" in config:
         _skip_test_for_model_version(config, model_version_requested)

--- a/src/simtools/testing/configuration.py
+++ b/src/simtools/testing/configuration.py
@@ -101,10 +101,12 @@ def configure(config, tmp_test_directory, request):
 
     """
     tmp_output_path = create_tmp_output_path(tmp_test_directory, config)
-    model_version_requested = request.config.getoption("--model_version").split(",")
+    model_version_requested = request.config.getoption("--model_version")
     model_version_requested = (
-        model_version_requested[0] if len(model_version_requested) == 1 else model_version_requested
+        model_version_requested.split(",") if model_version_requested else None
     )
+    if isinstance(model_version_requested, list) and len(model_version_requested) == 1:
+        model_version_requested = model_version_requested[0]
 
     if "CONFIGURATION" in config:
         _skip_test_for_model_version(config, model_version_requested)

--- a/src/simtools/testing/helpers.py
+++ b/src/simtools/testing/helpers.py
@@ -33,3 +33,24 @@ def _new_testeff_version():
             return False
     except FileNotFoundError as exc:
         raise FileNotFoundError("The testeff executable could not be found.") from exc
+
+
+def skip_multiple_version_test(config, model_version):
+    """Skip a test which is not meant for multiple versions if multiple versions are given."""
+    message = "Skipping test not meant for multiple model versions."
+
+    if not isinstance(model_version, list):
+        return None
+
+    config_model_version = config.get("CONFIGURATION", {}).get("MODEL_VERSION", [])
+
+    if not isinstance(config_model_version, list):
+        config_model_version = [config_model_version]
+
+    if 1 < len(model_version) != len(config_model_version):
+        return message
+
+    if len(model_version) > 1 and len(model_version) != len(config_model_version):
+        return message
+
+    return None

--- a/src/simtools/testing/helpers.py
+++ b/src/simtools/testing/helpers.py
@@ -50,7 +50,4 @@ def skip_multiple_version_test(config, model_version):
     if 1 < len(model_version) != len(config_model_version):
         return message
 
-    if len(model_version) > 1 and len(model_version) != len(config_model_version):
-        return message
-
     return None

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -64,9 +64,20 @@ def _validate_output_files(config, integration_test):
 
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):
     """Test simtel cfg files."""
-    test_simtel_cfg_file = integration_test.get("TEST_SIMTEL_CFG_FILES", {}).get(
-        from_command_line or from_config_file
-    )
+    test_simtel_cfg_file = None
+    test_simtel_cfg_files = integration_test.get("TEST_SIMTEL_CFG_FILES", {})
+    if isinstance(from_command_line, list):
+        for version in from_command_line:
+            if version in test_simtel_cfg_files:
+                test_simtel_cfg_file = test_simtel_cfg_files[version]
+                break
+    elif isinstance(from_config_file, list):
+        for version in from_config_file:
+            if version in test_simtel_cfg_files:
+                test_simtel_cfg_file = test_simtel_cfg_files[version]
+                break
+    else:
+        test_simtel_cfg_file = test_simtel_cfg_files.get(from_command_line or from_config_file)
     if test_simtel_cfg_file:
         _validate_simtel_cfg_files(config, test_simtel_cfg_file)
 

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -64,22 +64,21 @@ def _validate_output_files(config, integration_test):
 
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):
     """Test simtel cfg files."""
-    test_simtel_cfg_file = None
-    test_simtel_cfg_files = integration_test.get("TEST_SIMTEL_CFG_FILES", {})
-    if isinstance(from_command_line, list):
-        for version in from_command_line:
-            if version in test_simtel_cfg_files:
-                test_simtel_cfg_file = test_simtel_cfg_files[version]
-                break
-    elif isinstance(from_config_file, list):
-        for version in from_config_file:
-            if version in test_simtel_cfg_files:
-                test_simtel_cfg_file = test_simtel_cfg_files[version]
-                break
-    else:
-        test_simtel_cfg_file = test_simtel_cfg_files.get(from_command_line or from_config_file)
-    if test_simtel_cfg_file:
-        _validate_simtel_cfg_files(config, test_simtel_cfg_file)
+    cfg_files = integration_test.get("TEST_SIMTEL_CFG_FILES", {})
+    sources = (
+        from_command_line
+        if isinstance(from_command_line, list)
+        else (
+            from_config_file
+            if isinstance(from_config_file, list)
+            else [from_command_line or from_config_file]
+        )
+    )
+    for version in sources:
+        cfg = cfg_files.get(version)
+        if cfg:
+            _validate_simtel_cfg_files(config, cfg)
+            break
 
 
 def _validate_reference_output_file(config, integration_test):

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
@@ -19,7 +19,7 @@ CTA_SIMPIPE:
       CORE_SCATTER: 10 700 m
       DATA_DIRECTORY: simtools-data
       OUTPUT_PATH: simtools-output
-      SIM_TELARRAY_SEEDS: 1745,290
+      SIM_TELARRAY_INSTRUMENT_SEEDS: 1745,290
       CORSIKA_TEST_SEEDS: true
       PACK_FOR_GRID_REGISTER: simtools-grid-output
       LOG_LEVEL: DEBUG

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
@@ -1,0 +1,37 @@
+---
+CTA_SIMPIPE:
+  APPLICATIONS:
+  - APPLICATION: simtools-simulate-prod
+    TEST_NAME: gamma_20_deg_multiple_model_versions
+    CONFIGURATION:
+      SIMULATION_SOFTWARE: corsika_simtel
+      LABEL: multiple_model_versions
+      MODEL_VERSION: [6.0.0, 5.0.0]
+      SITE: South
+      ARRAY_LAYOUT_NAME: alpha
+      PRIMARY: gamma
+      RUN_NUMBER_START: 1
+      NUMBER_OF_RUNS: 1
+      AZIMUTH_ANGLE: South
+      ZENITH_ANGLE: 20
+      NSHOW: 5
+      ENERGY_RANGE: 100 GeV 500 GeV
+      CORE_SCATTER: 10 700 m
+      DATA_DIRECTORY: simtools-data
+      OUTPUT_PATH: simtools-output
+      SIM_TELARRAY_SEEDS: 1745,290
+      CORSIKA_TEST_SEEDS: true
+      PACK_FOR_GRID_REGISTER: simtools-grid-output
+      LOG_LEVEL: DEBUG
+    INTEGRATION_TESTS:
+    - TEST_OUTPUT_FILES:
+      - PATH_DESCRIPTOR: PACK_FOR_GRID_REGISTER
+        FILE: run000001_gamma_za20deg_azm180deg_South_alpha_6.0.0_multiple_model_versions.log_hist.tar.gz
+      - PATH_DESCRIPTOR: PACK_FOR_GRID_REGISTER
+        FILE: run000001_gamma_za20deg_azm180deg_South_alpha_6.0.0_multiple_model_versions.zst
+      - PATH_DESCRIPTOR: PACK_FOR_GRID_REGISTER
+        FILE: run000001_gamma_za20deg_azm180deg_South_alpha_5.0.0_multiple_model_versions.log_hist.tar.gz
+      - PATH_DESCRIPTOR: PACK_FOR_GRID_REGISTER
+        FILE: run000001_gamma_za20deg_azm180deg_South_alpha_5.0.0_multiple_model_versions.zst
+SCHEMA_NAME: application_workflow.metaschema
+SCHEMA_VERSION: 0.3.0

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -47,8 +47,10 @@ def test_applications_from_config(tmp_test_directory, config, request):
     if skip_message:
         pytest.skip(skip_message)
 
+    model_version = request.config.getoption("--model_version").split(",")
+    model_version = model_version[0] if len(model_version) == 1 else model_version
     logger.info(f"Test configuration from config file: {tmp_config}")
-    logger.info(f"Model version: {request.config.getoption('--model_version')}")
+    logger.info(f"Model version: {model_version}")
     logger.info(f"Application configuration: {tmp_config}")
     logger.info(f"Test requirement: {config.get('TEST_REQUIREMENT')}")
     logger.info(f"Test use case: {config.get('TEST_USE_CASE')}")
@@ -65,6 +67,6 @@ def test_applications_from_config(tmp_test_directory, config, request):
 
     validate_output.validate_application_output(
         tmp_config,
-        request.config.getoption("--model_version"),
-        config_file_model_version or request.config.getoption("--model_version"),
+        model_version,
+        config_file_model_version or model_version,
     )

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -49,6 +49,10 @@ def test_applications_from_config(tmp_test_directory, config, request):
 
     model_version = request.config.getoption("--model_version").split(",")
     model_version = model_version[0] if len(model_version) == 1 else model_version
+    skip_message = helpers.skip_multiple_version_test(tmp_config, model_version)
+    if skip_message:
+        pytest.skip(skip_message)
+
     logger.info(f"Test configuration from config file: {tmp_config}")
     logger.info(f"Model version: {model_version}")
     logger.info(f"Application configuration: {tmp_config}")

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -47,8 +47,10 @@ def test_applications_from_config(tmp_test_directory, config, request):
     if skip_message:
         pytest.skip(skip_message)
 
-    model_version = request.config.getoption("--model_version").split(",")
-    model_version = model_version[0] if len(model_version) == 1 else model_version
+    model_version = request.config.getoption("--model_version", default=None)
+    if model_version:
+        model_version = model_version.split(",")
+        model_version = model_version[0] if len(model_version) == 1 else model_version
     skip_message = helpers.skip_multiple_version_test(tmp_config, model_version)
     if skip_message:
         pytest.skip(skip_message)

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import copy
+import gzip
 import logging
 import math
 import shutil
@@ -256,7 +257,7 @@ def test_fill_results(array_simulator, shower_simulator, shower_array_simulator,
     shower_simulator._fill_results(input_file_list[1], run_number=5)
     assert len(shower_simulator.get_file_list("output")) == 1
     assert len(shower_simulator.get_file_list("corsika_log")) == 1
-    assert shower_simulator.get_file_list("hist")[0] is None
+    assert len(shower_simulator.get_file_list("hist")) == 0
 
 
 def test_get_list_of_files(shower_simulator):
@@ -337,15 +338,15 @@ def test_save_file_lists(shower_simulator, mocker, caplog):
     assert "No files to save for output files." in caplog.text
 
 
-def test_pack_for_register(array_simulator, mocker, caplog):
+def test_pack_for_register(array_simulator, mocker, model_version, caplog):
     mocker.patch.object(
         array_simulator,
         "get_file_list",
         side_effect=[
-            ["output_file1", "output_file2"],
-            ["log_file1", "log_file2"],
-            ["hist_file1", "hist_file2"],
-            ["corsika_log_file1", "corsika_log_file2"],
+            [f"output_file_{model_version}_simtel.zst"],
+            [f"log_file_{model_version}_simtel.log.gz"],
+            [f"log_file_corsika_{model_version}.log.gz"],
+            [f"hist_file_{model_version}_hist_log.zst"],
         ],
     )
     mocker.patch("shutil.move")
@@ -360,10 +361,8 @@ def test_pack_for_register(array_simulator, mocker, caplog):
     assert "Output files for the grid placed in" in caplog.text
     tarfile.open.assert_called_once()
     shutil.move.assert_any_call(
-        Path("output_file1"), Path("directory_for_grid_upload/output_file1")
-    )
-    shutil.move.assert_any_call(
-        Path("output_file2"), Path("directory_for_grid_upload/output_file2")
+        Path(f"output_file_{model_version}_simtel.zst"),
+        Path(f"directory_for_grid_upload/output_file_{model_version}_simtel.zst"),
     )
 
 
@@ -414,3 +413,116 @@ def test_validate_metadata(array_simulator, mocker, caplog):
     with caplog.at_level(logging.WARNING):
         array_simulator.validate_metadata()
     assert "No sim_telarray file found for model version 6.0.0:" in caplog.text
+
+
+def test_pack_for_register_with_multiple_versions(
+    io_handler, simulations_args_dict, db_config, mocker, caplog
+):
+    args_dict = copy.deepcopy(simulations_args_dict)
+    args_dict["simulation_software"] = "corsika_simtel"
+    args_dict["label"] = "local-test-shower-array-simulator"
+    model_versions = ["5.0.0", "6.0.0"]
+    args_dict["model_version"] = model_versions
+    local_shower_array_simulator = Simulator(
+        label=args_dict["label"],
+        args_dict=args_dict,
+        mongo_db_config=db_config,
+    )
+
+    # Define file patterns
+    file_patterns = {
+        "output": "output_file_{}_simtel.zst",
+        "log": "log_file_{}_simtel.log.gz",
+        "corsika_log": "log_file_corsika_{}.log.gz",
+        "hist": "hist_file_{}_hist_log.zst",
+    }
+
+    # Generate file lists for side effects
+    side_effects = [
+        [file_patterns["output"].format(v) for v in model_versions],
+        [file_patterns["log"].format(v) for v in model_versions],
+        [file_patterns["corsika_log"].format(model_versions[0])],
+        [file_patterns["hist"].format(v) for v in model_versions],
+    ]
+
+    # Mocking methods and objects
+    mocker.patch.object(local_shower_array_simulator, "get_file_list", side_effect=side_effects)
+    mocker.patch("shutil.move")
+
+    # Create a mock for tarfile.open that returns a mock context manager
+    mock_tar = mocker.MagicMock()
+    mock_tar_cm = mocker.MagicMock()
+    mock_tar_cm.__enter__ = mocker.MagicMock(return_value=mock_tar)
+    mock_tar_cm.__exit__ = mocker.MagicMock(return_value=None)
+    mock_tarfile_open = mocker.patch("tarfile.open", return_value=mock_tar_cm)
+
+    mocker.patch("pathlib.Path.exists", return_value=True)
+    mocker.patch.object(local_shower_array_simulator, "_copy_corsika_log_file_for_all_versions")
+
+    # Call the method
+    with caplog.at_level(logging.INFO):
+        local_shower_array_simulator.pack_for_register("directory_for_grid_upload")
+
+    # Assertions
+    assert "Packing the output files for registering on the grid" in caplog.text
+    assert "Output files for the grid placed in" in caplog.text
+    local_shower_array_simulator._copy_corsika_log_file_for_all_versions.assert_called_once()
+
+    # Verify tarfile operations
+    assert mock_tarfile_open.call_count > 0
+
+    # Generate expected additions using the same patterns
+    expected_additions = []
+    for version in model_versions:
+        for file_type in ["log", "hist"]:
+            filename = file_patterns[file_type].format(version)
+            expected_additions.append((filename, filename))
+
+    # Check tarball additions
+    for filepath, arcname in expected_additions:
+        mock_tar.add.assert_any_call(filepath, arcname=arcname)
+
+    # Check file movement
+    for version in model_versions:
+        output_file = file_patterns["output"].format(version)
+        shutil.move.assert_any_call(
+            Path(output_file),
+            Path(f"directory_for_grid_upload/{output_file}"),
+        )
+
+
+def test_copy_corsika_log_file_for_all_versions(array_simulator, mocker, tmp_test_directory):
+    # Mock array_models with multiple versions
+    array_simulator.array_models = [
+        mocker.Mock(model_version="5.0.0"),
+        mocker.Mock(model_version="6.0.0"),
+    ]
+
+    # Create a temporary directory for log files
+    original_log_dir = tmp_test_directory / "logs"
+    original_log_dir.mkdir()
+
+    # Create a mock original log file
+    original_log_file = original_log_dir / "log_file_5.0.0.log.gz"
+    with gzip.open(original_log_file, "wt") as f:
+        f.write("Original CORSIKA log content.")
+
+    # Mock the input corsika_log_files list
+    corsika_log_files = [str(original_log_file)]
+
+    # Call the method
+    array_simulator._copy_corsika_log_file_for_all_versions(corsika_log_files)
+
+    # Check that the new log file for the second model version was created
+    new_log_file = original_log_dir / "log_file_6.0.0.log.gz"
+    assert new_log_file.exists()
+
+    # Verify the content of the new log file
+    with gzip.open(new_log_file, "rt") as f:
+        content = f.read()
+        assert "Copy of CORSIKA log file from model version 5.0.0." in content
+        assert "Applicable also for 6.0.0" in content
+        assert "Original CORSIKA log content." in content
+
+    # Ensure the new log file was added to the corsika_log_files list
+    assert str(new_log_file) in corsika_log_files

--- a/tests/unit_tests/testing/test_helpers.py
+++ b/tests/unit_tests/testing/test_helpers.py
@@ -70,57 +70,57 @@ def test_new_testeff_version_file_not_found(builtins_open):
 
 
 def test_skip_multiple_version_test_single_version():
-    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
-    model_version = ["v1"]
+    config = {"CONFIGURATION": {"MODEL_VERSION": "5.0.0"}}
+    model_version = ["5.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result is None
 
 
 def test_skip_multiple_version_test_matching_multiple_versions():
-    config = {"CONFIGURATION": {"MODEL_VERSION": ["v1", "v2"]}}
-    model_version = ["v1", "v2"]
+    config = {"CONFIGURATION": {"MODEL_VERSION": ["5.0.0", "6.0.0"]}}
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result is None
 
 
 def test_skip_multiple_version_test_mismatched_multiple_versions():
-    config = {"CONFIGURATION": {"MODEL_VERSION": ["v1"]}}
-    model_version = ["v1", "v2"]
+    config = {"CONFIGURATION": {"MODEL_VERSION": ["5.0.0"]}}
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result == "Skipping test not meant for multiple model versions."
 
 
 def test_skip_multiple_version_test_no_model_version_in_config():
     config = {"CONFIGURATION": {}}
-    model_version = ["v1", "v2"]
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result == "Skipping test not meant for multiple model versions."
 
 
 def test_skip_multiple_version_test_empty_model_version_list():
     config = {"CONFIGURATION": {"MODEL_VERSION": []}}
-    model_version = ["v1", "v2"]
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result == "Skipping test not meant for multiple model versions."
 
 
 def test_skip_multiple_version_test_config_model_version_not_list():
-    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
-    model_version = ["v1", "v2"]
+    config = {"CONFIGURATION": {"MODEL_VERSION": "5.0.0"}}
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result == "Skipping test not meant for multiple model versions."
 
 
 def test_skip_multiple_version_test_no_configuration_key():
     config = {}
-    model_version = ["v1", "v2"]
+    model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result == "Skipping test not meant for multiple model versions."
 
 
 def test_skip_multiple_version_test_single_model_version_no_config_model_version():
     config = {"CONFIGURATION": {}}
-    model_version = ["v1"]
+    model_version = ["5.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result is None
 
@@ -133,7 +133,14 @@ def test_skip_multiple_version_test_empty_model_version():
 
 
 def test_skip_multiple_version_test_model_version_not_a_list():
-    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
-    model_version = "v1"
+    config = {"CONFIGURATION": {"MODEL_VERSION": "5.0.0"}}
+    model_version = "5.0.0"
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None
+
+
+def test_skip_multiple_version_test_model_version_not_list():
+    config = {"CONFIGURATION": {"MODEL_VERSION": ["5.0.0", "6.0.0"]}}
+    model_version = "5.0.0"  # Not a list
     result = helpers.skip_multiple_version_test(config, model_version)
     assert result is None

--- a/tests/unit_tests/testing/test_helpers.py
+++ b/tests/unit_tests/testing/test_helpers.py
@@ -67,3 +67,73 @@ def test_new_testeff_version_file_not_found(builtins_open):
                 FileNotFoundError, match="The testeff executable could not be found."
             ):
                 helpers._new_testeff_version()
+
+
+def test_skip_multiple_version_test_single_version():
+    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
+    model_version = ["v1"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None
+
+
+def test_skip_multiple_version_test_matching_multiple_versions():
+    config = {"CONFIGURATION": {"MODEL_VERSION": ["v1", "v2"]}}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None
+
+
+def test_skip_multiple_version_test_mismatched_multiple_versions():
+    config = {"CONFIGURATION": {"MODEL_VERSION": ["v1"]}}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result == "Skipping test not meant for multiple model versions."
+
+
+def test_skip_multiple_version_test_no_model_version_in_config():
+    config = {"CONFIGURATION": {}}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result == "Skipping test not meant for multiple model versions."
+
+
+def test_skip_multiple_version_test_empty_model_version_list():
+    config = {"CONFIGURATION": {"MODEL_VERSION": []}}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result == "Skipping test not meant for multiple model versions."
+
+
+def test_skip_multiple_version_test_config_model_version_not_list():
+    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result == "Skipping test not meant for multiple model versions."
+
+
+def test_skip_multiple_version_test_no_configuration_key():
+    config = {}
+    model_version = ["v1", "v2"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result == "Skipping test not meant for multiple model versions."
+
+
+def test_skip_multiple_version_test_single_model_version_no_config_model_version():
+    config = {"CONFIGURATION": {}}
+    model_version = ["v1"]
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None
+
+
+def test_skip_multiple_version_test_empty_model_version():
+    config = {"CONFIGURATION": {"MODEL_VERSION": []}}
+    model_version = []
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None
+
+
+def test_skip_multiple_version_test_model_version_not_a_list():
+    config = {"CONFIGURATION": {"MODEL_VERSION": "v1"}}
+    model_version = "v1"
+    result = helpers.skip_multiple_version_test(config, model_version)
+    assert result is None

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -455,3 +455,99 @@ def test_compare_value_from_parameter_dict():
     data_3 = "pixel_list.dat"
     assert validate_output._compare_value_from_parameter_dict(data_1, data_2)
     assert not validate_output._compare_value_from_parameter_dict(data_1, data_3)
+
+
+def test_test_simtel_cfg_files_with_command_line_version(mocker):
+    mock_validate_simtel_cfg_files = mocker.patch(
+        "simtools.testing.validate_output._validate_simtel_cfg_files"
+    )
+    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    integration_test = {
+        "TEST_SIMTEL_CFG_FILES": {
+            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
+            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+        }
+    }
+    from_command_line = ["5.0.0", "6.0.0"]
+    from_config_file = None
+
+    validate_output._test_simtel_cfg_files(
+        config, integration_test, from_command_line, from_config_file
+    )
+
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_6.0.0.cfg")
+
+
+def test_test_simtel_cfg_files_with_config_file_version(mocker):
+    mock_validate_simtel_cfg_files = mocker.patch(
+        "simtools.testing.validate_output._validate_simtel_cfg_files"
+    )
+    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    integration_test = {
+        "TEST_SIMTEL_CFG_FILES": {
+            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
+            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+        }
+    }
+    from_command_line = None
+    from_config_file = ["7.0.0", "8.0.0"]
+
+    validate_output._test_simtel_cfg_files(
+        config, integration_test, from_command_line, from_config_file
+    )
+
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_7.0.0.cfg")
+
+
+def test_test_simtel_cfg_files_with_single_version(mocker):
+    mock_validate_simtel_cfg_files = mocker.patch(
+        "simtools.testing.validate_output._validate_simtel_cfg_files"
+    )
+    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    integration_test = {
+        "TEST_SIMTEL_CFG_FILES": {
+            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
+            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+        }
+    }
+    from_command_line = "6.0.0"
+    from_config_file = None
+
+    validate_output._test_simtel_cfg_files(
+        config, integration_test, from_command_line, from_config_file
+    )
+
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_6.0.0.cfg")
+
+
+def test_test_simtel_cfg_files_no_matching_version(mocker):
+    mock_validate_simtel_cfg_files = mocker.patch(
+        "simtools.testing.validate_output._validate_simtel_cfg_files"
+    )
+    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    integration_test = {
+        "TEST_SIMTEL_CFG_FILES": {
+            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
+            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+        }
+    }
+    from_command_line = ["5.0.0"]
+    from_config_file = ["8.0.0"]
+
+    validate_output._test_simtel_cfg_files(
+        config, integration_test, from_command_line, from_config_file
+    )
+
+    mock_validate_simtel_cfg_files.assert_not_called()
+
+
+def test_test_simtel_cfg_files_no_test_simtel_cfg_files(mocker):
+    mock_validate_simtel_cfg_files = mocker.patch(
+        "simtools.testing.validate_output._validate_simtel_cfg_files"
+    )
+    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    integration_test = {}
+
+    validate_output._test_simtel_cfg_files(config, integration_test, None, None)
+
+    mock_validate_simtel_cfg_files.assert_not_called()


### PR DESCRIPTION
This adds an integration test which runs using two model versions. It required also adding that option in the command line, which resulted in a few changes which do not seem directly related. Also, the packing of the output files is taken care of in this PR, together with copying the CORSIKA log file so that it appears in all tarballs with log files for this particular production.