### PR TITLE
Add reading of primary_id from sim_telarray file; add conversion from eventio primary_id in PrimaryParticle

### DIFF
--- a/docs/changes/1566.feature.md
+++ b/docs/changes/1566.feature.md
@@ -1,0 +1,1 @@
+Add reading and conversion of primary_id from sim_telarray output.

--- a/tests/unit_tests/corsika/test_primary_particle.py
+++ b/tests/unit_tests/corsika/test_primary_particle.py
@@ -56,6 +56,26 @@ def test_corsika7_id():
     assert eta.pdg_id == 221
 
 
+def test_eventio_id():
+    test_dict = {
+        0: "gamma",
+        1: "electron",
+        -1: "positron",
+        2: "muon-",
+        -2: "muon+",
+        101: "proton",
+        -101: "p~",
+        402: "helium",
+    }
+    for eventio_id, name in test_dict.items():
+        p = PrimaryParticle(particle_id_type="eventio_id", particle_id=eventio_id)
+        assert p.eventio_id == eventio_id
+        assert p.name == name
+
+    with pytest.raises(ValueError, match="Invalid EventIO ID: 9999"):
+        PrimaryParticle(particle_id_type="eventio_id", particle_id=9999)
+
+
 def test_common_name():
     p = PrimaryParticle(particle_id_type="common_name", particle_id="proton")
 

--- a/tests/unit_tests/simtel/test_simtel_io_file_info.py
+++ b/tests/unit_tests/simtel/test_simtel_io_file_info.py
@@ -36,3 +36,4 @@ def test_get_corsika_run_header(test_file):
     run_header = get_corsika_run_header(test_file)
     assert isinstance(run_header, dict)
     assert run_header["run"] == 10
+    assert run_header["primary_id"] == 0


### PR DESCRIPTION
Two additions:

- eventio has a slightly different particle ID than CORSIKA (see manual). Add the conversion from event_io to the other usual particle IDs (corsika, PDG) in PrimaryParticle
- add reading of primary_id from sim_telarray file and add it to the run header information returned. Note that to get this value, the first MC shower needs to be read (assuming all particle types in a simulation run are the same).