### PR TITLE
Add sim-telarray to image label.

### DIFF
--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -141,7 +141,7 @@ jobs:
           - {build_opt: 'prod6-baseline', extra_def: ''}
 
     env:
-      LABELS: "${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}"
+      LABELS: "sim-telarray-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}"
 
     steps:
       - name: Checkout repository
@@ -229,7 +229,7 @@ jobs:
         model_version:
           - "6.0.0"
     container:
-      image: ghcr.io/gammasim/simtools-prod-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}
+      image: ghcr.io/gammasim/simtools-prod-sim-telarray-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}-${{ matrix.version.avx_instruction }}
       options: --user 0
 
     services:

--- a/.github/workflows/build-simtools-production-image.yml
+++ b/.github/workflows/build-simtools-production-image.yml
@@ -60,7 +60,7 @@ jobs:
           - {simtel_version: '250304', corsika_version: '78000', bernlohr_version: '1.69', hadronic_model: 'qgs3'}
 
     env:
-      LABELS: '${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}'
+      LABELS: 'sim-telarray-${{ matrix.version.simtel_version }}-corsika-${{ matrix.version.corsika_version }}-bernlohr-${{ matrix.version.bernlohr_version }}-${{ matrix.production.build_opt }}-${{ matrix.version.hadronic_model }}'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Add `sim_telarray` before the sim_telarray version for constant image naming.

Example run: https://github.com/gammasim/simtools/actions/runs/16267933070 and e.g. look at the last lines of:

```
build-args:
  - BUILD_OPT=prod6-sc
  - EXTRA_DEF=
  - HADRONIC_MODEL=qgs2
  - AVX_FLAG=no_opt
  - CORSIKA_VERSION=77500
  - BERNLOHR_VERSION=1.67
  - BUILD_BRANCH=image-label-with-simtel
  - GITLAB_TOKEN_CORSIKA_OPT_PATCHES=***
context: .
file: ./docker/Dockerfile-prod-opt
labels:
  - org.opencontainers.image.created=2025-07-14T13:37:40.466Z
  - org.opencontainers.image.description=Tools and applications for the Simulation System of the CTA Observatory.
  - org.opencontainers.image.licenses=BSD-3-Clause
  - org.opencontainers.image.revision=8505b223c14d121760c3b9e18e57565f6494a359
  - org.opencontainers.image.source=https://github.com/gammasim/simtools
  - org.opencontainers.image.title=simtools
  - org.opencontainers.image.url=https://github.com/gammasim/simtools
  - org.opencontainers.image.version=20250714-133740-prod
platforms:
  - linux/amd64
push: true
tags:
  - ghcr.io/gammasim/simtools-prod-sim-telarray-240205-corsika-77500-bernlohr-1.67-prod6-sc-qgs2-no_opt:20250714-133740
  - ghcr.io/gammasim/simtools-prod-sim-telarray-240205-corsika-77500-bernlohr-1.67-prod6-sc-qgs2-no_opt:latest
 ```

Closes #1648 