### PR TITLE
Simtools software versions for model parameters

### DIFF
--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -29,6 +29,12 @@ definitions:
       meta_schema_version:
         type: string
         description: "version of meta schema applied to this file (semver)"
+      deprecated:
+        type: boolean
+        description: "indicates if this parameter is deprecated"
+      deprecation_note:
+        type: string
+        description: "notes about deprecation"
       name:
         type: string
         description: "name of model parameter"

--- a/src/simtools/schemas/model_parameters/flasher_angular_distribution.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_angular_distribution.schema.yml
@@ -32,3 +32,4 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_bunch_size.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_bunch_size.schema.yml
@@ -28,3 +28,4 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_external_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_external_trigger.schema.yml
@@ -31,3 +31,5 @@ source:
 simulation_software:
   - name: sim_telarray
     internal_parameter_name: laser_external_trigger
+  - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_photons.schema.yml
@@ -33,3 +33,5 @@ source:
 simulation_software:
   - name: sim_telarray
     internal_parameter_name: laser_photons
+  - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_position.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_position.schema.yml
@@ -43,3 +43,4 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_offset.schema.yml
@@ -34,3 +34,5 @@ source:
 simulation_software:
   - name: sim_telarray
     internal_parameter_name: laser_pulse_offset
+  - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_shape.schema.yml
@@ -29,3 +29,4 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_type.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_type.schema.yml
@@ -28,3 +28,4 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_var_photons.schema.yml
@@ -30,3 +30,5 @@ source:
 simulation_software:
   - name: sim_telarray
     internal_parameter_name: laser_var_photons
+  - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/flasher_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_wavelength.schema.yml
@@ -32,3 +32,5 @@ source:
 simulation_software:
   - name: sim_telarray
     internal_parameter_name: laser_wavelength
+  - name: simtools
+    version: ">=0.21.0"

--- a/src/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -1,23 +1,23 @@
 %YAML 1.2
 ---
-title: Schema for flasher_angular_distribution_width model parameter
+title: Schema for laser_photons model parameter
+deprecated: true
+deprecation_note: "Replaced by flasher_photons"
 schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
-name: flasher_angular_distribution_width
+name: laser_photons
 description: |-
-  Characteristic width of the flasher angular emission distribution.
-  This is the RMS for Gaussian distributions or the maximum half
-  opening angle for conical shapes.
+  Number of laser photons at each photo detector.
 short_description: |-
-  Characteristic width of the flasher angular emission distribution.
+  Number of laser photons at each photo detector.
 data:
   - type: float64
-    unit: "deg"
-    default: 0
+    unit: dimensionless
+    default: 500
     allowed_range:
-      min: 0
+      min: 1
 instrument:
   class: Calibration
   type:
@@ -31,5 +31,6 @@ activity:
 source:
   - Initial instrument setup
 simulation_software:
+  - name: sim_telarray
   - name: simtools
-    version: ">=0.21.0"
+    version: "<0.21.0"

--- a/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
@@ -1,23 +1,24 @@
 %YAML 1.2
 ---
-title: Schema for flasher_angular_distribution_width model parameter
+title: Schema for laser_wavelength model parameter
+deprecated: true
+deprecation_note: "Replaced by flasher_wavelength"
 schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
-name: flasher_angular_distribution_width
+name: laser_wavelength
 description: |-
-  Characteristic width of the flasher angular emission distribution.
-  This is the RMS for Gaussian distributions or the maximum half
-  opening angle for conical shapes.
+  The wavelength of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit. Applies to both laser and LED type events.
 short_description: |-
-  Characteristic width of the flasher angular emission distribution.
+  Wavelength of light-source.
 data:
   - type: float64
-    unit: "deg"
-    default: 0
+    unit: "nm"
+    default: 400
     allowed_range:
-      min: 0
+      min: 200
 instrument:
   class: Calibration
   type:
@@ -31,5 +32,6 @@ activity:
 source:
   - Initial instrument setup
 simulation_software:
+  - name: sim_telarray
   - name: simtools
-    version: ">=0.21.0"
+    version: "<0.21.0"

--- a/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
@@ -1,23 +1,24 @@
 %YAML 1.2
 ---
-title: Schema for flasher_angular_distribution_width model parameter
+title: Schema for led_pulse_sigtime model parameter
+deprecated: true
+deprecation_note: "Replaced by flasher_pulse_width and flasher_pulse_shape"
 schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
-name: flasher_angular_distribution_width
+name: led_pulse_sigtime
 description: |-
