### PR TITLE
Single telescope array trigger

### DIFF
--- a/docs/changes/1690.bugfix.md
+++ b/docs/changes/1690.bugfix.md
@@ -1,0 +1,1 @@
+Fix array trigger writing for single telescope simulations.

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -509,7 +509,9 @@ class SimtelConfigWriter:
 
         trigger_lines = {}
         for tel_type, tel_list in trigger_per_telescope_type.items():
-            trigger_dict = self._get_array_triggers_for_telescope_type(array_triggers, tel_type)
+            trigger_dict = self._get_array_triggers_for_telescope_type(
+                array_triggers, tel_type, len(tel_list)
+            )
             trigger_lines[tel_type] = f"Trigger {trigger_dict['multiplicity']['value']} of "
             trigger_lines[tel_type] += ", ".join(map(str, tel_list))
             width = trigger_dict["width"]["value"] * u.Unit(trigger_dict["width"]["unit"]).to("ns")
@@ -529,7 +531,9 @@ class SimtelConfigWriter:
 
         return array_triggers_file
 
-    def _get_array_triggers_for_telescope_type(self, array_triggers, telescope_type):
+    def _get_array_triggers_for_telescope_type(
+        self, array_triggers, telescope_type, num_telescopes_of_type
+    ):
         """
         Get array trigger for a specific telescope type.
 
@@ -539,14 +543,19 @@ class SimtelConfigWriter:
             Array trigger definitions.
         telescope_type: str
             Telescope type.
+        num_telescopes_of_type: int
+            Number of telescopes of the specified type.
 
         Returns
         -------
         dict
             Array trigger for the telescope type.
         """
+        suffix = "_array"
+        if num_telescopes_of_type == 1:
+            suffix = "_single_telescope"
         for trigger_dict in array_triggers:
-            if trigger_dict["name"] == telescope_type + "_array":
+            if trigger_dict["name"] == telescope_type + suffix:
                 return trigger_dict
         return None
 


### PR DESCRIPTION
The array trigger file for sim_telarray is written 'on the fly' by `SimtelConfigWriter:_write_array_triggers_file`. The issue of the code was that always the stereo trigger requirement was written out, even for single telescope configurations.

Changed this to read the correct configuration from the `array_triggers` model parameter (e.g. ``MSTN_single_telescope`).


Check https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/blob/main/simulation-models/model_parameters/OBS-South/array_triggers/array_triggers-1.0.0.json?ref_type=heads to see the array trigger simulation model parameter.
