### PR TITLE
Add schema version to configuration metrics yml file.

### DIFF
--- a/src/simtools/schemas/production_configuration_metrics.schema.yml
+++ b/src/simtools/schemas/production_configuration_metrics.schema.yml
@@ -8,7 +8,6 @@ description: |
 version: 0.1.0
 name: production_configuration_metrics.metaschema
 type: object
-additionalProperties: false
 
 definitions:
   ErrorMetrics:
@@ -20,6 +19,16 @@ definitions:
         $ref: '#/definitions/ErrorMetric'
       energy_estimate:
         $ref: '#/definitions/ErrorMetric'
+      schema_version:
+        type: string
+        description: "Version of the schema."
+      schema_url:
+        type: string
+        format: uri
+        description: "URL of the schema."
+      schema_name:
+        type: string
+        description: "Name of the schema."
 
   ErrorMetric:
     type: object

--- a/src/simtools/schemas/production_configuration_metrics.schema.yml
+++ b/src/simtools/schemas/production_configuration_metrics.schema.yml
@@ -8,6 +8,7 @@ description: |
 version: 0.1.0
 name: production_configuration_metrics.metaschema
 type: object
+additionalProperties: false
 
 definitions:
   ErrorMetrics:

--- a/tests/resources/production_simulation_config_metrics.yml
+++ b/tests/resources/production_simulation_config_metrics.yml
@@ -21,3 +21,6 @@ energy_estimate:
       - 0.04
       - 200
     unit: TeV
+schema_name: production_configuration_metrics.metaschema
+schema_version: 0.1.0
+schema_url: https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/src/simtools/schemas/production_configuration_metrics.schema.yml


### PR DESCRIPTION
Every schema should have a schema_name and schema_version. Add this to the production configuration metrics schema.

To test it, use

```
 python src/simtools/applications/validate_file_using_schema.py --file_name tests/resources/production_simulation_config_metrics.yml --schema src/simtools/schemas/production_configuration_metrics.schema.yml --data_type schema
```