### PR TITLE
Address log-file testing problem for integration tests in corsika 7.8 containers

### DIFF
--- a/docs/changes/1712.bugfix.md
+++ b/docs/changes/1712.bugfix.md
@@ -1,0 +1,1 @@
+Fix warning messages in simtel metadata reader to avoid the log-file testing routines to fail.

--- a/src/simtools/simtel/simtel_io_metadata.py
+++ b/src/simtools/simtel/simtel_io_metadata.py
@@ -78,7 +78,7 @@ def _decode_dictionary(meta, encoding="utf8"):
         return {k.decode(encoding, errors="ignore"): v.decode(encoding) for k, v in meta.items()}
     except UnicodeDecodeError as e:
         _logger.warning(
-            f"Failed to decode metadata with encoding {encoding}: {e}. "
+            f"Unable to decode metadata with encoding {encoding}: {e}. "
             "Falling back to 'utf-8' with errors='ignore'."
         )
         return {safe_decode(k, encoding): safe_decode(v, encoding) for k, v in meta.items()}

--- a/src/simtools/testing/log_inspector.py
+++ b/src/simtools/testing/log_inspector.py
@@ -15,6 +15,8 @@ ERROR_PATTERNS = [
     re.compile(r"segmentation fault", re.IGNORECASE),
 ]
 
+IGNORE_PATTERNS = [re.compile(r"Falling back to 'utf-8' with errors='ignore'", re.IGNORECASE)]
+
 
 def inspect(log_text):
     """
@@ -41,7 +43,7 @@ def inspect(log_text):
             if "INFO::" in line:
                 continue
             for pattern in ERROR_PATTERNS:
-                if pattern.search(line):
+                if pattern.search(line) and not any(p.search(line) for p in IGNORE_PATTERNS):
                     issues.append((lineno, line))
                     break
 

--- a/src/simtools/testing/log_inspector.py
+++ b/src/simtools/testing/log_inspector.py
@@ -36,17 +36,17 @@ def inspect(log_text):
         True if no errors or warnings are found, False otherwise.
     """
     log_text = log_text if isinstance(log_text, list) else [log_text]
-    issues = []
-    for txt in log_text:
-        for lineno, line in enumerate(txt.splitlines(), 1):
-            # Skip lines containing "INFO::"
-            if "INFO::" in line:
-                continue
-            for pattern in ERROR_PATTERNS:
-                if pattern.search(line) and not any(p.search(line) for p in IGNORE_PATTERNS):
-                    issues.append((lineno, line))
-                    break
+
+    issues = [
+        (lineno, line)
+        for txt in log_text
+        for lineno, line in enumerate(txt.splitlines(), 1)
+        if "INFO::" not in line
+        and any(p.search(line) for p in ERROR_PATTERNS)
+        and not any(p.search(line) for p in IGNORE_PATTERNS)
+    ]
 
     for lineno, line in issues:
         _logger.error(f"Error or warning found in log at line {lineno}: {line.strip()}")
-    return len(issues) == 0
+
+    return not issues

--- a/tests/unit_tests/simtel/test_simtel_io_metadata.py
+++ b/tests/unit_tests/simtel/test_simtel_io_metadata.py
@@ -32,7 +32,7 @@ def test_decode_with_unicode_error(caplog):
     assert "key2" in result
     assert result["key1"] == "value1"
     assert result["key2"] == " invalid utf8"
-    assert "Failed to decode metadata with encoding utf-8" in caplog.text
+    assert "Unable to decode metadata with encoding utf-8" in caplog.text
 
 
 def test_read_sim_telarray_metadata(sim_telarray_file_gamma):

--- a/tests/unit_tests/testing/test_log_inspector.py
+++ b/tests/unit_tests/testing/test_log_inspector.py
@@ -61,3 +61,13 @@ def test_inspect_single_string_input(mock_logger):
     assert result is False
     assert len(mock_logger.records) == 1
     assert "Error or warning found in log at line 2" in mock_logger.text
+
+
+def test_inspect_ignore_patterns(mock_logger):
+    log_text = (
+        "WARNING::simtel_io_metadata(l80)::_decode_dictionary::Unable to decode metadata "
+        "with encoding utf8: 'utf-8' codec can't decode byte 0x80 in position 128: invalid "
+        "start byte. Falling back to 'utf-8' with errors='ignore'."
+    )
+    result = inspect(log_text)
+    assert result is True


### PR DESCRIPTION
This is an interesting issue. The integration tests for all simulate-prod steps are failing for the CORSIKA 7.8... containers.

The failing is in the log-file testing module which searches the log files for the following patterns:

```
ERROR_PATTERNS = [
    re.compile(r"error", re.IGNORECASE),
    re.compile(r"exception", re.IGNORECASE),
    re.compile(r"traceback", re.IGNORECASE),
    re.compile(r"\b(failed to|has failed)\b", re.IGNORECASE),
    re.compile(r"runtime\s*warning", re.IGNORECASE),
    re.compile(r"segmentation fault", re.IGNORECASE),
]
```

No for some reason there is a non-UTF8 pattern in the metadata. We had considered this when reading the metadata in `simtools.simtel.simtel_io_metadata` and handle this correctly. Unfortunately, the warning has a "Failed to..." in the warning text, triggering above ERROR_PATTERNS.

As this is safe, and 'Failed to...' is too strong for a simple warning, I changed the warning text to "Unable to...".

Additionally to above, an IGNORE_PATTERN is introduced to allow certain messages (as this problematic one) in the log file. I am aware that this is a bit of fine tuning, but this should be ok (there will be more: hard to control the error and warning messages from all the external software we are using).

Works, see https://github.com/gammasim/simtools/actions/runs/17268513488

(generally a bit puzzling; I was trying to reproduce it locally and don't get this warning)

Closes #1711