### PR TITLE
Fix short description of laser events

### DIFF
--- a/src/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -12,7 +12,7 @@ description: |-
   The camera lid is assumed to be open, i.e. events will also be subject to NSB.\
   A value of zero means that the data will not contain any such events.
 short_description: |-
-  Laser events for calibration at the start of the run.
+  Laser events used for flat fielding at the start of the run.
 data:
   - type: int64
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -12,7 +12,7 @@ description: |-
   The camera lid is assumed to be open, i.e. events will also be subject to NSB.\
   A value of zero means that the data will not contain any such events.
 short_description: |-
-  Relative variation of laser shots from shot to shot.
+  Laser events for calibration at the start of the run.
 data:
   - type: int64
     unit: dimensionless


### PR DESCRIPTION
Trivial change to fix the short description.

For the record, this parameter does not belong to the ILLN/ILLS (see [issue !18 in the simulation models repo](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/issues/18)), but I think it can wait to be fixed once we implement real calibration devices.