### PR TITLE
Change metadata to lower-case snake make. More consistent usage of schema versions.

### DIFF
--- a/docs/changes/1645.maintenance.md
+++ b/docs/changes/1645.maintenance.md
@@ -1,0 +1,1 @@
+Change metadata to lower-case snake make. More consistent usage of schema versions.

--- a/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
+++ b/src/simtools/applications/convert_geo_coordinates_of_array_elements.py
@@ -140,10 +140,10 @@ def _parse(label=None, description=None):
 def main():
     """Print a list of array elements."""
     label = Path(__file__).stem
-    data_model_name = "array_coordinates"
+    model_parameter_name = "array_coordinates"
     args_dict, db_config = _parse(
         label,
-        description=f"Print a list of array element positions ({data_model_name})",
+        description=f"Print a list of array element positions ({model_parameter_name})",
     )
 
     logger = logging.getLogger()
@@ -153,7 +153,7 @@ def main():
         site = args_dict.get("site", None)
         metadata, validate_schema_file = None, None
     else:
-        metadata = MetadataCollector(args_dict=args_dict, data_model_name=data_model_name)
+        metadata = MetadataCollector(args_dict=args_dict, model_parameter_name=model_parameter_name)
         site = metadata.get_site(from_input_meta=True)
         validate_schema_file = metadata.get_data_model_schema_file_name()
 

