### PR TITLE
Improve the run number arguments

### DIFF
--- a/docs/changes/1562.maintenance.md
+++ b/docs/changes/1562.maintenance.md
@@ -1,0 +1,1 @@
+Replace the "run_number_start" argument with "run_number_offset" (clearer) and re-introduce the "run_number" argument to allow specifying a run number (to which the offset is added).

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -389,8 +389,14 @@ class CommandLineParser(argparse.ArgumentParser):
                 "type": int,
                 "required": False,
             },
-            "run_number_start": {
-                "help": "Run number for the first run.",
+            "run_number_offset": {
+                "help": "An offset for the run number to be simulated.",
+                "type": int,
+                "required": False,
+                "default": 0,
+            },
+            "run_number": {
+                "help": "Run number to be simulated.",
                 "type": int,
                 "required": True,
                 "default": 1,

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -123,7 +123,8 @@ simtools-simulate-prod \\
     --nshow {args_dict["nshow"]} \\
     --energy_range {energy_range_string} \\
     --core_scatter {core_scatter_string} \\
-    --run_number_start $((process_id + {args_dict["run_number_start"]})) \\
+    --run_number_offset $((process_id)) \\
+    --run_number {args_dict["run_number"]} \\
     --number_of_runs 1 \\
     --submit_engine \"local\" \\
     --data_directory /tmp/simtools-data \\

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -123,8 +123,8 @@ simtools-simulate-prod \\
     --nshow {args_dict["nshow"]} \\
     --energy_range {energy_range_string} \\
     --core_scatter {core_scatter_string} \\
-    --run_number_offset $((process_id)) \\
-    --run_number {args_dict["run_number"]} \\
+    --run_number $((process_id)) \\
+    --run_number_offset {args_dict["run_number_offset"]} \\
     --number_of_runs 1 \\
     --submit_engine \"local\" \\
     --data_directory /tmp/simtools-data \\

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -181,7 +181,7 @@ class Simulator:
         """
         Initialize run list using the configuration values.
 
-        Uses 'run_number_offset', 'run_number' and 'number_of_runs' arguments
+        Uses 'run_number', 'run_number_offset' and 'number_of_runs' arguments
         to create a list of run numbers.
 
         Returns
@@ -192,7 +192,8 @@ class Simulator:
         Raises
         ------
         KeyError
-            If 'run_number' is not found in the configuration.
+            If 'run_number', 'run_number_offset' and 'number_of_runs' are
+            not found in the configuration.
         """
         try:
             offset_run_number = self.args_dict["run_number_offset"] + self.args_dict["run_number"]

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -195,18 +195,17 @@ class Simulator:
             If 'run_number' is not found in the configuration.
         """
         try:
+            offset_run_number = self.args_dict["run_number_offset"] + self.args_dict["run_number"]
             if self.args_dict["number_of_runs"] <= 1:
                 return self._validate_run_list_and_range(
-                    run_list=self.args_dict["run_number_offset"] + self.args_dict["run_number"],
+                    run_list=offset_run_number,
                     run_range=None,
                 )
             return self._validate_run_list_and_range(
                 run_list=None,
                 run_range=[
-                    self.args_dict["run_number_offset"] + self.args_dict["run_number"],
-                    self.args_dict["run_number_offset"]
-                    + self.args_dict["run_number"]
-                    + self.args_dict["number_of_runs"],
+                    offset_run_number,
+                    offset_run_number + self.args_dict["number_of_runs"],
                 ],
             )
         except KeyError as exc:

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -179,7 +179,10 @@ class Simulator:
 
     def _initialize_run_list(self):
         """
-        Initialize run list using the configuration values 'run_number_start' and 'number_of_runs'.
+        Initialize run list using the configuration values.
+
+        Uses 'run_number_offset', 'run_number' and 'number_of_runs' arguments
+        to create a list of run numbers.
 
         Returns
         -------
@@ -189,19 +192,27 @@ class Simulator:
         Raises
         ------
         KeyError
-            If 'run_number_start' or 'number_of_runs' are not found in the configuration.
+            If 'run_number' is not found in the configuration.
         """
         try:
+            if self.args_dict["number_of_runs"] <= 1:
+                return self._validate_run_list_and_range(
+                    run_list=self.args_dict["run_number_offset"] + self.args_dict["run_number"],
+                    run_range=None,
+                )
             return self._validate_run_list_and_range(
                 run_list=None,
                 run_range=[
-                    self.args_dict["run_number_start"],
-                    self.args_dict["run_number_start"] + self.args_dict["number_of_runs"],
+                    self.args_dict["run_number_offset"] + self.args_dict["run_number"],
+                    self.args_dict["run_number_offset"]
+                    + self.args_dict["run_number"]
+                    + self.args_dict["number_of_runs"],
                 ],
             )
         except KeyError as exc:
             self._logger.error(
-                "Error in initializing run list (missing 'run_number_start' or 'number_of_runs')"
+                "Error in initializing run list "
+                "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
             )
             raise exc
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,7 +324,8 @@ def corsika_config_data(model_version):
     """Corsika configuration data (as given by CorsikaConfig)."""
     return {
         "nshow": 100,
-        "run_number_start": 0,
+        "run_number_offset": 0,
+        "run_number": 1,
         "number_of_runs": 10,
         "event_number_first_shower": 1,
         "zenith_angle": 20 * u.deg,

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: test_layout
       PRIMARY: gamma
-      RUN_NUMBER_START: 10
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 10
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_corsika_corsika_particle_id.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_North_corsika_corsika_particle_id.yml
@@ -11,7 +11,8 @@ CTA_SIMPIPE:
       ARRAY_LAYOUT_NAME: test_layout
       PRIMARY: 1
       PRIMARY_ID_TYPE: corsika7_id
-      RUN_NUMBER_START: 10
+      RUN_NUMBER_OFFSET: 9
+      RUN_NUMBER: 1
       NUMBER_OF_RUNS: 2
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_for_trigger_rates.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_for_trigger_rates.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: 4mst
       PRIMARY: proton
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 2
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_South_pack_for_grid.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: test_layout
       PRIMARY: gamma
-      RUN_NUMBER_START: 10
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 10
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_az0deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_az0deg_South_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_multiple_model_versions.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_North_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 40
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_40_deg_South_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: beta
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 40
       NSHOW: 5

--- a/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_North_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 10

--- a/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_diffuse_20_deg_South_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: gamma
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 10

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_North.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_North.yml
@@ -13,8 +13,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: test_layout
       PRIMARY: gamma
-      RUN_NUMBER: 1
-      RUN_NUMBER_OFFSET: 9
+      RUN_NUMBER: 10
       NUMBER_OF_RUNS: 1
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20

--- a/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_North.yml
+++ b/tests/integration_tests/config/simulate_prod_htcondor_generator_gamma_20_deg_North.yml
@@ -13,7 +13,8 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: test_layout
       PRIMARY: gamma
-      RUN_NUMBER_START: 10
+      RUN_NUMBER: 1
+      RUN_NUMBER_OFFSET: 9
       NUMBER_OF_RUNS: 1
       AZIMUTH_ANGLE: North
       ZENITH_ANGLE: 20

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_North_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: North
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: proton
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 10

--- a/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
+++ b/tests/integration_tests/config/simulate_prod_proton_20_deg_South_check_output.yml
@@ -10,8 +10,7 @@ CTA_SIMPIPE:
       SITE: South
       ARRAY_LAYOUT_NAME: alpha
       PRIMARY: proton
-      RUN_NUMBER_START: 1
-      NUMBER_OF_RUNS: 1
+      RUN_NUMBER: 1
       AZIMUTH_ANGLE: South
       ZENITH_ANGLE: 20
       NSHOW: 10

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -79,8 +79,8 @@ simtools-simulate-prod \\
     --nshow {args_dict["nshow"]} \\
     --energy_range "{e_range_low} GeV {e_range_high} GeV" \\
     --core_scatter "{core_scatter_low} {core_scatter_high} m" \\
-    --run_number_offset $((process_id)) \\
-    --run_number {args_dict["run_number"]} \\
+    --run_number $((process_id)) \\
+    --run_number_offset {args_dict["run_number_offset"]} \\
     --number_of_runs 1 \\
     --submit_engine "local" \\
     --data_directory /tmp/simtools-data \\

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -49,7 +49,8 @@ def simulations_args_dict(corsika_config_data, model_version, simtel_path, submi
     args_dict["array_layout_name"] = "test_layout"
     args_dict["site"] = "North"
     args_dict["keep_seeds"] = False
-    args_dict["run_number_start"] = 1
+    args_dict["run_number"] = 1
+    args_dict["run_number_offset"] = 0
     args_dict["nshow"] = 10
     args_dict["submit_engine"] = submit_engine
     args_dict["extra_commands"] = None
@@ -119,14 +120,14 @@ def test_simulation_software(array_simulator, shower_simulator, shower_array_sim
 def test_initialize_run_list(shower_simulator, caplog):
     assert shower_simulator._initialize_run_list() == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     test_shower_simulator = copy.deepcopy(shower_simulator)
-    test_shower_simulator.args_dict.pop("run_number_start", None)
+    test_shower_simulator.args_dict.pop("run_number_offset", None)
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
             test_shower_simulator._initialize_run_list()
     assert (
-        "Error in initializing run list (missing 'run_number_start' or 'number_of_runs')"
-        in caplog.text
-    )
+        "Error in initializing run list "
+        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
+    ) in caplog.text
 
 
 def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -130,6 +130,56 @@ def test_initialize_run_list(shower_simulator, caplog):
     ) in caplog.text
 
 
+def test_initialize_run_list_valid_cases(shower_simulator):
+    # Test case where number_of_runs <= 1
+    shower_simulator.args_dict["number_of_runs"] = 1
+    shower_simulator.args_dict["run_number"] = 5
+    shower_simulator.args_dict["run_number_offset"] = 10
+    result = shower_simulator._initialize_run_list()
+    assert result == [15]  # run_number_offset + run_number
+
+    # Test case where number_of_runs > 1
+    shower_simulator.args_dict["number_of_runs"] = 3
+    shower_simulator.args_dict["run_number"] = 5
+    shower_simulator.args_dict["run_number_offset"] = 10
+    result = shower_simulator._initialize_run_list()
+    assert result == [15, 16, 17]  # range from 15 to 17
+
+
+def test_initialize_run_list_missing_keys(shower_simulator, caplog):
+    # Test missing 'run_number'
+    shower_simulator.args_dict.pop("run_number", None)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(KeyError):
+            shower_simulator._initialize_run_list()
+    assert (
+        "Error in initializing run list "
+        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
+    ) in caplog.text
+
+    # Test missing 'run_number_offset'
+    shower_simulator.args_dict["run_number"] = 5
+    shower_simulator.args_dict.pop("run_number_offset", None)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(KeyError):
+            shower_simulator._initialize_run_list()
+    assert (
+        "Error in initializing run list "
+        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
+    ) in caplog.text
+
+    # Test missing 'number_of_runs'
+    shower_simulator.args_dict["run_number_offset"] = 10
+    shower_simulator.args_dict.pop("number_of_runs", None)
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(KeyError):
+            shower_simulator._initialize_run_list()
+    assert (
+        "Error in initializing run list "
+        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
+    ) in caplog.text
+
+
 def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):
     for simulator_now in [shower_simulator, shower_array_simulator]:
         assert not simulator_now._validate_run_list_and_range(None, None)

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -21,6 +21,10 @@ from simtools.simulator import InvalidRunsToSimulateError, Simulator
 logger = logging.getLogger()
 
 CORSIKA_CONFIG_MOCK_PATCH = "simtools.simulator.CorsikaConfig"
+INITIALIZE_RUN_LIST_ERROR_MSG = (
+    "Error in initializing run list "
+    "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
+)
 
 
 @pytest.fixture
@@ -124,10 +128,7 @@ def test_initialize_run_list(shower_simulator, caplog):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
             test_shower_simulator._initialize_run_list()
-    assert (
-        "Error in initializing run list "
-        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
-    ) in caplog.text
+    assert INITIALIZE_RUN_LIST_ERROR_MSG in caplog.text
 
 
 def test_initialize_run_list_valid_cases(shower_simulator):
@@ -152,10 +153,7 @@ def test_initialize_run_list_missing_keys(shower_simulator, caplog):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
             shower_simulator._initialize_run_list()
-    assert (
-        "Error in initializing run list "
-        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
-    ) in caplog.text
+    assert INITIALIZE_RUN_LIST_ERROR_MSG in caplog.text
 
     # Test missing 'run_number_offset'
     shower_simulator.args_dict["run_number"] = 5
@@ -163,10 +161,7 @@ def test_initialize_run_list_missing_keys(shower_simulator, caplog):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
             shower_simulator._initialize_run_list()
-    assert (
-        "Error in initializing run list "
-        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
-    ) in caplog.text
+    assert INITIALIZE_RUN_LIST_ERROR_MSG in caplog.text
 
     # Test missing 'number_of_runs'
     shower_simulator.args_dict["run_number_offset"] = 10
@@ -174,10 +169,7 @@ def test_initialize_run_list_missing_keys(shower_simulator, caplog):
     with caplog.at_level(logging.ERROR):
         with pytest.raises(KeyError):
             shower_simulator._initialize_run_list()
-    assert (
-        "Error in initializing run list "
-        "(missing 'run_number', 'run_number_offset' or 'number_of_runs')."
-    ) in caplog.text
+    assert INITIALIZE_RUN_LIST_ERROR_MSG in caplog.text
 
 
 def test_validate_run_list_and_range(shower_simulator, shower_array_simulator):


### PR DESCRIPTION
Replace the "run_number_start" argument with "run_number_offset" (clearer) and re-introduce the "run_number" argument to allow specifying a run number (to which the offset is added).

Closes #1323.