### PR TITLE
Add had dec to metadata

### DIFF
--- a/docs/changes/2415.bugfix.md
+++ b/docs/changes/2415.bugfix.md
@@ -1,0 +1,1 @@
+Fix writing of HA/Dec to metadata.

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -350,6 +350,9 @@ def job_grid_row_to_simulate_prod_args(job_row, metadata=None):
     }
     if job_row.get("corsika_hadronic_transition_energy") is not None:
         args["corsika_hadronic_transition_energy"] = job_row["corsika_hadronic_transition_energy"]
+    for coordinate in ("ha", "dec"):
+        if job_row.get(coordinate) is not None:
+            args[coordinate] = job_row[coordinate]
     if metadata:
         for key in ("site", "simulation_software"):
             if metadata.get(key):

--- a/tests/unit_tests/applications/test_simulate_prod.py
+++ b/tests/unit_tests/applications/test_simulate_prod.py
@@ -156,7 +156,16 @@ def test_validate_single_interaction_models_rejects_lists(capsys):
 @pytest.mark.parametrize(
     ("row_args", "expected"),
     [
-        ((), {"run_number": 7, "primary": "gamma", "site": "North"}),
+        (
+            (),
+            {
+                "run_number": 7,
+                "primary": "gamma",
+                "site": "North",
+                "ha": 123 * u.deg,
+                "dec": -45 * u.deg,
+            },
+        ),
         (("--job_grid_row", 2), {"run_number": 11, "zenith_angle": 40 * u.deg}),
     ],
 )

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -278,8 +278,21 @@ def test_job_grid_row_to_simulate_prod_args_maps_fields():
     assert args["corsika_le_interaction"] == "urqmd"
     assert args["corsika_he_interaction"] == "epos"
     assert "corsika_hadronic_transition_energy" not in args
+    assert args["ha"] == 123 * u.deg
+    assert args["dec"] == -45 * u.deg
     assert args["run_number"] == 10
     assert "site" not in args
+
+
+def test_job_grid_row_to_simulate_prod_args_omits_missing_hadec_coordinates():
+    row = _job_rows()[0]
+    row.pop("ha")
+    row.pop("dec")
+
+    args = job_grid_io.job_grid_row_to_simulate_prod_args(row)
+
+    assert "ha" not in args
+    assert "dec" not in args
 
 
 def test_job_grid_row_to_simulate_prod_args_includes_explicit_transition_energy():


### PR DESCRIPTION
Issue #2415 is a real mapping omission, not a metadata-writer problem.

  ha and dec are correctly stored and deserialized from the job-grid ECSV, but job_grid_row_to_simulate_prod_args (src/simtools/
  production_configuration/job_grid_io.py:312) copies only the horizontal coordinates into args_dict. The metadata builder already writes both fields
  when present (job_metadata.py (src/simtools/production_configuration/job_metadata.py:38)), so it receives no values to write.

  Solution:

  - Extend the job-row-to-arguments conversion to carry optional ha and dec values through when they exist in the selected row.
  - Preserve their optional behavior: horizontal-coordinate grids should still produce no ha/dec keys and therefore no metadata entries.
  - Add focused regression tests:
      - conversion maps ha and dec;
      - parsing a job-grid file retains them in the resolved simulate_prod arguments;
      - optionally, an end-to-end metadata assertion confirms they appear in simulation_metadata.yml.


Closes #2415