--- a/src/simtools/data_model/data_reader.py
+++ b/src/simtools/data_model/data_reader.py
@@ -56,7 +56,6 @@ def read_table_from_file(file_name, schema_file=None, validate=False, metadata_f
         metadata = MetadataCollector(
             args_dict=None,
             metadata_file_name=(metadata_file if metadata_file is not None else file_name),
-            data_model_name=None,
         )
 
         _validator = validate_data.DataValidator(

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -446,7 +446,7 @@ class MetadataCollector:
             or self.args_dict.get("metadata_product_data_name")
             or "undefined_model_name"
         )
-        product_dict["data"]["model"]["version"] = self.schema_dict.get("version", "0.0.0")
+        product_dict["data"]["model"]["version"] = self.schema_dict.get("schema_version", "0.0.0")
         product_dict["data"]["model"]["type"] = self.schema_dict.get("meta_schema", None)
         product_dict["data"]["model"]["url"] = self.schema_file or self.args_dict.get(
             "metadata_product_data_url"

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -707,6 +707,6 @@ class MetadataCollector:
         input_metadata = (
             self.input_metadata if isinstance(self.input_metadata, list) else [self.input_metadata]
         )
-        if len(input_metadata) > 0:
+        if len(input_metadata) > 0 and input_metadata[0]:
             return input_metadata[0].get("reference", {}).get("version", "latest")
         return "latest"

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -187,6 +187,8 @@ class MetadataCollector:
             Name of schema file.
 
         """
+        print("A", self.args_dict)
+        print("B", self.top_level_meta)
         # from command line
         if self.args_dict.get("schema"):
             self._logger.debug(f"Schema file from command line: {self.args_dict['schema']}")

--- a/src/simtools/data_model/metadata_collector.py
+++ b/src/simtools/data_model/metadata_collector.py
@@ -41,8 +41,8 @@ class MetadataCollector:
         Command line parameters
     metadata_file_name: str
         Name of metadata file (only required when args_dict is None)
-    data_model_name: str
-        Name of data model parameter
+    model_parameter_name: str
+        Name of model parameter
     observatory: str
         Name of observatory (default: "cta")
     clean_meta: bool
@@ -53,7 +53,7 @@ class MetadataCollector:
         self,
         args_dict,
         metadata_file_name=None,
-        data_model_name=None,
+        model_parameter_name=None,
         observatory="cta",
         clean_meta=True,
     ):
@@ -63,7 +63,7 @@ class MetadataCollector:
         self.io_handler = io_handler.IOHandler()
 
         self.args_dict = args_dict if args_dict else {}
-        self.data_model_name = data_model_name
+        self.model_parameter_name = model_parameter_name
         self.schema_file = None
         self.schema_dict = None
         self.input_metadata = self._read_input_metadata_from_file(metadata_file_name)
@@ -204,9 +204,9 @@ class MetadataCollector:
             pass
 
         # from data model name
-        if self.data_model_name:
-            self._logger.debug(f"Schema file from data model name: {self.data_model_name}")
-            return str(schema.get_model_parameter_schema_file(self.data_model_name))
+        if self.model_parameter_name:
+            self._logger.debug(f"Schema file from data model name: {self.model_parameter_name}")
+            return str(schema.get_model_parameter_schema_file(self.model_parameter_name))
 
         # from first entry in input metadata (least preferred)
         try:

--- a/src/simtools/data_model/metadata_model.py
+++ b/src/simtools/data_model/metadata_model.py
@@ -133,7 +133,7 @@ def _fill_defaults_recursive(sub_schema, current_dict):
         Current dictionary to fill with default values.
     """
     if "properties" not in sub_schema:
-        _raise_missing_properties_error()
+        raise KeyError("Missing 'properties' key in schema.")
 
     for prop, prop_schema in sub_schema["properties"].items():
         _process_property(prop, prop_schema, current_dict)
@@ -162,10 +162,3 @@ def _process_property(prop, prop_schema, current_dict):
             current_dict[prop] = [{}]
             if "items" in prop_schema and isinstance(prop_schema["items"], dict):
                 _fill_defaults_recursive(prop_schema["items"], current_dict[prop][0])
-
-
-def _raise_missing_properties_error():
-    """Raise an error when the 'properties' key is missing in the schema."""
-    msg = "Missing 'properties' key in schema."
-    _logger.error(msg)
-    raise KeyError(msg)

--- a/src/simtools/data_model/metadata_model.py
+++ b/src/simtools/data_model/metadata_model.py
@@ -11,11 +11,14 @@ Follows CTAO top-level data model definition.
 import logging
 
 import simtools.data_model.schema
+import simtools.utils.general as gen
 
 _logger = logging.getLogger(__name__)
 
 
-def get_default_metadata_dict(schema_file=None, observatory="CTA", schema_version="latest"):
+def get_default_metadata_dict(
+    schema_file=None, observatory="CTA", schema_version="latest", lower_case=True
+):
     """
     Return metadata schema with default values.
 
@@ -29,6 +32,8 @@ def get_default_metadata_dict(schema_file=None, observatory="CTA", schema_versio
         Observatory name
     schema_version: str, optional
         Version of the schema to use. If not provided, the latest version is used.
+    lower_case: bool, optional
+        If True, all keys in the returned dictionary will be converted to lower case.
 
     Returns
     -------
@@ -38,7 +43,10 @@ def get_default_metadata_dict(schema_file=None, observatory="CTA", schema_versio
 
     """
     schema = simtools.data_model.schema.load_schema(schema_file, schema_version=schema_version)
-    return _fill_defaults(schema["definitions"], observatory.lower())
+    return gen.change_dict_keys_case(
+        data_dict=_fill_defaults(schema["definitions"], observatory.lower()),
+        lower_case=lower_case,
+    )
 
 
 def _resolve_references(yaml_data, observatory="CTA"):

--- a/src/simtools/data_model/metadata_model.py
+++ b/src/simtools/data_model/metadata_model.py
@@ -15,7 +15,7 @@ import simtools.data_model.schema
 _logger = logging.getLogger(__name__)
 
 
-def get_default_metadata_dict(schema_file=None, observatory="CTA"):
+def get_default_metadata_dict(schema_file=None, observatory="CTA", schema_version="latest"):
     """
     Return metadata schema with default values.
 
@@ -27,6 +27,8 @@ def get_default_metadata_dict(schema_file=None, observatory="CTA"):
         Schema file (jsonschema format) used for validation
     observatory: str
         Observatory name
+    schema_version: str, optional
+        Version of the schema to use. If not provided, the latest version is used.
 
     Returns
     -------
@@ -35,8 +37,8 @@ def get_default_metadata_dict(schema_file=None, observatory="CTA"):
 
 
     """
-    schema = simtools.data_model.schema.load_schema(schema_file)
-    return _fill_defaults(schema["definitions"], observatory)
+    schema = simtools.data_model.schema.load_schema(schema_file, schema_version=schema_version)
+    return _fill_defaults(schema["definitions"], observatory.lower())
 
 
 def _resolve_references(yaml_data, observatory="CTA"):
@@ -62,7 +64,7 @@ def _resolve_references(yaml_data, observatory="CTA"):
         parts = ref_path.split("/")
         ref_data = yaml_data
         for part in parts:
-            if part in ("definitions", observatory):
+            if part in ("definitions", observatory.lower()):
                 continue
             ref_data = ref_data.get(part, {})
         return ref_data

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -83,9 +83,9 @@ def get_model_parameter_schema_version(schema_version=None):
     schemas = gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA)
 
     if schema_version is None and schemas:
-        return schemas[0].get("version")
+        return schemas[0].get("schema_version")
 
-    if any(schema.get("version") == schema_version for schema in schemas):
+    if any(schema.get("schema_version") == schema_version for schema in schemas):
         return schema_version
 
     raise ValueError(f"Schema version {schema_version} not found in {MODEL_PARAMETER_METASCHEMA}.")
@@ -167,7 +167,7 @@ def get_schema_version_from_data(data, observatory="cta"):
     return "latest"
 
 
-def load_schema(schema_file=None, schema_version=None):
+def load_schema(schema_file=None, schema_version="latest"):
     """
     Load parameter schema from file.
 

--- a/src/simtools/data_model/schema.py
+++ b/src/simtools/data_model/schema.py
@@ -157,8 +157,9 @@ def get_schema_version_from_data(data, observatory="cta"):
     str
         Schema version. If not found, returns 'latest'.
     """
-    if data.get("schema_version"):
-        return data["schema_version"]
+    schema_version = data.get("schema_version") or data.get("SCHEMA_VERSION")
+    if schema_version:
+        return schema_version
     reference_version = data.get(observatory.upper(), {}).get("REFERENCE", {}).get(
         "VERSION"
     ) or data.get(observatory.lower(), {}).get("reference", {}).get("version")

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -3,8 +3,8 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsApplicationWorkflowConfiguration'
 title: SimPipe application workflow configuration metaschema
 description: YAML representation of application workflow configuration metaschema
-version: 0.4.0
-name: application_workflow.metaschema
+schema_version: 0.4.0
+schema_name: application_workflow.metaschema
 type: object
 additionalProperties: false
 

--- a/src/simtools/schemas/input/MST_mirror_2f_measurements.schema.yml
+++ b/src/simtools/schemas/input/MST_mirror_2f_measurements.schema.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 title: Schema for mirror panel 2F measurements
-version: 0.1.0
+schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0

--- a/src/simtools/schemas/input/single_pe_spectrum.schema.yml
+++ b/src/simtools/schemas/input/single_pe_spectrum.schema.yml
@@ -1,7 +1,7 @@
 %YAML 1.2
 ---
 title: Schema for single photon electron spectrum
-version: 0.1.0
+schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0

--- a/src/simtools/schemas/metadata.metaschema.yml
+++ b/src/simtools/schemas/metadata.metaschema.yml
@@ -2,7 +2,7 @@
 $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsOutputMetadata'
 title: SimPipe Output Metadata Metaschema
-description: YAML representation of model parameter metaschema
+description: YAML representation of metadata metaschema
 schema_version: 2.0.0
 schema_name: metadata.metaschema
 type: object
@@ -576,7 +576,7 @@ definitions:
 $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsOutputMetadata'
 title: SimPipe Output Metadata Metaschema
-description: YAML representation of model parameter metaschema
+description: YAML representation of metadata metaschema
 schema_version: 1.0.0
 schema_name: metadata.metaschema
 type: object

--- a/src/simtools/schemas/metadata.metaschema.yml
+++ b/src/simtools/schemas/metadata.metaschema.yml
@@ -3,7 +3,7 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsOutputMetadata'
 title: SimPipe Output Metadata Metaschema
 description: YAML representation of model parameter metaschema
-version: 0.1.0
+version: 0.2.0
 name: metadata.metaschema
 type: object
 additionalProperties: false
@@ -14,92 +14,92 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      CTA:
+      cta:
         $ref: '#/definitions/CTA'
     required:
-      - CTA
+      - cta
     description: SimPipe metadata definition
   CTA:
     type: object
     required:
-      - ACTIVITY
-      - CONTACT
-      - INSTRUMENT
-      - PROCESS
-      - PRODUCT
-      - REFERENCE
+      - activity
+      - contact
+      - instrument
+      - process
+      - product
+      - reference
     additionalProperties: false
     properties:
       ###############
-      REFERENCE:
+      reference:
         description: Reference fields
         required:
-          - VERSION
+          - version
         type: object
         additionalProperties: false
         properties:
-          VERSION:
+          version:
             type: string
             description: |-
               Version of the Reference metadata schema used in the data product
             default: 1.0.0
             pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
       ###############
-      CONTACT:
+      contact:
         title: Contact
         description: |-
           Describes the person or institution that is responsible for this
           data product.
         required:
-          - NAME
+          - name
         type: object
         additionalProperties: false
         properties:
-          ORGANIZATION:
+          organization:
             type: string
             description: |-
               Organization to which this data product is associated
             default: CTAO
-          NAME:
+          name:
             description: |-
               Name of contact within the organization
             anyOf:
               - type: string
               - type: "null"
             default: null
-          EMAIL:
+          email:
             description: Contact email address
             anyOf:
               - type: string
                 format: email
               - type: "null"
             default: null
-          ORCID:
+          orcid:
             description: ORCID identifier of the contact.
             anyOf:
               - type: string
               - type: "null"
             default: null
       ###############
-      PRODUCT:
+      product:
         title: Product
         description: |-
           Describes the details of the data product, including its type and
           links to the data model definition.
         required:
-          - DATA
-          - FORMAT
-          - ID
+          - data
+          - format
+          - id
         type: object
         additionalProperties: false
         properties:
-          DESCRIPTION:
+          description:
             anyOf:
               - type: string
               - type: "null"
             default: null
             description: Product description
-          CREATION_TIME:
+          creation_time:
             anyOf:
               - type: string
                 format: date-time
@@ -108,7 +108,7 @@ definitions:
             default: null
             description: |-
               Human-readable date and time of file creation, in ISO format.
-          ID:
+          id:
             anyOf:
               - type: string
                 format: uuid
@@ -117,16 +117,16 @@ definitions:
             default: null
             description: |-
               Product identifier.
-          DATA:
+          data:
             title: Data
             required:
-              - CATEGORY
-              - LEVEL
-              - MODEL
+              - category
+              - level
+              - model
             type: object
             additionalProperties: false
             properties:
-              CATEGORY:
+              category:
                 anyOf:
                   - type: string
                   - type: "null"
@@ -137,7 +137,7 @@ definitions:
                   - SIM
                   - CAL
                   - null
-              ASSOCIATION:
+              association:
                 anyOf:
                   - type: "null"
                   - type: string
@@ -151,7 +151,7 @@ definitions:
                   - Telescope
                   - Target
                   - null
-              LEVEL:
+              level:
                 anyOf:
                   - type: string
                   - type: "null"
@@ -169,7 +169,7 @@ definitions:
                   - DL5
                   - DL6
                   - null
-              TYPE:
+              type:
                 anyOf:
                   - type: string
                   - type: "null"
@@ -183,29 +183,29 @@ definitions:
                   - DataCube
                   - Catalog
                   - null
-              MODEL:
+              model:
                 title: Model
                 required:
-                  - NAME
-                  - VERSION
+                  - name
+                  - version
                 type: object
                 additionalProperties: false
                 properties:
-                  NAME:
+                  name:
                     anyOf:
                       - type: string
                       - type: "null"
                     default: null
                     description: |-
                       Identifying name of the data model used.
-                  VERSION:
+                  version:
                     anyOf:
                       - type: string
                       - type: "null"
                     default: null
                     description: |-
                       Version of the data model used.
-                  URL:
+                  url:
                     description: |-
                       Link to definition of data model.
                     anyOf:
@@ -213,35 +213,35 @@ definitions:
                         format: uri
                       - type: "null"
                     default: null
-                  TYPE:
+                  type:
                     description: |-
                       Type of data model (e.g. simpipe-schema).
                     anyOf:
                       - type: string
                       - type: "null"
                     default: null
-                  SUBTYPE:
+                  subtype:
                     description: |-
                       Additional subtype of data model.
                     anyOf:
                       - type: string
                       - type: "null"
-          FORMAT:
+          format:
             anyOf:
               - type: string
               - type: "null"
             default: null
-          VALID:
+          valid:
             type: object
             additionalProperties: false
             properties:
-              START:
+              start:
                 anyOf:
                   - type: string
                     format: date-time
                   - type: "null"
                 default: null
-              END:
+              end:
                 anyOf:
                   - type: string
                     format: date-time
@@ -250,7 +250,7 @@ definitions:
             title: Valid
             description: |-
               Time range of validity for this data product.
-          FILENAME:
+          filename:
             description: |-
               Name of the file containing the data product.
             anyOf:
@@ -258,17 +258,17 @@ definitions:
               - type: "null"
             default: null
       ###############
-      INSTRUMENT:
+      instrument:
         title: Instrument
         required:
-          - CLASS
-          - ID
-          - SITE
-          - TYPE
+          - class
+          - id
+          - site
+          - type
         type: object
         additionalProperties: false
         properties:
-          SITE:
+          site:
             anyOf:
               - type: "null"
               - type: string
@@ -278,7 +278,7 @@ definitions:
             example:
               - CTA-North
               - CTA-South
-          CLASS:
+          class:
             anyOf:
               - type: "null"
               - type: string
@@ -295,7 +295,7 @@ definitions:
               - photosensor
               - cameraModule
               - part
-          TYPE:
+          type:
             anyOf:
               - type: "null"
               - type: string
@@ -306,7 +306,7 @@ definitions:
               - MST
               - LST
               - SST
-          SUBTYPE:
+          subtype:
             anyOf:
               - type: "null"
               - type: string
@@ -316,7 +316,7 @@ definitions:
             example:
               - NectarCam
               - FlashCam
-          ID:
+          id:
             anyOf:
               - type: "null"
               - type: string
@@ -326,25 +326,25 @@ definitions:
               Unique ID of the specific instrument in the class.
             example:
               - MSTN-20
-          DESCRIPTION:
+          description:
             anyOf:
               - type: string
               - type: "null"
             default: null
             description: Instrument description
       ###############
-      PROCESS:
+      process:
         title: Process
         description: |-
           The top-level activity to which the activity that generated this
           product belongs, for example an Observation Block, and it's
           associated ID.
         required:
-          - TYPE
+          - type
         type: object
         additionalProperties: false
         properties:
-          TYPE:
+          type:
             description: |-
               General type of the process.
             anyOf:
@@ -357,7 +357,7 @@ definitions:
               - simulation
               - lab
               - null
-          SUBTYPE:
+          subtype:
             description: |-
               More specific class of the process if the class is not sufficient
               to describe it.
@@ -365,7 +365,7 @@ definitions:
               - type: "null"
               - type: string
             default: null
-          ID:
+          id:
             description: |-
               Unique identifier of the process.
             anyOf:
@@ -374,21 +374,21 @@ definitions:
               - type: number
             default: null
       ###############
-      ACTIVITY:
+      activity:
         title: Activity
         description: |-
           The specific software or task that generated this particular
           data product.
         required:
-          - ID
-          - NAME
-          - START
-          - END
-          - TYPE
+          - id
+          - name
+          - start
+          - end
+          - type
         type: object
         additionalProperties: false
         properties:
-          NAME:
+          name:
             description: |-
               Name of activity that produced this data product,
               e.g. the software/ script name.
@@ -396,7 +396,7 @@ definitions:
               - type: string
               - type: "null"
             default: null
-          TYPE:
+          type:
             description: |-
               General type of the activity.
             anyOf:
@@ -406,7 +406,7 @@ definitions:
             example:
               - software
               - user
-          ID:
+          id:
             description: |-
               Unique identifier of the instance of this activity.
             anyOf:
@@ -414,21 +414,21 @@ definitions:
               - type: "null"
               - type: number
             default: null
-          SOFTWARE:
+          software:
             title: Software
             description: |-
               The software used to generate this data product.
             type: object
             additionalProperties: false
             properties:
-              NAME:
+              name:
                 description: |-
                   Name of the software used to generate this data product.
                 anyOf:
                   - type: string
                   - type: "null"
                 default: null
-              VERSION:
+              version:
                 description: |-
                   Version of the software used to generate this data product.
                 anyOf:
@@ -436,9 +436,9 @@ definitions:
                   - type: "null"
                 default: null
             required:
-              - NAME
-              - VERSION
-          START:
+              - name
+              - version
+          start:
             description: |-
               Start time of the activity.
             anyOf:
@@ -446,7 +446,7 @@ definitions:
                 format: date-time
               - type: "null"
             default: null
-          END:
+          end:
             description: |-
               End time of the activity.
             anyOf:
@@ -455,14 +455,14 @@ definitions:
               - type: "null"
             default: null
       ###############
-      CONTEXT:
+      context:
         title: Context
         description: |-
           Additional context information for this data product.
         type: object
         additionalProperties: false
         properties:
-          NOTES:
+          notes:
             title: Context notes.
             description: |-
               Notes that provide additional context for this data product.
@@ -471,21 +471,21 @@ definitions:
               type: object
               additionalProperties: false
               properties:
-                TITLE:
+                title:
                   description: |-
                     Title of note.
                   anyOf:
                     - type: string
                     - type: "null"
                   default: null
-                TEXT:
+                text:
                   description: |-
                     Note text.
                   anyOf:
                     - type: string
                     - type: "null"
                   default: null
-                CREATION_TIME:
+                creation_time:
                   description: |-
                     Creation time of document.
                   anyOf:
@@ -494,8 +494,8 @@ definitions:
                     - type: "null"
                   default: null
               required:
-                - TEXT
-          DOCUMENT:
+                - text
+          document:
             title: Context documents.
             description: |-
               Documents that provide additional context for this data product.
@@ -504,28 +504,28 @@ definitions:
               type: object
               additionalProperties: false
               properties:
-                TYPE:
+                type:
                   description: |-
                     Type of document.
                   anyOf:
                     - type: string
                     - type: "null"
                   default: null
-                TITLE:
+                title:
                   description: |-
                     Title of document.
                   anyOf:
                     - type: string
                     - type: "null"
                   default: null
-                AUTHOR:
+                author:
                   description: |-
                     Author of document.
                   anyOf:
                     - type: string
                     - type: "null"
                   default: null
-                ID:
+                id:
                   description: |-
                     Unique identifier of document.
                   anyOf:
@@ -533,7 +533,7 @@ definitions:
                     - type: "null"
                     - type: number
                   default: null
-                CREATION_TIME:
+                creation_time:
                   description: |-
                     Creation time of document.
                   anyOf:
@@ -541,7 +541,7 @@ definitions:
                       format: date-time
                     - type: "null"
                   default: null
-                URL:
+                url:
                   description: |-
                     Link to document
                   anyOf:
@@ -550,11 +550,11 @@ definitions:
                     - type: "null"
                   default: null
               required:
-                - CREATION_TIME
-                - ID
-                - TITLE
-                - TYPE
-          ASSOCIATED_ELEMENTS:
+                - creation_time
+                - id
+                - title
+                - type
+          associated_elements:
             title: Associated elements.
             description: |-
               CTA elements associated with this data product
@@ -562,12 +562,12 @@ definitions:
               a certain camera).
             type: array
             items:
