### PR TITLE
Check files before packing into tar

### DIFF
--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -699,6 +699,11 @@ class Simulator:
                 with tarfile.open(tar_file_path, "w:gz") as tar:
                     files_to_tar = model_logs + model_hists + model_corsika_logs
                     for file_to_tar in files_to_tar:
+                        file_path = Path(file_to_tar)
+                        if not file_path.is_file():
+                            raise ValueError(f"Found irregular file while packing: {file_path}")
+                        if file_path.is_symlink():
+                            raise ValueError(f"Found symlink while packing: {file_path}")
                         tar.add(file_to_tar, arcname=Path(file_to_tar).name)
 
         for file_to_move in output_files:


### PR DESCRIPTION
Sonar complaints about tar package - I think this is to avoid 'zip bombing', see https://sonar-cta-dpps.zeuthen.desy.de/security_hotspots?id=gammasim_simtools_AY_ssha9WiFxsX-2oy_w&inNewCodePeriod=true

This PR tries to fix it.