### PR TITLE
Move sonar properties into github workflow

### DIFF
--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -137,7 +137,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
-            -Dsonar.projectKey="gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
+            -Dsonar.projectKey=gammasim_simtools_AY_ssha9WiFxsX-2oy_w
             -Dsonar.host.url=https://sonar-cta-dpps.zeuthen.desy.de
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.python.version=${{ matrix.python-version }}

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -139,6 +139,7 @@ jobs:
           args: >
             -Dsonar.projectKey=gammasim_simtools_AY_ssha9WiFxsX-2oy_w
             -Dsonar.host.url=https://sonar-cta-dpps.zeuthen.desy.de
+            -Dsonar.qualitygate.wait=true
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.python.version=${{ matrix.python-version }}
             -Dsonar.exclusions="**/docs/**,src/simtools/applications/*,**__init__.py"

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -142,7 +142,7 @@ jobs:
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.python.version=${{ matrix.python-version }}
             -Dsonar.exclusions="**/docs/**,src/simtools/applications/*,**__init__.py"
-            -Dsonar.coverage.exclusions="**/tests/**""
+            -Dsonar.coverage.exclusions="**/tests/**"
 
       - name: Random order
         if: github.event_name == 'schedule' && contains(matrix.extra-args, 'random-order')

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -135,7 +135,7 @@ jobs:
         if: contains(matrix.extra-args, 'codecov')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PROJECT_KEY: "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
+          SONAR_PROJECTKEY: "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
           SONAR_HOST_URL: "https://sonar-cta-dpps.zeuthen.desy.de"
           SONAR_QUALITY_GATE_WAIT: "true"
           SONAR_PYTHON_COVERAGE_REPORT_PATH: "coverage.xml"

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -135,13 +135,14 @@ jobs:
         if: contains(matrix.extra-args, 'codecov')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PROJECTKEY: "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
-          SONAR_HOST_URL: "https://sonar-cta-dpps.zeuthen.desy.de"
-          SONAR_QUALITY_GATE_WAIT: "true"
-          SONAR_PYTHON_COVERAGE_REPORT_PATH: "coverage.xml"
-          SONAR_PYTHON_VERSION: ${{ matrix.python-version }}
-          SONAR_EXCLUSIONS: "**/docs/**,src/simtools/applications/*,**__init__.py"
-          SONAR_COVERAGE_EXCLUSIONS: "**/tests/**"
+        with:
+          args: >
+            -Dsonar.projectKey="gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
+            -Dsonar.host.url=https://sonar-cta-dpps.zeuthen.desy.de
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.version=${{ matrix.python-version }}
+            -Dsonar.exclusions="**/docs/**,src/simtools/applications/*,**__init__.py"
+            -Dsonar.coverage.exclusions="**/tests/**""
 
       - name: Random order
         if: github.event_name == 'schedule' && contains(matrix.extra-args, 'random-order')

--- a/.github/workflows/CI-unittests.yml
+++ b/.github/workflows/CI-unittests.yml
@@ -135,6 +135,13 @@ jobs:
         if: contains(matrix.extra-args, 'codecov')
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
+          SONAR_HOST_URL: "https://sonar-cta-dpps.zeuthen.desy.de"
+          SONAR_QUALITY_GATE_WAIT: "true"
+          SONAR_PYTHON_COVERAGE_REPORT_PATH: "coverage.xml"
+          SONAR_PYTHON_VERSION: ${{ matrix.python-version }}
+          SONAR_EXCLUSIONS: "**/docs/**,src/simtools/applications/*,**__init__.py"
+          SONAR_COVERAGE_EXCLUSIONS: "**/tests/**"
 
       - name: Random order
         if: github.event_name == 'schedule' && contains(matrix.extra-args, 'random-order')

--- a/docs/changes/1578.maintenance.md
+++ b/docs/changes/1578.maintenance.md
@@ -1,1 +1,1 @@
-Move sonar properties into github workflow.
+Move sonar properties into GitHub workflow.

--- a/docs/changes/1578.maintenance.md
+++ b/docs/changes/1578.maintenance.md
@@ -1,1 +1,1 @@
-Move sonar properties into GitHub workflow.
+Simplified Sonar setup by moving properties into GitHub workflow.

--- a/docs/changes/1578.maintenance.md
+++ b/docs/changes/1578.maintenance.md
@@ -1,0 +1,1 @@
+Move sonar properties into github workflow.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,3 +329,12 @@ showcontent = true
 [tool.towncrier.fragment.model]
 name = "Simulation model"
 showcontent = true
+
+[tool.sonar]
+projectKey = "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
+host.url = "https://sonar-cta-dpps.zeuthen.desy.de"
+qualitygate.wait = true
+python.coverage.reportPaths = "coverage.xml"
+python.version = 3.12
+exclusions = "**/docs/**,src/simtools/applications/*,**__init__.py"
+coverage.exclusions = "**/tests/**"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,12 +329,3 @@ showcontent = true
 [tool.towncrier.fragment.model]
 name = "Simulation model"
 showcontent = true
-
-[tool.sonar]
-projectKey = "gammasim_simtools_AY_ssha9WiFxsX-2oy_w"
-host.url = "https://sonar-cta-dpps.zeuthen.desy.de"
-qualitygate.wait = true
-python.coverage.reportPaths = "coverage.xml"
-python.version = 3.12
-exclusions = "**/docs/**,src/simtools/applications/*,**__init__.py"
-coverage.exclusions = "**/tests/**"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.projectKey=gammasim_simtools_AY_ssha9WiFxsX-2oy_w
-sonar.host.url=https://sonar-cta-dpps.zeuthen.desy.de
-sonar.qualitygate.wait=true
-sonar.python.coverage.reportPaths=coverage.xml
-sonar.python.version=3.12
-sonar.exclusions=**/docs/**,src/simtools/applications/*,**__init__.py
-sonar.coverage.exclusions=**/tests/**


### PR DESCRIPTION
Tiny PR with no functional changes - moved sonar properties into the github workflow for the unit test - this simplifies maintenance, as all sonar-related values / calls are at the same place.