### PR TITLE
Allow CORSIKA limits to use layouts defined in simulation models

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -34,13 +34,19 @@ jobs:
         with:
           python-version: "3.12"
 
-
       - name: Check for non-ASCII characters
         run: |
-          output=$(find . -type f \
-          \( -name "*.py" -o -name "*.rst" -o -name "*.yml" -o -name "*.toml" \) \
-          -exec perl -ne 'print if /[^[:ascii:]]/ && !/latin/i' {} \;)
-          if [ -n "$output" ]; then
+          found=0
+          while IFS= read -r file; do
+            matches=$(perl -ne 'print if /[^[:ascii:]]/ && !/latin/i' "$file")
+            if [ -n "$matches" ]; then
+              echo "File: $file"
+              echo "$matches"
+              found=1
+            fi
+          done < <(find . -type f \( -name "*.py" -o -name "*.rst" -o -name "*.yml" -o -name "*.toml" \))
+
+          if [ "$found" -eq 1 ]; then
             echo "Non-ASCII characters found in documentation."
             exit 1
           fi

--- a/docs/changes/1619.feature.md
+++ b/docs/changes/1619.feature.md
@@ -1,0 +1,1 @@
+Allow CORSIKA limits to use layouts defined in simulation models database.

--- a/src/simtools/applications/generate_simtel_event_data.py
+++ b/src/simtools/applications/generate_simtel_event_data.py
@@ -36,7 +36,7 @@ The output consists of an HDF5 or FITS file containing the following tables:
 +-------------------+---------+-----------------------------------------------+
 | azimuth           | float32 | Azimuth angle (rad)                           |
 +-------------------+---------+-----------------------------------------------+