-  Characteristic width of the flasher angular emission distribution.
-  This is the RMS for Gaussian distributions or the maximum half
-  opening angle for conical shapes.
+  To be used (non-zero) if the pulse shape of the light emitted from the flat-fielding \
+  or single-p.e. calibration unit follows a Gaussian, with the given number standing for the sigma of the Gaussian.
 short_description: |-
-  Characteristic width of the flasher angular emission distribution.
+  Gaussian sigma LED pulse width.
 data:
   - type: float64
-    unit: "deg"
-    default: 0
+    unit: "ns"
+    default: 0.0
     allowed_range:
-      min: 0
+      min: 0.0
 instrument:
   class: Calibration
   type:
@@ -31,5 +32,6 @@ activity:
 source:
   - Initial instrument setup
 simulation_software:
+  - name: sim_telarray
   - name: simtools
-    version: ">=0.21.0"
+    version: "<0.21.0"

--- a/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -1,27 +1,32 @@
 %YAML 1.2
 ---
-title: Schema for flasher_pulse_width model parameter
+title: Schema for pedestal_events model parameter
+deprecated: true
+deprecation_note: "Replaced by configuration parameter in corresponding application"
 schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
-name: flasher_pulse_width
+name: pedestal_events
 description: |-
-  Flasher pulse shape characteristic width.
-  For 'TopHat', this is the pulse width, for 'Gauss' the rms, for 'Exponential' the decay time.
+  Number of pedestal events at start of run with camera lid open (same NSB as for normal events).
 short_description: |-
-  Flasher pulse shape width.
+  Number of pedestal events at start of run with camera lid open (same NSB as for normal events).
 data:
-  - type: float64
-    unit: ns
+  - type: int64
+    unit: dimensionless
     default: 0
     allowed_range:
       min: 0
 instrument:
-  class: Calibration
+  class: Camera
   type:
-    - ILLN
-    - ILLS
+    - LSTN
+    - LSTS
+    - MSTx-NectarCam
+    - MSTx-FlashCam
+    - SSTS
+    - SCTS
 activity:
   setting:
     - SetParameterFromExternal
@@ -31,6 +36,5 @@ source:
   - Initial instrument setup
 simulation_software:
   - name: sim_telarray
-    internal_parameter_name: laser_pulse_twidth
   - name: simtools
-    version: ">=0.21.0"
+    version: "<0.21.0"

--- a/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
+++ b/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
@@ -1,28 +1,29 @@
 %YAML 1.2
 ---
-title: Schema for flasher_angular_distribution_width model parameter
+title: Schema for photons_per_run model parameter
+deprecated: true
+deprecation_note: "Replaced by configuration parameter in corresponding application"
 schema_version: 0.1.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
-name: flasher_angular_distribution_width
+name: photons_per_run
 description: |-
-  Characteristic width of the flasher angular emission distribution.
-  This is the RMS for Gaussian distributions or the maximum half
-  opening angle for conical shapes.
+  Number of total emitted photons by the calibration light source per run.
 short_description: |-
-  Characteristic width of the flasher angular emission distribution.
+  Number of photons per run.
 data:
   - type: float64
-    unit: "deg"
-    default: 0
+    unit: dimensionless
+    default: 1e10
     allowed_range:
-      min: 0
+      min: 1
 instrument:
   class: Calibration
   type:
     - ILLN
     - ILLS
+
 activity:
   setting:
     - SetParameterFromExternal
@@ -31,5 +32,6 @@ activity:
 source:
   - Initial instrument setup
 simulation_software:
+  - name: sim_telarray
   - name: simtools
-    version: ">=0.21.0"
+    version: "<0.21.0"

--- a/tests/unit_tests/data_model/test_schema.py
+++ b/tests/unit_tests/data_model/test_schema.py
@@ -295,3 +295,93 @@ def test_get_schema_for_version_warns_on_version_mismatch(caplog):
         result = schema._get_schema_for_version(test_schema, DUMMY_FILE, "2.0.0")
     assert result == test_schema
     assert "Schema version 2.0.0 does not match 1.0.0" in caplog.text
