### PR TITLE
New utility simtools-verify-simulation-model-production-tables to verify completeness of model parameter repository.

### DIFF
--- a/docs/changes/1592.feature.md
+++ b/docs/changes/1592.feature.md
@@ -1,0 +1,1 @@
+New utility simtools-verify-simulation-model-production-tables to verify completeness of model parameter repository.

--- a/docs/source/api-reference/mc_model.md
+++ b/docs/source/api-reference/mc_model.md
@@ -57,6 +57,15 @@ The array of imaging atmospheric Cherenkov telescopes is abstracted in the simul
 
 ```
 
+## model_repository
+
+(model-repository)
+
+```{eval-rst}
+.. automodule:: model.model_repository
+   :members:
+```
+
 ## model utilities
 
 (model-utils)=

--- a/docs/source/api-reference/mc_model.md
+++ b/docs/source/api-reference/mc_model.md
@@ -59,7 +59,7 @@ The array of imaging atmospheric Cherenkov telescopes is abstracted in the simul
 
 ## model_repository
 
-(model-repository)
+(model-repository)=
 
 ```{eval-rst}
 .. automodule:: model.model_repository

--- a/docs/source/user-guide/applications.md
+++ b/docs/source/user-guide/applications.md
@@ -65,3 +65,4 @@ simtools-validate-camera-fov <applications/simtools-validate-camera-fov>
 simtools-validate-cumulative-psf <applications/simtools-validate-cumulative-psf>
 simtools-validate-file-using-schema  <applications/simtools-validate-file-using-schema>
 simtools-validate-optics <applications/simtools-validate-optics>
+simtools-verify-simulation-model-production-tables <applications/simtools-verify-simulation-model-production-tables>

--- a/docs/source/user-guide/applications/simtools-verify-simulation-model-production-tables.rst
+++ b/docs/source/user-guide/applications/simtools-verify-simulation-model-production-tables.rst
@@ -1,0 +1,6 @@
+
+simtools-verify-simulation-model-production-tables
+==================================================
+
+.. automodule:: verify_simulation_model_production_tables
+   :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ scripts.simtools-validate-camera-fov = "simtools.applications.validate_camera_fo
 scripts.simtools-validate-cumulative-psf = "simtools.applications.validate_cumulative_psf:main"
 scripts.simtools-validate-file-using-schema = "simtools.applications.validate_file_using_schema:main"
 scripts.simtools-validate-optics = "simtools.applications.validate_optics:main"
+scripts.simtools-verify-simulation-model-production-tables = "simtools.applications.verify_simulation_model_production_tables:main"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/simtools/applications/verify_simulation_model_production_tables.py
+++ b/src/simtools/applications/verify_simulation_model_production_tables.py
@@ -40,9 +40,12 @@ def main():  # noqa: D103
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
 