-| nsb_level         | float64 | Night sky background level (photons/deg²/ns)  |
+| nsb_level         | float64 | Night sky background level (photons/deg^2/ns) |
 +-------------------+---------+-----------------------------------------------+
 
 **SHOWERS**

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -4,34 +4,51 @@ r"""
 Derive CORSIKA configuration limits for energy, core distance, and viewcone radius.
 
 This tool determines configuration limits based on triggered events from broad-range
-simulations. It supports setting:
+simulations. It supports the derivation of the following CORSIKA configuration parameters:
 
-- **ERANGE**: Derives the lower energy limit; upper limit is user-defined.
-- **CSCAT**: Derives the upper core distance; lower limit is user-defined.
-- **VIEWCONE**: Derives the viewcone radius; lower limit is user-defined.
+- **ERANGE**: lower energy limit
+- **CSCAT**: upper core distance
+- **VIEWCONE**: viewcone radius
 
+Broad-range simulations in this context are simulation sets generated with wide-ranging
+definitions for above parameters.
 Limits are computed based on a configurable maximum event loss fraction.
 Results are provided as a table with the following columns:
 
-- particle_type: Particle type (e.g., gamma, proton, electron).
-- telescope_ids: List of telescope IDs used in the simulation.
-- zenith: Zenith angle.
-- azimuth: Azimuth angle.
-- nsb: Night sky background level
-- layout: Layout of the telescope array used in the simulation.
-- lower_energy_limit: Derived lower energy limit.
-- upper_radius_limit: Derived upper radial distance limit.
-- viewcone_radius: Derived upper viewcone radius limit.
++---------------------+-----------+--------+-----------------------------------------------+
+| Field               | Data Type | Units  | Description                                   |
++=====================+===========+========+===============================================+
+| primary_particle    | string    |        | Particle type (e.g., gamma, proton).          |
++---------------------+-----------+--------+-----------------------------------------------+
+| array_name          | string    |        | Array name (custom or as defined in           |
+|                     |           |        | 'array_layouts').                             |
++---------------------+-----------+--------+-----------------------------------------------+
+| telescope_ids       | string    |        | Comma-separated list of telescope IDs         |
+|                     |           |        | of this array.                                |
++---------------------+-----------+--------+-----------------------------------------------+
+| zenith              | float64   | deg    | Direction of array pointing zenith.           |
++---------------------+-----------+--------+-----------------------------------------------+
+| azimuth             | float64   | deg    | Direction of array pointing azimuth.          |
++---------------------+-----------+--------+-----------------------------------------------+
+| nsb_level           | float64   |        | Night sky background level.                   |
++---------------------+-----------+--------+-----------------------------------------------+
+| lower_energy_limit  | float64   | TeV    | Derived lower energy limit (**ERANGE**)       |
++---------------------+-----------+--------+-----------------------------------------------+
+| upper_radius_limit  | float64   | m      | Derived upper core distance limit (**CSCAT**) |
++---------------------+-----------+--------+-----------------------------------------------+
+| viewcone_radius     | float64   | deg    | Derived viewcone radius limit (**VIEWCONE**)  |
++---------------------+-----------+--------+-----------------------------------------------+
 
 The input event data files are generated using the application simtools-generate-simtel-event-data
-and are required for each point in the lookup table.
+and are required for each point in the observational parameter space (e.g., array pointing
+directions, level of night sky background, etc.).
 
 Command line arguments
 ----------------------
 event_data_files (str, required)
-    Path to a file containing event data files derived with 'simtools-generate-simtel-event-data'.
+    Path to reduced event data file.
 telescope_ids (str, required)
-    Path to a file containing telescope configurations.
+    Custom array layout file containing telescope IDs.
 loss_fraction (float, required)
     Maximum event-loss fraction for limit computation.
 plot_histograms (bool, optional)
@@ -76,8 +93,18 @@ def _parse():
     config.parser.add_argument(
         "--telescope_ids",
         type=str,
-        required=True,
+        required=False,
         help="Path to a file containing telescope configurations.",
+    )
+    config.parser.add_argument(
+        "--layouts",
+        type=str,
+        nargs="+",
+        required=False,
+        help=(
+            "List of array layouts as defined in the model parameters database. "
+            "Use 'all' to include all available layouts."
+        ),
     )
     config.parser.add_argument(
         "--loss_fraction",
@@ -91,7 +118,7 @@ def _parse():
         action="store_true",
         default=False,
     )
-    return config.initialize(db_config=False, output=True)
+    return config.initialize(db_config=True, output=True)
 
 
 def main():

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -47,7 +47,7 @@ Command line arguments
 ----------------------
 event_data_files (str, required)
     Path to reduced event data file.
-telescope_ids (str, required)
+telescope_ids (str, optional)
     Custom array layout file containing telescope IDs.
 loss_fraction (float, required)
     Maximum event-loss fraction for limit computation.
@@ -97,16 +97,6 @@ def _parse():
         help="Path to a file containing telescope configurations.",
     )
     config.parser.add_argument(
-        "--layouts",
-        type=str,
-        nargs="+",
-        required=False,
-        help=(
-            "List of array layouts as defined in the model parameters database. "
-            "Use 'all' to include all available layouts."
-        ),
-    )
-    config.parser.add_argument(
         "--loss_fraction",
         type=float,
         required=True,
@@ -118,17 +108,25 @@ def _parse():
         action="store_true",
         default=False,
     )
-    return config.initialize(db_config=True, output=True)
+    return config.initialize(
+        db_config=True,
+        output=True,
+        simulation_model=[
+            "site",
+            "model_version",
+            "layout",
+        ],
+    )
 
 
 def main():
     """Derive limits for energy, radial distance, and viewcone."""
-    args_dict, _ = _parse()
+    args_dict, db_config = _parse()
 
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict.get("log_level", "info")))
 
-    generate_corsika_limits_grid(args_dict)
+    generate_corsika_limits_grid(args_dict, db_config)
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -58,7 +58,19 @@ output_file (str, optional)
 
 Example
 -------
-Derive limits for a given file with a specified loss fraction.
+
+Derive limits for a list of array layouts (use 'all' to derive limits for all layouts):
+
+.. code-block:: console
+
+    simtools-production-derive-corsika-limits \\
+        --event_data_files path/to/event_data_files.yaml \\
+        --array_layout_name alpha,beta \\
+        --loss_fraction 1e-6 \\
+        --plot_histograms \\
+        --output_file corsika_simulation_limits_lookup.ecsv
+
+Derive limits for a given file for custom defined array layouts:
 
 .. code-block:: console
 

--- a/src/simtools/configuration/commandline_parser.py
+++ b/src/simtools/configuration/commandline_parser.py
@@ -474,7 +474,8 @@ class CommandLineParser(argparse.ArgumentParser):
         _layout_group = job_group.add_mutually_exclusive_group(required=required)
         _layout_group.add_argument(
             "--array_layout_name",
-            help="array layout name (e.g., alpha, subsystem_msts)",
+            help="array layout name(s) (e.g., alpha, subsystem_msts)",
+            nargs="+",
             type=str,
             required=False,
         )

--- a/src/simtools/layout/array_layout_utils.py
+++ b/src/simtools/layout/array_layout_utils.py
@@ -275,7 +275,11 @@ def get_array_layouts_from_db(
     """
     layout_names = []
     if layout_name:
