### PR TITLE
Remove duplication of reading yaml/json files in simtools.utils.general

### DIFF
--- a/docs/changes/1522.maintenance.md
+++ b/docs/changes/1522.maintenance.md
@@ -1,0 +1,1 @@
+Remove duplication of reading yaml/json files in simtools.utils.general.

--- a/src/simtools/utils/general.py
+++ b/src/simtools/utils/general.py
@@ -137,13 +137,9 @@ def collect_data_from_http(url):
                 tmp_file, url, Path(url).suffix.lower(), None
             )
     except TypeError as exc:
-        msg = "Invalid url {url}"
-        _logger.error(msg)
-        raise TypeError(msg) from exc
+        raise TypeError(f"Invalid url {url}") from exc
     except urllib.error.HTTPError as exc:
-        msg = f"Failed to download file from {url}"
-        _logger.error(msg)
-        raise FileNotFoundError(msg) from exc
+        raise FileNotFoundError(f"Failed to download file from {url}") from exc
 
     _logger.debug(f"Downloaded file from {url}")
     return data
@@ -190,7 +186,7 @@ def _collect_data_from_different_file_types(file, file_name, suffix, yaml_docume
 
 
 def _collect_data_from_yaml_file(file, file_name, yaml_document):
-    """Collect data from a yaml file."""
+    """Collect data from a yaml file (allow for multi-document yaml files)."""
     try:
         return yaml.safe_load(file)
     except yaml.constructor.ConstructorError:

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -58,12 +58,10 @@ def test_collect_dict_data(io_handler) -> None:
         gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA, 999)
 
     # document type not supported
-    assert (
+    with pytest.raises(TypeError, match=r"^Failed to read file"):
         gen.collect_data_from_file(
             "tests/resources/run1_proton_za20deg_azm0deg_North_1LST_test-lst-array.corsika.zst"
         )
-        is None
-    )
 
 
 def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
@@ -90,8 +88,8 @@ def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
     with open(test_unsupported, "w") as f:
         f.write("some content")
 
-    result = gen.collect_data_from_file(test_unsupported)
-    assert result is None
+    with pytest.raises(TypeError, match=r"^Failed to read"):
+        gen.collect_data_from_file(test_unsupported)
 
 
 def test_collect_dict_from_url(io_handler) -> None:


### PR DESCRIPTION
Exactly the same logic was used to read files from disk or url and implemented twice. Merged this by using a function.

Also some minor doc string and error message improvements to general.py

