### PR TITLE
Docker improvements: linter application; bug fix in extra flags

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -79,6 +79,11 @@ jobs:
         run: |
           pre-commit run --all-files
 
+      - name: Lint docker files
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: ./docker/Dockerfile-*
+
       - name: Lint Code Base
         uses: super-linter/super-linter@v7
         env:

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -79,10 +79,16 @@ jobs:
         run: |
           pre-commit run --all-files
 
+      - name: Get Dockerfile list
+        id: dockerfile-list
+        run: |
+          files=$(find ./docker -name "Dockerfile-*" | paste -sd " " -)
+          echo "docker_files=$files" >> "$GITHUB_OUTPUT"
+
       - name: Lint docker files
         uses: hadolint/hadolint-action@v3.1.0
         with:
-          dockerfile: ./docker/Dockerfile-*
+          dockerfile: ${{ steps.dockerfile-list.outputs.docker_files }}
 
       - name: Lint Code Base
         uses: super-linter/super-linter@v7

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -45,6 +45,12 @@ jobs:
             exit 1
           fi
 
+      - name: Lint Docker files
+        run: |
+          find ./docker -name "Dockerfile-*" -print0 | while IFS= read -r -d '' dockerfile; do
+            docker run --rm -i ghcr.io/hadolint/hadolint < "$dockerfile"
+          done
+
       - name: install packages not included in super-linter
         run: |
           pip install validate-pyproject
@@ -78,18 +84,6 @@ jobs:
       - name: Pre-commit
         run: |
           pre-commit run --all-files
-
-      - name: Get Dockerfile list
-        id: dockerfile-list
-        run: |
-          files=$(find ./docker -name "Dockerfile-*" | paste -sd " " -)
-          echo "docker_files=$files" >> "$GITHUB_OUTPUT"
-
-      - name: Lint Docker files
-        run: |
-          for dockerfile in $(find ./docker -name "Dockerfile-*"); do
-            docker run --rm -i ghcr.io/hadolint/hadolint < "$dockerfile"
-          done
 
       - name: Lint Code Base
         uses: super-linter/super-linter@v7

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -85,10 +85,11 @@ jobs:
           files=$(find ./docker -name "Dockerfile-*" | paste -sd " " -)
           echo "docker_files=$files" >> "$GITHUB_OUTPUT"
 
-      - name: Lint docker files
-        uses: hadolint/hadolint-action@v3.1.0
-        with:
-          dockerfile: ${{ steps.dockerfile-list.outputs.docker_files }}
+      - name: Lint Docker files
+        run: |
+          for dockerfile in $(find ./docker -name "Dockerfile-*"); do
+            docker run --rm -i ghcr.io/hadolint/hadolint < "$dockerfile"
+          done
 
       - name: Lint Code Base
         uses: super-linter/super-linter@v7

--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -89,8 +89,6 @@ jobs:
         uses: super-linter/super-linter@v7
         env:
           VALIDATE_ALL_CODEBASE: false
-          # docker
-          VALIDATE_DOCKERFILE_HADOLINT: true
           # .env file
           VALIDATE_ENV: true
           # language

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,9 +1,19 @@
+# Dockerfile for simtools development.
+#
+# Based on the CORSIKA and sim_telarray image.
+# All dependencies for simtools are installed,
+# but not simtools itself. It is expected that
+# simtools is installed in an external directory
+# mounted in the container.
+#
+# hadolint global ignore=DL3007,DL3013,DL3041
+# (ignore warning about using latest - this is a dev image)
 ARG BUILD_OPT="prod6-baseline"
 ARG HADRONIC_MODEL="qgs2"
 ARG SIMTEL_VERSION="240927"
 ARG CORSIKA_VERSION="77550"
 ARG BERNLOHR_VERSION="1.68"
-FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${SIMTEL_VERSION}-corsika-${CORSIKA_VERSION}-bernlohr-${BERNLOHR_VERSION}-${BUILD_OPT}-${HADRONIC_MODEL}
+FROM ghcr.io/gammasim/simtools-corsika-sim-telarray-${SIMTEL_VERSION}-corsika-${CORSIKA_VERSION}-bernlohr-${BERNLOHR_VERSION}-${BUILD_OPT}-${HADRONIC_MODEL}:latest
 WORKDIR /workdir
 ARG PYTHON_VERSION="3.12"
 
@@ -12,11 +22,12 @@ RUN microdnf update -y && microdnf install -y \
     python${PYTHON_VERSION}-pip python${PYTHON_VERSION}-devel wget && \
     microdnf clean all
 