-        layout_names.append(layout_name)
+        layout_names.append(
+            layout_name[0]
+            if isinstance(layout_name, list) and len(layout_name) == 1
+            else layout_name
+        )
     else:
         site_model = SiteModel(site=site, model_version=model_version, mongo_db_config=db_config)
         layout_names = site_model.get_list_of_array_layouts()

--- a/src/simtools/model/array_model.py
+++ b/src/simtools/model/array_model.py
@@ -59,7 +59,11 @@ class ArrayModel:
         self.mongo_db_config = mongo_db_config
         self.model_version = model_version
         self.label = label
-        self.layout_name = layout_name
+        self.layout_name = (
+            layout_name[0]
+            if isinstance(layout_name, list) and len(layout_name) == 1
+            else layout_name
+        )
         self._config_file_path = None
         self._config_file_directory = None
         self.io_handler = io_handler.IOHandler()

--- a/src/simtools/production_configuration/derive_corsika_limits_grid.py
+++ b/src/simtools/production_configuration/derive_corsika_limits_grid.py
@@ -9,12 +9,13 @@ from astropy.table import Column, Table
 import simtools.utils.general as gen
 from simtools.data_model.metadata_collector import MetadataCollector
 from simtools.io_operations import io_handler
+from simtools.model.site_model import SiteModel
 from simtools.production_configuration.derive_corsika_limits import LimitCalculator
 
 _logger = logging.getLogger(__name__)
 
 
-def generate_corsika_limits_grid(args_dict):
+def generate_corsika_limits_grid(args_dict, db_config=None):
     """
     Generate CORSIKA limits for a grid of parameters.
 
@@ -24,9 +25,21 @@ def generate_corsika_limits_grid(args_dict):
     ----------
     args_dict : dict
         Dictionary containing command line arguments.
+    db_config : dict, optional
+        Database configuration dictionary.
     """
     event_data_files = gen.collect_data_from_file(args_dict["event_data_files"])["files"]
-    telescope_configs = gen.collect_data_from_file(args_dict["telescope_ids"])["telescope_configs"]
+    if args_dict.get("array_layout_name"):
+        telescope_configs = _read_array_layouts_from_db(
+            args_dict["array_layout_name"],
+            args_dict.get("site"),
+            args_dict.get("model_version"),
+            db_config,
+        )
+    else:
+        telescope_configs = gen.collect_data_from_file(args_dict["telescope_ids"])[
+            "telescope_configs"
+        ]
 
     results = []
     for file_path in event_data_files:
@@ -187,3 +200,31 @@ def _create_table_columns(cols, columns, units):
             col = Column(data=col_data, name=k, unit=units.get(k))
         table_cols.append(col)
     return table_cols
