### PR TITLE
Change dummy trigger thresholds to easier-to-spot values.

### DIFF
--- a/docs/changes/1591.maintenance.md
+++ b/docs/changes/1591.maintenance.md
@@ -1,0 +1,1 @@
+Change dummy trigger thresholds to easier-to-spot values.

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -556,9 +556,9 @@ class SimtelConfigWriter:
             "disc_bins": 10,
             "fadc_sum_bins": 10,
             "fadc_sum_offset": 0,
-            "asum_threshold": 0,
-            "dsum_threshold": 0,
-            "discriminator_threshold": 1,
+            "asum_threshold": 9999,
+            "dsum_threshold": 9999,
+            "discriminator_threshold": 9999,
             "fadc_amplitude": 1.0,
             "discriminator_amplitude": 1.0,
         }


### PR DESCRIPTION
#1553 suggest to change dummy thresholds to easier to spot values.

Closes also [simulation models issue 20](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/issues/20).