### PR TITLE
Allow to use current prod6 simulations for reduced event data generation

### DIFF
--- a/src/simtools/applications/merge_tables.py
+++ b/src/simtools/applications/merge_tables.py
@@ -29,7 +29,7 @@ Merge tables from two files generated with 'simtools-generate-simtel-event-data'
 .. code-block:: console
 
     simtools-merge-tables \\
-        --input file1 file2' \\
+        --input_files file1 file2' \\
         --table_names 'SHOWERS TRIGGERS FILE_INFO' \\
         --output_file merged_tables.hdf5
 
@@ -57,15 +57,10 @@ def _parse(label, description):
 
     input_group = config.parser.add_mutually_exclusive_group(required=True)
     input_group.add_argument(
-        "--input",
+        "--input_files",
         type=str,
         nargs="+",
-        help="Input file(s) (e.g., 'file1 file2')",
-    )
-    input_group.add_argument(
-        "--input_list",
-        type=str,
-        help="File with list of input files with tables.",
+        help="Input file(s) (e.g., 'file1 file2') or a file with a list of input files.",
     )
     config.parser.add_argument(
         "--table_names",
@@ -86,12 +81,15 @@ def main():  # noqa: D103
     )
     logger = logging.getLogger()
     logger.setLevel(gen.get_log_level_from_user(args_dict["log_level"]))
-    logger.info(f"Loading input files from: {args_dict['input']}")
+    logger.info(f"Loading input files: {args_dict['input_files']}")
+
+    # accept fits.gz files (.gz)
+    input_files = gen.get_list_of_files_from_command_line(
+        args_dict["input_files"], [".hdf5", ".gz"]
+    )
 
     output_path = io_handler.IOHandler().get_output_directory(label)
     output_filepath = Path(output_path).joinpath(f"{args_dict['output_file']}")
