### PR TITLE
Introduce handling of telescope-dependent CORSIKA starting grammage

### DIFF
--- a/docs/changes/1539.feature.md
+++ b/docs/changes/1539.feature.md
@@ -1,0 +1,1 @@
+Allow `corsika_starting_grammage` to be telescope-type dependent.

--- a/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
@@ -1,5 +1,52 @@
 ---
 title: Schema for corsika_starting_grammage model parameter
+version: 0.3.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: corsika_starting_grammage
+description: |-
+  Starting altitude of the primary particle in mass overburden for all showers.
+  This parameter should be set to values other than '0.' for specialized studies
+  only. See CORSIKA manual for details.
+instrument:
+  class: configuration_corsika
+data:
+  - type: dict
+    json_schema:
+      type: array
+      items:
+        type: object
+        properties:
+          instrument:
+            type: string
+            default: null
+            description: "Instrument name."
+          primary_particle:
+            type: string
+            format: common_particle_name
+            default: "default"
+            description: "Primary particle type."
+          value:
+            type: number
+            default: 0.0
+            minimum: 0.0
+        required:
+          - primary_particle
+          - value
+        additionalProperties: false
+activity:
+  setting:
+    - SetParameterFromExternal
+  validation:
+    - ValidateParameterByExpert
+source:
+  - Configuration
+simulation_software:
+  - name: corsika
+...
+---
+title: Schema for corsika_starting_grammage model parameter
 version: 0.2.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -13,6 +13,7 @@ from simtools.corsika.corsika_config import CorsikaConfig, InvalidCorsikaInputEr
 logger = logging.getLogger()
 
 CORSIKA_CONFIG_MODE_PARAMETER = "simtools.corsika.corsika_config.ModelParameter"
+MUON_PLUS_PARTICLE = "muon+"
 
 
 @pytest.fixture
@@ -53,7 +54,7 @@ def corsika_configuration_parameters_muon_grammage(gcm2, corsika_configuration_p
     params["corsika_starting_grammage"] = {
         "value": [
             {
-                "primary_particle": "muon+",
+                "primary_particle": MUON_PLUS_PARTICLE,
                 "value": 10.0,
             },
             {
@@ -74,7 +75,7 @@ def corsika_configuration_parameters_teltype_grammage(gcm2, corsika_configuratio
         "value": [
             {
                 "instrument": "LSTS-design",
-                "primary_particle": "muon+",
+                "primary_particle": MUON_PLUS_PARTICLE,
                 "value": 10.0,
             },
             {
@@ -84,7 +85,7 @@ def corsika_configuration_parameters_teltype_grammage(gcm2, corsika_configuratio
             },
             {
                 "instrument": "SSTS-design",
-                "primary_particle": "muon+",
+                "primary_particle": MUON_PLUS_PARTICLE,
                 "value": 50.0,
             },
             {


### PR DESCRIPTION
Fixing `FIXCHI` (CORSIKA starting grammage) is mostly important for muon simulations. The value is telescope-type dependent.

Related to [gitlab merge request 45](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/45) - please look at the data structure there to understand the change in functionality.

Which telescope to choose?

- in most cases, muon simulations will be single-telescope simulations (meaning: the telescope type used is obviously the one simulated)
- for array-style muon simulations with different telescope types, we choose the starting value highest up in the atmosphere (min value)

Closes #1328 
