### PR TITLE
Copy CORSIKA log in binary mode

### DIFF
--- a/docs/changes/1582.maintenance.md
+++ b/docs/changes/1582.maintenance.md
@@ -1,0 +1,1 @@
+Copy the CORSIKA log in binary mode instead of text mode.

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -772,15 +772,17 @@ class Simulator:
                 original_version, model.model_version
             )
 
-            with gzip.open(new_log, "wt") as new_file:
-                new_file.write(
+            with gzip.open(new_log, "wb") as new_file:
+                header = (
                     f"###############################################################\n"
                     f"Copy of CORSIKA log file from model version {original_version}.\n"
                     f"Applicable also for {model.model_version} (same CORSIKA configuration,\n"
                     f"different sim_telarray model versions in the same run).\n"
                     f"###############################################################\n\n"
                 )
-                with gzip.open(original_log, "rt") as orig_file:
+                new_file.write(header.encode("utf-8"))
+
+                with gzip.open(original_log, "rb") as orig_file:
                     shutil.copyfileobj(orig_file, new_file)
 
             corsika_log_files.append(str(new_log))


### PR DESCRIPTION
For some reason sometimes on the grid the copying of the CORSIKA log fails. Copying it directly in binary mode should avoid this error, regardless of the underlying reason. It is very hard to debug the underlying reason as well because I cannot reproduce it locally. Either way, this change should not hurt.