### PR TITLE
Remove 'instrument:type' and 'instrument:site' in model parameter schema files.

### DIFF
--- a/docs/changes/1803.maintenance.md
+++ b/docs/changes/1803.maintenance.md
@@ -1,0 +1,1 @@
+Remove 'instrument:type' and 'instrument:site' in model parameter schema files.

--- a/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+++ b/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
@@ -260,18 +260,6 @@ definitions:
           - Telescope
           - configuration_sim_telarray
           - configuration_corsika
-      type:
-        type: array
-        items:
-          $ref: '#/definitions/InstrumentTypeElement'
-      site:
-        type: array
-        description: "associated CTAO site"
-        items:
-          type: string
-          enum:
-            - North
-            - South
     required:
       - class
     title: Instrument

--- a/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/adjust_gain.schema.yml
@@ -20,11 +20,6 @@ data:
       max: 10.
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/altitude.schema.yml
@@ -19,11 +19,6 @@ data:
       min: 0.0
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_coordinates.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_coordinates.schema.yml
@@ -15,11 +15,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_coordinates_UTM.schema.yml
@@ -59,11 +59,6 @@ data:
         unit: dimensionless
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_ground.schema.yml
@@ -21,13 +21,6 @@ data:
     description: Array element altitude above reference_point_altitude
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_element_position_utm.schema.yml
@@ -21,13 +21,6 @@ data:
     description: Array element altitude above sea level.
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_layouts.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_layouts.schema.yml
@@ -33,11 +33,6 @@ data:
         additionalProperties: false
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_triggers.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_triggers.schema.yml
@@ -76,11 +76,6 @@ data:
         required: [name, multiplicity, width, hard_stereo, min_separation]
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/array_window.schema.yml
+++ b/src/simtools/schemas/model_parameters/array_window.schema.yml
@@ -18,13 +18,6 @@ data:
     default: 1000.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_clipping.schema.yml
@@ -19,9 +19,6 @@ data:
     condition: default_trigger==AnalogSum
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/asum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_offset.schema.yml
@@ -16,13 +16,6 @@ data:
     condition: default_trigger==AnalogSum
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_shaping.schema.yml
@@ -16,13 +16,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/asum_threshold.schema.yml
@@ -18,13 +18,6 @@ data:
     condition: default_trigger==AnalogSum
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
+++ b/src/simtools/schemas/model_parameters/atmospheric_profile.schema.yml
@@ -14,11 +14,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/atmospheric_transmission.schema.yml
@@ -16,11 +16,6 @@ data:
     default: 'atm_trans_2147_1_10_2_0_2147.dat'
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
+++ b/src/simtools/schemas/model_parameters/axes_offsets.schema.yml
@@ -34,13 +34,6 @@ data:
       is zero.
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/calibration_devices.schema.yml
+++ b/src/simtools/schemas/model_parameters/calibration_devices.schema.yml
@@ -19,13 +19,6 @@ data:
         description: "Calibration device name"
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_diameter.schema.yml
@@ -18,13 +18,6 @@ data:
       max: 1000.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_body_shape.schema.yml
@@ -24,13 +24,6 @@ data:
       max: 3
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_file.schema.yml
@@ -18,13 +18,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_config_rotate.schema.yml
@@ -16,13 +16,6 @@ data:
     unit: deg
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_efficiency.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 1.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_degraded_map.schema.yml
@@ -22,13 +22,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_depth.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_depth.schema.yml
@@ -20,13 +20,6 @@ data:
       max: 1000.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_filter.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_filter.schema.yml
@@ -25,13 +25,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_filter_incidence_angle.schema.yml
@@ -15,9 +15,6 @@ data:
     default: 'no_such_file.dat'
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_pixels.schema.yml
@@ -17,13 +17,6 @@ data:
       max: 11328
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/camera_transmission.schema.yml
@@ -21,13 +21,6 @@ data:
       max: 1.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
+++ b/src/simtools/schemas/model_parameters/channels_per_chip.schema.yml
@@ -18,13 +18,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/correct_nsb_spectrum_to_telescope_altitude.schema.yml
@@ -17,13 +17,6 @@ data:
     default: "atm_trans_2200_1_3_0_0_0.dat"
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_observation_level.schema.yml
@@ -17,11 +17,6 @@ data:
       min: 0.0
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
@@ -44,7 +44,6 @@ source:
   - Configuration
 simulation_software:
   - name: corsika
-...
 ---
 title: Schema for corsika_starting_grammage model parameter
 schema_version: 0.2.0