-              $ref: '#/definitions/CTA/properties/INSTRUMENT'
-          ASSOCIATED_DATA:
+              $ref: '#/definitions/CTA/properties/instrument'
+          associated_data:
             title: Associated data.
             description: |-
               Associated data products (e.g., this data product
               has been derived using the associated data).
             type: array
             items:
-              $ref: '#/definitions/CTA/properties/PRODUCT'
+              $ref: '#/definitions/CTA/properties/product'

--- a/src/simtools/schemas/metadata.metaschema.yml
+++ b/src/simtools/schemas/metadata.metaschema.yml
@@ -3,8 +3,8 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsOutputMetadata'
 title: SimPipe Output Metadata Metaschema
 description: YAML representation of model parameter metaschema
-version: 0.2.0
-name: metadata.metaschema
+schema_version: 2.0.0
+schema_name: metadata.metaschema
 type: object
 additionalProperties: false
 
@@ -15,11 +15,11 @@ definitions:
     additionalProperties: false
     properties:
       cta:
-        $ref: '#/definitions/CTA'
+        $ref: '#/definitions/cta'
     required:
       - cta
     description: SimPipe metadata definition
-  CTA:
+  cta:
     type: object
     required:
       - activity
@@ -42,7 +42,7 @@ definitions:
             type: string
             description: |-
               Version of the Reference metadata schema used in the data product
