### PR TITLE
Replace file lists `tests/resources/simtel_output_files.txt` used for testing by explicitly listing of files.

### DIFF
--- a/docs/changes/1629.maintenance.md
+++ b/docs/changes/1629.maintenance.md
@@ -1,0 +1,1 @@
+Replace file lists `tests/resources/simtel_output_files.txt` used for testing by explicitly listing of files.

--- a/tests/integration_tests/config/calculate_trigger_rate_file_list.yml
+++ b/tests/integration_tests/config/calculate_trigger_rate_file_list.yml
@@ -5,7 +5,8 @@ CTA_SIMPIPE:
     TEST_NAME: file_list
     CONFIGURATION:
       SIMTEL_FILE_NAMES:
-      - ./tests/resources/simtel_output_files.txt
+      - ./tests/resources/proton_run000201_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst
+      - ./tests/resources/proton_run000202_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst
       SAVE_TABLES: true
       OUTPUT_PATH: simtools-output
     INTEGRATION_TESTS:

--- a/tests/integration_tests/config/generate_sim_telarray_histograms_file_lists.yml
+++ b/tests/integration_tests/config/generate_sim_telarray_histograms_file_lists.yml
@@ -4,7 +4,9 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-generate-sim-telarray-histograms
     TEST_NAME: hist_file_list
     CONFIGURATION:
-      HIST_FILE_NAMES: ./tests/resources/simtel_output_files.txt
+      HIST_FILE_NAMES:
+      - ./tests/resources/proton_run000201_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst
+      - ./tests/resources/proton_run000202_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst
       PDF: true
       OUTPUT_FILE_NAME: test_simtel_hist_name
       OUTPUT_PATH: simtools-output

--- a/tests/resources/simtel_output_files.txt
+++ b/tests/resources/simtel_output_files.txt
@@ -1,2 +1,0 @@
-./tests/resources/proton_run000201_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst
-./tests/resources/proton_run000202_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst

--- a/tests/unit_tests/simtel/test_simtel_io_histograms.py
+++ b/tests/unit_tests/simtel/test_simtel_io_histograms.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+from pathlib import Path
 
 import astropy.units as u
 import matplotlib.pyplot as plt
@@ -22,11 +23,18 @@ logger = logging.getLogger()
 
 
 @pytest.fixture
-def sim_telarray_file_proton_list(io_handler):
-    return io_handler.get_input_data_file(
-        file_name="simtel_output_files.txt",
-        test=True,
+def sim_telarray_file_proton_list(io_handler, tmp_test_directory):
+    output_file = tmp_test_directory / "simtel_output_files.txt"
+    resource_dir = Path("./tests/resources")
+    files = sorted(
+        resource_dir.glob(
+            "proton_run00020*_za20deg_azm000deg_North_alpha_6.0.0_test_file.simtel.zst"
+        )
     )
+    with output_file.open("w") as f:
+        for file in files:
+            f.write(f"{file}\n")
+    return output_file
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #1621 — I'm still not convinced, but it's based on a customer complaint.
