### PR TITLE
Add pre-commit caching

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -87,6 +87,14 @@ jobs:
         run: |
           git ls-files 'src/simtools/*.py' | xargs pylint -v
 
+      - name: Cache pre-commit to avoid rate limits of npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pre-commit-
+
       - name: Pre-commit
         run: |
           pre-commit run --all-files


### PR DESCRIPTION
The CI-Linter workflows fails lately regularly due to npm rate-limit (HTTP 429) error during pre-commit hook setup. Add a caching of the installation to limit the number of calls.