+
+
+def test_validate_deprecation_and_version(caplog, monkeypatch):
+    """Test _validate_deprecation_and_version function covering all edge cases."""
+    # Mock simtools version for predictable testing
+    monkeypatch.setattr("simtools.version.__version__", "1.0.0")
+
+    # Test 1: Non-dict data should return early without errors
+    schema._validate_deprecation_and_version("not_a_dict")
+    schema._validate_deprecation_and_version(None)
+    schema._validate_deprecation_and_version([1, 2, 3])
+
+    # Test 2: Empty dict should not raise errors
+    schema._validate_deprecation_and_version({})
+
+    # Test 3: Deprecated data should log warning
+    with caplog.at_level(logging.WARNING):
+        schema._validate_deprecation_and_version({"deprecated": True})
+    assert "Data is deprecated" in caplog.text
+    caplog.clear()
+
+    # Test 4: Deprecated data with custom note
+    with caplog.at_level(logging.WARNING):
+        schema._validate_deprecation_and_version(
+            {"deprecated": True, "deprecation_note": "Use new version instead"}
+        )
+    assert "Use new version instead" in caplog.text
+    caplog.clear()
+
+    # Test 5: Non-deprecated data should not warn
+    with caplog.at_level(logging.WARNING):
+        schema._validate_deprecation_and_version({"deprecated": False})
+    assert "deprecated" not in caplog.text
+
+    # Test 6: Valid version constraint should pass
+    valid_data = {"simulation_software": [{"name": "simtools", "version": ">=1.0.0"}]}
+    schema._validate_deprecation_and_version(valid_data)
+
+    # Test 7: Multiple software entries, only simtools matters
+    multi_sw_data = {
+        "simulation_software": [
+            {"name": "other_software", "version": ">=2.0.0"},
+            {"name": "simtools", "version": ">=0.5.0"},
+            {"name": "another_software", "version": ">=3.0.0"},
+        ]
+    }
+    schema._validate_deprecation_and_version(multi_sw_data)
+
+    # Test 8: Invalid version constraint should raise ValueError
+    invalid_data = {"simulation_software": [{"name": "simtools", "version": ">=2.0.0"}]}
+    with pytest.raises(
+        ValueError, match="Version 1.0.0 of simtools does not match constraint >=2.0.0"
+    ):
+        schema._validate_deprecation_and_version(invalid_data)
+
+    # Test 9: Software without version constraint should pass
+    no_version_data = {"simulation_software": [{"name": "simtools"}]}
+    schema._validate_deprecation_and_version(no_version_data)
+
+    # Test 10: Software with None version should pass
+    none_version_data = {"simulation_software": [{"name": "simtools", "version": None}]}
+    schema._validate_deprecation_and_version(none_version_data)
+
+    # Test 11: Complex version constraints
+    complex_constraints = ["==1.0.0", ">=1.0.0,<2.0.0", "~=1.0", "!=0.9.0"]
+    for constraint in complex_constraints:
+        data = {"simulation_software": [{"name": "simtools", "version": constraint}]}
+        schema._validate_deprecation_and_version(data)
+
+    # Test 12: Version constraint with whitespace should be handled
+    whitespace_data = {"simulation_software": [{"name": "simtools", "version": "  >=1.0.0  "}]}
+    schema._validate_deprecation_and_version(whitespace_data)
+
+    # Test 13: Custom software name parameter
+    custom_sw_data = {"simulation_software": [{"name": "custom_tool", "version": ">=1.0.0"}]}
+    schema._validate_deprecation_and_version(custom_sw_data, software_name="custom_tool")
+
+    # Test 14: No matching software name should pass
+    no_match_data = {"simulation_software": [{"name": "other_software", "version": ">=2.0.0"}]}
+    schema._validate_deprecation_and_version(no_match_data)
+
+    # Test 15: Combined deprecation and version validation
+    combined_data = {
+        "deprecated": True,
+        "deprecation_note": "Old version",
+        "simulation_software": [{"name": "simtools", "version": ">=0.5.0"}],
+    }
+    with caplog.at_level(logging.WARNING):
+        schema._validate_deprecation_and_version(combined_data)
+    assert "Old version" in caplog.text


### PR DESCRIPTION
Add validation tests for software version ranges to model parameters.

This covers the following scenarios (as e.g. we have now for the flasher / laser / illuminators updates):

- model parameters are not used in newer simtools versions
- model parameters are renamed
- new model parameters are introduced

This PR adds:

- the validation of the version string in the model parameter schema files (e.g., validate simtools “>0.20.0,<0.25.0”)
- a deprecated field plus warning

Updated the schema files for the model parameters introduced for the flasher updates. 

Keep the following parameters which will be deprecated after merging #1744 (but we should be able to run the older versions):

- led_pulse_sigtime, pedestal_events, laser_photons, photons_per_run