+# hadolint ignore=SC1091
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
     python${PYTHON_VERSION} -m venv env && \
     source env/bin/activate && \
-    pip install -U pip && \
-    pip install toml-to-requirements && \
+    pip install --no-cache-dir -U pip && \
+    pip install --no-cache-dir toml-to-requirements && \
     toml-to-req --toml-file pyproject.toml --optional-lists dev,doc,tests && \
     pip uninstall -y toml-to-requirements && \
     pip install --no-cache-dir -r requirements.txt

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -6,8 +6,10 @@
 # simtools is installed in an external directory
 # mounted in the container.
 #
-# hadolint global ignore=DL3007,DL3013,DL3041
-# (ignore warning about using latest - this is a dev image)
+# hadolint global ignore=DL3007,DL3013,DL3041,SC1091
+# - DL3007, DL3041: ignore warnings about using latest
+# - DL3013: ignore warnings about installing non-specific versions with microdnf)
+# - SC1091: ignore warning about not being able to source the bashrc
 ARG BUILD_OPT="prod6-baseline"
 ARG HADRONIC_MODEL="qgs2"
 ARG SIMTEL_VERSION="240927"
@@ -22,7 +24,6 @@ RUN microdnf update -y && microdnf install -y \
     python${PYTHON_VERSION}-pip python${PYTHON_VERSION}-devel wget && \
     microdnf clean all
 
-# hadolint ignore=SC1091
 RUN wget --quiet https://raw.githubusercontent.com/gammasim/simtools/main/pyproject.toml && \
     python${PYTHON_VERSION} -m venv env && \
     source env/bin/activate && \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -4,7 +4,7 @@
 # Requires CORSIKA and sim_telarray source code tarballs (plus tarball for
 # CORSIKA optimized build) to be in the same directory as this Dockerfile.
 #
-# hadolint global ignore=DL3013,DL3033,DL3041
+## hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -4,7 +4,9 @@
 # Requires CORSIKA and sim_telarray source code tarballs (plus tarball for
 # CORSIKA optimized build) to be in the same directory as this Dockerfile.
 #
-# hadolint global ignore=DL3013,DL3033,DL3041
+# hadolint global ignore=DL3013,DL3033,DL3041,SC1091
+# - DL3013, DL3033: ignore warnings about installing non-specific versions with microdnf or yum)
+# - SC1091: ignore warning about not being able to source the bashrc
 FROM almalinux:9.5 AS build_image
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
@@ -132,7 +134,6 @@ RUN microdnf update -y && microdnf install -y \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 
-# hadolint ignore=SC1091
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
   && git clone -b "$BUILD_BRANCH" "${SIMTOOLS_REQUIREMENT}" --depth 1 \
   && python${PYTHON_VERSION} -m venv env \

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -6,8 +6,6 @@
 #
 # hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
-WORKDIR /workdir/sim_telarray
-ENV GCC_PATH="/usr/bin/"
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
 ARG HADRONIC_MODEL="qgs2"
@@ -17,6 +15,9 @@ ARG BERNLOHR_VERSION="1.68"
 ARG BUILD_BRANCH=main
 ARG PYTHON_VERSION=3.12
 ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
+
+ENV GCC_PATH="/usr/bin/"
+WORKDIR /workdir/sim_telarray
 
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
@@ -34,7 +35,7 @@ RUN tar -zxf corsika-$CORSIKA_VERSION.tar.gz && \
 
 # Apply patches for non-optimized / optimized CORSIKA
 WORKDIR /workdir/sim_telarray/corsika-$CORSIKA_VERSION
-RUN if [ $CORSIKA_VERSION -eq 77550 ]; then \
+RUN if [ "$CORSIKA_VERSION" = "77550" ]; then \
         patch -b -p0 src/corsika.F < "../corsika-77550.patch"; \
     fi && \
     if [ "$AVX_FLAG" = "no_opt" ]; then \
@@ -46,9 +47,10 @@ RUN if [ $CORSIKA_VERSION -eq 77550 ]; then \
     fi
 
 # Build non-optimized / optimized CORSIKA
-WORKDIR /workdir/sim_telarray/
+WORKDIR /workdir/sim_telarray
 RUN make -C "corsika-$CORSIKA_VERSION" clean && rm -f ./*/*.a lib/*/*.a && \
     AVX_EXTRA_FLAG=$([ "$AVX_FLAG" = "avx512f" ] && echo "-ffp-contract=off" || echo "") && \