-            default: 1.0.0
+            default: 2.0.0
             pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
       ###############
       contact:
@@ -562,7 +562,7 @@ definitions:
               a certain camera).
             type: array
             items:
-              $ref: '#/definitions/CTA/properties/instrument'
+              $ref: '#/definitions/cta/properties/instrument'
           associated_data:
             title: Associated data.
             description: |-
@@ -570,4 +570,578 @@ definitions:
               has been derived using the associated data).
             type: array
             items:
-              $ref: '#/definitions/CTA/properties/product'
+              $ref: '#/definitions/cta/properties/product'
+...
+---
+$schema: http://json-schema.org/draft-06/schema#
+$ref: '#/definitions/SimtoolsOutputMetadata'
+title: SimPipe Output Metadata Metaschema
+description: YAML representation of model parameter metaschema
+schema_version: 1.0.0
+schema_name: metadata.metaschema
+type: object
+additionalProperties: false
+
+
+definitions:
+  SimtoolsOutputMetadata:
+    type: object
+    additionalProperties: false
+    properties:
+      CTA:
+        $ref: '#/definitions/CTA'
+    required:
+      - CTA
+    description: SimPipe metadata definition
+  CTA:
+    type: object
+    required:
+      - ACTIVITY
+      - CONTACT
+      - INSTRUMENT
+      - PROCESS
+      - PRODUCT
+      - REFERENCE
+    additionalProperties: false
+    properties:
+      ###############
+      REFERENCE:
+        description: Reference fields
+        required:
+          - VERSION
+        type: object
+        additionalProperties: false
+        properties:
+          VERSION:
+            type: string
+            description: |-
+              Version of the Reference metadata schema used in the data product
+            default: 1.0.0
+            pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+      ###############
+      CONTACT:
+        title: Contact
+        description: |-
+          Describes the person or institution that is responsible for this
+          data product.
+        required:
+          - NAME
+        type: object
+        additionalProperties: false
+        properties:
+          ORGANIZATION:
+            type: string
+            description: |-
+              Organization to which this data product is associated
+            default: CTAO
+          NAME:
+            description: |-
+              Name of contact within the organization
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+          EMAIL:
+            description: Contact email address
+            anyOf:
+              - type: string
+                format: email
+              - type: "null"
+            default: null
+          ORCID:
+            description: ORCID identifier of the contact.
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+      ###############
+      PRODUCT:
+        title: Product
+        description: |-
+          Describes the details of the data product, including its type and
+          links to the data model definition.
+        required:
+          - DATA
+          - FORMAT
+          - ID
+        type: object
+        additionalProperties: false
+        properties:
+          DESCRIPTION:
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+            description: Product description
+          CREATION_TIME:
+            anyOf:
+              - type: string
+                format: date-time
+              - type: "null"
+            format: date-time
+            default: null
+            description: |-
+              Human-readable date and time of file creation, in ISO format.
+          ID:
+            anyOf:
+              - type: string
+                format: uuid
+              - type: "null"
+              - type: number
+            default: null
+            description: |-
+              Product identifier.
+          DATA:
+            title: Data
+            required:
+              - CATEGORY
+              - LEVEL
+              - MODEL
+            type: object
+            additionalProperties: false
+            properties:
+              CATEGORY:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                default: null
+                description: |-
+                  CTA data identifier
+                enum:
+                  - SIM
+                  - CAL
+                  - null
+              ASSOCIATION:
+                anyOf:
+                  - type: "null"
+                  - type: string
+                default: null
+                description: |-
+                  Array element association.
+                enum:
+                  - CTA
+                  - Site
+                  - Subarray
+                  - Telescope
+                  - Target
+                  - null
+              LEVEL:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                default: null
+                description: |-
+                  CTA data level
+                enum:
+                  - R0
+                  - R1
+                  - DL0
+                  - DL1
+                  - DL2
+                  - DL3
+                  - DL4
+                  - DL5
+                  - DL6
+                  - null
+              TYPE:
+                anyOf:
+                  - type: string
+                  - type: "null"
+                default: null
+                description: |-
+                  CTA data type.
+                enum:
+                  - Event
+                  - Monitoring
+                  - Service
+                  - DataCube
+                  - Catalog
+                  - null
+              MODEL:
+                title: Model
+                required:
+                  - NAME
+                  - VERSION
+                type: object
+                additionalProperties: false
+                properties:
+                  NAME:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    default: null
+                    description: |-
+                      Identifying name of the data model used.
+                  VERSION:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    default: null
+                    description: |-
+                      Version of the data model used.
+                  URL:
+                    description: |-
+                      Link to definition of data model.
+                    anyOf:
+                      - type: string
+                        format: uri
+                      - type: "null"
+                    default: null
+                  TYPE:
+                    description: |-
+                      Type of data model (e.g. simpipe-schema).
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    default: null
+                  SUBTYPE:
+                    description: |-
+                      Additional subtype of data model.
+                    anyOf:
+                      - type: string
+                      - type: "null"
+          FORMAT:
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+          VALID:
+            type: object
+            additionalProperties: false
+            properties:
+              START:
+                anyOf:
+                  - type: string
+                    format: date-time
+                  - type: "null"
+                default: null
+              END:
+                anyOf:
+                  - type: string
+                    format: date-time
+                  - type: "null"
+                default: null
+            title: Valid
+            description: |-
+              Time range of validity for this data product.
+          FILENAME:
+            description: |-
+              Name of the file containing the data product.
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+      ###############
+      INSTRUMENT:
+        title: Instrument
+        required:
+          - CLASS
+          - ID
+          - SITE
+          - TYPE
+        type: object
+        additionalProperties: false
+        properties:
+          SITE:
+            anyOf:
+              - type: "null"
+              - type: string
+            description: |-
+              CTA Site.
+            default: null
+            example:
+              - CTA-North
+              - CTA-South
+          CLASS:
+            anyOf:
+              - type: "null"
+              - type: string
+            default: null
+            description: |-
+              General class of instrument to which this data product applies.
+            example:
+              - array
+              - subarray
+              - telescope
+              - camera
+              - optics
+              - mirrorPanel
+              - photosensor
+              - cameraModule
+              - part
+          TYPE:
+            anyOf:
+              - type: "null"
+              - type: string
+            default: null
+            description: |-
+              The specific type of instrument in the class.
+            example:
+              - MST
+              - LST
+              - SST
+          SUBTYPE:
+            anyOf:
+              - type: "null"
+              - type: string
+            default: null
+            description: |-
+              Sub-type of the instrument.
+            example:
+              - NectarCam
+              - FlashCam
+          ID:
+            anyOf:
+              - type: "null"
+              - type: string
+              - type: number
+            default: null
+            description: |-
+              Unique ID of the specific instrument in the class.
+            example:
+              - MSTN-20
+          DESCRIPTION:
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+            description: Instrument description
+      ###############
+      PROCESS:
+        title: Process
+        description: |-
+          The top-level activity to which the activity that generated this
+          product belongs, for example an Observation Block, and it's
+          associated ID.
+        required:
+          - TYPE
+        type: object
+        additionalProperties: false
+        properties:
+          TYPE:
+            description: |-
+              General type of the process.
+            anyOf:
+              - type: "null"
+              - type: string
+            default: null
+            enum:
+              - observation
+              - calibration
+              - simulation
+              - lab
+              - null
+          SUBTYPE:
+            description: |-
+              More specific class of the process if the class is not sufficient
+              to describe it.
+            anyOf:
+              - type: "null"
+              - type: string
+            default: null
+          ID:
+            description: |-
+              Unique identifier of the process.
+            anyOf:
+              - type: "null"
+              - type: string
+              - type: number
+            default: null
+      ###############
+      ACTIVITY:
+        title: Activity
+        description: |-
+          The specific software or task that generated this particular
+          data product.
+        required:
+          - ID
+          - NAME
+          - START
+          - END
+          - TYPE
+        type: object
+        additionalProperties: false
+        properties:
+          NAME:
+            description: |-
+              Name of activity that produced this data product,
+              e.g. the software/ script name.
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+          TYPE:
+            description: |-
+              General type of the activity.
+            anyOf:
+              - type: string
+              - type: "null"
+            default: null
+            example:
+              - software
+              - user
+          ID:
+            description: |-
+              Unique identifier of the instance of this activity.
+            anyOf:
+              - type: string
+              - type: "null"
+              - type: number
+            default: null
+          SOFTWARE:
+            title: Software
+            description: |-
+              The software used to generate this data product.
+            type: object
+            additionalProperties: false
+            properties:
+              NAME:
+                description: |-
+                  Name of the software used to generate this data product.
+                anyOf:
+                  - type: string
+                  - type: "null"
+                default: null
+              VERSION:
+                description: |-
+                  Version of the software used to generate this data product.
+                anyOf:
+                  - type: string
+                  - type: "null"
+                default: null
+            required:
+              - NAME
+              - VERSION
+          START:
+            description: |-
+              Start time of the activity.
+            anyOf:
+              - type: string
+                format: date-time
+              - type: "null"
+            default: null
+          END:
+            description: |-
+              End time of the activity.
+            anyOf:
+              - type: string
+                format: date-time
+              - type: "null"
+            default: null
+      ###############
+      CONTEXT:
+        title: Context
+        description: |-
+          Additional context information for this data product.
+        type: object
+        additionalProperties: false
+        properties:
+          NOTES:
+            title: Context notes.
+            description: |-
+              Notes that provide additional context for this data product.
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                TITLE:
+                  description: |-
+                    Title of note.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                TEXT:
+                  description: |-
+                    Note text.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                CREATION_TIME:
+                  description: |-
+                    Creation time of document.
+                  anyOf:
+                    - type: string
+                      format: date-time
+                    - type: "null"
+                  default: null
+              required:
+                - TEXT
+          DOCUMENT:
+            title: Context documents.
+            description: |-
+              Documents that provide additional context for this data product.
+            type: array
+            items:
+              type: object
+              additionalProperties: false
+              properties:
+                TYPE:
+                  description: |-
+                    Type of document.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                TITLE:
+                  description: |-
+                    Title of document.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                AUTHOR:
+                  description: |-
+                    Author of document.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                  default: null
+                ID:
+                  description: |-
+                    Unique identifier of document.
+                  anyOf:
+                    - type: string
+                    - type: "null"
+                    - type: number
+                  default: null
+                CREATION_TIME:
+                  description: |-
+                    Creation time of document.
+                  anyOf:
+                    - type: string
+                      format: date-time
+                    - type: "null"
+                  default: null
+                URL:
+                  description: |-
+                    Link to document
+                  anyOf:
+                    - type: string
+                      format: uri
+                    - type: "null"
+                  default: null
+              required:
+                - CREATION_TIME
+                - ID
+                - TITLE
+                - TYPE
+          ASSOCIATED_ELEMENTS:
+            title: Associated elements.
+            description: |-
+              CTA elements associated with this data product
+              (e.g., this data product is to be used to model
+              a certain camera).
+            type: array
+            items:
+              $ref: '#/definitions/CTA/properties/INSTRUMENT'
+          ASSOCIATED_DATA:
+            title: Associated data.
+            description: |-
+              Associated data products (e.g., this data product
+              has been derived using the associated data).
+            type: array
+            items:
+              $ref: '#/definitions/CTA/properties/PRODUCT'