-
-    input_files = args_dict.get("input") or gen.collect_data_from_file(args_dict["input_list"])
 
     io_table_handler.merge_tables(
         input_files,

--- a/src/simtools/applications/merge_tables.py
+++ b/src/simtools/applications/merge_tables.py
@@ -2,7 +2,7 @@ r"""
 Merge tables from multiple input files into single tables.
 
 Allows to merge tables (e.g., astropy tables) from multiple input files into a single file.
-The input files can be in HDF5 or FITS format. The merged tables will be saved in the
+The input files can be of HDF5 or FITS format.
 specified output file.
 
 Merging large tables in FITS are not recommended, as it may lead to
@@ -14,7 +14,7 @@ input str
     Input file(s) (e.g., 'file1 file2').
 input_list str
     File with list of input files with tables.
-table_names str
+table_names list of str
     Names of tables to merge from each input file.
 output_file str
     Output file name.

--- a/src/simtools/applications/merge_tables.py
+++ b/src/simtools/applications/merge_tables.py
@@ -1,11 +1,11 @@
 r"""
 Merge tables from multiple input files into single tables.
 
-Allows to merge tables from multiple input files into a single file.
+Allows to merge tables (e.g., astropy tables) from multiple input files into a single file.
 The input files can be in HDF5 or FITS format. The merged tables will be saved in the
 specified output file.
 
-Note that merging large tables in FITS are not recommended, as it may lead to
+Merging large tables in FITS are not recommended, as it may lead to
 performance issues.
 
 Command line arguments
@@ -24,7 +24,7 @@ output_path str
 Example
 -------
 
-Merge tables from two files into a single file.
+Merge tables from two files generated with 'simtools-generate-simtel-event-data' into a single file.
 
 .. code-block:: console
 

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -70,8 +70,9 @@ def _parse():
     config.parser.add_argument(
         "--event_data_files",
         type=str,
+        nargs="+",
         required=True,
-        help="Path to a file containing event data file paths.",
+        help="List of event data files or ascii file listing data files ",
     )
     config.parser.add_argument(
         "--telescope_ids",

--- a/src/simtools/production_configuration/derive_corsika_limits_grid.py
+++ b/src/simtools/production_configuration/derive_corsika_limits_grid.py
@@ -25,7 +25,9 @@ def generate_corsika_limits_grid(args_dict):
     args_dict : dict
         Dictionary containing command line arguments.
     """
-    event_data_files = gen.collect_data_from_file(args_dict["event_data_files"])["files"]
+    event_data_files = gen.get_list_of_files_from_command_line(
+        args_dict["event_data_files"], [".hdf5", ".gz"]
+    )  # accept fits.gz files (.gz)
     telescope_configs = gen.collect_data_from_file(args_dict["telescope_ids"])["telescope_configs"]
 
     results = []

--- a/src/simtools/production_configuration/derive_corsika_limits_grid.py
+++ b/src/simtools/production_configuration/derive_corsika_limits_grid.py
@@ -44,6 +44,7 @@ def generate_corsika_limits_grid(args_dict, db_config=None):
         ]
 
     results = []
+    # TODO - does this implicitly mean one file per point in the parameter space?
     for file_path in event_data_files:
         for array_name, telescope_ids in telescope_configs.items():
             _logger.info(f"Processing file: {file_path} with telescope config: {array_name}")

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -2,10 +2,14 @@
 """Read metadata from sim_telarray files."""
 
 import logging
+import re
 from functools import cache
 
 from eventio import EventIOFile
+from eventio.iact import InputCard
 from eventio.simtel import HistoryMeta
+
+from simtools.utils import names
 
 _logger = logging.getLogger(__name__)
 
@@ -124,7 +128,69 @@ def get_sim_telarray_telescope_id_to_telescope_name_mapping(file):
         Dictionary mapping telescope IDs to telescope names.
     """
     _, telescope_meta = read_sim_telarray_metadata(file)
-    return {
-        tel_id: meta.get("optics_config_name", f"Unknown-{tel_id}")
-        for tel_id, meta in telescope_meta.items()
-    }
+    telescope_map = {}
+    for i, (tel_id, meta) in enumerate(telescope_meta.items()):
+        try:
+            telescope_name = names.validate_array_element_name(
+                meta.get("optics_config_name", f"Unknown-{tel_id}")
+            )
+        except ValueError:
+            telescope_name = _guess_telescope_name_for_legacy_files(i, file)
+        if telescope_name is not None:
+            telescope_map[tel_id] = telescope_name
+
+    return telescope_map
+
+
+def _guess_telescope_name_for_legacy_files(tel_counter, file):
+    """
+    Guess telescope names for legacy sim_telarray files with incomplete metadata.
+
+    Parameters
+    ----------
+    tel_counter: int
+        Telescope counter, used to index into the telescope list.
+    file: str, Path
+        Path to the sim_telarray file.
+
+    Returns
+    -------
+    str, None
+        Guessed telescope name or None if not found.
+    """
+    telescope_list = _get_telescope_list_from_input_card(file)
+    try:
+        return names.validate_array_element_name(telescope_list[tel_counter])
+    except (IndexError, ValueError):
+        pass
+    return None
+
+
+@cache
+def _get_telescope_list_from_input_card(file):
+    """
+    Return telescope list from CORSIKA input card.
+
+    Note hardwired regex pattern with telescope naming convention.
+    This function is intended for legacy files where metadata is incomplete.
+
+    Parameters
+    ----------
+    file: str, Path
+        Path to the sim_telarray file.
+
+    Returns
+    -------
+    list
+        List of telescope names as found in CORSIKA input card.
+    """
+    with EventIOFile(file) as f:
+        for o in f:
+            if isinstance(o, InputCard):
+                input_card = o.parse().decode("utf-8")
+                regex = (
+                    r"TELESCOPE\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+[-\d.E]+\s+"
+                    r"# \(ID=\d+\)\s+(LST[N|S]|MST[N|S]|S[S|C]TS)\s+([^\s]+)"
+                )
+                return [f"{m[0]}-{m[1]}" for m in re.findall(regex, input_card)]
+    return []

--- a/tests/integration_tests/config/merge_tables_one_fits.yml
+++ b/tests/integration_tests/config/merge_tables_one_fits.yml
@@ -4,7 +4,7 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-merge-tables
     TEST_NAME: one_fits
     CONFIGURATION:
-      INPUT: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
+      INPUT_FILES: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
       TABLE_NAMES:
       - SHOWERS
       - TRIGGERS

--- a/tests/integration_tests/config/merge_tables_two_fits.yml
+++ b/tests/integration_tests/config/merge_tables_two_fits.yml
@@ -4,7 +4,7 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-merge-tables
     TEST_NAME: two_fits
     CONFIGURATION:
-      INPUT:
+      INPUT_FILES:
       - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
       - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
       TABLE_NAMES:

--- a/tests/integration_tests/config/merge_tables_two_hdf5.yml
+++ b/tests/integration_tests/config/merge_tables_two_hdf5.yml
@@ -1,0 +1,20 @@
+---
+CTA_SIMPIPE:
+  APPLICATIONS:
+  - APPLICATION: simtools-merge-tables
+    TEST_NAME: two_hdf5
+    CONFIGURATION:
+      INPUT:
+      - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+      - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+      TABLE_NAMES:
+      - SHOWERS
+      - TRIGGERS
+      - FILE_INFO
+      OUTPUT_PATH: simtools-output
+      OUTPUT_FILE: merged.hdf5
+      USE_PLAIN_OUTPUT_PATH: true
+    INTEGRATION_TESTS:
+    - OUTPUT_FILE: merged.hdf5
+SCHEMA_NAME: application_workflow.metaschema
+SCHEMA_VERSION: 0.3.0

--- a/tests/integration_tests/config/merge_tables_two_hdf5.yml
+++ b/tests/integration_tests/config/merge_tables_two_hdf5.yml
@@ -4,7 +4,7 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-merge-tables
     TEST_NAME: two_hdf5
     CONFIGURATION:
-      INPUT:
+      INPUT_FILES:
       - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
       - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
       TABLE_NAMES:

--- a/tests/integration_tests/config/production_derive_corsika_limits_fits.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_fits.yml
@@ -4,7 +4,8 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-production-derive-corsika-limits
     TEST_NAME: fits
     CONFIGURATION:
-      EVENT_DATA_FILES: tests/resources/production_event_data_fits_files.yml
+      EVENT_DATA_FILES:
+      - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
       LOSS_FRACTION: 1.e-3
       TELESCOPE_IDS: tests/resources/production_layouts_telescope_ids.yml
       OUTPUT_PATH: simtools-output

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
@@ -2,7 +2,7 @@
 CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-production-derive-corsika-limits
-    TEST_NAME: hdf5
+    TEST_NAME: hdf5_arrays_from_file
     CONFIGURATION:
       EVENT_DATA_FILES:
       - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
@@ -4,7 +4,8 @@ CTA_SIMPIPE:
   - APPLICATION: simtools-production-derive-corsika-limits
     TEST_NAME: hdf5
     CONFIGURATION:
-      EVENT_DATA_FILES: tests/resources/production_event_data_hdf5_files.yml
+      EVENT_DATA_FILES:
+      - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
       LOSS_FRACTION: 1.e-3
       TELESCOPE_IDS: tests/resources/production_layouts_telescope_ids.yml
       OUTPUT_PATH: simtools-output

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
@@ -2,9 +2,10 @@
 CTA_SIMPIPE:
   APPLICATIONS:
   - APPLICATION: simtools-production-derive-corsika-limits
-    TEST_NAME: hdf5
+    TEST_NAME: hdf5_arrays_from_db
     CONFIGURATION:
-      EVENT_DATA_FILES: tests/resources/production_event_data_hdf5_files.yml
+      EVENT_DATA_FILES:
+      - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
       LOSS_FRACTION: 1.e-3
       MODEL_VERSION: 6.0.0
       SITE: North

--- a/tests/resources/production_event_data_fits_files.yml
+++ b/tests/resources/production_event_data_fits_files.yml
@@ -1,3 +1,0 @@
----
-files:
-  - "tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz"

--- a/tests/resources/production_event_data_hdf5_files.yml
+++ b/tests/resources/production_event_data_hdf5_files.yml
@@ -1,3 +1,0 @@
----
-files:
-  - "tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5"

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
@@ -46,9 +46,10 @@ def mock_results():
 def test_generate_corsika_limits_grid(mocker, mock_args_dict):
     """Test generate_corsika_limits_grid function."""
     # Mock dependencies
+    mock_list = mocker.patch("simtools.utils.general.get_list_of_files_from_command_line")
+    mock_list.return_value = ["file1.fits", "file2.fits"]
     mock_collect = mocker.patch("simtools.utils.general.collect_data_from_file")
     mock_collect.side_effect = [
-        {"files": ["file1.fits", "file2.fits"]},
         {"telescope_configs": {"LST": [1, 2], "MST": [3, 4]}},
     ]
 
@@ -63,9 +64,10 @@ def test_generate_corsika_limits_grid(mocker, mock_args_dict):
     generate_corsika_limits_grid(mock_args_dict)
 
     # Verify calls
-    assert mock_collect.call_count == 2
+    assert mock_collect.call_count == 1
     assert mock_process.call_count == 4  # 2 files * 2 configs
     assert mock_write.call_count == 1
+    assert mock_list.call_count == 1
 
 
 def test_process_file(mocker):
@@ -198,8 +200,8 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     args["site"] = "North"
     args["model_version"] = "v1.2.3"
 
-    mock_collect = mocker.patch("simtools.utils.general.collect_data_from_file")
-    mock_collect.return_value = {"files": ["file1.fits", "file2.fits"]}
+    mock_collect = mocker.patch("simtools.utils.general.get_list_of_files_from_command_line")
+    mock_collect.return_value = ["file1.fits", "file2.fits"]
 
     mock_read_layouts = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits_grid._read_array_layouts_from_db"
@@ -215,7 +217,7 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
 
     generate_corsika_limits_grid(args)
 
-    mock_collect.assert_called_once_with(args["event_data_files"])
+    mock_collect.assert_called_once()
     mock_read_layouts.assert_called_once_with(
         args["array_layout_name"], args["site"], args["model_version"], None
     )


### PR DESCRIPTION
Main change in this pull request is to use the CORSIKA input cards to convert sim_telarray telescope IDs to array element names for the current prod6 simulations which do no include the full metadata header generated when running productions using simtools.

This code is fine-tuned to those input cards and should be used for prod6-North only.

Other are generalizing the reading of input list and cleanup of testing.

## Copilot summary

This pull request introduces several updates to improve file handling, metadata processing, and testing across the `simtools` project. The most significant changes include renaming and consolidating input file arguments, enhancing metadata extraction for legacy files, and updating integration and unit tests to reflect these changes.

### File Handling Updates:

* Renamed the `--input` argument to `--input_files` in `merge_tables.py` and updated its functionality to accept a list of files or a file containing paths.

### Metadata Processing Enhancements:

* Enhanced `get_sim_telarray_telescope_id_to_telescope_name_mapping` to handle legacy files with incomplete metadata by introducing `_guess_telescope_name_for_legacy_files` and `_get_telescope_list_from_input_card`. These functions extract telescope names from CORSIKA input cards using regex. [[1]](diffhunk://#diff-c2e0bb37a0a83d7ac442f66100cec99e5a805ea2ac70e508a289b32e62d9a211L127-R196) [[2]](diffhunk://#diff-c2e0bb37a0a83d7ac442f66100cec99e5a805ea2ac70e508a289b32e62d9a211R5-R13)

### Integration Test Updates:

* Updated integration test configurations to use the new `INPUT_FILES` and `EVENT_DATA_FILES` arguments, removing references to deprecated list files. [[1]](diffhunk://#diff-61eb2320c27d0a8ee824ea84a6924cdf0fdf369258075cff72937aa5e2844634L7-R7) [[2]](diffhunk://#diff-f83f4f5421e5fc78f46002a85643654015bf244d2288df9acdd5d3ba71d37525L7-R7) [[3]](diffhunk://#diff-3408f2a3d01961a6203087fb64985f39835aa2cfdb5ffa031e27af33885505ffR1-R20) [[4]](diffhunk://#diff-2f939da639e724e8394e225744cdaf380048ea1a6804ae6c3739773fe2be1d2eL7-R8) [[5]](diffhunk://#diff-e09c81e9f140d646e5ec7e4d97a4d2836b40655ad609b0bf187a54eddefc060cL5-R8) [[6]](diffhunk://#diff-b1e68cb475e1af246180969bb4de2b729fdb7ceec06e0b0a5270b10d29713264L5-R8)
* Removed obsolete resource files `production_event_data_fits_files.yml` and `production_event_data_hdf5_files.yml`. [[1]](diffhunk://#diff-532efe79d5c9ef5c5944b16d0b85c72ffb6273bc40b4182677daafc8548ec4c3L1-L3) [[2]](diffhunk://#diff-8e982db5b6b9ff5af7fdb82f1262cb88b397edba9ee90b2f8e17ea433646468dL1-L3)

### Unit Test Updates:

* Updated unit tests in `test_derive_corsika_limits_grid.py` to mock `get_list_of_files_from_command_line` instead of `collect_data_from_file`. Adjusted assertions to reflect the new file handling logic. [[1]](diffhunk://#diff-6d6ea1cffe438e93a6f915fb33ab63d4e9e8537dc33f6c52b1bfbd532ae37187R49-L51) [[2]](diffhunk://#diff-6d6ea1cffe438e93a6f915fb33ab63d4e9e8537dc33f6c52b1bfbd532ae37187L201-R204)
* Added unit tests for `_get_telescope_list_from_input_card` and `_guess_telescope_name_for_legacy_files` to ensure proper handling of legacy metadata.

