### PR TITLE
Address code smell reported by sonar

### DIFF
--- a/src/simtools/runners/corsika_runner.py
+++ b/src/simtools/runners/corsika_runner.py
@@ -257,5 +257,5 @@ class CorsikaRunner:
             file_type=file_type,
             run_number=run_number,
             mode=mode,
-            model_version_index=model_version_index,
+            _model_version_index=model_version_index,
         )

--- a/src/simtools/runners/runner_services.py
+++ b/src/simtools/runners/runner_services.py
@@ -227,7 +227,7 @@ class RunnerServices:
         file_type,
         run_number=None,
         mode=None,
-        model_version_index=0,
+        _model_version_index=0,
     ):  # pylint: disable=unused-argument
         """
         Get a CORSIKA/sim_telarray style file name for various log and data file types.

--- a/src/simtools/runners/simtel_runner.py
+++ b/src/simtools/runners/simtel_runner.py
@@ -256,5 +256,5 @@ class SimtelRunner:
             file_type=file_type,
             run_number=run_number,
             mode=mode,
-            model_version_index=model_version_index,
+            _model_version_index=model_version_index,
         )

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -65,15 +65,12 @@ def _validate_output_files(config, integration_test):
 def _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file):
     """Test simtel cfg files."""
     cfg_files = integration_test.get("TEST_SIMTEL_CFG_FILES", {})
-    sources = (
-        from_command_line
-        if isinstance(from_command_line, list)
-        else (
-            from_config_file
-            if isinstance(from_config_file, list)
-            else [from_command_line or from_config_file]
-        )
-    )
+    if isinstance(from_command_line, list):
+        sources = from_command_line
+    elif isinstance(from_config_file, list):
+        sources = from_config_file
+    else:
+        sources = [from_command_line or from_config_file]
     for version in sources:
         cfg = cfg_files.get(version)
         if cfg:

--- a/tests/unit_tests/testing/test_helpers.py
+++ b/tests/unit_tests/testing/test_helpers.py
@@ -7,6 +7,8 @@ import pytest
 
 from simtools.testing import helpers
 
+SKIPPING_TEST = "Skipping test not meant for multiple model versions."
+
 
 @pytest.fixture
 def new_testeff_version():
@@ -87,35 +89,35 @@ def test_skip_multiple_version_test_mismatched_multiple_versions():
     config = {"CONFIGURATION": {"MODEL_VERSION": ["5.0.0"]}}
     model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
-    assert result == "Skipping test not meant for multiple model versions."
+    assert result == SKIPPING_TEST
 
 
 def test_skip_multiple_version_test_no_model_version_in_config():
     config = {"CONFIGURATION": {}}
     model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
-    assert result == "Skipping test not meant for multiple model versions."
+    assert result == SKIPPING_TEST
 
 
 def test_skip_multiple_version_test_empty_model_version_list():
     config = {"CONFIGURATION": {"MODEL_VERSION": []}}
     model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
-    assert result == "Skipping test not meant for multiple model versions."
+    assert result == SKIPPING_TEST
 
 
 def test_skip_multiple_version_test_config_model_version_not_list():
     config = {"CONFIGURATION": {"MODEL_VERSION": "5.0.0"}}
     model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
-    assert result == "Skipping test not meant for multiple model versions."
+    assert result == SKIPPING_TEST
 
 
 def test_skip_multiple_version_test_no_configuration_key():
     config = {}
     model_version = ["5.0.0", "6.0.0"]
     result = helpers.skip_multiple_version_test(config, model_version)
-    assert result == "Skipping test not meant for multiple model versions."
+    assert result == SKIPPING_TEST
 
 
 def test_skip_multiple_version_test_single_model_version_no_config_model_version():

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -12,6 +12,11 @@ from simtools.testing import validate_output
 
 logging.getLogger().setLevel(logging.DEBUG)
 
+PATH_TO_OUTPUT = "/path/to/output"
+PATCH_TO_VALIDATE_CFG = "simtools.testing.validate_output._validate_simtel_cfg_files"
+PATH_CFG_6 = "/path/to/simtel_cfg_6.0.0.cfg"
+PATH_CFG_7 = "/path/to/simtel_cfg_7.0.0.cfg"
+
 
 @pytest.fixture
 def create_json_file(tmp_test_directory):
@@ -60,7 +65,7 @@ def test_path():
 
 @pytest.fixture
 def output_path():
-    return "/path/to/output"
+    return PATH_TO_OUTPUT
 
 
 @pytest.fixture
@@ -85,7 +90,7 @@ def mock_validate_reference_output_file(mocker):
 
 @pytest.fixture
 def mock_validate_simtel_cfg_files(mocker):
-    return mocker.patch("simtools.testing.validate_output._validate_simtel_cfg_files")
+    return mocker.patch(PATCH_TO_VALIDATE_CFG)
 
 
 @pytest.fixture
@@ -440,7 +445,7 @@ def test_validate_simtel_cfg_files(mocker, test_path):
     mocker.patch("simtools.testing.validate_output._compare_simtel_cfg_files", return_value=True)
     config = {
         "CONFIGURATION": {
-            "OUTPUT_PATH": "/path/to/output",
+            "OUTPUT_PATH": PATH_TO_OUTPUT,
             "MODEL_VERSION": "3.4.5",
             "LABEL": "label",
         },
@@ -458,14 +463,12 @@ def test_compare_value_from_parameter_dict():
 
 
 def test_test_simtel_cfg_files_with_command_line_version(mocker):
-    mock_validate_simtel_cfg_files = mocker.patch(
-        "simtools.testing.validate_output._validate_simtel_cfg_files"
-    )
-    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    mock_validate_simtel_cfg_files = mocker.patch(PATCH_TO_VALIDATE_CFG)
+    config = {"CONFIGURATION": {"OUTPUT_PATH": PATH_TO_OUTPUT}}
     integration_test = {
         "TEST_SIMTEL_CFG_FILES": {
-            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
-            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+            "6.0.0": PATH_CFG_6,
+            "7.0.0": PATH_CFG_7,
         }
     }
     from_command_line = ["5.0.0", "6.0.0"]
@@ -475,18 +478,16 @@ def test_test_simtel_cfg_files_with_command_line_version(mocker):
         config, integration_test, from_command_line, from_config_file
     )
 
-    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_6.0.0.cfg")
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, PATH_CFG_6)
 
 
 def test_test_simtel_cfg_files_with_config_file_version(mocker):
-    mock_validate_simtel_cfg_files = mocker.patch(
-        "simtools.testing.validate_output._validate_simtel_cfg_files"
-    )
-    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    mock_validate_simtel_cfg_files = mocker.patch(PATCH_TO_VALIDATE_CFG)
+    config = {"CONFIGURATION": {"OUTPUT_PATH": PATH_TO_OUTPUT}}
     integration_test = {
         "TEST_SIMTEL_CFG_FILES": {
-            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
-            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+            "6.0.0": PATH_CFG_6,
+            "7.0.0": PATH_CFG_7,
         }
     }
     from_command_line = None
@@ -496,18 +497,16 @@ def test_test_simtel_cfg_files_with_config_file_version(mocker):
         config, integration_test, from_command_line, from_config_file
     )
 
-    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_7.0.0.cfg")
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, PATH_CFG_7)
 
 
 def test_test_simtel_cfg_files_with_single_version(mocker):
-    mock_validate_simtel_cfg_files = mocker.patch(
-        "simtools.testing.validate_output._validate_simtel_cfg_files"
-    )
-    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    mock_validate_simtel_cfg_files = mocker.patch(PATCH_TO_VALIDATE_CFG)
+    config = {"CONFIGURATION": {"OUTPUT_PATH": PATH_TO_OUTPUT}}
     integration_test = {
         "TEST_SIMTEL_CFG_FILES": {
-            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
-            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+            "6.0.0": PATH_CFG_6,
+            "7.0.0": PATH_CFG_7,
         }
     }
     from_command_line = "6.0.0"
@@ -517,18 +516,16 @@ def test_test_simtel_cfg_files_with_single_version(mocker):
         config, integration_test, from_command_line, from_config_file
     )
 
-    mock_validate_simtel_cfg_files.assert_called_once_with(config, "/path/to/simtel_cfg_6.0.0.cfg")
+    mock_validate_simtel_cfg_files.assert_called_once_with(config, PATH_CFG_6)
 
 
 def test_test_simtel_cfg_files_no_matching_version(mocker):
-    mock_validate_simtel_cfg_files = mocker.patch(
-        "simtools.testing.validate_output._validate_simtel_cfg_files"
-    )
-    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    mock_validate_simtel_cfg_files = mocker.patch(PATCH_TO_VALIDATE_CFG)
+    config = {"CONFIGURATION": {"OUTPUT_PATH": PATH_TO_OUTPUT}}
     integration_test = {
         "TEST_SIMTEL_CFG_FILES": {
-            "6.0.0": "/path/to/simtel_cfg_6.0.0.cfg",
-            "7.0.0": "/path/to/simtel_cfg_7.0.0.cfg",
+            "6.0.0": PATH_CFG_6,
+            "7.0.0": PATH_CFG_7,
         }
     }
     from_command_line = ["5.0.0"]
@@ -542,10 +539,8 @@ def test_test_simtel_cfg_files_no_matching_version(mocker):
 
 
 def test_test_simtel_cfg_files_no_test_simtel_cfg_files(mocker):
-    mock_validate_simtel_cfg_files = mocker.patch(
-        "simtools.testing.validate_output._validate_simtel_cfg_files"
-    )
-    config = {"CONFIGURATION": {"OUTPUT_PATH": "/path/to/output"}}
+    mock_validate_simtel_cfg_files = mocker.patch(PATCH_TO_VALIDATE_CFG)
+    config = {"CONFIGURATION": {"OUTPUT_PATH": PATH_TO_OUTPUT}}
     integration_test = {}
 
     validate_output._test_simtel_cfg_files(config, integration_test, None, None)

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -17,6 +17,8 @@ from astropy.table import Table
 import simtools.utils.general as gen
 from simtools.constants import MODEL_PARAMETER_METASCHEMA
 
+FAILED_TO_READ_FILE_ERROR = r"^Failed to read file"
+
 url_desy = "https://www.desy.de"
 url_simtools_main = "https://github.com/gammasim/simtools/"
 url_simtools = "https://raw.githubusercontent.com/gammasim/simtools/main/"
@@ -54,11 +56,11 @@ def test_collect_dict_data(io_handler) -> None:
     _dict = gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA, 0)
     assert _dict["version"] != "0.1.0"
 
-    with pytest.raises(gen.InvalidConfigDataError, match=r"^Failed to read file"):
+    with pytest.raises(gen.InvalidConfigDataError, match=FAILED_TO_READ_FILE_ERROR):
         gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA, 999)
 
     # document type not supported
-    with pytest.raises(TypeError, match=r"^Failed to read file"):
+    with pytest.raises(TypeError, match=FAILED_TO_READ_FILE_ERROR):
         gen.collect_data_from_file(
             "tests/resources/run1_proton_za20deg_azm0deg_North_1LST_test-lst-array.corsika.zst"
         )
@@ -72,7 +74,7 @@ def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
         f.write("invalid: {\n")  # Invalid YAML syntax
 
     # Test with invalid YAML file
-    with pytest.raises(Exception, match=r"^Failed to read file"):
+    with pytest.raises(Exception, match=FAILED_TO_READ_FILE_ERROR):
         gen.collect_data_from_file(test_file)
 
     # Test with invalid JSON file


### PR DESCRIPTION
Addresses code smell accumulated during the DESY power cut, see https://sonar-cta-dpps.zeuthen.desy.de/project/issues?resolved=false&types=CODE_SMELL&inNewCodePeriod=true&id=gammasim_simtools_AY_ssha9WiFxsX-2oy_w

Closes #1536 

Something I learnt: adding a "_" to a function argument tells the linter to ignore it.