--- a/src/simtools/schemas/model_parameter.metaschema.yml
+++ b/src/simtools/schemas/model_parameter.metaschema.yml
@@ -5,8 +5,8 @@ title: SimPipe DB Model Parameter Metaschema
 description: |
   YAML representation of db model parameter metaschema
   (based on simulation model DB).
-version: 0.3.0
-name: modelparameter.metaschema
+schema_version: 0.3.0
+schema_name: modelparameter.metaschema
 type: object
 additionalProperties: false
 
@@ -118,8 +118,8 @@ title: SimPipe DB Model Parameter Metaschema
 description: |
   YAML representation of db model parameter metaschema
   (based on simulation model DB).
-version: 0.2.0
-name: modelparameter.metaschema
+schema_version: 0.2.0
+schema_name: modelparameter.metaschema
 type: object
 additionalProperties: false
 
@@ -209,8 +209,8 @@ title: SimPipe DB Model Parameter Metaschema
 description: |
   YAML representation of db model parameter metaschema
   (based on model_parameters DB).
-version: 0.1.0
-name: modelparameter.metaschema
+schema_version: 0.1.0
+schema_name: modelparameter.metaschema
 type: object
 additionalProperties: false
 

--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -3,7 +3,7 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsDataAndModelParameters'
 title: SimPipe Data and Model Parameter Metaschema
 description: YAML representation of data and model parameter metaschema
-version: 0.1.0
+schema_version: 0.1.0
 name: model_parameter_and_data_schema.metaschema
 type: object
 
@@ -16,7 +16,7 @@ definitions:
       title:
         type: string
         description: "title for schema file"
-      version:
+      schema_version:
         type: string
         description: "version of this schema file (semver)"
       meta_schema:
@@ -64,7 +64,7 @@ definitions:
           $ref: 'plot_configuration.metaschema.yml#/definitions/plot'
         description: "List of plotting configurations"
     required:
-      - version
+      - schema_version
       - meta_schema
       - meta_schema_version
       - name

--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -3,7 +3,7 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsDataAndModelParameters'
 title: SimPipe Data and Model Parameter Metaschema
 description: YAML representation of data and model parameter metaschema
-schema_version: 0.1.0
+version: 0.1.0
 name: model_parameter_and_data_schema.metaschema
 type: object
 

--- a/src/simtools/schemas/plot_configuration.metaschema.yml
+++ b/src/simtools/schemas/plot_configuration.metaschema.yml
@@ -3,8 +3,8 @@ $schema: http://json-schema.org/draft-06/schema#
 $ref: '#/definitions/SimtoolsPlotConfiguration'
 title: SimPipe plot configuration metaschema
 description: YAML representation of plot configuration metaschema
-version: 0.1.0
-name: plot_configuration.metaschema
+schema_version: 0.1.0
+schema_name: plot_configuration.metaschema
 type: object
 
 definitions:

--- a/src/simtools/schemas/production_configuration_metrics.schema.yml
+++ b/src/simtools/schemas/production_configuration_metrics.schema.yml
@@ -5,8 +5,8 @@ title: Statistical Error Metrics Schema
 description: |
   YAML representation of simulation production configuration
   metrics.
-version: 0.1.0
-name: production_configuration_metrics.metaschema
+schema_version: 0.1.0
+schema_name: production_configuration_metrics.metaschema
 type: object
 additionalProperties: false
 

--- a/src/simtools/schemas/production_tables.schema.yml
+++ b/src/simtools/schemas/production_tables.schema.yml
@@ -5,8 +5,8 @@ title: SimPipe DB Production Model Metaschema
 description: |
   YAML representation of DB production model metaschema
   (based on simulation model DB).
-version: 0.1.0
-name: production_table.metaschema
+schema_version: 0.1.0
+schema_name: production_table.metaschema
 type: object
 additionalProperties: false
 

--- a/tests/resources/MLTdata-preproduction.meta.yml
+++ b/tests/resources/MLTdata-preproduction.meta.yml
@@ -1,71 +1,67 @@
 ---
