### PR TITLE
Bug fix in configuring hard-stereo array triggers.

### DIFF
--- a/docs/changes/1778.bugfix.md
+++ b/docs/changes/1778.bugfix.md
@@ -1,0 +1,1 @@
+Bug fix in configuring hard-stereo array triggers (`hard_stereo` should be `hardstereo` in `array_trigger.dat`).

--- a/src/simtools/simtel/simtel_config_writer.py
+++ b/src/simtools/simtel/simtel_config_writer.py
@@ -515,7 +515,7 @@ class SimtelConfigWriter:
             width = trigger_dict["width"]["value"] * u.Unit(trigger_dict["width"]["unit"]).to("ns")
             trigger_lines[tel_type] += f" width {width}"
             if trigger_dict.get("hard_stereo"):
-                trigger_lines[tel_type] += " hard_stereo"
+                trigger_lines[tel_type] += " hardstereo"
             if all(trigger_dict["min_separation"][key] is not None for key in ["value", "unit"]):
                 min_sep = trigger_dict["min_separation"]["value"] * u.Unit(
                     trigger_dict["min_separation"]["unit"]

--- a/tests/unit_tests/simtel/test_simtel_config_writer.py
+++ b/tests/unit_tests/simtel/test_simtel_config_writer.py
@@ -154,6 +154,7 @@ def test_convert_model_parameters_to_simtel_format(
     with open(Path(model_path) / value) as f:
         content = f.read()
         assert "Trigger 1 of 1" in content
+        assert "hardstereo" in content
 
 
 def test_get_sim_telarray_metadata_with_model_parameters(simtel_config_writer):


### PR DESCRIPTION
`hard_stereo` should be `hardstereo` in `array_trigger.dat`

Doing this in `simtools.simtel.simtel_config_writer` follows what do already with `minsep` (which is `min_separation` in the simulation models).

Closes #1779