### PR TITLE
Bugfix in preparing sim_telarray comment for shower simulations

### DIFF
--- a/docs/changes/1825.bugfix.md
+++ b/docs/changes/1825.bugfix.md
@@ -1,0 +1,1 @@
+Bugfix in preparing sim_telarray comment for shower simulations: power-law configuration (used to fill histograms) set at the wrong place.

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -95,14 +95,14 @@ class SimulatorArray(SimtelRunner):
         str
             Command to run sim_telarray.
         """
-        command = f" {input_file}"
-        command += f" | gzip > {self._log_file} 2>&1 || exit"
-        command += super().get_config_option(
+        command = super().get_config_option(
             "power_law",
             SimulatorArray.get_power_law_for_sim_telarray_histograms(
                 self.corsika_config.primary_particle
             ),
         )
+        command += f" {input_file}"
+        command += f" | gzip > {self._log_file} 2>&1 || exit"
         return command
 
     def _make_run_command_for_calibration_simulations(self, input_file=None):


### PR DESCRIPTION
Power-law configuration (used to fill histograms) set at the wrong place.

Closes #1822 