-CTA:
-  REFERENCE:
-    VERSION: 1.0.0
-  ACTIVITY:
-    NAME: mirror_2f_measurement
-    ID: null
-    TYPE: null
-    START: null
-    END: null
-  # Organization and person submitting these data
-  CONTACT:
-    ORGANIZATION: 'MST Consortium'
-    NAME: 'MST Mirror Responsible Person'
-    EMAIL: 'a@email.org'
-  # Description of instrument which obtained these data
-  INSTRUMENT:
-    SITE: 'The 2f test stand'
-    CLASS: mirrorPanel
-    TYPE: MLT
-    SUBTYPE: pre-production
-    ID: unique-ID-of-mirror-panel-test-stand
-  # Description of the process which generated these data
-  PROCESS:
-    TYPE: lab
-    ID: unique-ID-of-measurement-process
-  # Description of the submitted data product
-  PRODUCT:
-    DESCRIPTION: |-
-      Mirror curvature radius and PSF measurements
-      from 2f test stand
-    CREATION_TIME: '2020-03-20T12:00:00+00:00'
-    ID: null
-    VALID:
-      START: '2020-03-20T12:00:00+00:00'
-      END: '2024-03-20T12:00:00+00:00'
-    FORMAT: ascii.ecsv
-    DATA:
-      CATEGORY: CAL
-      LEVEL: R1
-      TYPE: Service
-      ASSOCIATION: Telescope
-      MODEL:
-        NAME: simpipe-schema
-        VERSION: 0.1.0
+cta:
+  reference:
+    version: 2.0.0
+  activity:
+    name: mirror_2f_measurement
+    id: null
+    type: null
+    start: null
+    end: null
+  contact:
+    organization: MST Consortium
+    name: MST Mirror Responsible Person
+    email: a@email.org
+  instrument:
+    site: The 2f test stand
+    class: mirrorPanel
+    type: MLT
+    subtype: pre-production
+    id: unique-ID-of-mirror-panel-test-stand
+  process:
+    type: lab
+    id: unique-ID-of-measurement-process
+  product:
+    description: 'Mirror curvature radius and PSF measurements
+
+      from 2f test stand'
+    creation_time: '2020-03-20T12:00:00+00:00'
+    id: null
+    valid:
+      start: '2020-03-20T12:00:00+00:00'
+      end: '2024-03-20T12:00:00+00:00'
+    format: ascii.ecsv
+    data:
+      category: CAL
+      level: R1
+      type: Service
+      association: Telescope
+      model:
+        name: simpipe-schema
+        version: 0.1.0
         # yamllint disable rule:line-length
-        URL: "https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/input/MST_mirror_2f_measurements.schema.yml"
-  CONTEXT:
-    ASSOCIATED_ELEMENTS:
-      - SITE: South
-        CLASS: MST
-        TYPE: FlashCam
-        SUBTYPE: D
-        ID: MSTS
-      - SITE: North
-        CLASS: MST
-        TYPE: NectarCam
-        SUBTYPE: D
-        ID: MSTN
-    DOCUMENT:
-      - TYPE: Issue
-        ID: 22570
-        URL: https://forge.in2p3.fr/issues/22570
-        CREATION_TIME: null
-        TITLE: null
-      - TYPE: Presentation
-        # yamllint disable rule:line-length
-        URL: "https://indico.cta-observatory.org/login/?next=%2Fevent%2F2680%2Fcontributions%2F23371%2Fattachments%2F17190%2F22730%2F200320_MST_optics.pdf"
-        CREATION_TIME: null
-        TITLE: null
-        ID: null
+        url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/input/MST_mirror_2f_measurements.schema.yml
+  context:
+    associated_elements:
+    - site: South
+      class: MST
+      type: FlashCam
+      subtype: D
+      id: MSTS
+    - site: North
+      class: MST
+      type: NectarCam
+      subtype: D
+      id: MSTN
+    document:
+    - type: Issue
+      id: 22570
+      url: https://forge.in2p3.fr/issues/22570
+      creation_time: null
+      title: null
+    - type: Presentation
+      # yamllint disable rule:line-length
+      url: https://indico.cta-observatory.org/login/?next=%2Fevent%2F2680%2Fcontributions%2F23371%2Fattachments%2F17190%2F22730%2F200320_MST_optics.pdf
+      creation_time: null
+      title: null
+      id: null

--- a/tests/resources/num_gains.meta.yml
+++ b/tests/resources/num_gains.meta.yml
@@ -1,61 +1,51 @@
 ---
-CTA:
-  REFERENCE:
-    VERSION: 1.0.0
-  # Name of activity that produced this data product
-  ACTIVITY:
-    NAME: specification
-    ID: null
-    TYPE: null
-    START: null
-    END: null
-  # Organization and person submitting these data
-  CONTACT:
-    ORGANIZATION: 'CTAO'
-    NAME: 'CTAO Monte Carlo Team'
-    EMAIL: 'a@email.org'
-  # Description of instrument which obtained these data
-  # (this might be e.g., a calibration device, telescope)
-  INSTRUMENT:
-    SITE: North
-    CLASS: null
-    TYPE: LSTN
-    ID: design
-  # Description of the process which generated these data
-  PROCESS:
-    TYPE: null
-    ID: null
-  # Description of the submitted data product
-  PRODUCT:
-    DESCRIPTION: >
-      Number of gains.
-    CREATION_TIME: '2017-05-08T12:00:00+00:00'
-    ID: null
-    VALID:
-      START: '2017-05-08T12:00:00+00:00'
-    FORMAT: number
-    FILENAME: null
-    DATA:
-      CATEGORY: null
-      LEVEL: null
-      TYPE: Service
-      ASSOCIATION: Telescope
-      MODEL:
-        NAME: num_gains
-        VERSION: 0.1.0
-        URL: https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/src/simtools/schemas/model_parameters/num_gains.schema.yml
-  # Additional information about the data product.
-  CONTEXT:
-    # List of relevant documents
-    DOCUMENT:
-      - TYPE: CTAO-MC-DOC
-        TITLE: "CTA Monte Carlo Model LST Appendix (last update: 04 May 2020)"
-        ID: null
-        CREATION_TIME: '2020-04-20T12:00:00+00:00'
-        URL: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/verification/verification-process/lst/-/blob/master/Appendix-LST.pdf
-    # List of array elements this data product is associated with
-    ASSOCIATED_ELEMENTS:
-      - SITE: North
-        CLASS: null
-        TYPE: LSTN
-        ID: design
+cta:
+  reference:
+    version: 2.0.0
+  activity:
+    name: specification
+    id: null
+    type: null
+    start: null
+    end: null
+  contact:
+    organization: CTAO
+    name: CTAO Monte Carlo Team
+    email: a@email.org
+  instrument:
+    site: North
+    class: null
+    type: LSTN
+    id: design
+  process:
+    type: null
+    id: null
+  product:
+    description: Number of gains.
+    creation_time: '2017-05-08T12:00:00+00:00'
+    id: null
+    valid:
+      start: '2017-05-08T12:00:00+00:00'
+    format: number
+    filename: null
+    data:
+      category: null
+      level: null
+      type: Service
+      association: Telescope
+      model:
+        name: num_gains
+        version: 0.1.0
+        url: https://raw.githubusercontent.com/gammasim/simtools/refs/heads/main/src/simtools/schemas/model_parameters/num_gains.schema.yml
+  context:
+    document:
+    - type: CTAO-MC-DOC
+      title: 'CTA Monte Carlo Model LST Appendix (last update: 04 May 2020)'
+      id: null
+      creation_time: '2020-04-20T12:00:00+00:00'
+      url: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/verification/verification-process/lst/-/blob/master/Appendix-LST.pdf
+    associated_elements:
+    - site: North
+      class: null
+      type: LSTN
+      id: design

--- a/tests/resources/telescope_positions-North-utm.meta.yml
+++ b/tests/resources/telescope_positions-North-utm.meta.yml
@@ -1,57 +1,52 @@
 ---
