### PR TITLE
Add functionality to compare derived model parameters with DB values to integration tests (examples for simtools-validate-camera-efficiency).

### DIFF
--- a/docs/changes/1666.feature.md
+++ b/docs/changes/1666.feature.md
@@ -1,0 +1,1 @@
+Add functionality to compare derived model parameters with DB values to integration tests (examples for simtools-validate-camera-efficiency).

--- a/src/simtools/schemas/application_workflow.metaschema.yml
+++ b/src/simtools/schemas/application_workflow.metaschema.yml
@@ -103,6 +103,24 @@ definitions:
         description: |
           "Reference file used for comparison."
         type: string
+      model_parameter_validation:
+        description: |
+          "Validation of model parameters against reference values."
+        type: object
+        additionalProperties: false
+        properties:
+          parameter_file:
+            description: |
+              "Path to the JSON file containing model parameters."
+            type: string
+          reference_parameter_name:
+            description: |
+              "Name of the parameter to validate against the reference."
+            type: string
+          tolerance:
+            description: |
+              "Allowed tolerance for floating point comparison."
+            type: number
       test_simtel_cfg_files:
         description: |
           "Reference file used for comparison of sim_telarray configuration files."

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -7,12 +7,15 @@ import numpy as np
 from astropy.table import Table
 
 import simtools.utils.general as gen
+from simtools.db import db_handler
 from simtools.testing import assertions
 
 _logger = logging.getLogger(__name__)
 
 
-def validate_application_output(config, from_command_line=None, from_config_file=None):
+def validate_application_output(
+    config, from_command_line=None, from_config_file=None, db_config=None
+):
     """
     Validate application output against expected output.
 
@@ -37,7 +40,7 @@ def validate_application_output(config, from_command_line=None, from_config_file
         _logger.info(f"Testing application output: {integration_test}")
 
         if from_command_line == from_config_file:
-            _validate_output_files(config, integration_test)
+            _validate_output_files(config, integration_test, db_config)
 
             if "file_type" in integration_test:
                 assert assertions.assert_file_type(
@@ -49,7 +52,7 @@ def validate_application_output(config, from_command_line=None, from_config_file
         _test_simtel_cfg_files(config, integration_test, from_command_line, from_config_file)
 
 
-def _validate_output_files(config, integration_test):
+def _validate_output_files(config, integration_test, db_config):
     """Validate output files."""
     if "reference_output_file" in integration_test:
         _validate_reference_output_file(config, integration_test)
@@ -59,6 +62,12 @@ def _validate_output_files(config, integration_test):
         _validate_output_path_and_file(
             config,
             [{"path_descriptor": "output_path", "file": integration_test["output_file"]}],
+        )
+    if "model_parameter_validation" in integration_test:
+        _validate_model_parameter_json_file(
+            config,
+            integration_test["model_parameter_validation"],
+            db_config,
         )
 
 
@@ -112,6 +121,44 @@ def _validate_output_path_and_file(config, integration_file_tests):
                 output_file_path,
                 file_test["expected_output"],
             )
+
+
+def _validate_model_parameter_json_file(config, model_parameter_validation, db_config):
+    """
+    Validate model parameter json file and compare it with a reference parameter from the database.
+
+    Requires database connection to pull the model parameter for a given telescope or site model.
+
+    Parameters
+    ----------
+    config: dict
+        Configuration dictionary.
+    model_parameter_validation: str
+        Path to the model parameter json file.
+
+    """
+    _logger.info(f"Checking model parameter json file: {model_parameter_validation}")
+    db = db_handler.DatabaseHandler(mongo_db_config=db_config)
+
+    reference_parameter_name = model_parameter_validation.get("reference_parameter_name")
+
+    reference_model_parameter = db.get_model_parameter(
+        parameter=reference_parameter_name,
+        site=config["configuration"].get("site"),
+        array_element_name=config["configuration"].get("telescope"),
+        model_version=config["configuration"].get("model_version"),
+    )
+    parameter_file = (
+        Path(config["configuration"]["output_path"])
+        / config["configuration"].get("telescope")
+        / model_parameter_validation["parameter_file"]
+    )
+    model_parameter = gen.collect_data_from_file(parameter_file)
+    assert _compare_value_from_parameter_dict(
+        model_parameter["value"],
+        reference_model_parameter[reference_parameter_name]["value"],
+        model_parameter_validation["tolerance"],
+    )
 
 
 def compare_files(file1, file2, tolerance=1.0e-5, test_columns=None):

--- a/src/simtools/testing/validate_output.py
+++ b/src/simtools/testing/validate_output.py
@@ -133,8 +133,8 @@ def _validate_model_parameter_json_file(config, model_parameter_validation, db_c
     ----------
     config: dict
         Configuration dictionary.
-    model_parameter_validation: str
-        Path to the model parameter json file.
+    model_parameter_validation: dict
+        Dictionary with model parameter validation configuration.
 
     """
     _logger.info(f"Checking model parameter json file: {model_parameter_validation}")

