### PR TITLE
Add the sequential command line argument 

### DIFF
--- a/docs/changes/1561.feature.md
+++ b/docs/changes/1561.feature.md
@@ -1,0 +1,1 @@
+Add the sequential option to simulations using multipipe. With this option the CORSIKA and sim_telarray instances run in sequential order as far as possible. This mode is useful particularly on the grid, where typically we request a single core per job.

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -142,6 +142,17 @@ def _parse(description=None):
         type=int,
         required=False,
     )
+    sim_telarray_seed_group.add_argument(
+        "--sequential",
+        help=(
+            "If set to true, run CORSIKA and sim_telarray instances in sequential order "
+            "as far as possible. This mode is useful particularly on the grid, "
+            "where typically we request a single core per job. "
+            "If not set, the CORSIKA and sim_telarray instances are run in parallel."
+        ),
+        type=bool,
+        default=False,
+    )
     return config.initialize(
         db_config=True,
         job_submission=True,

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -122,6 +122,17 @@ def _parse(description=None):
         required=False,
         default=False,
     )
+    config.parser.add_argument(
+        "--sequential",
+        help=(
+            "If set to true, run CORSIKA and sim_telarray instances in sequential order "
+            "as far as possible. This mode is useful particularly on the grid, "
+            "where typically we request a single core per job. "
+            "If not set, the CORSIKA and sim_telarray instances are run in parallel."
+        ),
+        action="store_true",
+        default=False,
+    )
     sim_telarray_seed_group = config.parser.add_argument_group(
         title="Random seeds for sim_telarray instrument setup",
     )
@@ -141,17 +152,6 @@ def _parse(description=None):
         help="Number of random instrument instances initialized in sim_telarray.",
         type=int,
         required=False,
