### PR TITLE
Fix invalid switcher.json file

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,4 +1,4 @@
 [
   {"version": "latest", "url": "https://gammasim.github.io/simtools/", "preferred": true},
-  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"},
+  {"version": "v0.16.0", "url": "https://gammasim.github.io/simtools/v0.16.0/"}
 ]

--- a/docs/changes/1615.maintenance.md
+++ b/docs/changes/1615.maintenance.md
@@ -1,1 +1,1 @@
-Add json checker to pre-commit linter.
+Add JSON checker to pre-commit linter.


### PR DESCRIPTION
Fixes a bug in the switcher.json file (simply typo) which makes the documentation generation fail, see https://github.com/gammasim/simtools/actions/runs/15905219989/job/44858139726

Note that the doc pipeline will continue to fail, as sphinx still uses the json file from main, see conf.py:

```
    "switcher": {
        "json_url": "https://raw.githubusercontent.com/gammasim/simtools/refs/heads/invalid-switcher-json/docs/_static/switcher.json",
        "version_match": "latest",
    },
```

But this PR fixes an obvious json error. So this can be reviewed.
(please review #1615 first, as it is merge to this one as well)