-CTA:
-  REFERENCE:
-    VERSION: 1.0.0
-  ACTIVITY:
-    NAME: telescope_positions
-    ID: null
-    TYPE: null
-    START: null
-    END: null
-  # Organization and person submitting these data
-  CONTACT:
-    ORGANIZATION: 'CTAO North'
-    NAME: 'CTAO Project Scientist'
-    EMAIL: 'a@email.org'
-  # Description of instrument which obtained these data
-  INSTRUMENT:
-    SITE: North
-    CLASS: null
-    TYPE: null
-    ID: null
-  # Description of the process which generated these data
-  PROCESS:
-    TYPE: null
-    ID: null
-  # Description of the submitted data product
-  PRODUCT:
-    DESCRIPTION: >
-      Telescope positions for the CTAO Northern site
-      (UTM coordinate system). Consistent with
-      document CTA-SPE-PSC-000000-0001 1c.
-    CREATION_TIME: '2022-05-30T12:00:00+00:00'
-    ID: null
-    VALID:
-      START: '2022-05-30T12:00:00+00:00'
-    FORMAT: ascii.ecsv
-    FILENAME: telescope_positions-North-utm.ecsv
-    DATA:
-      CATEGORY: CAL
-      LEVEL: R1
-      TYPE: Service
-      ASSOCIATION: Subarray
-      MODEL:
-        NAME: array_coordinates_utm
-        VERSION: 0.1.0
-        URL: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
-  CONTEXT:
-    DOCUMENT:
-      - TYPE: CTAO-DOC
-        TITLE: Layouts of the CTAO Arrays
-        ID: CTA-SPE-PSC-000000-0001 1c
-        CREATION_TIME: '2022-05-30T12:00:00+00:00'
-    ASSOCIATED_ELEMENTS:
-      - SITE: North
-        CLASS: array
-        TYPE: null
-        ID: null
+cta:
+  reference:
+    version: 2.0.0
+  activity:
+    name: telescope_positions
+    id: null
+    type: null
+    start: null
+    end: null
+  contact:
+    organization: CTAO North
+    name: CTAO Project Scientist
+    email: a@email.org
+  instrument:
+    site: North
+    class: null
+    type: null
+    id: null
+  process:
+    type: null
+    id: null
+  product:
+    description: >
+      Telescope positions for the CTAO Northern site (UTM coordinate system).
+      Consistent with document CTA-SPE-PSC-000000-0001 1c.
+    creation_time: '2022-05-30T12:00:00+00:00'
+    id: null
+    valid:
+      start: '2022-05-30T12:00:00+00:00'
+    format: ascii.ecsv
+    filename: telescope_positions-North-utm.ecsv
+    data:
+      category: CAL
+      level: R1
+      type: Service
+      association: Subarray
+      model:
+        name: array_coordinates_utm
+        version: 0.1.0
+        url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+  context:
+    document:
+    - type: CTAO-DOC
+      title: Layouts of the CTAO Arrays
+      id: CTA-SPE-PSC-000000-0001 1c
+      creation_time: '2022-05-30T12:00:00+00:00'
+    associated_elements:
+    - site: North
+      class: array
+      type: null
+      id: null

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -28,7 +28,7 @@ def test_get_data_model_schema_file_name():
     assert schema_file is None
 
     args_dict = {"schema": str(METADATA_JSON_SCHEMA)}
-    _collector = metadata_collector.MetadataCollector(args_dict)
+    _collector = metadata_collector.MetadataCollector(args_dict, clean_meta=False)
     schema_file = _collector.get_data_model_schema_file_name()
     assert schema_file == args_dict["schema"]
 

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -48,15 +48,17 @@ def test_get_data_model_schema_file_name():
     assert schema_file is None
 
     # from data model_name
-    _collector.data_model_name = "array_coordinates"
+    _collector.model_parameter_name = "array_coordinates"
     schema_file = _collector.get_data_model_schema_file_name()
-    assert Path(schema_file) == (schema.get_model_parameter_schema_file(_collector.data_model_name))
+    assert Path(schema_file) == (
+        schema.get_model_parameter_schema_file(_collector.model_parameter_name)
+    )
 
     # from input metadata
     _collector.input_metadata = [
         {"cta": {"product": {"data": {"model": {"url": "from_input_meta"}}}}}
     ]
-    _collector.data_model_name = None
+    _collector.model_parameter_name = None
     schema_file = _collector.get_data_model_schema_file_name()
     assert schema_file == "from_input_meta"
 

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -33,7 +33,6 @@ def test_get_data_model_schema_file_name():
     assert schema_file == args_dict["schema"]
 
     # from metadata
-    print("AAAAA", _collector.top_level_meta)
     _collector.top_level_meta["cta"]["product"]["data"]["model"]["url"] = str(
         SCHEMA_PATH / "top_level_meta.schema.yml"
     )

--- a/tests/unit_tests/data_model/test_metadata_collector.py
+++ b/tests/unit_tests/data_model/test_metadata_collector.py
@@ -33,6 +33,7 @@ def test_get_data_model_schema_file_name():
     assert schema_file == args_dict["schema"]
 
     # from metadata
+    print("AAAAA", _collector.top_level_meta)
     _collector.top_level_meta["cta"]["product"]["data"]["model"]["url"] = str(
         SCHEMA_PATH / "top_level_meta.schema.yml"
     )

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from simtools.data_model import metadata_model
@@ -39,7 +37,7 @@ def test_resolve_references():
     assert metadata_model._resolve_references(yaml_data) == expected_result
 
 
