### PR TITLE
Skip pre-commit check for commit to main in CI-Linter

### DIFF
--- a/.github/workflows/CI-linter.yml
+++ b/.github/workflows/CI-linter.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Pre-commit
         run: |
-          pre-commit run --all-files
+          SKIP=no-commit-to-branch pre-commit run --all-files
 
       - name: Save pre-commit cache
         if: success()  # only save if previous steps succeeded


### PR DESCRIPTION
PR #1819 introduced a pre-commit check to avoid commit to main. This leads to failure in the nightly CI-linter runs (see e.g. [here](https://github.com/gammasim/simtools/actions/runs/18237393695/job/51933597511), as they are running on main.

Add a SKIP command to exclude the `no-commit-to-branch` step in the CI.