### PR TITLE
Add upcoming release to version list for version switcher. Correct URL to json file.

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,5 +1,5 @@
 [
   {"version": "latest", "url": "https://gammasim.github.io/simtools/", "preferred": true},
   {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"},
-  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.17.0/"}
+  {"version": "v0.17.0", "url": "https://gammasim.github.io/simtools/v0.17.0/"}
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,5 +1,5 @@
 [
-  {"version": "dev", "url": "https://gammasim.github.io/simtools/", "preferred": true},
+  {"version": "latest", "url": "https://gammasim.github.io/simtools/", "preferred": true},
   {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"},
   {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.17.0/"}
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,4 +1,5 @@
 [
   {"version": "dev", "url": "https://gammasim.github.io/simtools/", "preferred": true},
-  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"}
+  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"},
+  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.17.0/"}
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,8 +149,8 @@ html_theme_options = {
     ],
     "navigation_with_keys": False,
     "switcher": {
-        "json_url": "https://raw.githubusercontent.com/gammasim/simtools/refs/heads/doc-preparation/docs/_static/switcher.json",
-        "version_match": "dev",
+        "json_url": "https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/docs/_static/switcher.json",
+        "version_match": "latest",
     },
     "check_switcher": True,
 }

--- a/docs/source/developer-guide/maintainer_documentation.md
+++ b/docs/source/developer-guide/maintainer_documentation.md
@@ -22,10 +22,11 @@ Simtools releases are versioned following the [Semantic Versioning 2.0.0](https:
 To prepare a release, the following steps are required:
 
 1. Open a pull request to prepare a release.  Run the changelog workflow using Towncrier to add entries to `CHANGELOG.md`. This should be the last pull request to be merged before making the actual release.
-2. Prepare a GitHub release with the version number and a summary of the changes.
-3. Pypi deployment is done automatically by the CI/CD pipeline.
-4. Docker images are automatically built, tagged with the version number, and pushed to the [gammasim/simtools](https://github.com/orgs/gammasim/packages?repo_name=simtools).
-5. A DOI is issued automatically by Zenodo.
+2. Add a new line to [docs/_static/switcher.json](docs/_static/switcher.json) indicating the new version.
+3. Prepare a GitHub release with the version number and a summary of the changes.
+4. Pypi deployment is done automatically by the CI/CD pipeline.
+5. Docker images are automatically built, tagged with the version number, and pushed to the [gammasim/simtools](https://github.com/orgs/gammasim/packages?repo_name=simtools).
+6. A DOI is issued automatically by Zenodo.
 
 ## Conda feedstock
 


### PR DESCRIPTION
#1560 add the concept of the version switcher to the documentation. 

- forgot to update to to-be-release 0.17.0 (this should be replaced by a CI step)
- fixed url in conf.py to the json file defining the versions
- changed from 'dev' to 'latest' for simplicity.