@@ -87,7 +86,6 @@ source:
   - Configuration
 simulation_software:
   - name: corsika
-...
 ---
 title: Schema for corsika_starting_grammage model parameter
 schema_version: 0.1.0

--- a/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
+++ b/src/simtools/schemas/model_parameters/corsika_starting_grammage.schema.yml
@@ -44,6 +44,7 @@ source:
   - Configuration
 simulation_software:
   - name: corsika
+...
 ---
 title: Schema for corsika_starting_grammage model parameter
 schema_version: 0.2.0
@@ -86,6 +87,7 @@ source:
   - Configuration
 simulation_software:
   - name: corsika
+...
 ---
 title: Schema for corsika_starting_grammage model parameter
 schema_version: 0.1.0

--- a/src/simtools/schemas/model_parameters/dark_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/dark_events.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/default_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/default_trigger.schema.yml
@@ -17,13 +17,6 @@ data:
       - DigitalSum
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/design_model.schema.yml
+++ b/src/simtools/schemas/model_parameters/design_model.schema.yml
@@ -13,13 +13,6 @@ data:
     default: ""
 instrument:
   class: Telescope
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_ac_coupled.schema.yml
@@ -13,13 +13,6 @@ data:
     default: true
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/disc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_bins.schema.yml
@@ -20,13 +20,6 @@ data:
       max: 160
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/disc_start.schema.yml
+++ b/src/simtools/schemas/model_parameters/disc_start.schema.yml
@@ -22,13 +22,6 @@ data:
       max: 159
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_amplitude.schema.yml
@@ -16,13 +16,6 @@ description: |-
   discriminators/comparators.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: mV

--- a/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_fall_time.schema.yml
@@ -14,13 +14,6 @@ short_description: |-
   reset to false.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: ns

--- a/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_gate_length.schema.yml
@@ -14,13 +14,6 @@ description: |-
 short_description: Effective discriminator gate length.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: ns

--- a/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_hysteresis.schema.yml
@@ -13,13 +13,6 @@ description: |-
 short_description: Value of the discriminator hysteresis.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: mV

--- a/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_amplitude.schema.yml
@@ -14,13 +14,6 @@ short_description: |-
   trigger group coincidence unit.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: mV

--- a/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_output_var_percent.schema.yml
@@ -14,13 +14,6 @@ short_description: |-
   of a pixel discriminator.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: float64
     unit: pct

--- a/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_pulse_shape.schema.yml
@@ -14,13 +14,6 @@ data:
     default: 'unspecified_shape.dat'
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_rise_time.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_scale_threshold.schema.yml
@@ -19,13 +19,6 @@ data:
       max: 2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_sigsum_over_threshold.schema.yml