+    AVX_EXTRA_FLAG="" && \
     CFLAGS="" && CXXFLAGS="" && FFLAGS="" && \
     if [ "$AVX_FLAG" = "no_opt" ]; then \
         CFLAGS="-g  -std=c99 -O3"; \
@@ -80,7 +82,7 @@ RUN touch corsika-$CORSIKA_VERSION.tar.gz && \
 RUN mv ./corsika-7*/run corsika-run && \
     rm -rf ./corsika-7[0-9]* && \
     find . -name "*.tar.gz" -delete && \
-    find . -name "doc*" -type d -exec rm -rf {} + 2>/dev/null && \
+    find . -name "doc*" -type d -exec rm -rf "{}" + 2>/dev/null && \
     find . -name "*.o" -delete && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
@@ -109,12 +111,12 @@ RUN echo "build_opt: $BUILD_OPT" > ./build_opts.yml && \
     echo "bernlohr_version: $BERNLOHR_VERSION" >> ./build_opts.yml
 
 FROM almalinux:9.5-minimal
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-WORKDIR /workdir
 ARG BUILD_BRANCH=main
 ARG SIMTOOLS_REQUIREMENT="https://github.com/gammasim/simtools.git"
 ARG PYTHON_VERSION=3.12
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
+WORKDIR /workdir
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update -y && microdnf install -y \
     bc \
@@ -126,7 +128,7 @@ RUN microdnf update -y && microdnf install -y \
     gcc-c++ \
     git \
     libgfortran \
-    python${PYTHON_VERSION}-devel && \
+    python${PYTHON_VERSION}-pip && \
     microdnf clean all && \
     rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -1,3 +1,10 @@
+# Dockerfile for production build of the CTAO Simulation Pipeline.
+#
+# Contains CORSIKA (non-optimized / optimized), sim_telarray, and simtools
+# Requires CORSIKA and sim_telarray source code tarballs (plus tarball for
+# CORSIKA optimized build) to be in the same directory as this Dockerfile.
+#
+# hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ENV GCC_PATH="/usr/bin/"
@@ -14,7 +21,8 @@ ARG SIMTOOLS_REQUIREMENT="git+https://github.com/gammasim/simtools.git"
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
     autoconf automake csh patch perl which bzip2 && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 ADD corsika_simtelarray.tar.gz .
 ADD corsikaOptPatch.tar.gz ./corsika-$CORSIKA_VERSION
@@ -25,43 +33,44 @@ RUN tar -zxf corsika-$CORSIKA_VERSION.tar.gz && \
     bernlohr-$BERNLOHR_VERSION.tar.gz
 
 # Apply patches for non-optimized / optimized CORSIKA
-RUN cd corsika-$CORSIKA_VERSION && \
-    if [[ $CORSIKA_VERSION -eq 77550 ]]; then \
-        (cd src && patch -b -p0 corsika.F < "../../corsika-77550.patch"); \
+WORKDIR /workdir/sim_telarray/corsika-$CORSIKA_VERSION
+RUN if [ $CORSIKA_VERSION -eq 77550 ]; then \
+        patch -b -p0 src/corsika.F < "../corsika-77550.patch"; \
     fi && \
-    if [[ "$AVX_FLAG" == "no_opt" ]]; then \
-        ../corsika_build_script $HADRONIC_MODEL generic; \
+    if [ "$AVX_FLAG" = "no_opt" ]; then \
+        ../corsika_build_script "$HADRONIC_MODEL" generic; \
     else \
         ./corsika_opt_patching.sh && \
         autoreconf && \
-        ../corsika_build_script $HADRONIC_MODEL generic cerenkopt vlibm; \
+        ../corsika_build_script "$HADRONIC_MODEL" generic cerenkopt vlibm; \
     fi
 
 # Build non-optimized / optimized CORSIKA
-RUN make -C corsika-$CORSIKA_VERSION clean && rm -f */*.a lib/*/*.a && \
+WORKDIR /workdir/sim_telarray/
+RUN make -C "corsika-$CORSIKA_VERSION" clean && rm -f ./*/*.a lib/*/*.a && \
     AVX_EXTRA_FLAG=$([ "$AVX_FLAG" = "avx512f" ] && echo "-ffp-contract=off" || echo "") && \
     CFLAGS="" && CXXFLAGS="" && FFLAGS="" && \