--- a/tests/integration_tests/config/validate_camera_efficiency_lstn-02.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_lstn-02.yml
@@ -7,15 +7,14 @@ applications:
     site: North
     telescope: LSTN-02
     zenith_angle: 0.
+    parameter_version: 0.0.99
     write_reference_nsb_rate_as_parameter: true
     use_plain_output_path: true
-    parameter_version: 0.0.99
     log_level: debug
   integration_tests:
   - model_parameter_validation:
       parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
       reference_parameter_name: nsb_pixel_rate
-      reference_parameter_version: 1.0.0
       tolerance: 1.e-1
   test_name: LSTN
 schema_name: application_workflow.metaschema

--- a/tests/integration_tests/config/validate_camera_efficiency_lstn-02.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_lstn-02.yml
@@ -11,6 +11,12 @@ applications:
     use_plain_output_path: true
     parameter_version: 0.0.99
     log_level: debug
+  integration_tests:
+  - model_parameter_validation:
+      parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
+      reference_parameter_name: nsb_pixel_rate
+      reference_parameter_version: 1.0.0
+      tolerance: 1.e-1
   test_name: LSTN
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/config/validate_camera_efficiency_mstx_flashcam_south.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_mstx_flashcam_south.yml
@@ -8,6 +8,7 @@ applications:
     site: South
     telescope: MSTx-FlashCam
     zenith_angle: 0.
+    parameter_version: 0.0.99
     write_reference_nsb_rate_as_parameter: true
     use_plain_output_path: true
     log_level: debug
@@ -18,6 +19,10 @@ applications:
   - output_file: validate_camera_efficiency_MSTx-FlashCam_cherenkov.pdf
   - output_file: camera_efficiency_summary_South_MSTx-FlashCam_za0.0deg_azm000deg_validate_camera_efficiency.txt
   - output_file: camera_efficiency_table_South_MSTx-FlashCam_za0.0deg_azm000deg_validate_camera_efficiency.ecsv
+  - model_parameter_validation:
+      parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
+      reference_parameter_name: nsb_pixel_rate
+      tolerance: 1.e-1
   test_name: MSTS
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/config/validate_camera_efficiency_mstx_nectarcam_north.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_mstx_nectarcam_north.yml
@@ -7,6 +7,7 @@ applications:
     site: North
     telescope: MSTx-NectarCam
     zenith_angle: 0.
+    parameter_version: 0.0.99
     write_reference_nsb_rate_as_parameter: true
     use_plain_output_path: true
     log_level: debug
@@ -17,6 +18,10 @@ applications:
   - output_file: validate_camera_efficiency_MSTx-NectarCam_cherenkov.pdf
   - output_file: camera_efficiency_summary_North_MSTx-NectarCam_za0.0deg_azm000deg_validate_camera_efficiency.txt
   - output_file: camera_efficiency_table_North_MSTx-NectarCam_za0.0deg_azm000deg_validate_camera_efficiency.ecsv
+  - model_parameter_validation:
+      parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
+      reference_parameter_name: nsb_pixel_rate
+      tolerance: 1.e-1
   test_name: MSTN
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/config/validate_camera_efficiency_ssts.yml
+++ b/tests/integration_tests/config/validate_camera_efficiency_ssts.yml
@@ -7,6 +7,7 @@ applications:
     output_path: simtools-output
     site: South
     telescope: SSTS-design
+    parameter_version: 0.0.99
     write_reference_nsb_rate_as_parameter: true
     use_plain_output_path: true
     zenith_angle: 0.
@@ -17,6 +18,10 @@ applications:
   - output_file: validate_camera_efficiency_SSTS-design_cherenkov.pdf
   - output_file: camera_efficiency_summary_South_SSTS-design_za0.0deg_azm000deg_validate_camera_efficiency.txt
   - output_file: camera_efficiency_table_South_SSTS-design_za0.0deg_azm000deg_validate_camera_efficiency.ecsv
