### PR TITLE
Protect against non-unicode characters in CORSIKA log file

### DIFF
--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -751,7 +751,6 @@ class Simulator:
         ----------
         corsika_log_files: list
             List containing the original CORSIKA log file path.
-
         """
         original_log = Path(corsika_log_files[0])
         # Find which model version the original log belongs to
@@ -772,7 +771,8 @@ class Simulator:
                 original_version, model.model_version
             )
 
-            with gzip.open(new_log, "wb") as new_file:
+            with gzip.open(new_log, "wt", encoding="utf-8") as new_file:
+                # Write the header to the new file
                 header = (
                     f"###############################################################\n"
                     f"Copy of CORSIKA log file from model version {original_version}.\n"
@@ -780,9 +780,11 @@ class Simulator:
                     f"different sim_telarray model versions in the same run).\n"
                     f"###############################################################\n\n"
                 )
-                new_file.write(header.encode("utf-8"))
+                new_file.write(header)
 
-                with gzip.open(original_log, "rb") as orig_file:
-                    shutil.copyfileobj(orig_file, new_file)
+                # Copy the content of the original log file, ignoring invalid characters
+                with gzip.open(original_log, "rt", encoding="utf-8", errors="ignore") as orig_file:
+                    for line in orig_file:
+                        new_file.write(line)
 
             corsika_log_files.append(str(new_log))


### PR DESCRIPTION
Sometimes the CORSIKA log file contains non-unicode characters which leads to errors when copying it. The changes here should protect against that happening with minimal loss of info.