### PR TITLE
Derive corsika limit application to be used with single input file

### DIFF
--- a/docs/changes/1641.maintenance.md
+++ b/docs/changes/1641.maintenance.md
@@ -1,0 +1,1 @@
+Clarify input data to derivation of CORSIKA limits with `simtools-production-derive-corsika-limit`.

--- a/src/simtools/applications/production_derive_corsika_limits.py
+++ b/src/simtools/applications/production_derive_corsika_limits.py
@@ -45,7 +45,7 @@ directions, level of night sky background, etc.).
 
 Command line arguments
 ----------------------
-event_data_files (str, required)
+event_data_file (str, required)
     Path to reduced event data file.
 telescope_ids (str, optional)
     Custom array layout file containing telescope IDs.
@@ -64,7 +64,7 @@ Derive limits for a list of array layouts (use 'all' to derive limits for all la
 .. code-block:: console
 
     simtools-production-derive-corsika-limits \\
-        --event_data_files path/to/event_data_files.yaml \\
+        --event_data_file event_dat_file.hdf5 \\
         --array_layout_name alpha,beta \\
         --loss_fraction 1e-6 \\
         --plot_histograms \\
@@ -75,7 +75,7 @@ Derive limits for a given file for custom defined array layouts:
 .. code-block:: console
 
     simtools-production-derive-corsika-limits \\
-        --event_data_files path/to/event_data_files.yaml \\
+        --event_data_file event_dat_file.hdf5 \\
         --telescope_ids path/to/telescope_configs.yaml \\
         --loss_fraction 1e-6 \\
         --plot_histograms \\
@@ -97,11 +97,10 @@ def _parse():
         description="Derive limits for energy, radial distance, and viewcone."
     )
     config.parser.add_argument(
-        "--event_data_files",
+        "--event_data_file",
         type=str,
-        nargs="+",
         required=True,
-        help="List of event data files or ascii file listing data files ",
+        help="Event data file containing reduced event data.",
     )
     config.parser.add_argument(
         "--telescope_ids",

--- a/src/simtools/production_configuration/derive_corsika_limits_grid.py
+++ b/src/simtools/production_configuration/derive_corsika_limits_grid.py
@@ -28,9 +28,6 @@ def generate_corsika_limits_grid(args_dict, db_config=None):
     db_config : dict, optional
         Database configuration dictionary.
     """
-    event_data_files = gen.get_list_of_files_from_command_line(
-        args_dict["event_data_files"], [".hdf5", ".gz"]
-    )  # accept fits.gz files (.gz)
     if args_dict.get("array_layout_name"):
         telescope_configs = _read_array_layouts_from_db(
             args_dict["array_layout_name"],
@@ -44,18 +41,19 @@ def generate_corsika_limits_grid(args_dict, db_config=None):
         ]
 
     results = []
-    for file_path in event_data_files:
-        for array_name, telescope_ids in telescope_configs.items():
-            _logger.info(f"Processing file: {file_path} with telescope config: {array_name}")
-            result = _process_file(
-                file_path,
-                array_name,
-                telescope_ids,
-                args_dict["loss_fraction"],
-                args_dict["plot_histograms"],
-            )
-            result["layout"] = array_name
-            results.append(result)
+    for array_name, telescope_ids in telescope_configs.items():
+        _logger.info(
+            f"Processing file: {args_dict['event_data_file']} with telescope config: {array_name}"
+        )
+        result = _process_file(
+            args_dict["event_data_file"],
+            array_name,
+            telescope_ids,
+            args_dict["loss_fraction"],
+            args_dict["plot_histograms"],
+        )
+        result["layout"] = array_name
+        results.append(result)
 
     write_results(results, args_dict)
 

--- a/tests/integration_tests/config/production_derive_corsika_limits_fits.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_fits.yml
@@ -2,8 +2,7 @@
 applications:
 - application: simtools-production-derive-corsika-limits
   configuration:
-    event_data_files:
-    - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.fits.gz
     loss_fraction: 0.001
     output_file: corsika_simulation_limits_lookup.ecsv
     output_path: simtools-output

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5.yml
@@ -2,8 +2,7 @@
 applications:
 - application: simtools-production-derive-corsika-limits
   configuration:
-    event_data_files:
-    - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
     loss_fraction: 0.001
     output_file: corsika_simulation_limits_lookup.ecsv
     output_path: simtools-output

--- a/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
+++ b/tests/integration_tests/config/production_derive_corsika_limits_hdf5_db_arrays.yml
@@ -5,8 +5,7 @@ applications:
     array_layout_name:
     - 1lst
     - alpha
-    event_data_files:
-    - tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
+    event_data_file: tests/resources/proton_za20deg_azm000deg_North_alpha_6.0.0_reduced_event_data.hdf5
     loss_fraction: 0.001
     model_version: 6.0.0
     output_file: corsika_simulation_limits_lookup.ecsv

--- a/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
+++ b/tests/unit_tests/production_configuration/test_derive_corsika_limits_grid.py
@@ -16,7 +16,7 @@ from simtools.production_configuration.derive_corsika_limits_grid import (
 def mock_args_dict():
     """Create mock arguments dictionary."""
     return {
-        "event_data_files": "data_files.yml",
+        "event_data_file": "data_files.hdf5",
         "telescope_ids": "telescope_ids.yml",
         "loss_fraction": 0.2,
         "plot_histograms": False,
@@ -46,8 +46,6 @@ def mock_results():
 def test_generate_corsika_limits_grid(mocker, mock_args_dict):
     """Test generate_corsika_limits_grid function."""
     # Mock dependencies
-    mock_list = mocker.patch("simtools.utils.general.get_list_of_files_from_command_line")
-    mock_list.return_value = ["file1.fits", "file2.fits"]
     mock_collect = mocker.patch("simtools.utils.general.collect_data_from_file")
     mock_collect.side_effect = [
         {"telescope_configs": {"LST": [1, 2], "MST": [3, 4]}},
@@ -65,9 +63,8 @@ def test_generate_corsika_limits_grid(mocker, mock_args_dict):
 
     # Verify calls
     assert mock_collect.call_count == 1
-    assert mock_process.call_count == 4  # 2 files * 2 configs
+    assert mock_process.call_count == 2  # 2 configs
     assert mock_write.call_count == 1
-    assert mock_list.call_count == 1
 
 
 def test_process_file(mocker):
@@ -200,9 +197,6 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
     args["site"] = "North"
     args["model_version"] = "v1.2.3"
 
-    mock_collect = mocker.patch("simtools.utils.general.get_list_of_files_from_command_line")
-    mock_collect.return_value = ["file1.fits", "file2.fits"]
-
     mock_read_layouts = mocker.patch(
         "simtools.production_configuration.derive_corsika_limits_grid._read_array_layouts_from_db"
     )
@@ -217,9 +211,8 @@ def test_generate_corsika_limits_grid_with_db_layouts(mocker, mock_args_dict):
 
     generate_corsika_limits_grid(args)
 
-    mock_collect.assert_called_once()
     mock_read_layouts.assert_called_once_with(
         args["array_layout_name"], args["site"], args["model_version"], None
     )
-    assert mock_process.call_count == 4  # 2 files * 2 layouts
+    assert mock_process.call_count == 2  # 2 layouts
     assert mock_write.call_count == 1


### PR DESCRIPTION
`simtools-production-derive-corsika-limits` should be applied to a single input file only, as it calculate the limits for a single grid point, see issue #1634.

Remove her the possibility to give a list as files as input.