### PR TITLE
Reduce number of log-messages (INFO) for uploaded model parameters to DB

### DIFF
--- a/docs/changes/1559.maintenance.md
+++ b/docs/changes/1559.maintenance.md
@@ -1,0 +1,1 @@
+Reduce number of log-messages (INFO) for uploaded model parameters to DB.

--- a/src/simtools/db/db_handler.py
+++ b/src/simtools/db/db_handler.py
@@ -759,7 +759,7 @@ class DatabaseHandler:
         """
         db_name = self._get_db_name(db_name)
         collection = self.get_collection(db_name, "production_tables")
-        self._logger.info(f"Adding production for {production_table.get('collection')} to to DB")
+        self._logger.debug(f"Adding production for {production_table.get('collection')} to to DB")
         collection.insert_one(production_table)
         DatabaseHandler.production_table_cached.clear()
 
@@ -809,13 +809,13 @@ class DatabaseHandler:
                 raise ValueError(f"File is not UTF-8 encoded: {file_path}")
             files_to_add_to_db.add(f"{file_path}")
 
-        self._logger.info(
+        self._logger.debug(
             f"Adding a new entry to DB {db_name} and collection {collection_name}:\n{par_dict}"
         )
         collection.insert_one(par_dict)
 
         for file_to_insert_now in files_to_add_to_db:
-            self._logger.info(f"Will also add the file {file_to_insert_now} to the DB")
+            self._logger.debug(f"Will also add the file {file_to_insert_now} to the DB")
             self.insert_file_to_db(file_to_insert_now, db_name)
 
         self._reset_parameter_cache()

--- a/src/simtools/db/db_model_upload.py
+++ b/src/simtools/db/db_model_upload.py
@@ -27,7 +27,7 @@ def add_values_from_json_to_db(file, collection, db, db_name, file_prefix):
         Path to location of all additional files to be uploaded.
     """
     par_dict = gen.collect_data_from_file(file_name=file)
-    logger.info(
+    logger.debug(
         f"Adding the following parameter to the DB: {par_dict['parameter']} "
         f"version {par_dict['parameter_version']} "
         f"(collection {collection} in database {db_name})"
@@ -120,7 +120,7 @@ def _read_production_table(model_dict, file, model_name):
         },
     )
     parameter_dict = gen.collect_data_from_file(file_name=file)
-    logger.info(f"Reading production table for {array_element} (collection {collection})")
+    logger.debug(f"Reading production table for {array_element} (collection {collection})")
     try:
         if array_element in ("configuration_corsika", "configuration_sim_telarray"):
             model_dict[collection]["parameters"] = parameter_dict["parameters"]


### PR DESCRIPTION
Uploading the model parameters to the DB results in a huge number of log messages (several messages per parameter and per telescope), which makes debugging hard (especially on the github/gitlab CI, where it means endless scrolling). Additional, some messages are almost identical (e.g., both the `db_model_upload` and the `db_handler` module is reporting `Adding production table for..`, while one is calling the other).

This PR changes the log-level for some of the messages from INFO to DEBUG to reduce the number of messages.
