### PR TITLE
Schema for info.yml files used in simulation models

### DIFF
--- a/src/simtools/applications/validate_file_using_schema.py
+++ b/src/simtools/applications/validate_file_using_schema.py
@@ -61,12 +61,15 @@ def _parse(label, description):
 
     """
     config = configurator.Configurator(label=label, description=description)
-    group = config.parser.add_mutually_exclusive_group(required=True)
-    group.add_argument("--file_name", help="File to be validated")
-    group.add_argument(
+    config.parser.add_argument(
+        "--file_name",
+        help="File to be validated (full path or name pattern, e.g., '*.json')",
+        default="*.json",
+    )
+    config.parser.add_argument(
         "--file_directory",
         help=(
-            "Directory with json files to be validated. "
+            "Directory with files to be validated. "
             "If no schema file is provided, the assumption is that model "
             "parameters are validated and the schema files are taken from "
             f"{MODEL_PARAMETER_SCHEMA_PATH}."
@@ -124,7 +127,7 @@ def _get_json_file_list(file_directory=None, file_name=None):
     """Return list of json files in a directory."""
     file_list = []
     if file_directory is not None:
-        file_list = list(Path(file_directory).rglob("*.json"))
+        file_list = list(Path(file_directory).rglob(file_name))
         if not file_list:
             raise FileNotFoundError(f"No files found in {file_directory}")
     elif file_name is not None:

--- a/src/simtools/schemas/common_definitions.schema.yml
+++ b/src/simtools/schemas/common_definitions.schema.yml
@@ -1,0 +1,39 @@
+---
+$schema: http://json-schema.org/draft-06/schema#
+$id: common_definitions.schema.yml
+title: Common Schema Definitions
+description: |
+  Common definitions and patterns used across multiple schema files
+schema_version: 0.1.0
+schema_name: common_definitions
+type: object
+
+$defs:
+  telescope_name_pattern:
+    type: string
+    description: |
+      Pattern for valid telescope names including:
+      - Standard telescope types (LST, MST, SST, CT) with site (N/S/x) and number
+      - Design telescopes with specific camera types (FlashCam, NectarCam)
+      - Observatory sites (North/South)
+      - Dummy telescopes for testing
+    pattern: '^([A-Za-z](ST|LL|CT|SF)[N,S,x]-\d{2,3}|[A-Za-z](ST|LL|CT|SF)[N,S,x]-(design|FlashCam|NectarCam)|OBS-(North|South)|Dummy-Telescope)$'
+    examples:
+      - "LSTN-01"
+      - "MSTN-02"
+      - "SSTN-03"
+      - "LSTN-design"
+      - "MSTN-FlashCam"
+      - "SSTN-NectarCam"
+      - "OBS-North"
+      - "OBS-South"
+      - "Dummy-Telescope"
+
+  semantic_version_pattern:
+    type: string
+    description: Semantic version pattern (MAJOR.MINOR.PATCH)
+    pattern: '^\d+\.\d+\.\d+$'
+    examples:
+      - "1.0.0"
+      - "2.1.3"
+      - "0.5.12"

--- a/src/simtools/schemas/production_tables.schema.yml
+++ b/src/simtools/schemas/production_tables.schema.yml
@@ -18,9 +18,7 @@ definitions:
         type: string
         description: Name of the production table.
       model_version:
-        type: string
-        description: Model version.
-        pattern: '^\d+\.\d+\.\d+$'
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
       parameters:
         type: object
         description: Model parameters.
@@ -28,12 +26,9 @@ definitions:
           type: object
           description: Model parameter.
           additionalProperties:
-            type: string
-            description: Parameter version (semantical versioning).
-            pattern: '^\d+\.\d+\.\d+$'
+            $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
         propertyNames:
-          description: Allowed parameter name patterns.
-          pattern: '^([A-Za-z](ST|LL|CT|SF)[N,S,x]-\d{2,3}|[A-Za-z](ST|LL|CT|SF)[N,S,x]-(design|FlashCam|NectarCam)|OBS-(North|South)|Dummy-Telescope)$'
+          $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
       design_model:
         type: object
         description: Design models.

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -12,8 +12,7 @@ definitions:
   SimulationModelsInfo:
     properties:
       model_version:
-        type: string
-        description: The version of the CTAO model.
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
       model_update:
         type: string
         description: The type of update for the model version.
@@ -24,13 +23,21 @@ definitions:
         type: array
         description: A list of previous model versions.
         items:
-          type: string
+          $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
       description:
         type: string
         description: A detailed description of the model changes.
       changes:
         type: object
         description: A map of design names to their parameter changes.
+        propertyNames:
+          $ref: 'common_definitions.schema.yml#/$defs/telescope_name_pattern'
+        additionalProperties:
+          type: object
+          additionalProperties:
+            anyOf:
+              - $ref: '#/$defs/ParameterValue'
+              - $ref: '#/$defs/DeprecatedParameter'
     required:
       - model_version
       - model_update
@@ -53,7 +60,7 @@ $defs:
     type: object
     properties:
       version:
-        type: string
+        $ref: 'common_definitions.schema.yml#/$defs/semantic_version_pattern'
       value:
         oneOf:
           - type: string
@@ -62,8 +69,10 @@ $defs:
           - type: array
           - type: object
       unit:
-        type: string
+        oneOf:
+          - type: string
+          - type: array
+          - type: "null"
     required:
       - version
-      - value
     additionalProperties: false

--- a/src/simtools/schemas/simulation_models_info.schema.yml
+++ b/src/simtools/schemas/simulation_models_info.schema.yml
@@ -1,0 +1,69 @@
+---
+$schema: http://json-schema.org/draft-06/schema#
+$ref: '#/definitions/SimulationModelsInfo'
+title: Production and simulation model information schema
+description: Schema for validating 'info.yml' files used to update CTAO simulation models.
+schema_version: 0.1.0
+schema_name: simulation_models_info.metaschema
+type: object
+additionalProperties: false
+
+definitions:
+  SimulationModelsInfo:
+    properties:
+      model_version:
+        type: string
+        description: The version of the CTAO model.
+      model_update:
+        type: string
+        description: The type of update for the model version.
+        enum:
+          - patch_update
+          - full_update
+      model_version_history:
+        type: array
+        description: A list of previous model versions.
+        items:
+          type: string
+      description:
+        type: string
+        description: A detailed description of the model changes.
+      changes:
+        type: object
+        description: A map of design names to their parameter changes.
+    required:
+      - model_version
+      - model_update
+      - model_version_history
+      - description
+      - changes
+
+$defs:
+  DeprecatedParameter:
+    type: object
+    properties:
+      deprecated:
+        type: boolean
+        const: true
+    required:
+      - deprecated
+    additionalProperties: false
+
+  ParameterValue:
+    type: object
+    properties:
+      version:
+        type: string
+      value:
+        oneOf:
+          - type: string
+          - type: number
+          - type: boolean
+          - type: array
+          - type: object
+      unit:
+        type: string
+    required:
+      - version
+      - value
+    additionalProperties: false


### PR DESCRIPTION
As usual: any configuration in simtools should be validated and should have a schema.

This PR introduces a new schema file for the `info.yml` files used in the simulation models repository to generate new or patch updates model version.

- generalize some definitions for the schema files in `common_definitions.schema.yml`
- improve alidate_file_using_schema.py to find in the example below all `info.yml` files in the given directory (but see #1789 , this application needs attention)

I have tested this with e.g.:

```
python src/simtools/applications/validate_file_using_schema.py --file_directory ../simulation-models/simulation-models/ --file_name "info.yml" --schema src/simtools/schemas/simulation_models_info.schema.yml --data_type schema
```