@@ -25,13 +25,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_threshold.schema.yml
@@ -16,13 +16,6 @@ data:
     condition: default_trigger==Majority
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_time_over_threshold.schema.yml
@@ -14,8 +14,7 @@ description: |-
   threshold and signal integral conditions have to be met before a `true'
   output signal starts. Normally, either of them being non-zero should be
   sufficient.
-short_description: Time over threshold required before logic response switches to
-  true.
+short_description: Time over threshold required before logic response switches to true.
 data:
   - type: float64
     unit: ns
@@ -26,13 +25,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_gate_length.schema.yml
@@ -21,13 +21,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_sigsum_over_threshold.schema.yml
@@ -22,13 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_threshold.schema.yml
@@ -19,13 +19,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/discriminator_var_time_over_threshold.schema.yml
@@ -19,13 +19,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/dish_shape_length.schema.yml
@@ -24,11 +24,6 @@ data:
     condition: mirror_class==1
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_clipping.schema.yml
@@ -10,8 +10,7 @@ description: |-
   The amplitude level (in ADC counts above pedestal) at which the digitized
   signal from each pixel (after optional shaping) is clipped for its
   contribution to the digital sum trigger.
-short_description: Amplitude level at which the digitized signal from each pixel is
-  clipped.
+short_description: Amplitude level at which the digitized signal from each pixel is clipped.
 data:
   - type: int64
     default: 0
@@ -21,9 +20,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_ignore_below.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_offset.schema.yml
@@ -20,9 +20,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pedsub.schema.yml
@@ -17,9 +17,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_pre_clipping.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_prescale.schema.yml
@@ -27,9 +27,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_max.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_presum_shift.schema.yml
@@ -28,9 +28,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping.schema.yml
@@ -27,9 +27,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_shaping_renormalize.schema.yml
@@ -15,9 +15,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_threshold.schema.yml
@@ -1,4 +1,3 @@
-%YAML 1.2
 ---
 title: Schema for dsum_threshold model parameter
 schema_version: 0.2.0
@@ -14,8 +13,7 @@ description: |-
   triggered. The assigned threshold value would have to be one count lower
   than in a camera-internal trigger implementation (like MSTx-FlashCam) where
   reaching (\'>=\') the threshold is enough.
-short_description: Amplitude level above which a digital sum leads to a telescope
-  trigger.
+short_description: Amplitude level above which a digital sum leads to a telescope trigger.
 data:
   - type: int64
     unit: count
@@ -25,9 +23,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal
@@ -39,7 +34,6 @@ source:
   - Observation execution
 simulation_software:
   - name: sim_telarray
-...
 ---
 title: Schema for dsum_threshold model parameter
 schema_version: 0.1.0
@@ -55,8 +49,7 @@ description: |-
   triggered. The assigned threshold value would have to be one count lower
   than in a camera-internal trigger implementation (like MSTx-FlashCam) where
   reaching (\'>=\') the threshold is enough.
-short_description: Amplitude level above which a digital sum leads to a telescope
-  trigger.
+short_description: Amplitude level above which a digital sum leads to a telescope trigger.
 data:
   - type: float64
     unit: count
@@ -66,9 +59,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
+++ b/src/simtools/schemas/model_parameters/dsum_zero_clip.schema.yml
@@ -25,9 +25,6 @@ data:
     condition: default_trigger==DigitalSum
 instrument:
   class: Camera
-  type:
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/effective_focal_length.schema.yml
@@ -71,13 +71,6 @@ data:
     default: 0.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetEffectiveFocalLength

--- a/src/simtools/schemas/model_parameters/epsg_code.schema.yml
+++ b/src/simtools/schemas/model_parameters/epsg_code.schema.yml
@@ -21,11 +21,6 @@ data:
       max: 32767
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_ac_coupled.schema.yml
@@ -17,13 +17,6 @@ data:
     default: 1
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -12,7 +12,8 @@ description: |-
   (per time slice) for a photo-electron with average (not most probable)
   signal.  This is after photo detector, preamplifier, cable, and shaper
   at the input of the ADC or FADC.
-short_description: Peak amplitude above pedestal for a photo electron with average signal.
+short_description: |-
+  Peak amplitude above pedestal for a photo electron with average signal.
 data:
   - type: float64
     description: FADC amplitude (for high-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_amplitude.schema.yml
@@ -12,8 +12,7 @@ description: |-
   (per time slice) for a photo-electron with average (not most probable)
   signal.  This is after photo detector, preamplifier, cable, and shaper
   at the input of the ADC or FADC.
-short_description: Peak amplitude above pedestal for a photo electron with average
-  signal.
+short_description: Peak amplitude above pedestal for a photo electron with average signal.
 data:
   - type: float64
     description: FADC amplitude (for high-gain channel in case of dual-readout chain).
@@ -23,13 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_bins.schema.yml
@@ -22,13 +22,6 @@ data:
       max: 160
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_compensate_pedestal.schema.yml
@@ -29,13 +29,6 @@ data:
       min: -1
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_dev_pedestal.schema.yml
@@ -24,8 +24,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - null
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_compensate_pedestal.schema.yml
@@ -21,13 +21,6 @@ data:
       min: 0.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_err_pedestal.schema.yml
@@ -31,13 +31,6 @@ data:
       min: 0.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -12,8 +12,7 @@ description: |-
   (per time slice) for a photo-electron with average (not most probable)
   signal.  This is after photo detector, preamplifier, cable, and shaper
   at the input of the ADC or FADC.
-short_description: Peak amplitude above pedestal for a photo electron with average
-  signal (low-gain channels).
+short_description: Peak amplitude above pedestal for a photo electron with average signal (low-gain channels).
 data:
   - type: float64
     description: FADC amplitude (for low-gain channel in case of dual-readout chain).
@@ -24,13 +23,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_amplitude.schema.yml
@@ -12,7 +12,8 @@ description: |-
   (per time slice) for a photo-electron with average (not most probable)
   signal.  This is after photo detector, preamplifier, cable, and shaper
   at the input of the ADC or FADC.
-short_description: Peak amplitude above pedestal for a photo electron with average signal (low-gain channels).
+short_description: |-
+  Peak amplitude above pedestal for a photo electron with average signal (low-gain channels).
 data:
   - type: float64
     description: FADC amplitude (for low-gain channel in case of dual-readout chain).

--- a/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_compensate_pedestal.schema.yml
@@ -30,13 +30,6 @@ data:
       min: -1
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_dev_pedestal.schema.yml
@@ -23,8 +23,6 @@ data:
       min: -2.0
 instrument:
   class: Camera
-  type:
-    - null
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_compensate_pedestal.schema.yml
@@ -22,13 +22,6 @@ data:
     condition: num_gains==2
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_err_pedestal.schema.yml
@@ -31,13 +31,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_signal.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 65535
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_max_sum.schema.yml
@@ -26,8 +26,6 @@ data:
       min: -2
 instrument:
   class: Camera
-  type:
-    - null
 activity:
   setting:
     - null

--- a/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_noise.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_pedestal.schema.yml
@@ -19,13 +19,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sensitivity.schema.yml
@@ -27,13 +27,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_sysvar_pedestal.schema.yml
@@ -23,13 +23,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_pedestal.schema.yml
@@ -22,13 +22,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_lg_var_sensitivity.schema.yml
@@ -19,13 +19,6 @@ data:
       min: -2.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_long_event_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_long_event_threshold.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-FlashCam
-    - SSTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_long_sum_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_long_sum_bins.schema.yml
@@ -25,9 +25,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-FlashCam
-    - SSTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_long_sum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_long_sum_offset.schema.yml
@@ -22,9 +22,6 @@ data:
     default: 0
 instrument:
   class: Camera
-  type:
-    - MSTx-FlashCam
-    - SSTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_signal.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 65535
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_max_sum.schema.yml
@@ -26,8 +26,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - null
 activity:
   setting:
     - null

--- a/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_mhz.schema.yml
@@ -13,13 +13,6 @@ data:
     unit: MHz
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_noise.schema.yml
@@ -22,13 +22,6 @@ data:
       max: 100.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pedestal.schema.yml
@@ -19,13 +19,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_pulse_shape.schema.yml
@@ -18,13 +18,6 @@ data:
     default: 'unspecified_shape.dat'
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetReadoutPulseShape

--- a/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sensitivity.schema.yml
@@ -27,13 +27,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_bins.schema.yml
@@ -24,13 +24,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sum_offset.schema.yml
@@ -24,13 +24,6 @@ data:
       max: 160
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_sysvar_pedestal.schema.yml
@@ -23,13 +23,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_pedestal.schema.yml
@@ -22,13 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/fadc_var_sensitivity.schema.yml
@@ -19,13 +19,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/fake_mirror_list.schema.yml
+++ b/src/simtools/schemas/model_parameters/fake_mirror_list.schema.yml
@@ -18,9 +18,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_angular_distribution.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_angular_distribution.schema.yml
@@ -20,9 +20,6 @@ data:
       - Parallel
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_angular_distribution_width.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_angular_distribution_width.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_bunch_size.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_bunch_size.schema.yml
@@ -16,9 +16,6 @@ data:
       min: 1.
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_external_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_external_trigger.schema.yml
@@ -18,9 +18,6 @@ data:
     default: false
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_photons.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 1
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_position.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_position.schema.yml
@@ -31,9 +31,6 @@ data:
     default: primary_mirror_frame
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_pulse_exp_decay.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_exp_decay.schema.yml
@@ -16,9 +16,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_offset.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0.0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_pulse_shape.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_shape.schema.yml
@@ -17,9 +17,6 @@ data:
       - Exponential
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_pulse_width.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_pulse_width.schema.yml
@@ -19,9 +19,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_type.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_type.schema.yml
@@ -16,9 +16,6 @@ data:
       - illuminator
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_var_photons.schema.yml
@@ -17,9 +17,6 @@ data:
       max: 1
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flasher_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/flasher_wavelength.schema.yml
@@ -19,9 +19,6 @@ data:
       min: 200
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/flatfielding.schema.yml
+++ b/src/simtools/schemas/model_parameters/flatfielding.schema.yml
@@ -15,13 +15,6 @@ description: |-
   have equal single-p.e. amplitudes.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 data:
   - type: boolean
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_length.schema.yml
@@ -26,13 +26,6 @@ data:
       max: 10000.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_parameters.schema.yml
@@ -142,9 +142,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/focal_surface_ref_radius.schema.yml
@@ -14,9 +14,6 @@ data:
     default: 1.0
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/focus_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/focus_offset.schema.yml
@@ -47,13 +47,6 @@ data:
     default: 0.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/gain_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/gain_variation.schema.yml
@@ -22,13 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_horizontal.schema.yml
@@ -8,18 +8,13 @@ meta_schema_version: 0.1.0
 name: geomag_horizontal
 short_description: Horizontal component of geomagnetic field.
 description: |-
-   Horizontal component in direction of magnetic North of the geomagnetic
-   field at given site.
+  Horizontal component in direction of magnetic North of the geomagnetic
+  field at given site.
 data:
   - type: float64
     unit: uT
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetGeomagneticField

--- a/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_rotation.schema.yml
@@ -8,8 +8,8 @@ meta_schema_version: 0.1.0
 name: geomag_rotation
 short_description: Rotation angle between geographic South and geomagnetic North.
 description: |-
-   Rotation angle between geographic South and geomagnetic North direction
-   (corresponds to CORSIKA ARRANG parameter).
+  Rotation angle between geographic South and geomagnetic North direction
+  (corresponds to CORSIKA ARRANG parameter).
 data:
   - type: float64
     unit: deg
@@ -18,11 +18,6 @@ data:
       max: 180.0
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetGeomagneticField

--- a/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/geomag_vertical.schema.yml
@@ -8,18 +8,13 @@ meta_schema_version: 0.1.0
 name: geomag_vertical
 short_description: Vertical component of geomagnetic field.
 description: |-
-   Vertical component in downwards direction of the geomagnetic
-   field at given site.
+  Vertical component in downwards direction of the geomagnetic
+  field at given site.
 data:
   - type: float64
     unit: uT
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetGeomagneticField

--- a/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/hg_lg_variation.schema.yml
@@ -19,11 +19,6 @@ data:
       max: 0.25
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_maximum.schema.yml
@@ -16,13 +16,6 @@ data:
       min: 100000
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
+++ b/src/simtools/schemas/model_parameters/iobuf_output_maximum.schema.yml
@@ -16,13 +16,6 @@ data:
       min: 100000
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_events.schema.yml
@@ -24,9 +24,6 @@ data:
 
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_external_trigger.schema.yml
@@ -23,9 +23,6 @@ data:
 
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_photons.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 1
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_exptime.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_offset.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_sigtime.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_pulse_twidth.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_var_photons.schema.yml
@@ -21,9 +21,6 @@ data:
       max: 1
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/laser_wavelength.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 200
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/led_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_events.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/led_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_photons.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0.05
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_offset.schema.yml
@@ -20,9 +20,6 @@ data:
     default: 0.0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_pulse_sigtime.schema.yml
@@ -21,9 +21,6 @@ data:
       min: 0.0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/led_var_photons.schema.yml
@@ -22,9 +22,6 @@ data:
       max: 1.0
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_incidence_angle.schema.yml
@@ -20,13 +20,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetLightGuideEfficiency

--- a/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
+++ b/src/simtools/schemas/model_parameters/lightguide_efficiency_vs_wavelength.schema.yml
@@ -22,13 +22,6 @@ data:
     default: null
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetLightGuideEfficiency

--- a/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photoelectrons.schema.yml
@@ -17,13 +17,6 @@ data:
     default: -1
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/min_photons.schema.yml
+++ b/src/simtools/schemas/model_parameters/min_photons.schema.yml
@@ -14,13 +14,6 @@ data:
     default: -1
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_distance.schema.yml
@@ -16,11 +16,6 @@ data:
     condition: mirror_class==1
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetMirrorPanelAlignment

--- a/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_horizontal.schema.yml
@@ -42,13 +42,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetMirrorPanelAlignment

--- a/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_align_random_vertical.schema.yml
@@ -42,13 +42,6 @@ data:
     default: 0.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetMirrorPanelAlignment

--- a/src/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -12,7 +12,8 @@ description: |-
   parabolic primary made of a single piece (1), and a a secondary mirror
   optics (2), with primary and secondary each made of a single piece.
   Class 3 represents a simple Fresnel lens implementation.
-short_description: Parameter to control the type of mirror used (DC, parabolic or SC).
+short_description: |-
+  Parameter to control the type of mirror used (DC, parabolic or SC).
 data:
   - type: uint64
     unit: dimensionless

--- a/src/simtools/schemas/model_parameters/mirror_class.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_class.schema.yml
@@ -12,8 +12,7 @@ description: |-
   parabolic primary made of a single piece (1), and a a secondary mirror
   optics (2), with primary and secondary each made of a single piece.
   Class 3 represents a simple Fresnel lens implementation.
-short_description: Parameter to control the type of mirror used (DC, parabolic or
-  SC).
+short_description: Parameter to control the type of mirror used (DC, parabolic or SC).
 data:
   - type: uint64
     unit: dimensionless
@@ -23,13 +22,6 @@ data:
       max: 3
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_degraded_reflection.schema.yml
@@ -32,13 +32,6 @@ data:
       max: 1.
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_focal_length.schema.yml
@@ -24,11 +24,6 @@ data:
     condition: mirror_class==1
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_list.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_list.schema.yml
@@ -14,13 +14,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_offset.schema.yml
@@ -22,13 +22,6 @@ data:
     default: 130.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflection_random_angle.schema.yml
@@ -39,13 +39,6 @@ data:
       max: 2.0
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetMirrorPanelRandomReflection

--- a/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/mirror_reflectivity.schema.yml
@@ -18,13 +18,6 @@ data:
     default: 'no_such_reflectivity.dat'
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/multiplicity_offset.schema.yml
@@ -27,13 +27,6 @@ data:
       max: 0.5
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/muon_mono_threshold.schema.yml
+++ b/src/simtools/schemas/model_parameters/muon_mono_threshold.schema.yml
@@ -26,13 +26,6 @@ data:
     unit: dimensionless
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_autoscale_airmass.schema.yml
@@ -33,13 +33,6 @@ data:
       max: 1.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_gain_drop_scale.schema.yml
@@ -22,9 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_offaxis.schema.yml
@@ -60,13 +60,6 @@ data:
     unit: dimensionless
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetNightSkyBackgroundRate

--- a/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_pixel_rate.schema.yml
@@ -24,13 +24,6 @@ data:
       min: 0.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetNightSkyBackgroundRate

--- a/src/simtools/schemas/model_parameters/nsb_reference_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_reference_spectrum.schema.yml
@@ -18,11 +18,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_reference_value.schema.yml
@@ -17,11 +17,6 @@ data:
     default: 0.24
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_scaling_factor.schema.yml
@@ -19,11 +19,6 @@ data:
       max: 1000.0
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_sky_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_sky_map.schema.yml
@@ -23,11 +23,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/nsb_spectrum.schema.yml
@@ -15,11 +15,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/num_gains.schema.yml
+++ b/src/simtools/schemas/model_parameters/num_gains.schema.yml
@@ -16,13 +16,6 @@ data:
       max: 2
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
+++ b/src/simtools/schemas/model_parameters/only_triggered_telescopes.schema.yml
@@ -15,13 +15,6 @@ data:
     default: true
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/optics_properties.schema.yml
+++ b/src/simtools/schemas/model_parameters/optics_properties.schema.yml
@@ -15,13 +15,6 @@ data:
     default: 'no_such_file.dat'
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/parabolic_dish.schema.yml
+++ b/src/simtools/schemas/model_parameters/parabolic_dish.schema.yml
@@ -18,9 +18,6 @@ data:
     default: false
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
+++ b/src/simtools/schemas/model_parameters/pedestal_events.schema.yml
@@ -20,13 +20,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/photon_delay.schema.yml
+++ b/src/simtools/schemas/model_parameters/photon_delay.schema.yml
@@ -18,13 +18,6 @@ data:
     default: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
+++ b/src/simtools/schemas/model_parameters/photons_per_run.schema.yml
@@ -20,10 +20,6 @@ data:
       min: 1
 instrument:
   class: Calibration
-  type:
-    - ILLN
-    - ILLS
-
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixel_cells.schema.yml
@@ -20,9 +20,6 @@ data:
       min: 0
 instrument:
   class: Camera
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixels_parallel.schema.yml
@@ -39,9 +39,6 @@ data:
     condition: mirror_class==2
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/pixeltrg_time_step.schema.yml
@@ -21,13 +21,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_average_gain.schema.yml
@@ -17,11 +17,6 @@ data:
       max: 30000000.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_collection_efficiency.schema.yml
@@ -24,11 +24,6 @@ data:
     default: 1.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_gain_index.schema.yml
@@ -19,11 +19,6 @@ data:
       max: 15.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_photoelectron_spectrum.schema.yml
@@ -17,13 +17,6 @@ data:
     default: 'no_such_pe_spectrum.dat'
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -33,7 +33,8 @@ data:
     default: 300.
     allowed_range:
       min: 0.0
-    developer_note: "This parameter can describe in sim_telarray the fraction of total\nnominal voltage in case total nominal voltage is set to zero."
+    developer_note: |-
+      "This parameter can describe in sim_telarray the fraction of total nominal voltage in case total nominal voltage is set to zero."
   - name: total_nominal_voltage
     type: float64
     default: 1100.
@@ -41,7 +42,8 @@ data:
     unit: V
     allowed_range:
       min: 0.0
-    developer_note: "If zero (or one), the third value of the fixed voltage is assumed to\nrepresent the fraction of the total nominal voltage in sim_telarray."
+    developer_note: |-
+      "If zero (or one), the third value of the fixed voltage is assumed to represent the fraction of the total nominal voltage in sim_telarray."
 instrument:
   class: Camera
 activity:

--- a/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_transit_time.schema.yml
@@ -33,8 +33,7 @@ data:
     default: 300.
     allowed_range:
       min: 0.0
-    developer_note: "This parameter can describe in sim_telarray the fraction of total\n\
-      nominal voltage in case total nominal voltage is set to zero."
+    developer_note: "This parameter can describe in sim_telarray the fraction of total\nnominal voltage in case total nominal voltage is set to zero."
   - name: total_nominal_voltage
     type: float64
     default: 1100.
@@ -42,15 +41,9 @@ data:
     unit: V
     allowed_range:
       min: 0.0
-    developer_note: "If zero (or one), the third value of the fixed voltage is assumed\
-      \ to\nrepresent the fraction of the total nominal voltage in sim_telarray."
+    developer_note: "If zero (or one), the third value of the fixed voltage is assumed to\nrepresent the fraction of the total nominal voltage in sim_telarray."
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-FlashCam
-    - MSTx-NectarCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/pm_voltage_variation.schema.yml
@@ -22,11 +22,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_degraded_map.schema.yml
@@ -25,13 +25,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_diameter.schema.yml
@@ -17,9 +17,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_hole_diameter.schema.yml
@@ -17,9 +17,6 @@ data:
     condition: mirror_class==2
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_incidence_angle.schema.yml
@@ -15,9 +15,6 @@ data:
     default: 'no_such_file.dat'
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_parameters.schema.yml
@@ -151,9 +151,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_ref_radius.schema.yml
@@ -20,9 +20,6 @@ data:
     condition: mirror_class==2
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
+++ b/src/simtools/schemas/model_parameters/primary_mirror_segmentation.schema.yml
@@ -17,9 +17,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/qe_variation.schema.yml
+++ b/src/simtools/schemas/model_parameters/qe_variation.schema.yml
@@ -23,13 +23,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
+++ b/src/simtools/schemas/model_parameters/quantum_efficiency.schema.yml
@@ -20,13 +20,6 @@ data:
     default: 'no_such_qe.dat'
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -6,7 +6,8 @@ meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: random_focal_length
-developer_note: Note - Description changed significantly in the sim_telarray manual.
+developer_note: |-
+  Note - Description changed significantly in the sim_telarray manual.
 description: |-
   The spread of random fluctuations in mirror panel focal lengths.
   These parameters get only applied if the focal lengths in the mirror list

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -6,8 +6,7 @@ meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: random_focal_length
-developer_note: Note - Description changed significantly in the sim_telarray manual
-  - Note
+developer_note: Note - Description changed significantly in the sim_telarray manual - Note
 description: |-
   The spread of random fluctuations in mirror panel focal lengths.
   These parameters get only applied if the focal lengths in the mirror list
@@ -28,11 +27,6 @@ data:
     condition: mirror_class==1
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_focal_length.schema.yml
@@ -6,7 +6,7 @@ meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
 meta_schema_version: 0.1.0
 name: random_focal_length
-developer_note: Note - Description changed significantly in the sim_telarray manual - Note
+developer_note: Note - Description changed significantly in the sim_telarray manual.
 description: |-
   The spread of random fluctuations in mirror panel focal lengths.
   These parameters get only applied if the focal lengths in the mirror list

--- a/src/simtools/schemas/model_parameters/random_generator.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_generator.schema.yml
@@ -18,13 +18,6 @@ data:
     default: "Ranlux"
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/random_mono_probability.schema.yml
+++ b/src/simtools/schemas/model_parameters/random_mono_probability.schema.yml
@@ -19,13 +19,6 @@ data:
       max: 1.
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_altitude.schema.yml
@@ -17,11 +17,6 @@ data:
       min: 0.0
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_latitude.schema.yml
@@ -18,11 +18,6 @@ data:
       max: 90.0
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_longitude.schema.yml
@@ -18,11 +18,6 @@ data:
       max: 180.0
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_east.schema.yml
@@ -18,11 +18,6 @@ data:
       min: 0.
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
+++ b/src/simtools/schemas/model_parameters/reference_point_utm_north.schema.yml
@@ -18,11 +18,6 @@ data:
       min: 0.
 instrument:
   class: Site
-  type:
-    - Observatory
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/sampled_output.schema.yml
+++ b/src/simtools/schemas/model_parameters/sampled_output.schema.yml
@@ -13,13 +13,6 @@ data:
     default: true
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
+++ b/src/simtools/schemas/model_parameters/save_pe_with_amplitude.schema.yml
@@ -16,13 +16,6 @@ data:
     default: false
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_baffle.schema.yml
@@ -62,9 +62,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_map.schema.yml
@@ -25,9 +25,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_degraded_reflection.schema.yml
@@ -25,9 +25,6 @@ data:
     condition: mirror_class==2
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_diameter.schema.yml
@@ -17,9 +17,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_hole_diameter.schema.yml
@@ -20,9 +20,6 @@ data:
     condition: mirror_class==2
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_incidence_angle.schema.yml
@@ -15,9 +15,6 @@ data:
     default: 'no_such_file.dat'
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_parameters.schema.yml
@@ -151,9 +151,6 @@ data:
     default: 0.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_ref_radius.schema.yml
@@ -20,9 +20,6 @@ data:
     default: 1.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_reflectivity.schema.yml
@@ -16,9 +16,6 @@ data:
     default: 'no_such_reflectivity.dat'
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_segmentation.schema.yml
@@ -20,9 +20,6 @@ data:
     default: null
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_diameter.schema.yml
@@ -22,9 +22,6 @@ data:
     default: -1.
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
+++ b/src/simtools/schemas/model_parameters/secondary_mirror_shadow_offset.schema.yml
@@ -22,9 +22,6 @@ data:
     default: 0.0
 instrument:
   class: Structure
-  type:
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/stars.schema.yml
+++ b/src/simtools/schemas/model_parameters/stars.schema.yml
@@ -20,11 +20,6 @@ data:
     default: null
 instrument:
   class: Site
-  type:
-    - Atmosphere
-  site:
-    - North
-    - South
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
+++ b/src/simtools/schemas/model_parameters/store_photoelectrons.schema.yml
@@ -23,13 +23,6 @@ data:
       max: 10000
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
+++ b/src/simtools/schemas/model_parameters/tailcut_scale.schema.yml
@@ -20,13 +20,6 @@ data:
       max: 10.0
 instrument:
   class: configuration_sim_telarray
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_axis_height.schema.yml
@@ -12,13 +12,6 @@ data:
     unit: m
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_angle.schema.yml
@@ -17,13 +17,6 @@ data:
     default: 0.001
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_random_error.schema.yml
@@ -16,13 +16,6 @@ data:
     default: 0.001
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_sphere_radius.schema.yml
@@ -17,13 +17,6 @@ data:
     unit: m
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
+++ b/src/simtools/schemas/model_parameters/telescope_transmission.schema.yml
@@ -89,13 +89,6 @@ data:
     unit: dimensionless
 instrument:
   class: Structure
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_sigsum.schema.yml
@@ -22,13 +22,6 @@ data:
     condition: default_trigger==Majority
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
+++ b/src/simtools/schemas/model_parameters/teltrig_min_time.schema.yml
@@ -17,13 +17,6 @@ data:
     condition: default_trigger==Majority
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_calib_error.schema.yml
@@ -17,13 +17,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_error.schema.yml
@@ -18,13 +18,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_compensate_step.schema.yml
@@ -19,13 +19,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_error.schema.yml
@@ -26,13 +26,6 @@ data:
       min: -1.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
+++ b/src/simtools/schemas/model_parameters/transit_time_jitter.schema.yml
@@ -17,13 +17,6 @@ data:
       min: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_current_limit.schema.yml
@@ -13,13 +13,6 @@ data:
     default: 20.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_delay_compensation.schema.yml
@@ -34,13 +34,6 @@ data:
     default: 0.0
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal

--- a/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
+++ b/src/simtools/schemas/model_parameters/trigger_pixels.schema.yml
@@ -21,13 +21,6 @@ data:
       min: 1
 instrument:
   class: Camera
-  type:
-    - LSTN
-    - LSTS
-    - MSTx-NectarCam
-    - MSTx-FlashCam
-    - SSTS
-    - SCTS
 activity:
   setting:
     - SetParameterFromExternal


### PR DESCRIPTION
Remove these fields as in the data model used now we:

- define the relation instrument - model parameter and site - model parameter in the production tables in the simulation models.

simtools does not use this information. Additionally, the fields are not updated, are incomplete or outdated.

Note! The unit test "tests/unit_tests/io/test_ascii_handler.py::test_collect_dict_from_url" must fail (as it compares the meta_schema_url result with the schema. They will pass as soon as this PR is merged to main.