-    )
-    sim_telarray_seed_group.add_argument(
-        "--sequential",
-        help=(
-            "If set to true, run CORSIKA and sim_telarray instances in sequential order "
-            "as far as possible. This mode is useful particularly on the grid, "
-            "where typically we request a single core per job. "
-            "If not set, the CORSIKA and sim_telarray instances are run in parallel."
-        ),
-        type=bool,
-        default=False,
     )
     return config.initialize(
         db_config=True,

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -125,10 +125,8 @@ def _parse(description=None):
     config.parser.add_argument(
         "--sequential",
         help=(
-            "If set to true, run CORSIKA and sim_telarray instances in sequential order "
-            "as far as possible. This mode is useful particularly on the grid, "
-            "where typically we request a single core per job. "
-            "If not set, the CORSIKA and sim_telarray instances are run in parallel."
+            "Enables single-core mode (as far as possible); "
+            "otherwise, CORSIKA and sim_telarray run in parallel."
         ),
         action="store_true",
         default=False,

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -42,6 +42,7 @@ class CorsikaSimtelRunner:
         keep_seeds=False,
         use_multipipe=False,
         sim_telarray_seeds=None,
+        sequential=False,
     ):
         self._logger = logging.getLogger(__name__)
         self.corsika_config = (
@@ -53,6 +54,7 @@ class CorsikaSimtelRunner:
         self._simtel_path = simtel_path
         self.sim_telarray_seeds = sim_telarray_seeds
         self.label = label
+        self.sequential = "--sequential" if sequential else ""
 
         self.base_corsika_config.set_output_file_and_directory(use_multipipe)
         self.corsika_runner = CorsikaRunner(
@@ -167,7 +169,8 @@ class CorsikaSimtelRunner:
         )
         with open(multipipe_script, "w", encoding="utf-8") as file:
             multipipe_command = Path(self._simtel_path).joinpath(
-                f"sim_telarray/bin/multipipe_corsika -c {multipipe_file} || echo 'Fan-out failed'"
+                f"sim_telarray/bin/multipipe_corsika -c {multipipe_file} {self.sequential} "
+                "|| echo 'Fan-out failed'"
             )
             file.write(f"{multipipe_command}")
 

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -301,6 +301,8 @@ class Simulator:
             runner_args["keep_seeds"] = self.args_dict.get("corsika_test_seeds", False)
         if runner_class is not CorsikaRunner:
             runner_args["sim_telarray_seeds"] = self.sim_telarray_seeds
+        if runner_class is CorsikaSimtelRunner:
+            runner_args["sequential"] = self.args_dict.get("sequential", False)
 
         return runner_class(**runner_args)
 

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -115,6 +115,31 @@ def test_write_multipipe_script(corsika_simtel_runner):
         assert "bin/multipipe_corsika" in script_content
         assert f"-c {multipipe_file}" in script_content
         assert "'Fan-out failed'" in script_content
+        assert "--sequential" not in script_content
+
+
+def test_write_multipipe_script_sequential(corsika_simtel_runner):
+    # Set the sequential attribute
+    corsika_simtel_runner.sequential = "--sequential"
+
+    # Export and write the multipipe script
+    corsika_simtel_runner._export_multipipe_script(run_number=1)
+    multipipe_file = Path(
+        corsika_simtel_runner.base_corsika_config.config_file_path.parent
+    ).joinpath(corsika_simtel_runner.base_corsika_config.get_corsika_config_file_name("multipipe"))
+    corsika_simtel_runner._write_multipipe_script(multipipe_file)
+    script = Path(corsika_simtel_runner.base_corsika_config.config_file_path.parent).joinpath(
+        "run_cta_multipipe"
+    )
+
+    # Assertions
+    assert script.exists()
+    with open(script) as f:
+        script_content = f.read()
+        assert "bin/multipipe_corsika" in script_content
+        assert f"-c {multipipe_file}" in script_content
+        assert "'Fan-out failed'" in script_content
+        assert "--sequential" in script_content
 
 
 def test_get_file_name(corsika_simtel_runner, simulation_file):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -20,6 +20,8 @@ from simtools.simulator import InvalidRunsToSimulateError, Simulator
 
 logger = logging.getLogger()
 
+CORSIKA_CONFIG_MOCK_PATCH = "simtools.simulator.CorsikaConfig"
+
 
 @pytest.fixture
 def input_file_list():
@@ -557,7 +559,7 @@ def test_get_seed_for_random_instrument_instances(shower_simulator):
 
 def test_initialize_simulation_runner_with_corsika(shower_simulator, db_config, mocker):
     # Mock CorsikaConfig to avoid actual initialization
-    mock_corsika_config = mocker.patch("simtools.simulator.CorsikaConfig", autospec=True)
+    mock_corsika_config = mocker.patch(CORSIKA_CONFIG_MOCK_PATCH, autospec=True)
     mock_corsika_runner = mocker.patch("simtools.simulator.CorsikaRunner", autospec=True)
 
     # Call the method
@@ -583,7 +585,7 @@ def test_initialize_simulation_runner_with_corsika(shower_simulator, db_config, 
 def test_initialize_simulation_runner_with_sim_telarray(array_simulator, db_config, mocker):
     # Mock SimulatorArray to avoid actual initialization
     mock_simulator_array = mocker.patch("simtools.simulator.SimulatorArray", autospec=True)
-    mock_corsika_config = mocker.patch("simtools.simulator.CorsikaConfig", autospec=True)
+    mock_corsika_config = mocker.patch(CORSIKA_CONFIG_MOCK_PATCH, autospec=True)
 
     # Call the method
     simulation_runner = array_simulator._initialize_simulation_runner(db_config)
@@ -603,7 +605,7 @@ def test_initialize_simulation_runner_with_corsika_sim_telarray(
     shower_array_simulator, db_config, mocker
 ):
     # Mock CorsikaConfig and CorsikaSimtelRunner to avoid actual initialization
-    mock_corsika_config = mocker.patch("simtools.simulator.CorsikaConfig", autospec=True)
+    mock_corsika_config = mocker.patch(CORSIKA_CONFIG_MOCK_PATCH, autospec=True)
     mock_corsika_simtel_runner = mocker.patch(
         "simtools.simulator.CorsikaSimtelRunner", autospec=True
     )


### PR DESCRIPTION
Add the sequential option for simulations using multipipe. With this option the CORSIKA and sim_telarray instances run in sequential order as far as possible. This mode is useful particularly on the grid, where typically we request a single core per job.

Closes #1552.