+
+
+def _read_array_layouts_from_db(layouts, site, model_version, db_config):
+    """
+    Read array layouts from the database.
+
+    Parameters
+    ----------
+    layouts : list[str]
+        List of layout names to read. If "all", read all available layouts.
+    site : str
+        Site name for the array layouts.
+    model_version : str
+        Model version for the array layouts.
+    db_config : dict
+        Database configuration dictionary.
+
+    Returns
+    -------
+    dict
+        Dictionary mapping layout names to telescope IDs.
+    """
+    site_model = SiteModel(site=site, model_version=model_version, mongo_db_config=db_config)
+    layout_names = site_model.get_list_of_array_layouts() if layouts == ["all"] else layouts
+    layout_dict = {}
+    for layout_name in layout_names:
+        layout_dict[layout_name] = site_model.get_array_elements_for_layout(layout_name)
+    return layout_dict

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
@@ -1,0 +1,22 @@
+---
+CTA_SIMPIPE:
+  APPLICATIONS:
+  - APPLICATION: simtools-production-derive-corsika-limits
+    TEST_NAME: hdf5
+    CONFIGURATION:
+      EVENT_DATA_FILES: tests/resources/production_event_data_hdf5_files.yml
+      LOSS_FRACTION: 1.e-3
+      MODEL_VERSION: 6.0.0
+      SITE: North
+      ARRAY_LAYOUT_NAME:
+      - "1lst"
+      - "alpha"
+      OUTPUT_PATH: simtools-output
+      OUTPUT_FILE: corsika_simulation_limits_lookup.ecsv
+      USE_PLAIN_OUTPUT_PATH: true
+      PLOT_HISTOGRAMS: true
+    INTEGRATION_TESTS:
+    - OUTPUT_FILE: corsika_simulation_limits_lookup.ecsv
+    - OUTPUT_FILE: corsika_simulation_limits_lookup.meta.yml
+SCHEMA_NAME: application_workflow.metaschema
+SCHEMA_VERSION: 0.3.0

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
@@ -5,6 +5,7 @@ from astropy.table import Table
 from simtools.production_configuration.derive_corsika_limits_grid import (
     _create_results_table,
     _process_file,
+    _read_array_layouts_from_db,
     _round_value,
     generate_corsika_limits_grid,
     write_results,
@@ -136,3 +137,87 @@ def test_round_value():
     assert _round_value("other_key", 1.2345) == 1.2345
     assert _round_value("zenith", 45.678) == 45.678
     assert _round_value("unknown", "string_value") == "string_value"
+
+
+def test_read_array_layouts_from_db_specific_layouts(mocker):
+    """Test _read_array_layouts_from_db with specific layout names."""
+    mock_site_model = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits_grid.SiteModel"
+    )
+    instance = mock_site_model.return_value
+    instance.get_array_elements_for_layout.side_effect = (
+        lambda name: [1, 2] if name == "LST" else [3, 4]
+    )
+
+    layouts = ["LST", "MST"]
+    site = "North"
+    model_version = "v1.0.0"
+    db_config = {"host": "localhost"}
+
+    result = _read_array_layouts_from_db(layouts, site, model_version, db_config)
+
+    assert result == {"LST": [1, 2], "MST": [3, 4]}
+    mock_site_model.assert_called_once_with(
+        site=site, model_version=model_version, mongo_db_config=db_config
+    )
+    assert instance.get_array_elements_for_layout.call_count == 2
+    instance.get_array_elements_for_layout.assert_any_call("LST")
+    instance.get_array_elements_for_layout.assert_any_call("MST")
+
+
+def test_read_array_layouts_from_db_all_layouts(mocker):
+    """Test _read_array_layouts_from_db with 'all' layouts."""
+    mock_site_model = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits_grid.SiteModel"
+    )
+    instance = mock_site_model.return_value
+    instance.get_list_of_array_layouts.return_value = ["LST", "MST"]
+    instance.get_array_elements_for_layout.side_effect = (
+        lambda name: [10, 20] if name == "LST" else [30, 40]
+    )
+
+    layouts = ["all"]
+    site = "South"
+    model_version = "v2.0.0"
+    db_config = {"host": "db"}
+
+    result = _read_array_layouts_from_db(layouts, site, model_version, db_config)
+
+    assert result == {"LST": [10, 20], "MST": [30, 40]}
+    instance.get_list_of_array_layouts.assert_called_once()
+    assert instance.get_array_elements_for_layout.call_count == 2
+    instance.get_array_elements_for_layout.assert_any_call("LST")
+    instance.get_array_elements_for_layout.assert_any_call("MST")
+
+
+def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
+    """Test generate_corsika_limits_grid using _read_array_layouts_from_db."""
+    # Prepare args_dict to use array_layout_name
+    args = mock_args_dict.copy()
+    args["array_layout_name"] = ["LST", "MST"]
+    args["site"] = "North"
+    args["model_version"] = "v1.2.3"
+
+    mock_collect = mocker.patch("simtools.utils.general.collect_data_from_file")
+    mock_collect.return_value = {"files": ["file1.fits", "file2.fits"]}
+
+    mock_read_layouts = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits_grid._read_array_layouts_from_db"
+    )
+    mock_read_layouts.return_value = {"LST": [1, 2], "MST": [3, 4]}
+
+    mock_process = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits_grid._process_file"
+    )
+    mock_write = mocker.patch(
+        "simtools.production_configuration.derive_corsika_limits_grid.write_results"
+    )
+
+    generate_corsika_limits_grid(args)
+
+    mock_collect.assert_called_once_with(args["event_data_files"])
+    mock_read_layouts.assert_called_once_with(
+        args["array_layout_name"], args["site"], args["model_version"], None
+    )
+    assert mock_process.call_count == 4  # 2 files * 2 layouts
+    assert mock_write.call_count == 1


### PR DESCRIPTION
Limits on energy range, core scatter area and viewcone depend on the telescopes selected. Add the possibility to use array layouts defined in the database to derive these limits.

Additional improve application docstrings. 