### PR TITLE
Highlight or grey out telescopes

### DIFF
--- a/src/simtools/applications/plot_array_layout.py
+++ b/src/simtools/applications/plot_array_layout.py
@@ -56,6 +56,12 @@ axes_range : float, optional
     Range of the both axes in meters.
 marker_scaling : float, optional.
     Scaling factor for plotting of array elements, optional.
+grayed_out_array_elements : list, optional
+    List of array elements to plot as gray circles.
+highlighted_array_elements : list, optional
+    List of array elements to plot with red circles around them.
+legend_location : str, optional
+    Location of the legend (default "best").
 
 Examples
 --------
@@ -97,6 +103,17 @@ Plot all layouts for the North site and model version 6.0.0:
 .. code-block:: console
 
     simtools-plot-array-layout --site North --plot_all_layouts --model_version=6.0.0
+
+Plot layout with some telescopes grayed out and others highlighted:
+
+.. code-block:: console
+
+    simtools-plot-array-layout --site North
+                               --array_layout_name alpha
+                               --model_version=6.0.0
+                               --grayed_out_array_elements LSTN-01 LSTN-02
+                               --highlighted_array_elements MSTN-01 MSTN-02
+                               --legend_location "upper right"
 """
 
 import logging
@@ -175,6 +192,33 @@ def _parse(label, description, usage=None):
         type=str,
         required=False,
         default=None,
+    )
+    config.parser.add_argument(
+        "--grayed_out_array_elements",
+        help="List of array elements to plot as gray circles.",
+        type=str,
+        nargs="*",
+        required=False,
+        default=None,
+    )
+    config.parser.add_argument(
+        "--highlighted_array_elements",
+        help="List of array elements to plot with red circles around them.",
+        type=str,
+        nargs="*",
+        required=False,
+        default=None,
+    )
+    config.parser.add_argument(
+        "--legend_location",
+        help=(
+            "Location of the legend (e.g., 'best', 'upper right', 'upper left', "
+            "'lower left', 'lower right', 'right', 'center left', 'center right', "
+            "'lower center', 'upper center', 'center')."
+        ),
+        type=str,
+        required=False,
+        default="best",
     )
     return config.initialize(
         db_config=True,
@@ -282,6 +326,9 @@ def main():
             axes_range=args_dict["axes_range"],
             marker_scaling=args_dict["marker_scaling"],
             background_telescopes=background_layout,
+            grayed_out_elements=args_dict["grayed_out_array_elements"],
+            highlighted_elements=args_dict["highlighted_array_elements"],
+            legend_location=args_dict["legend_location"],
         )
         site_string = ""
         if layout.get("site") is not None:

--- a/src/simtools/visualization/plot_array_layout.py
+++ b/src/simtools/visualization/plot_array_layout.py
@@ -20,6 +20,9 @@ def plot_array_layout(
     axes_range=None,
     marker_scaling=1.0,
     background_telescopes=None,
+    grayed_out_elements=None,
+    highlighted_elements=None,
+    legend_location="best",
 ):
     """
     Plot telescope array layout.