-    if [[ "$AVX_FLAG" == "no_opt" ]]; then \
+    if [ "$AVX_FLAG" = "no_opt" ]; then \
         CFLAGS="-g  -std=c99 -O3"; \
         CXXFLAGS="-g  -std=c99 -O3"; \
         FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -O3"; \
     else \
-        CFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
-        CXXFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
-        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${avx_512_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
+        CFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${AVX_EXTRA_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
+        CXXFLAGS="-g -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${AVX_EXTRA_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
+        FFLAGS="-g -ffixed-line-length-132 -fno-automatic -frecord-marker=4 -std=legacy -DCERENKOPT -DVLIBM -std=c99 -O3 ${AVX_FLAG:+-m$AVX_FLAG} ${AVX_EXTRA_FLAG} -DVECTOR_SIZE=8 -DVECTOR_LENGTH=8"; \
     fi && \
-    make -C corsika-$CORSIKA_VERSION \
+    make -C "corsika-$CORSIKA_VERSION" \
         CC="${GCC_PATH}/gcc -static" \
         CXX="${GCC_PATH}/g++ -static" \
         CPP="${GCC_PATH}/gcc -static -E" \
         F77="${GCC_PATH}/gfortran -L/lib64/" \
         CFLAGS="${CFLAGS}" \
         CXXFLAGS="${CXXFLAGS}" \
-        FFLAGS="$FFLAGS" \
+        FFLAGS="${FFLAGS}" \
         install
 
 # Rename executable to 'corsika'
-RUN mv -f corsika-$CORSIKA_VERSION/run/corsika$CORSIKA_VERSIONLinux_* corsika-$CORSIKA_VERSION/run/corsika
+RUN mv -f "corsika-${CORSIKA_VERSION}/run/corsika${CORSIKA_VERSION}Linux_"* "corsika-${CORSIKA_VERSION}/run/corsika"
 # Build sim_telarray
 RUN touch corsika-$CORSIKA_VERSION.tar.gz && \
     export NO_CORSIKA=1 EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
@@ -76,29 +85,31 @@ RUN mv ./corsika-7*/run corsika-run && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 # Unzip QGSJet tables; remove tables not needed (e.g. remove qgs3 tables when using qgs2)
-RUN cd corsika-run && \
-    if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
+WORKDIR /workdir/sim_telarray/corsika-run
+RUN if [ "$HADRONIC_MODEL" = "qgs3" ]; then \
         if [ -f qgsdat-III.bz2 ]; then \
             bzip2 -dq qgsdat-III.bz2; \
         fi; \
         rm -f -v qgsdat-II-04.bz2; \
     fi && \
-    if [[ "$HADRONIC_MODEL" == "qgs2" ]]; then \
+    if [ "$HADRONIC_MODEL" = "qgs2" ]; then \
         if [ -f qgsdat-II-04.bz2 ]; then \
             bzip2 -dq qgsdat-II-04.bz2; \
         fi; \
         rm -f -v qgsdat-III.bz2; \
     fi
 
-# create a yml file in workdir with the build options
-RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
-    echo "extra_def: $EXTRA_DEF" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "hadronic_model: $HADRONIC_MODEL" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "avx_flag: $AVX_FLAG" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "corsika_version: $CORSIKA_VERSION" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "bernlohr_version: $BERNLOHR_VERSION" >> /workdir/sim_telarray/build_opts.yml
+# Add a yml file in workdir with the build options
+WORKDIR /workdir/sim_telarray
+RUN echo "build_opt: $BUILD_OPT" > ./build_opts.yml && \
+    echo "extra_def: $EXTRA_DEF" >> ./build_opts.yml && \
+    echo "hadronic_model: $HADRONIC_MODEL" >> ./build_opts.yml && \
+    echo "avx_flag: $AVX_FLAG" >> ./build_opts.yml && \
+    echo "corsika_version: $CORSIKA_VERSION" >> ./build_opts.yml && \
+    echo "bernlohr_version: $BERNLOHR_VERSION" >> ./build_opts.yml
 
 FROM almalinux:9.5-minimal
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /workdir
 ARG BUILD_BRANCH=main
 ARG SIMTOOLS_REQUIREMENT="https://github.com/gammasim/simtools.git"
@@ -116,16 +127,17 @@ RUN microdnf update -y && microdnf install -y \
     git \
     libgfortran \
     python${PYTHON_VERSION}-devel && \
-    microdnf clean all
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 
+# hadolint ignore=SC1091
 RUN BUILD_BRANCH=$(echo $BUILD_BRANCH | sed 's#refs/tags/##') \
-  && git clone -b $BUILD_BRANCH ${SIMTOOLS_REQUIREMENT} --depth 1 \
+  && git clone -b "$BUILD_BRANCH" "${SIMTOOLS_REQUIREMENT}" --depth 1 \
   && python${PYTHON_VERSION} -m venv env \
   && source env/bin/activate \
-  && pip install -U pip \
+  && pip install --no-cache-dir -U pip \
   && pip install --no-cache-dir "git+${SIMTOOLS_REQUIREMENT}@${BUILD_BRANCH}" \
-  && echo ". /workdir/env/bin/activate" >> ~/.bashrc t
+  && echo ". /workdir/env/bin/activate" >> ~/.bashrc
 
 ENV SIMTEL_PATH="/workdir/sim_telarray"
 ENV PATH="/workdir/env/bin/:$PATH"
-SHELL ["/bin/bash", "-c"]

--- a/docker/Dockerfile-prod-opt
+++ b/docker/Dockerfile-prod-opt
@@ -4,7 +4,7 @@
 # Requires CORSIKA and sim_telarray source code tarballs (plus tarball for
 # CORSIKA optimized build) to be in the same directory as this Dockerfile.
 #
-## hadolint global ignore=DL3013,DL3033,DL3041
+# hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -4,6 +4,8 @@
 # Used as base image for the simtools-dev image.
 #
 # hadolint global ignore=DL3013,DL3033,DL3041
+# - DL3041: ignore warnings about using latest
+# - DL3013, DL3033: ignore warnings about installing non-specific versions with microdnf or yum)
 FROM almalinux:9.5 AS build_image
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -1,3 +1,9 @@
+# Dockerfile for CORSIKA and sim_telarray.
+#
+# Contains CORSIKA (non-optimized) and sim_telarray.
+# Used as base image for the simtools-dev image.
+#
+# hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
 WORKDIR /workdir/sim_telarray
 ARG BUILD_OPT="prod6-sc"
@@ -9,38 +15,48 @@ ARG BERNLOHR_VERSION="1.68"
 
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
-    csh patch perl which && \
-    yum clean all
+    csh patch perl which bzip2 && \
+    yum clean all && \
+    rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 ADD corsika_simtelarray.tar.gz .
 RUN rm -f examples-with-data.tar.gz && \
     rm -f sim_telarray_config.tar.gz && \
     export EXTRA_DEFINES="${EXTRA_DEF}" && ./build_all $BUILD_OPT $HADRONIC_MODEL gsl
 
-# corsika source code is removed to follow
-# the corsika non-distribution policy.
+# CORSIKA source code is removed to follow
+# the CORSIKA non-distribution policy.
 RUN mv ./corsika-7*/run corsika-run && \
     rm -rf ./corsika-7[0-9]* && \
     find . -name "*.tar.gz" -delete && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
-# remove unnecessary large QGSJet tables (e.g. remove qgs3 tables when using qgs2)
-RUN if [[ "$HADRONIC_MODEL" == "qgs3" ]]; then \
-        find . -name "qgsdat-II-04.bz2" -exec rm -fv {} \; ; \
+# Unzip QGSJet tables; remove tables not needed (e.g. remove qgs3 tables when using qgs2)
+WORKDIR /workdir/sim_telarray/corsika-run
+RUN if [ "$HADRONIC_MODEL" = "qgs3" ]; then \
+        if [ -f qgsdat-III.bz2 ]; then \
+            bzip2 -dq qgsdat-III.bz2; \
+        fi; \
+        rm -f -v qgsdat-II-04.bz2; \
     fi && \
-    if [[ "$HADRONIC_MODEL" == "qgs2" ]]; then \
-        find . -name "qgsdat-III.bz2" -exec rm -fv {} \; ; \
+    if [ "$HADRONIC_MODEL" = "qgs2" ]; then \
+        if [ -f qgsdat-II-04.bz2 ]; then \
+            bzip2 -dq qgsdat-II-04.bz2; \
+        fi; \
+        rm -f -v qgsdat-III.bz2; \
     fi
 
-# create a yml file in workdir with the build options
-RUN echo "build_opt: $BUILD_OPT" > /workdir/sim_telarray/build_opts.yml && \
-    echo "extra_def: $EXTRA_DEF" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "hadronic_model: $HADRONIC_MODEL" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "avx_flag: $AVX_FLAG" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "corsika_version: $CORSIKA_VERSION" >> /workdir/sim_telarray/build_opts.yml && \
-    echo "bernlohr_version: $BERNLOHR_VERSION" >> /workdir/sim_telarray/build_opts.yml
+# Add a yml file in workdir with the build options
+WORKDIR /workdir/sim_telarray
+RUN echo "build_opt: $BUILD_OPT" > ./build_opts.yml && \
+    echo "extra_def: $EXTRA_DEF" >> ./build_opts.yml && \
+    echo "hadronic_model: $HADRONIC_MODEL" >> ./build_opts.yml && \
+    echo "avx_flag: $AVX_FLAG" >> ./build_opts.yml && \
+    echo "corsika_version: $CORSIKA_VERSION" >> ./build_opts.yml && \
+    echo "bernlohr_version: $BERNLOHR_VERSION" >> ./build_opts.yml
 
 FROM almalinux:9.5-minimal
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /workdir
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
 
@@ -50,10 +66,11 @@ RUN microdnf update -y && microdnf install -y \
     gsl-devel \
     gcc-fortran \
     procps && \
-    microdnf clean all
+    microdnf clean all && \
+    rm -rf /var/cache/dnf/* /tmp/* /var/tmp/*
 
 # create a symbolic link to the corsika executable
-RUN cprog=$(/bin/ls /workdir/sim_telarray/corsika-run/corsika*$(uname)_* 2>/dev/null | tail -1) && \
-    ln -sf $cprog /workdir/sim_telarray/corsika-run/corsika
+RUN cprog=$(/bin/ls /workdir/sim_telarray/corsika-run/corsika*"$(uname)"_* 2>/dev/null | tail -1) && \
+    ln -sf "$cprog" /workdir/sim_telarray/corsika-run/corsika
 
 ENV SIMTEL_PATH="/workdir/sim_telarray"

--- a/docker/Dockerfile-simtelarray
+++ b/docker/Dockerfile-simtelarray
@@ -5,13 +5,15 @@
 #
 # hadolint global ignore=DL3013,DL3033,DL3041
 FROM almalinux:9.5 AS build_image
-WORKDIR /workdir/sim_telarray
 ARG BUILD_OPT="prod6-sc"
 ARG EXTRA_DEF="-DMAXIMUM_TELESCOPES=128"
 ARG HADRONIC_MODEL="qgs2"
 ARG AVX_FLAG="no_opt"
 ARG CORSIKA_VERSION="77550"
 ARG BERNLOHR_VERSION="1.68"
+
+ENV GCC_PATH="/usr/bin/"
+WORKDIR /workdir/sim_telarray
 
 RUN yum update -y && yum install -y \
     gcc-fortran gsl-devel libgfortran \
@@ -56,9 +58,9 @@ RUN echo "build_opt: $BUILD_OPT" > ./build_opts.yml && \
     echo "bernlohr_version: $BERNLOHR_VERSION" >> ./build_opts.yml
 
 FROM almalinux:9.5-minimal
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-WORKDIR /workdir
 COPY --from=build_image /workdir/sim_telarray/ /workdir/sim_telarray/
+WORKDIR /workdir
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN microdnf update -y && microdnf install -y \
     bc \

--- a/docs/changes/1544.maintenance.md
+++ b/docs/changes/1544.maintenance.md
@@ -1,1 +1,1 @@
-Docker file improvements: linter application; bug fix in extra flags for optimized CORSIKA compilation.
+Docker file improvements: linter application; bugfix in extra flags for optimized CORSIKA compilation.

--- a/docs/changes/1544.maintenance.md
+++ b/docs/changes/1544.maintenance.md
@@ -1,0 +1,1 @@
+Docker file improvements: linter application; bug fix in extra flags for optimized CORSIKA compilation.


### PR DESCRIPTION
This maintenance PR:

1. fixes a bug in setting the avx 512 instruction (used an undefined variable `avx_512_FLAG`)
2. apply hadolint linter comments
3. synchronized 'Dockerfile-prod-opt` as much as possible with the docker file in SimPipe (see [here](https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simpipe/-/blob/main/Dockerfile?ref_type=heads) and [merge request](https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simpipe/-/merge_requests/24))
4. add a docstring on top of the docker files
5. fix CI-linter workflow and run hadolint in a separate step; tested that this actually works (in contrast to superlinter; which seems not to pick up the errors / issues in the docker file) with this [action workflow](https://github.com/gammasim/simtools/actions/runs/14797476811/job/41548021222)

On 3.: need to discuss this how to avoid having almost identical dockerfiles here in simtools and in SimPipe.

Closes #1538 