+  - model_parameter_validation:
+      parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
+      reference_parameter_name: nsb_pixel_rate
+      tolerance: 1.e-1
   test_name: SSTS
 schema_name: application_workflow.metaschema
 schema_version: 0.4.0

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -30,7 +30,7 @@ for config, test_id in zip(test_configs, test_ids):
 
 
 @pytest.mark.parametrize("config", test_parameters)
-def test_applications_from_config(tmp_test_directory, config, request):
+def test_applications_from_config(tmp_test_directory, config, request, db_config):
     """
     Test all applications from config files found in the config directory.
 
@@ -76,4 +76,5 @@ def test_applications_from_config(tmp_test_directory, config, request):
         tmp_config,
         model_version,
         config_file_model_version or model_version,
+        db_config=db_config,
     )

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -16,6 +16,7 @@ PATH_TO_OUTPUT = "/path/to/output"
 PATCH_TO_VALIDATE_CFG = "simtools.testing.validate_output._validate_simtel_cfg_files"
 PATH_CFG_6 = "/path/to/simtel_cfg_6.0.0.cfg"
 PATH_CFG_7 = "/path/to/simtel_cfg_7.0.0.cfg"
+TEST_PARAM_JSON = "test_param.json"
 
 
 @pytest.fixture
@@ -599,7 +600,7 @@ def test_validate_model_parameter_json_file(mocker, output_path):
     }
     model_parameter_validation = {
         "reference_parameter_name": "reference_param",
-        "parameter_file": "test_param.json",
+        "parameter_file": TEST_PARAM_JSON,
         "tolerance": 1.0e-5,
     }
 
@@ -615,7 +616,7 @@ def test_validate_model_parameter_json_file(mocker, output_path):
         model_version="1.0.0",
     )
     mock_collect_data_from_file.assert_called_once_with(
-        Path(output_path) / "test_telescope" / "test_param.json"
+        Path(output_path) / "test_telescope" / TEST_PARAM_JSON
     )
     mock_compare_value.assert_called_once_with([1.0, 2.0, 3.0], [1.0, 2.0, 3.0], 1.0e-5)
 
@@ -643,7 +644,7 @@ def test_validate_model_parameter_json_file_mismatch(mocker, output_path):
     }
     model_parameter_validation = {
         "reference_parameter_name": "reference_param",
-        "parameter_file": "test_param.json",
+        "parameter_file": TEST_PARAM_JSON,
         "tolerance": 1.0e-5,
     }
 
@@ -660,6 +661,6 @@ def test_validate_model_parameter_json_file_mismatch(mocker, output_path):
         model_version="1.0.0",
     )
     mock_collect_data_from_file.assert_called_once_with(
-        Path(output_path) / "test_telescope" / "test_param.json"
+        Path(output_path) / "test_telescope" / TEST_PARAM_JSON
     )
     mock_compare_value.assert_called_once_with([1.1, 2.1, 3.1], [1.0, 2.0, 3.0], 1.0e-5)

--- a/tests/unit_tests/testing/test_validate_output.py
+++ b/tests/unit_tests/testing/test_validate_output.py
@@ -404,7 +404,7 @@ def test_validate_application_output_with_reference_output_file(
 
     validate_output.validate_application_output(config, "6.0.0")
     mock_validate_simtel_cfg_files.assert_called_once()
-    mock_validate_model_parameter_json_file.called_one()
+    mock_validate_model_parameter_json_file.assert_called_once()
 
 
 def test_validate_application_output_with_assertion_error(output_path):


### PR DESCRIPTION
Add functionality to compare derived model parameters with DB values to integration tests (examples for simtools-validate-camera-efficiency).

Additions to integration tests config:

```
  - model_parameter_validation:
      parameter_file: nsb_pixel_rate/nsb_pixel_rate-0.0.99.json
      reference_parameter_name: nsb_pixel_rate
      tolerance: 1.e-1
```

Meaning comparing the output of the current application (`nsb_pixel_rate/nsb_pixel_rate-0.0.99.json`) to the reference parameter called `nsb_pixel_rate` with a tolerance of 10% (this is rather large, but required for the NSB rates). The model version is taken from the test configuration.

Closes #1156 