@@ -36,6 +39,12 @@ def plot_array_layout(
         Marker size scale factor.
     background_telescopes : Table or None
         Optional background telescope table.
+    grayed_out_elements : list or None
+        List of telescope names to plot as gray circles.
+    highlighted_elements : list or None
+        List of telescope names to plot with red circles around them.
+    legend_location : str
+        Location of the legend (default "best").
 
     Returns
     -------
@@ -44,25 +53,58 @@ def plot_array_layout(
     """
     fig, ax = plt.subplots(1)
 
-    patches, plot_range = get_patches(ax, telescopes, show_tel_label, axes_range, marker_scaling)
+    patches, plot_range, highlighted_patches = get_patches(
+        ax,
+        telescopes,
+        show_tel_label,
+        axes_range,
+        marker_scaling,
+        grayed_out_elements,
+        highlighted_elements,
+    )
 
     if background_telescopes is not None:
-        bg_patches, bg_range = get_patches(
+        bg_patches, bg_range, _ = get_patches(
             ax, background_telescopes, False, axes_range, marker_scaling
         )
         ax.add_collection(PatchCollection(bg_patches, match_original=True, alpha=0.1))
         if axes_range is None:
             plot_range = max(plot_range, bg_range)
 
-    update_legend(ax, telescopes)
-    finalize_plot(ax, patches, "Easting [m]", "Northing [m]", plot_range)
+    update_legend(ax, telescopes, grayed_out_elements, legend_location)
+    finalize_plot(ax, patches, "Easting [m]", "Northing [m]", plot_range, highlighted_patches)
 
     return fig
 
 
-def get_patches(ax, telescopes, show_tel_label, axes_range, marker_scaling):
+def get_patches(
+    ax,
+    telescopes,
+    show_tel_label,
+    axes_range,
+    marker_scaling,
+    grayed_out_elements=None,
+    highlighted_elements=None,
+):
     """
     Get plot patches and axis range.
+
+    Parameters
+    ----------
+    ax : Axes
+        Matplotlib axes object.
+    telescopes : Table
+        Telescope data table.
+    show_tel_label : bool
+        Show telescope labels.
+    axes_range : float or None
+        Axis range, auto if None.
+    marker_scaling : float
+        Marker size scale factor.
+    grayed_out_elements : list or None
+        List of telescope names to plot as gray circles.
+    highlighted_elements : list or None
+        List of telescope names to plot with red circles around them.
 
     Returns
     -------
@@ -70,28 +112,45 @@ def get_patches(ax, telescopes, show_tel_label, axes_range, marker_scaling):
         List of telescope patches.
     axes_range : float
         Calculated or input axis range.
+    highlighted_patches : list
+        List of highlighted telescope patches.
     """
     pos_x, pos_y = get_positions(telescopes)
     telescopes["pos_x_rotated"] = Column(pos_x)
     telescopes["pos_y_rotated"] = Column(pos_y)
 
-    patches, radii = create_patches(telescopes, marker_scaling, show_tel_label, ax)
+    patches, radii, highlighted_patches = create_patches(
+        telescopes, marker_scaling, show_tel_label, ax, grayed_out_elements, highlighted_elements
+    )
 
     if axes_range:
-        return patches, axes_range
+        return patches, axes_range, highlighted_patches
 
     r = max(radii).value
     max_x = max(abs(pos_x.min().value), abs(pos_x.max().value)) + r
     max_y = max(abs(pos_y.min().value), abs(pos_y.max().value)) + r
     updated_axes_range = max(max_x, max_y) * 1.1
 
-    return patches, updated_axes_range
+    return patches, updated_axes_range, highlighted_patches
 
 
 @u.quantity_input(x=u.m, y=u.m, radius=u.m)
-def get_telescope_patch(name, x, y, radius):
+def get_telescope_patch(name, x, y, radius, is_grayed_out=False):
     """
     Create patch for a telescope.
+
+    Parameters
+    ----------
+    name : str
+        Telescope name.
+    x : Quantity
+        X position.
+    y : Quantity
+        Y position.
+    radius : Quantity
+        Telescope radius.
+    is_grayed_out : bool
+        Whether to plot telescope in gray.
 
     Returns
     -------
@@ -101,20 +160,24 @@ def get_telescope_patch(name, x, y, radius):
     tel_type = names.get_array_element_type_from_name(name)
     x, y, r = x.to(u.m), y.to(u.m), radius.to(u.m)
 
+    # Use gray color if telescope is grayed out
+    color = "gray" if is_grayed_out else leg_h.get_telescope_config(tel_type)["color"]
+
     if tel_type == "SCTS":
         return mpatches.Rectangle(
             ((x - r / 2).value, (y - r / 2).value),
             width=r.value,
             height=r.value,
-            fill=False,
-            color=leg_h.get_telescope_config(tel_type)["color"],
+            fill=is_grayed_out,  # Fill if grayed out
+            color=color,
         )
 
     return mpatches.Circle(
         (x.value, y.value),
         radius=r.value,
-        fill=tel_type.startswith("MST"),
-        color=leg_h.get_telescope_config(tel_type)["color"],
+        fill=is_grayed_out or tel_type.startswith("MST"),  # Always fill if grayed out
+        alpha=0.5 if is_grayed_out else 1.0,
+        color=color,
     )
 
 
@@ -141,9 +204,26 @@ def get_positions(telescopes):
     return transf.rotate(x, y, locale_rotate_angle) if locale_rotate_angle != 0 else (x, y)
 
 
-def create_patches(telescopes, scale, show_label, ax):
+def create_patches(
+    telescopes, scale, show_label, ax, grayed_out_elements=None, highlighted_elements=None
+):
     """
     Create telescope patches and labels.
+
+    Parameters
+    ----------
+    telescopes : Table
+        Telescope data table.
+    scale : float
+        Marker size scale factor.
+    show_label : bool
+        Show telescope labels.
+    ax : Axes
+        Matplotlib axes object.
+    grayed_out_elements : list or None
+        List of telescope names to plot as gray circles.
+    highlighted_elements : list or None
+        List of telescope names to plot with red circles around them.
 
     Returns
     -------
@@ -151,9 +231,15 @@ def create_patches(telescopes, scale, show_label, ax):
         Shape patches.
     radii : list
         Telescope radii.
+    highlighted_patches : list
+        List of highlighted telescope patches.
     """
-    patches, radii = [], []
+    patches, radii, highlighted_patches = [], [], []
     fontsize, scale_factor = (4, 2) if len(telescopes) > 30 else (8, 1)
+
+    # Convert lists to sets for faster lookup
+    grayed_out_set = set(grayed_out_elements) if grayed_out_elements else set()
+    highlighted_set = set(highlighted_elements) if highlighted_elements else set()
 
     for tel in telescopes:
         name = get_telescope_name(tel)
@@ -161,14 +247,30 @@ def create_patches(telescopes, scale, show_label, ax):
         radii.append(radius)
         tel_type = names.get_array_element_type_from_name(name)
 
+        # Check if telescope should be grayed out
+        is_grayed_out = name in grayed_out_set
+        is_highlighted = name in highlighted_set
+
         patches.append(
             get_telescope_patch(
                 tel_type,
                 tel["pos_x_rotated"],
                 tel["pos_y_rotated"],
                 scale_factor * radius * scale,
+                is_grayed_out=is_grayed_out,
             )
         )
+
+        # Add red circle for highlighted telescopes
+        if is_highlighted:
+            highlight_patch = mpatches.Circle(
+                (tel["pos_x_rotated"].value, tel["pos_y_rotated"].value),
+                radius=(scale_factor * radius * scale * 4).value,
+                fill=False,
+                color="red",
+                linewidth=1,
+            )
+            highlighted_patches.append(highlight_patch)
 
         if show_label:
             ax.text(
@@ -180,7 +282,7 @@ def create_patches(telescopes, scale, show_label, ax):
                 fontsize=fontsize,
             )
 
-    return patches, radii
+    return patches, radii, highlighted_patches
 
 
 def get_telescope_name(tel):
@@ -211,10 +313,17 @@ def get_sphere_radius(tel):
     return tel["sphere_radius"] if "sphere_radius" in tel.colnames else 10.0 * u.m
 
 
-def update_legend(ax, telescopes):
+def update_legend(ax, telescopes, grayed_out_elements=None, legend_location="best"):
     """Add legend for telescope types and counts."""
-    names_list = [get_telescope_name(tel) for tel in telescopes]
-    types = [names.get_array_element_type_from_name(n) for n in names_list]
+    grayed_out_set = set(grayed_out_elements) if grayed_out_elements else set()
+
+    # Filter out grayed out telescopes from legend counts
+    types = []
+    for tel in telescopes:
+        tel_name = get_telescope_name(tel)
+        if tel_name not in grayed_out_set:
+            types.append(names.get_array_element_type_from_name(tel_name))
+
     counts = Counter(types)
 
     objs, labels = [], []
@@ -237,12 +346,17 @@ def update_legend(ax, telescopes):
 
             handler_map[telescope_type] = BaseLegendHandlerWrapper(telescope_type)
 
-    ax.legend(objs, labels, handler_map=handler_map, prop={"size": 11}, loc="best")
+    ax.legend(objs, labels, handler_map=handler_map, prop={"size": 11}, loc=legend_location)
 
 
-def finalize_plot(ax, patches, x_title, y_title, axes_range):
+def finalize_plot(ax, patches, x_title, y_title, axes_range, highlighted_patches=None):
     """Finalize plot appearance and limits."""
     ax.add_collection(PatchCollection(patches, match_original=True))
+
+    # Add highlighted patches if any
+    if highlighted_patches:
+        ax.add_collection(PatchCollection(highlighted_patches, match_original=True))
+
     ax.set(xlabel=x_title, ylabel=y_title)
     ax.tick_params(labelsize=8)
     ax.axis("square")


### PR DESCRIPTION
This is not a real PR, but just some changes made ad hoc in order to produce a plot which greys out the LSTs not included in Beta and highlights the five SSTs added with PNRR. The changes were all written by copilot and therefore not thoroughly checked. Tests for these changes are also missing. To produce the plot I used the configuration shown in [pnrr_array_plot_config.txt](https://github.com/user-attachments/files/22656999/pnrr_array_plot_config.txt) with the command `python src/simtools/applications/plot_array_layout.py --config pnrr_array_plot_config.yml` (note the change from `txt` to `yml`.

The resulting plot is shown below.

<img width="1998" height="1880" alt="array_layout_list_South_ground" src="https://github.com/user-attachments/assets/4faf3699-943a-48ff-99d2-20cccc3df8ce" />