-def test_fill_defaults(caplog):
+def test_fill_defaults():
     schema = {
         "CTA": {
             "properties": {
@@ -105,8 +103,5 @@ def test_fill_defaults(caplog):
         }
     }
 
-    with caplog.at_level(logging.ERROR):
-        with pytest.raises(KeyError):
-            metadata_model._fill_defaults(schema)
-
-    assert "Missing 'properties' key in schema." in caplog.text
+    with pytest.raises(KeyError, match="Missing 'properties' key in schema."):
+        metadata_model._fill_defaults(schema)

--- a/tests/unit_tests/data_model/test_metadata_model.py
+++ b/tests/unit_tests/data_model/test_metadata_model.py
@@ -11,9 +11,9 @@ def test_get_default_metadata_dict():
     assert isinstance(_top_meta, dict)
     assert len(_top_meta) > 0
 
-    assert "VERSION" in _top_meta["CTA"]["REFERENCE"]
-    assert _top_meta["CTA"]["REFERENCE"]["VERSION"] == "1.0.0"
-    assert _top_meta["CTA"]["CONTACT"]["ORGANIZATION"] == "CTAO"
+    assert "version" in _top_meta["cta"]["reference"]
+    assert _top_meta["cta"]["reference"]["version"] == "2.0.0"
+    assert _top_meta["cta"]["contact"]["organization"] == "CTAO"
 
 
 def test_resolve_references():

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -154,17 +154,10 @@ def test_load_schema(caplog, tmp_test_directory):
     with pytest.raises(FileNotFoundError):
         schema.load_schema(schema_file="not_existing_file")
 
-    # schema versions
-    with pytest.raises(ValueError, match=r"^Schema version not given in"):
-        schema.load_schema(MODEL_PARAMETER_METASCHEMA)
-
     _schema_1 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.1.0")
-    assert _schema_1["version"] == "0.1.0"
+    assert _schema_1["schema_version"] == "0.1.0"
     _schema_2 = schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2.0")
-    assert _schema_2["version"] == "0.2.0"
-
-    with pytest.raises(ValueError, match=r"^Schema version 0.2 not found in"):
-        schema.load_schema(MODEL_PARAMETER_METASCHEMA, "0.2")
+    assert _schema_2["schema_version"] == "0.2.0"
 
     # test a single doc yaml file (write a temporary schema file; to make sure it is a single doc)
     tmp_schema_file = Path(tmp_test_directory) / "schema.yml"

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -204,3 +204,92 @@ def test_retrieve_yaml_schema_from_uri(tmp_path, monkeypatch):
     bad_uri = "file:/not_existing_file.schema.yml"
     with pytest.raises(FileNotFoundError):
         schema._retrieve_yaml_schema_from_uri(bad_uri)
+
+
+def test_get_schema_version_from_data_with_schema_version():
+    data = {"schema_version": "1.2.3"}
+    result = schema.get_schema_version_from_data(data)
+    assert result == "1.2.3"
+
+
+def test_get_schema_version_from_data_with_uppercase_reference():
+    data = {"CTA": {"REFERENCE": {"VERSION": "2.0.0"}}}
+    result = schema.get_schema_version_from_data(data)
+    assert result == "2.0.0"
+
+
+def test_get_schema_version_from_data_with_lowercase_reference():
+    data = {"cta": {"reference": {"version": "3.1.4"}}}
+    result = schema.get_schema_version_from_data(data)
+    assert result == "3.1.4"
+
+
+def test_get_schema_version_from_data_with_no_version():
+    data = {"foo": "bar"}
+    result = schema.get_schema_version_from_data(data)
+    assert result == "latest"
+
+
+def test_get_schema_version_from_data_with_custom_observatory():
+    data = {"VERITAS": {"REFERENCE": {"VERSION": "0.9.8"}}}
+    result = schema.get_schema_version_from_data(data, observatory="veritas")
+    assert result == "0.9.8"
+
+
+def test_get_schema_version_from_data_with_custom_observatory_lowercase():
+    data = {"veritas": {"reference": {"version": "0.9.9"}}}
+    result = schema.get_schema_version_from_data(data, observatory="veritas")
+    assert result == "0.9.9"
+
+
+def test_get_schema_for_version_with_dict():
+    test_schema = {"schema_version": "1.0.0", "name": "test"}
+    result = schema._get_schema_for_version(test_schema, "dummy_file.yml", "1.0.0")
+    assert result == test_schema
+
+
+def test_get_schema_for_version_with_list_and_latest():
+    schema_list = [
+        {"schema_version": "2.0.0", "name": "latest"},
+        {"schema_version": "1.0.0", "name": "old"},
+    ]
+    result = schema._get_schema_for_version(schema_list, "dummy_file.yml", "latest")
+    assert result["schema_version"] == "2.0.0"
+
+
+def test_get_schema_for_version_with_list_and_specific_version():
+    schema_list = [
+        {"schema_version": "2.0.0", "name": "latest"},
+        {"schema_version": "1.0.0", "name": "old"},
+    ]
+    result = schema._get_schema_for_version(schema_list, "dummy_file.yml", "1.0.0")
+    assert result["schema_version"] == "1.0.0"
+
+
+def test_get_schema_for_version_with_list_and_missing_version():
+    schema_list = [
+        {"schema_version": "2.0.0", "name": "latest"},
+        {"schema_version": "1.0.0", "name": "old"},
+    ]
+    with pytest.raises(ValueError, match="Schema version 3.0.0 not found in dummy_file.yml."):
+        schema._get_schema_for_version(schema_list, "dummy_file.yml", "3.0.0")
+
+
+def test_get_schema_for_version_with_none_version():
+    test_schema = {"schema_version": "1.0.0", "name": "test"}
+    with pytest.raises(ValueError, match="Schema version not given in dummy_file.yml."):
+        schema._get_schema_for_version(test_schema, "dummy_file.yml", None)
+
+
+def test_get_schema_for_version_with_empty_list():
+    schema_list = []
+    with pytest.raises(ValueError, match="No schemas found in dummy_file.yml."):
+        schema._get_schema_for_version(schema_list, "dummy_file.yml", "latest")
+
+
+def test_get_schema_for_version_warns_on_version_mismatch(caplog):
+    test_schema = {"schema_version": "1.0.0", "name": "test"}
+    with caplog.at_level("WARNING"):
+        result = schema._get_schema_for_version(test_schema, "dummy_file.yml", "2.0.0")
+    assert result == test_schema
+    assert "Schema version 2.0.0 does not match 1.0.0" in caplog.text

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -15,6 +15,8 @@ from simtools.constants import (
 from simtools.data_model import schema
 from simtools.utils import general as gen
 
+DUMMY_FILE = "dummy_file.yml"
+
 
 def test_get_model_parameter_schema_files(tmp_test_directory):
     par, files = schema.get_model_parameter_schema_files()
@@ -244,7 +246,7 @@ def test_get_schema_version_from_data_with_custom_observatory_lowercase():
 
 def test_get_schema_for_version_with_dict():
     test_schema = {"schema_version": "1.0.0", "name": "test"}
-    result = schema._get_schema_for_version(test_schema, "dummy_file.yml", "1.0.0")
+    result = schema._get_schema_for_version(test_schema, DUMMY_FILE, "1.0.0")
     assert result == test_schema
 
 
@@ -253,7 +255,7 @@ def test_get_schema_for_version_with_list_and_latest():
         {"schema_version": "2.0.0", "name": "latest"},
         {"schema_version": "1.0.0", "name": "old"},
     ]
-    result = schema._get_schema_for_version(schema_list, "dummy_file.yml", "latest")
+    result = schema._get_schema_for_version(schema_list, DUMMY_FILE, "latest")
     assert result["schema_version"] == "2.0.0"
 
 
@@ -262,7 +264,7 @@ def test_get_schema_for_version_with_list_and_specific_version():
         {"schema_version": "2.0.0", "name": "latest"},
         {"schema_version": "1.0.0", "name": "old"},
     ]
-    result = schema._get_schema_for_version(schema_list, "dummy_file.yml", "1.0.0")
+    result = schema._get_schema_for_version(schema_list, DUMMY_FILE, "1.0.0")
     assert result["schema_version"] == "1.0.0"
 
 
@@ -272,24 +274,24 @@ def test_get_schema_for_version_with_list_and_missing_version():
         {"schema_version": "1.0.0", "name": "old"},
     ]
     with pytest.raises(ValueError, match="Schema version 3.0.0 not found in dummy_file.yml."):
-        schema._get_schema_for_version(schema_list, "dummy_file.yml", "3.0.0")
+        schema._get_schema_for_version(schema_list, DUMMY_FILE, "3.0.0")
 
 
 def test_get_schema_for_version_with_none_version():
     test_schema = {"schema_version": "1.0.0", "name": "test"}
     with pytest.raises(ValueError, match="Schema version not given in dummy_file.yml."):
-        schema._get_schema_for_version(test_schema, "dummy_file.yml", None)
+        schema._get_schema_for_version(test_schema, DUMMY_FILE, None)
 
 
 def test_get_schema_for_version_with_empty_list():
     schema_list = []
     with pytest.raises(ValueError, match="No schemas found in dummy_file.yml."):
-        schema._get_schema_for_version(schema_list, "dummy_file.yml", "latest")
+        schema._get_schema_for_version(schema_list, DUMMY_FILE, "latest")
 
 
 def test_get_schema_for_version_warns_on_version_mismatch(caplog):
     test_schema = {"schema_version": "1.0.0", "name": "test"}
     with caplog.at_level("WARNING"):
-        result = schema._get_schema_for_version(test_schema, "dummy_file.yml", "2.0.0")
+        result = schema._get_schema_for_version(test_schema, DUMMY_FILE, "2.0.0")
     assert result == test_schema
     assert "Schema version 2.0.0 does not match 1.0.0" in caplog.text

--- a/tests/unit_tests/utils/test_general.py
+++ b/tests/unit_tests/utils/test_general.py
@@ -54,7 +54,7 @@ def test_collect_dict_data(io_handler) -> None:
 
     # file with several documents - get first document
     _dict = gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA, 0)
-    assert _dict["version"] != "0.1.0"
+    assert _dict["schema_version"] != "0.1.0"
 
     with pytest.raises(gen.InvalidConfigDataError, match=FAILED_TO_READ_FILE_ERROR):
         gen.collect_data_from_file(MODEL_PARAMETER_METASCHEMA, 999)


### PR DESCRIPTION
Two items are addressed:

- metadata is changed to lower-case snake_make, see #1630 
- schema versions are now consistently named `schema_version` (not not sometimes `version`).
- minor naming changes to improve readability

Overall these code bits are quite complex (or the issue is complex).

**Important**

The following integration test must fail, as it reads a schema from the github main branch over the network:

```
tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-validate-file-using-schema_yml_validate_schema_schema_from_meta]
```

Closes #1630