### PR TITLE
Change minimum python version requirement to 3.12 (following CTAO recommendation).

### DIFF
--- a/docs/changes/1799.maintenance.md
+++ b/docs/changes/1799.maintenance.md
@@ -1,0 +1,1 @@
+Change minimum python version requirement to 3.12 (following CTAO recommendation).

--- a/docs/source/user-guide/getting_started.md
+++ b/docs/source/user-guide/getting_started.md
@@ -63,7 +63,7 @@ simtools is available as a Python package from [PypPi](https://pypi.org/project/
 To install, prepare a python environment, e.g.:
 
 ```console
-mamba create --name simtools-prod python=3.11
+mamba create --name simtools-prod python=3.12
 mamba activate simtools-prod
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,11 @@ license-files = [ "LICENSE" ]
 authors = [
   { name = "simtools developers", email = "simtools-developer@desy.de" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
   "Intended Audience :: Science/Research",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Astronomy",


### PR DESCRIPTION
(see title).

Note all tests and docker files use already 3.12.