-    model_repository.verify_simulation_model_production_tables(
+    if not model_repository.verify_simulation_model_production_tables(
         simulation_models_path=args_dict["simulation_models_path"]
-    )
+    ):
+        raise RuntimeError(
+            "Verification failed: Some model parameters are missing in the repository."
+        )
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/verify_simulation_model_production_tables.py
+++ b/src/simtools/applications/verify_simulation_model_production_tables.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+
+"""
+Verify simulation model production tables and model parameters for completeness.
+
+This application is a utility to be used in the CI pipeline of the SimulationModels
+repository. It checks that all model parameters defined in the production tables
+exist in the simulation models repository.
+
+"""
+
+import logging
+
+from simtools.configuration import configurator
+from simtools.model import model_repository
+from simtools.utils import general as gen
+
+
+def _parse():
+    """Parse command line arguments."""
+    config = configurator.Configurator(
+        description=(
+            "Verify simulation model production tables and model parameters for completeness. "
+            "This application checks that all model parameters defined in the production tables "
+            "exist in the simulation models repository."
+        )
+    )
+    config.parser.add_argument(
+        "--simulation_models_path",
+        help="Path to the simulation models repository.",
+        type=str,
+        required=True,
+    )
+    return config.initialize(db_config=False, output=False, paths=False)
+
+
+def main():  # noqa: D103
+    args_dict, _ = _parse()
+
+    logger = logging.getLogger()
+    logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
+
+    model_repository.verify_simulation_model_production_tables(
+        simulation_models_path=args_dict["simulation_models_path"]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -1,0 +1,134 @@
+"""Utilities for managing the simulation models repository.
+
+Simulation model parameters and production tables are managed through
+a gitlab repository ('SimulationModels'). This module provides service
+functions to interact with and verify the repository.
+"""
+
+import logging
+from pathlib import Path
+
+from simtools.utils import general as gen
+from simtools.utils import names
+
+_logger = logging.getLogger(__name__)
+
+
+def verify_simulation_model_production_tables(simulation_models_path):
+    """
+    Verify the simulation model production tables in the specified path.
+
+    Checks that all model parameters defined in the production tables are
+    present in the simulation models repository.
+
+    Parameters
+    ----------
+    simulation_models_path : str
+        Path to the simulation models repository.
+
+    Returns
+    -------
+    bool
+        True if all parameters found, False if any missing.
+    """
+    productions_path = Path(simulation_models_path) / "simulation-models" / "productions"
+    production_files = list(productions_path.rglob("*.json"))
+
+    _logger.info(
+        f"Verifying {len(production_files)} simulation model production "
+        f"tables in {simulation_models_path}"
+    )
+
+    missing_files = []
+    total_checked = 0
+
+    for production_file in production_files:
+        file_missing, file_checked = _verify_model_parameters_for_production(
+            simulation_models_path, production_file
+        )
+        missing_files.extend(file_missing)
+        total_checked += file_checked
+
+    _logger.info(f"Checked {total_checked} parameters, {len(missing_files)} missing")
+
+    if missing_files:
+        for missing_file in missing_files:
+            _logger.error(f"Missing: {missing_file}")
+        return False
+
+    _logger.info("Verification passed: All parameters found")
+    return True
+
+
+def _verify_model_parameters_for_production(simulation_models_path, production_file):
+    """
+    Verify that model parameters defined in the production tables exist.
+
+    Parameters
+    ----------
+    simulation_models_path : str
+        Path to the simulation models repository.
+    production_file : Path
+        Path to the production file.
+
+    Returns
+    -------
+    tuple
+        (missing_files_list, total_checked_count)
+    """
+    production_table = gen.collect_data_from_file(production_file)
+    missing_files = []
+    total_checked = 0
+
+    parameters = production_table.get("parameters", {})
+    for array_element, par_dict in parameters.items():
+        if isinstance(par_dict, dict):
+            for param_name, param_version in par_dict.items():
+                total_checked += 1
+                parameter_file = _get_model_parameter_file_path(
+                    simulation_models_path, array_element, param_name, param_version
+                )
+                if parameter_file and not parameter_file.exists():
+                    missing_files.append(str(parameter_file))
+
+    return missing_files, total_checked
+
+
+def _get_model_parameter_file_path(
+    simulation_models_path, array_element, parameter_name, parameter_version
+):
+    """
+    Get the file path for a model parameter.
+
+    Take into account path structure based on collections and array elements.
+
+    Parameters
+    ----------
+    simulation_models_path : str
+        Path to the simulation models repository.
+    array_element : str
+        Name of the array element (e.g., 'telescope').
+    parameter_name : str
+        Name of the parameter.
+    parameter_version : str
+        Version of the parameter.
+
+    Returns
+    -------
+    Path
+        The file path to the model parameter JSON file.
+    """
+    collection = names.get_collection_name_from_parameter_name(parameter_name)
+    return (
+        Path(simulation_models_path)
+        / "simulation-models"
+        / "model_parameters"
+        / (
+            collection
+            if collection in ("configuration_sim_telarray", "configuration_corsika")
+            else ""
+        )
+        / (array_element if collection != "configuration_corsika" else "")
+        / parameter_name
+        / f"{parameter_name}-{parameter_version}.json"
+    )

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -1,0 +1,199 @@
+"""Unit tests for model_repository module."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from simtools.model import model_repository
+
+
+def test_verify_simulation_model_production_tables_success(tmp_path):
+    """Test successful verification of production tables."""
+    productions_path = tmp_path / "simulation-models" / "productions"
+    productions_path.mkdir(parents=True)
+
+    production_data = {
+        "parameters": {"telescope": {"camera_config": "1.0.0", "optics_config": "2.1.0"}}
+    }
+
+    production_file = productions_path / "test_production.json"
+    production_file.write_text(json.dumps(production_data))
+
+    with patch(
+        "simtools.model.model_repository._verify_model_parameters_for_production"
+    ) as mock_verify:
+        mock_verify.return_value = ([], 2)
+
+        result = model_repository.verify_simulation_model_production_tables(str(tmp_path))
+
+        assert result is True
+        mock_verify.assert_called_once()
+
+
+def test_verify_simulation_model_production_tables_missing_files(tmp_path):
+    """Test verification with missing parameter files."""
+    productions_path = tmp_path / "simulation-models" / "productions"
+    productions_path.mkdir(parents=True)
+
+    production_file = productions_path / "test_production.json"
+    production_file.write_text('{"parameters": {}}')
+
+    with patch(
+        "simtools.model.model_repository._verify_model_parameters_for_production"
+    ) as mock_verify:
+        mock_verify.return_value = (["/missing/file.json"], 1)
+
+        result = model_repository.verify_simulation_model_production_tables(str(tmp_path))
+
+        assert result is False
+
+
+def test_verify_simulation_model_production_tables_no_production_files(tmp_path):
+    """Test verification with no production files."""
+    productions_path = tmp_path / "simulation-models" / "productions"
+    productions_path.mkdir(parents=True)
+
+    result = model_repository.verify_simulation_model_production_tables(str(tmp_path))
+
+    assert result is True
+
+
+@patch("simtools.utils.general.collect_data_from_file")
+def test_verify_model_parameters_for_production_with_missing_files(mock_collect_data, tmp_path):
+    """Test verification of model parameters with missing files."""
+    production_data = {
+        "parameters": {"telescope": {"camera_config": "1.0.0", "mirror_config": "2.0.0"}}
+    }
+    mock_collect_data.return_value = production_data
+
+    production_file = Path("test_production.json")
+
+    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+        mock_file = Mock()
+        mock_file.exists.return_value = False
+        mock_get_path.return_value = mock_file
+
+        missing_files, total_checked = model_repository._verify_model_parameters_for_production(
+            str(tmp_path), production_file
+        )
+
+        assert total_checked == 2
+        assert len(missing_files) == 2
+
+
+@patch("simtools.utils.general.collect_data_from_file")
+def test_verify_model_parameters_for_production_all_files_exist(mock_collect_data, tmp_path):
+    """Test verification when all parameter files exist."""
+    production_data = {"parameters": {"telescope": {"camera_config": "1.0.0"}}}
+    mock_collect_data.return_value = production_data
+
+    production_file = Path("test_production.json")
+
+    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+        mock_file = Mock()
+        mock_file.exists.return_value = True
+        mock_get_path.return_value = mock_file
+
+        missing_files, total_checked = model_repository._verify_model_parameters_for_production(
+            str(tmp_path), production_file
+        )
+
+        assert total_checked == 1
+        assert len(missing_files) == 0
+
+
+@patch("simtools.utils.general.collect_data_from_file")
+def test_verify_model_parameters_for_production_no_parameters(mock_collect_data, tmp_path):
+    """Test verification with no parameters in production file."""
+    production_data = {}
+    mock_collect_data.return_value = production_data
+
+    production_file = Path("test_production.json")
+
+    missing_files, total_checked = model_repository._verify_model_parameters_for_production(
+        str(tmp_path), production_file
+    )
+
+    assert total_checked == 0
+    assert len(missing_files) == 0
+
+
+@patch("simtools.utils.general.collect_data_from_file")
+def test_verify_model_parameters_for_production_non_dict_parameters(mock_collect_data, tmp_path):
+    """Test verification with non-dict parameter values."""
+    production_data = {"parameters": {"telescope": "not_a_dict", "array": {"valid_param": "1.0.0"}}}
+    mock_collect_data.return_value = production_data
+
+    production_file = Path("test_production.json")
+
+    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+        mock_file = Mock()
+        mock_file.exists.return_value = True
+        mock_get_path.return_value = mock_file
+
+        missing_files, total_checked = model_repository._verify_model_parameters_for_production(
+            str(tmp_path), production_file
+        )
+
+        assert total_checked == 1
+
+
+@patch("simtools.utils.names.get_collection_name_from_parameter_name")
+def test_get_model_parameter_file_path_regular_collection(mock_get_collection, tmp_path):
+    """Test getting file path for regular collection."""
+    mock_get_collection.return_value = "camera"
+
+    result = model_repository._get_model_parameter_file_path(
+        str(tmp_path), "telescope", "camera_config", "1.0.0"
+    )
+
+    expected = (
+        tmp_path
+        / "simulation-models"
+        / "model_parameters"
+        / "telescope"
+        / "camera_config"
+        / "camera_config-1.0.0.json"
+    )
+    assert result == expected
+
+
+@patch("simtools.utils.names.get_collection_name_from_parameter_name")
+def test_get_model_parameter_file_path_configuration_sim_telarray(mock_get_collection, tmp_path):
+    """Test getting file path for configuration_sim_telarray collection."""
+    mock_get_collection.return_value = "configuration_sim_telarray"
+
+    result = model_repository._get_model_parameter_file_path(
+        str(tmp_path), "telescope", "sim_telarray_config", "1.0.0"
+    )
+
+    expected = (
+        tmp_path
+        / "simulation-models"
+        / "model_parameters"
+        / "configuration_sim_telarray"
+        / "telescope"
+        / "sim_telarray_config"
+        / "sim_telarray_config-1.0.0.json"
+    )
+    assert result == expected
+
+
+@patch("simtools.utils.names.get_collection_name_from_parameter_name")
+def test_get_model_parameter_file_path_configuration_corsika(mock_get_collection, tmp_path):
+    """Test getting file path for configuration_corsika collection."""
+    mock_get_collection.return_value = "configuration_corsika"
+
+    result = model_repository._get_model_parameter_file_path(
+        str(tmp_path), "telescope", "corsika_config", "1.0.0"
+    )
+
+    expected = (
+        tmp_path
+        / "simulation-models"
+        / "model_parameters"
+        / "configuration_corsika"
+        / "corsika_config"
+        / "corsika_config-1.0.0.json"
+    )
+    assert result == expected

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -6,6 +6,9 @@ from unittest.mock import Mock, patch
 
 from simtools.model import model_repository
 
+TEST_PRODUCTION_FILE = "test_production.json"
+PATH_PATCH = "simtools.model.model_repository._get_model_parameter_file_path"
+
 
 def test_verify_simulation_model_production_tables_success(tmp_path):
     """Test successful verification of production tables."""
@@ -15,8 +18,8 @@ def test_verify_simulation_model_production_tables_success(tmp_path):
     production_data = {
         "parameters": {"telescope": {"camera_config": "1.0.0", "optics_config": "2.1.0"}}
     }
+    production_file = productions_path / TEST_PRODUCTION_FILE
 
-    production_file = productions_path / "test_production.json"
     production_file.write_text(json.dumps(production_data))
 
     with patch(
@@ -35,7 +38,7 @@ def test_verify_simulation_model_production_tables_missing_files(tmp_path):
     productions_path = tmp_path / "simulation-models" / "productions"
     productions_path.mkdir(parents=True)
 
-    production_file = productions_path / "test_production.json"
+    production_file = productions_path / TEST_PRODUCTION_FILE
     production_file.write_text('{"parameters": {}}')
 
     with patch(
@@ -61,14 +64,15 @@ def test_verify_simulation_model_production_tables_no_production_files(tmp_path)
 @patch("simtools.utils.general.collect_data_from_file")
 def test_verify_model_parameters_for_production_with_missing_files(mock_collect_data, tmp_path):
     """Test verification of model parameters with missing files."""
+
     production_data = {
         "parameters": {"telescope": {"camera_config": "1.0.0", "mirror_config": "2.0.0"}}
     }
     mock_collect_data.return_value = production_data
 
-    production_file = Path("test_production.json")
+    production_file = Path(TEST_PRODUCTION_FILE)
 
-    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+    with patch(PATH_PATCH) as mock_get_path:
         mock_file = Mock()
         mock_file.exists.return_value = False
         mock_get_path.return_value = mock_file
@@ -87,9 +91,9 @@ def test_verify_model_parameters_for_production_all_files_exist(mock_collect_dat
     production_data = {"parameters": {"telescope": {"camera_config": "1.0.0"}}}
     mock_collect_data.return_value = production_data
 
-    production_file = Path("test_production.json")
+    production_file = Path(TEST_PRODUCTION_FILE)
 
-    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+    with patch(PATH_PATCH) as mock_get_path:
         mock_file = Mock()
         mock_file.exists.return_value = True
         mock_get_path.return_value = mock_file
@@ -108,7 +112,7 @@ def test_verify_model_parameters_for_production_no_parameters(mock_collect_data,
     production_data = {}
     mock_collect_data.return_value = production_data
 
-    production_file = Path("test_production.json")
+    production_file = Path(TEST_PRODUCTION_FILE)
 
     missing_files, total_checked = model_repository._verify_model_parameters_for_production(
         str(tmp_path), production_file
@@ -124,9 +128,9 @@ def test_verify_model_parameters_for_production_non_dict_parameters(mock_collect
     production_data = {"parameters": {"telescope": "not_a_dict", "array": {"valid_param": "1.0.0"}}}
     mock_collect_data.return_value = production_data
 
-    production_file = Path("test_production.json")
+    production_file = Path(TEST_PRODUCTION_FILE)
 
-    with patch("simtools.model.model_repository._get_model_parameter_file_path") as mock_get_path:
+    with patch(PATH_PATCH) as mock_get_path:
         mock_file = Mock()
         mock_file.exists.return_value = True
         mock_get_path.return_value = mock_file


### PR DESCRIPTION
This is a utility to run in the Simulation-Models gitlab CI. Checks that all parameters defined in the production tables actually exists. The tool

- loops over all production tables 
- loops over all model parameters defined in these production tables and test the the corresponding json files exist

Hard to come up with a integration tests without having to clone the Simulation-Models repository or generating small copy if it in the test/resources directory. This is why at this point there is no integration test for this application (suggestions are welcome).

The application works, as it actually finds missing parameters in the Simulation-Models repository, see this [CI-job](https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/356746).

Please review together with https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/54

Closes #1553.

