### PR TITLE
alpha_mst does not exist anymore

### DIFF
--- a/src/simtools/applications/plot_array_layout.py
+++ b/src/simtools/applications/plot_array_layout.py
@@ -13,7 +13,7 @@ For the following options, array element positions are retrieved from the model 
   (``--plot_all_layouts``)
 
 * from a model parameter file
-  (e.g., ``-array_layout_parameter_file tests/resources/model_parameters/array_layouts-2.0.1.json``)
+  (e.g., ``-array_layout_parameter_file tests/resources/model_parameters/array_layouts-2.0.2.json``)
 
 * from a list of array elements (e.g., ``-array_element_list MSTN-01, MSTN-02``).
   Positions are retrieved from the database.
@@ -88,7 +88,7 @@ Plot layout from a parameter file with a list of telescopes:
 .. code-block:: console
 
     simtools-plot-array-layout
-        --array_layout_parameter_file tests/resources/model_parameters/array_layouts-2.0.1.json
+        --array_layout_parameter_file tests/resources/model_parameters/.json
         --model_version 6.0.0
 
 

--- a/tests/integration_tests/config/plot_array_layout_from_array_layouts_json.yml
+++ b/tests/integration_tests/config/plot_array_layout_from_array_layouts_json.yml
@@ -2,7 +2,7 @@
 applications:
 - application: simtools-plot-array-layout
   configuration:
-    array_layout_parameter_file: tests/resources/model_parameters/array_layouts-2.0.1.json
+    array_layout_parameter_file: tests/resources/model_parameters/array_layouts-2.0.2.json
     model_version: 6.0.0
     output_path: simtools-output
   integration_tests:

--- a/tests/integration_tests/config/submit_array_layouts.yml
+++ b/tests/integration_tests/config/submit_array_layouts.yml
@@ -2,7 +2,7 @@
 applications:
 - application: simtools-submit-array-layouts
   configuration:
-    array_layouts: tests/resources/model_parameters/array_layouts-2.0.1.json
+    array_layouts: tests/resources/model_parameters/array_layouts-2.0.2.json
     model_version: 6.0.0
     output_path: simtools-output
     updated_parameter_version: 1.0.98

--- a/tests/resources/model_parameters/array_layouts-2.0.2.json
+++ b/tests/resources/model_parameters/array_layouts-2.0.2.json
@@ -3,7 +3,7 @@
     "parameter": "array_layouts",
     "instrument": "OBS-North",
     "site": "North",
-    "parameter_version": "2.0.1",
+    "parameter_version": "2.0.2",
     "unique_id": null,
     "value": [
         {
@@ -37,7 +37,7 @@
             ]
         },
         {
-            "name": "subsystem_msts",
+            "name": "extension_msts",
             "elements": [
                 "MSTN-01",
                 "MSTN-02",
@@ -56,7 +56,7 @@
             ]
         },
         {
-            "name": "alpha_msts",
+            "name": "subsystem_msts",
             "elements": [
                 "MSTN-01",
                 "MSTN-02",


### PR DESCRIPTION
Update array layouts in testing as alpha_msts does not exist anymore.

The array layout alpha_mst does not exist anymore, see https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/merge_requests/60

As we were too lazy to generate a new production (see discussion in the gitlab issue), we have to fix the integration tests now in simtools and propagate the newest array layout into tests/resources/model_parameters.
