### PR TITLE
Mark pytest.fixture io_handler as `autouse=True`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def data_path():
     return "./data/"
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def io_handler(tmp_test_directory, data_path):
     """Define io_handler fixture including output and model directories."""
     tmp_io_handler = simtools.io.io_handler.IOHandler()

--- a/tests/unit_tests/camera/test_camera_efficiency.py
+++ b/tests/unit_tests/camera/test_camera_efficiency.py
@@ -26,7 +26,7 @@ def config_data_lst(model_version_prod5, simtel_path):
 
 
 @pytest.fixture
-def camera_efficiency_lst(io_handler, db_config, config_data_lst):
+def camera_efficiency_lst(db_config, config_data_lst):
     return CameraEfficiency(
         config_data=config_data_lst,
         db_config=db_config,
@@ -71,7 +71,7 @@ def test_load_files(camera_efficiency_lst):
     assert camera_efficiency_lst._file["log"].name == _name + ".log"
 
 
-def test_simulate(io_handler, camera_efficiency_lst, caplog, mocker):
+def test_simulate(camera_efficiency_lst, caplog, mocker):
     mock_run = mocker.patch.object(SimulatorCameraEfficiency, "run")
     with caplog.at_level(logging.INFO):
         camera_efficiency_lst.simulate()

--- a/tests/unit_tests/corsika/test_corsika_config.py
+++ b/tests/unit_tests/corsika/test_corsika_config.py
@@ -104,7 +104,7 @@ def test_repr(corsika_config_mock_array_model):
     assert "site" in repr(corsika_config_mock_array_model)
 
 
-def test_fill_corsika_configuration(io_handler, corsika_config_mock_array_model):
+def test_fill_corsika_configuration(corsika_config_mock_array_model):
     empty_config = CorsikaConfig(
         array_model=None, label="test-corsika-config", args_dict=None, db_config=None
     )
@@ -132,9 +132,7 @@ def test_fill_corsika_configuration(io_handler, corsika_config_mock_array_model)
         assert key in corsika_config_mock_array_model.config
 
 
-def test_fill_corsika_configuration_model_version(
-    io_handler, corsika_config_mock_array_model, gcm2
-):
+def test_fill_corsika_configuration_model_version(corsika_config_mock_array_model, gcm2):
     """Test handling a list of model versions as input, taking the first one only."""
 
     with patch(CORSIKA_CONFIG_MODE_PARAMETER) as mock_model_parameter:
@@ -490,7 +488,7 @@ def test_generate_corsika_input_file_with_test_seeds(corsika_config_mock_array_m
             assert f"SEED {seed} 0 0" in file_content
 
 
-def test_get_corsika_config_file_name(corsika_config_mock_array_model, io_handler, model_version):
+def test_get_corsika_config_file_name(corsika_config_mock_array_model, model_version):
     file_name = (
         "proton_run000001_za020deg_azm000deg_cone0-10_South_"
         f"test_layout_{model_version}_test-corsika-config"

--- a/tests/unit_tests/corsika/test_corsika_histograms.py
+++ b/tests/unit_tests/corsika/test_corsika_histograms.py
@@ -113,7 +113,7 @@ def test_hist_config_custom_config(corsika_histograms_instance):
     assert hist_config == custom_config
 
 
-def test_hist_config_save_and_read_yml(corsika_histograms_instance, io_handler):
+def test_hist_config_save_and_read_yml(corsika_histograms_instance):
     # Test producing the yaml file
     temp_hist_config = corsika_histograms_instance.hist_config
     corsika_histograms_instance.hist_config_to_yaml()
@@ -154,7 +154,7 @@ def test_create_histograms(corsika_histograms_instance):
         assert isinstance(corsika_histograms_instance.hist_time_altitude[0], bh.Histogram)
 
 
-def test_fill_histograms_no_rotation(corsika_output_file_name, io_handler):
+def test_fill_histograms_no_rotation(corsika_output_file_name):
     # Sample test of photons: 1 telescope, 2 photons
     photons = [
         {
@@ -291,7 +291,7 @@ def test_set_histograms_passing_config(corsika_histograms_instance):
     assert corsika_histograms_instance.hist_position[0][:, :, sum].axes[0].edges[-1] == 500
 
 
-def test_raise_if_no_histogram(corsika_output_file_name, caplog, io_handler):
+def test_raise_if_no_histogram(corsika_output_file_name, caplog):
     corsika_histograms_instance_not_hist = CorsikaHistograms(corsika_output_file_name)
     with pytest.raises(HistogramNotCreatedError):
         corsika_histograms_instance_not_hist._raise_if_no_histogram()
@@ -796,7 +796,7 @@ def test_dict_2d_distributions(corsika_histograms_instance_set_histograms):
     )
 
 
-def test_export_event_header_1d_histogram(corsika_histograms_instance_set_histograms, io_handler):
+def test_export_event_header_1d_histogram(corsika_histograms_instance_set_histograms):
     corsika_event_header_example = {
         "total_energy": "event_1d_histograms_total_energy",
         "azimuth": "event_1d_histograms_azimuth",
@@ -812,7 +812,7 @@ def test_export_event_header_1d_histogram(corsika_histograms_instance_set_histog
     assert len(tables) == 4
 
 
-def test_export_event_header_2d_histogram(corsika_histograms_instance_set_histograms, io_handler):
+def test_export_event_header_2d_histogram(corsika_histograms_instance_set_histograms):
     # Test writing the default photon histograms as well
     corsika_histograms_instance_set_histograms.export_histograms()
     tables = read_hdf5(corsika_histograms_instance_set_histograms.hdf5_file_name)
@@ -867,7 +867,7 @@ def test_parse_telescope_indices_none(corsika_dummy_input, tmp_path):
         assert ch.parse_telescope_indices(None) is None
 
 
-def test_parse_telescope_indices_valid(corsika_dummy_input, tmp_path, io_handler):
+def test_parse_telescope_indices_valid(corsika_dummy_input, tmp_path):
     with (
         mock.patch.object(CorsikaHistograms, "read_event_information"),
         mock.patch.object(CorsikaHistograms, "_initialize_header"),
@@ -877,7 +877,7 @@ def test_parse_telescope_indices_valid(corsika_dummy_input, tmp_path, io_handler
         assert np.array_equal(indices, np.array([1, 2, 3]))
 
 
-def test_parse_telescope_indices_invalid(corsika_dummy_input, tmp_path, io_handler):
+def test_parse_telescope_indices_invalid(corsika_dummy_input, tmp_path):
     with (
         mock.patch.object(CorsikaHistograms, "read_event_information"),
         mock.patch.object(CorsikaHistograms, "_initialize_header"),
@@ -887,7 +887,7 @@ def test_parse_telescope_indices_invalid(corsika_dummy_input, tmp_path, io_handl
             ch.parse_telescope_indices(["a", "2"])
 
 
-def test_should_overwrite(corsika_dummy_input, tmp_path, io_handler):
+def test_should_overwrite(corsika_dummy_input, tmp_path):
     with (
         mock.patch.object(CorsikaHistograms, "read_event_information"),
         mock.patch.object(CorsikaHistograms, "_initialize_header"),
@@ -901,7 +901,7 @@ def test_should_overwrite(corsika_dummy_input, tmp_path, io_handler):
         assert ch.should_overwrite(False, None, None) is False
 
 
-def test_run_export_pipeline_minimal(corsika_dummy_input, tmp_path, io_handler):
+def test_run_export_pipeline_minimal(corsika_dummy_input, tmp_path):
     # Mock heavy operations inside pipeline
     with (
         mock.patch.object(CorsikaHistograms, "read_event_information"),
@@ -941,7 +941,7 @@ def test_run_export_pipeline_minimal(corsika_dummy_input, tmp_path, io_handler):
             assert out["pdf_photons"].name == "photons.pdf"
 
 
-def test_run_export_pipeline_event1d_event2d_and_hdf5(corsika_dummy_input, tmp_path, io_handler):
+def test_run_export_pipeline_event1d_event2d_and_hdf5(corsika_dummy_input, tmp_path):
     # Cover event1d/event2d branches and write_hdf5 path, including overwrite flag logic
     with (
         mock.patch.object(CorsikaHistograms, "read_event_information"),

--- a/tests/unit_tests/data_model/test_model_data_writer.py
+++ b/tests/unit_tests/data_model/test_model_data_writer.py
@@ -86,7 +86,7 @@ def test_write_dict_to_model_parameter_json(tmp_test_directory):
     assert Path(data_file).is_file()
 
 
-def test_dump(args_dict, io_handler):
+def test_dump(args_dict):
     empty_table = Table()
 
     args_dict["output_file"] = "test_file.ecsv"

--- a/tests/unit_tests/io/test_ascii_handler.py
+++ b/tests/unit_tests/io/test_ascii_handler.py
@@ -57,7 +57,7 @@ def test_collect_dict_data(io_handler) -> None:
         )
 
 
-def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
+def test_collect_data_from_file_exceptions(io_handler) -> None:
     """Test error handling in collect_data_from_file."""
     # Create an invalid YAML file
     test_file = io_handler.get_output_file(file_name="invalid.yml")
@@ -85,7 +85,7 @@ def test_collect_data_from_file_exceptions(io_handler, caplog) -> None:
         ascii_handler.collect_data_from_file(test_unsupported)
 
 
-def test_collect_dict_from_url(io_handler) -> None:
+def test_collect_dict_from_url() -> None:
     _file = MODEL_PARAMETER_SCHEMA_PATH / "num_gains.schema.yml"
     _reference_dict = ascii_handler.collect_data_from_file(_file)
 

--- a/tests/unit_tests/layout/test_array_layout.py
+++ b/tests/unit_tests/layout/test_array_layout.py
@@ -14,14 +14,14 @@ logger = logging.getLogger()
 
 
 @pytest.fixture
-def array_layout_north_instance(io_handler, db_config, model_version):
+def array_layout_north_instance(db_config, model_version):
     return ArrayLayout(
         site="North", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )
 
 
 @pytest.fixture
-def array_layout_south_instance(io_handler, db_config, model_version):
+def array_layout_south_instance(db_config, model_version):
     return ArrayLayout(
         site="South", mongo_db_config=db_config, model_version=model_version, name="test_layout"
     )

--- a/tests/unit_tests/model/test_array_model.py
+++ b/tests/unit_tests/model/test_array_model.py
@@ -16,7 +16,7 @@ logger = logging.getLogger()
 
 
 @pytest.fixture
-def array_model_from_list(db_config, io_handler, model_version):
+def array_model_from_list(db_config, model_version):
     return ArrayModel(
         label="test",
         site="North",
@@ -26,7 +26,7 @@ def array_model_from_list(db_config, io_handler, model_version):
     )
 
 
-def test_array_model_from_file(db_config, io_handler, model_version, telescope_north_test_file):
+def test_array_model_from_file(db_config, model_version, telescope_north_test_file):
     am = ArrayModel(
         label="test",
         site="North",
@@ -37,7 +37,7 @@ def test_array_model_from_file(db_config, io_handler, model_version, telescope_n
     assert am.number_of_telescopes == 13
 
 
-def test_array_model_init_without_layout_or_telescope_list(db_config, io_handler, model_version):
+def test_array_model_init_without_layout_or_telescope_list(db_config, model_version):
     with pytest.raises(ValueError, match=r"No array elements found."):
         ArrayModel(
             label="test",
@@ -58,7 +58,7 @@ def test_site(array_model):
     assert am.site == "North"
 
 
-def test_exporting_config_files(db_config, io_handler, model_version):
+def test_exporting_config_files(db_config, model_version):
     am = ArrayModel(
         label="test",
         site="North",
@@ -100,13 +100,13 @@ def test_exporting_config_files(db_config, io_handler, model_version):
         assert Path(am.get_config_directory()).joinpath(model_file).exists()
 
 
-def test_load_array_element_positions_from_file(array_model, io_handler, telescope_north_test_file):
+def test_load_array_element_positions_from_file(array_model, telescope_north_test_file):
     am = array_model
     telescopes = am._load_array_element_positions_from_file(telescope_north_test_file, "North")
     assert len(telescopes) > 0
 
 
-def test_get_telescope_position_parameter(array_model, io_handler):
+def test_get_telescope_position_parameter(array_model):
     am = array_model
     assert am._get_telescope_position_parameter(
         "LSTN-01", "North", 10.0 * u.m, 200.0 * u.cm, 30.0 * u.m, "2.0.0"
@@ -126,17 +126,17 @@ def test_get_telescope_position_parameter(array_model, io_handler):
     }
 
 
-def test_get_config_file(model_version, array_model, io_handler):
+def test_get_config_file(model_version, array_model):
     am = array_model
     assert am.config_file_path.name == "CTA-test_layout-North-" + model_version + "_test.cfg"
 
 
-def test_get_config_directory(array_model, io_handler):
+def test_get_config_directory(array_model):
     am = array_model
     assert am.get_config_directory().is_dir()
 
 
-def test_export_array_elements_as_table(array_model, io_handler):
+def test_export_array_elements_as_table(array_model):
     am = array_model
     table_ground = am.export_array_elements_as_table(coordinate_system="ground")
     assert isinstance(table_ground, QTable)
@@ -149,7 +149,7 @@ def test_export_array_elements_as_table(array_model, io_handler):
     assert len(table_utm) > 0
 
 
-def test_get_array_elements_from_list(array_model, io_handler):
+def test_get_array_elements_from_list(array_model):
     am = array_model
     assert am._get_array_elements_from_list(["LSTN-01", "MSTN-01"]) == {
         "LSTN-01": None,
@@ -161,7 +161,7 @@ def test_get_array_elements_from_list(array_model, io_handler):
     assert "LSTN-01" in all_msts_plus_lst
 
 
-def test_get_all_array_elements_of_type(array_model, io_handler):
+def test_get_all_array_elements_of_type(array_model):
     am = array_model
     assert am._get_all_array_elements_of_type("LSTS") == {
         "LSTS-01": None,
@@ -232,7 +232,7 @@ def test_pack_model_files(array_model, io_handler, tmp_path, model_version):
         assert array_model.pack_model_files() is None
 
 
-def test_get_additional_simtel_metadata(array_model, caplog, mocker):
+def test_get_additional_simtel_metadata(array_model, mocker):
     array_model_cp = copy.deepcopy(array_model)
     array_model_cp.sim_telarray_seeds = {"seeds": 1234}
     mocker.patch.object(array_model_cp.site_model, "get_nsb_integrated_flux", return_value=42.0)

--- a/tests/unit_tests/model/test_mirrors.py
+++ b/tests/unit_tests/model/test_mirrors.py
@@ -49,7 +49,7 @@ def write_tmp_mirror_list(io_handler, tmp_test_directory, incomplete_mirror_tabl
     )
 
 
-def test_read_mirror_list_from_sim_telarray(io_handler, mirror_template_simtel, tmp_test_directory):
+def test_read_mirror_list_from_sim_telarray(mirror_template_simtel, tmp_test_directory):
     mirrors = mirror_template_simtel
     assert 198 == mirrors.number_of_mirrors
     assert mirrors.mirror_diameter.value == pytest.approx(151.0)
@@ -67,7 +67,7 @@ def test_read_mirror_list_from_sim_telarray(io_handler, mirror_template_simtel, 
     assert "mirror_z" not in red_mirrors.mirror_table.columns
 
 
-def test_read_mirror_list_from_ecsv(io_handler, mirror_template_ecsv):
+def test_read_mirror_list_from_ecsv(mirror_template_ecsv):
     mirrors = mirror_template_ecsv
     assert 198 == mirrors.number_of_mirrors
     assert mirrors.mirror_diameter.value == pytest.approx(151.0)
@@ -149,23 +149,23 @@ def assert_mirror_parameters(mirror_x, mirror_y, mirror_diameter, focal_length, 
     assert shape_type.value == 3
 
 
-def test_get_single_mirror_parameters_ecsv(io_handler, mirror_template_ecsv):
+def test_get_single_mirror_parameters_ecsv(mirror_template_ecsv):
     mirrors = mirror_template_ecsv
     assert_mirror_parameters(*mirrors.get_single_mirror_parameters(198))
 
 
-def test_get_single_mirror_parameters_simtel(io_handler, mirror_template_simtel):
+def test_get_single_mirror_parameters_simtel(mirror_template_simtel):
     mirrors = mirror_template_simtel
     assert_mirror_parameters(*mirrors.get_single_mirror_parameters(198))
 
 
-def test_get_single_mirror_parameters_simtel_wrong_id(io_handler, mirror_template_simtel):
+def test_get_single_mirror_parameters_simtel_wrong_id(mirror_template_simtel):
     logger.info("Wrong mirror id returns the first mirror table row")
     mirrors = mirror_template_simtel
     assert_mirror_parameters(*mirrors.get_single_mirror_parameters(9999))
 
 
-def test_get_single_mirror_parameters_simtel_missing_column(io_handler, mirror_template_simtel):
+def test_get_single_mirror_parameters_simtel_missing_column(mirror_template_simtel):
     logger.info("Removing column mirror_x")
     mirrors = mirror_template_simtel
     mirrors.mirror_table.rename_column("mirror_x", "mirror_xa")

--- a/tests/unit_tests/model/test_model_parameter.py
+++ b/tests/unit_tests/model/test_model_parameter.py
@@ -226,7 +226,7 @@ def test_flen_type(telescope_model_lst):
     assert isinstance(flen_info["value"], float)
 
 
-def test_updating_export_model_files(db_config, io_handler, model_version):
+def test_updating_export_model_files(db_config, model_version):
     tel = TelescopeModel(
         site="North",
         telescope_name="LSTN-01",

--- a/tests/unit_tests/ray_tracing/test_psf_analysis.py
+++ b/tests/unit_tests/ray_tracing/test_psf_analysis.py
@@ -52,7 +52,7 @@ def test_init_zero_focal_length(caplog):
     assert "Focal length is zero; no conversion from cm to deg possible." in caplog.text
 
 
-def test_reading_simtel_file(args_dict, io_handler, tmp_test_directory, mocker, caplog):
+def test_reading_simtel_file(io_handler, tmp_test_directory, mocker, caplog):
     test_file = io_handler.get_test_data_file(
         file_name=(
             "ray_tracing_photons_North_LSTN-01_d10.0km_za20.0deg_off0.000deg_validate_optics.lis.gz"

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -37,7 +37,7 @@ def simulation_file(model_version):
 
 
 @pytest.fixture
-def corsika_simtel_runner(io_handler, corsika_config_mock_array_model, simtel_path):
+def corsika_simtel_runner(corsika_config_mock_array_model, simtel_path):
     """CorsikaSimtelRunner object."""
     return CorsikaSimtelRunner(
         corsika_config=corsika_config_mock_array_model,
@@ -48,7 +48,7 @@ def corsika_simtel_runner(io_handler, corsika_config_mock_array_model, simtel_pa
 
 
 @pytest.fixture
-def corsika_simtel_runner_calibration(io_handler, corsika_config_mock_array_model, simtel_path):
+def corsika_simtel_runner_calibration(corsika_config_mock_array_model, simtel_path):
     """CorsikaSimtelRunner object."""
     return CorsikaSimtelRunner(
         corsika_config=corsika_config_mock_array_model,

--- a/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
+++ b/tests/unit_tests/simtel/test_simulator_camera_efficiency.py
@@ -97,7 +97,7 @@ def test_check_run_result(simulator_camera_efficiency):
 
 
 @pytest.mark.xfail(reason="Test requires Derived-Values Database")
-def test_get_one_dim_distribution(io_handler, db_config, simtel_path, model_version_prod5):
+def test_get_one_dim_distribution(db_config, simtel_path, model_version_prod5):
     logger.warning(
         "Running test_get_one_dim_distribution using prod5 model "
         " (prod6 model with 1D transmission function)"


### PR DESCRIPTION
Some modules / classes expect an existing IOHandler singleton (which is reasonable given our approach). This is unfortunately not consistently applied in the unit tests and we get therefore failures as [here](https://github.com/gammasim/simtools/actions/runs/18147695914/job/51652564767).

This PR marks the pytest.fixture `io_handler` as `autouse=True`. As this is a singleton, it will not be generated per function but only once. 

Remove all function-wise calls of this fixture in the unit tests (which were quite repetitive).