### PR TITLE
Fix release link template in towncrier.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,7 +318,7 @@ package = "simtools"
 directory = "docs/changes"
 filename = "CHANGELOG.md"
 underlines = [ "", "", "" ]
-title_format = "## [{version}](https://github.com/gammasim/simtools/tree/{version}) - {project_date}"
+title_format = "## [{version}](https://github.com/gammasim/simtools/releases/tag/{version}) - {project_date}"
 issue_format = "[#{issue}](https://github.com/gammasim/simtools/pull/{issue})"
 start_string = "<!-- towncrier release notes start -->\n"
 


### PR DESCRIPTION
A surprising number of links in the towncrier-generate CHANGELOG did not work (see #1707) and it turns out that the link template in the towncrier configuration is wrong. This PR fixes this.