### PR TITLE
Select avx for simulate prod

### DIFF
--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -4,6 +4,18 @@ name: build-simtools-prod
 
 on:
   workflow_dispatch:
+    inputs:
+      avx_flag:
+        description: "Build only this AVX variant"
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - generic
+          - avx2
+          - avx512f
+          - sse4
   push:
     tags:
       - 'v*-rc*'
@@ -43,9 +55,19 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - id: config
+        env:
+          AVX_FLAG: ${{ inputs.avx_flag || 'all' }}
         run: |
           python -m pip install packaging pyyaml
-          python src/simtools/applications/dependency_versions.py --format github-output >> "$GITHUB_OUTPUT"
+          python src/simtools/applications/dependency_versions.py --format github-output > dependency-output
+          if [[ "${AVX_FLAG}" != "all" ]]; then
+            production_matrix=$(sed -n 's/^production_matrix=//p' dependency-output | \
+              jq -c --arg avx_flag "${AVX_FLAG}" 'map(select(.avx_flag == $avx_flag))')
+            sed '/^production_matrix=/d' dependency-output > filtered-output
+            printf 'production_matrix=%s\n' "${production_matrix}" >> filtered-output
+            mv filtered-output dependency-output
+          fi
+          cat dependency-output >> "$GITHUB_OUTPUT"
 
   build-simtools-prod:
     runs-on: ubuntu-latest
@@ -210,7 +232,7 @@ jobs:
     permissions:
       contents: read
     needs: build-simtools-prod
-    if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc')) }}
+    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || inputs.avx_flag == 'all' || inputs.avx_flag == 'generic') }}
     uses: ./.github/workflows/CI-integrationtests.yml
     secrets: inherit
     with:

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       avx_flag:
-        description: "Build only this AVX variant"
+        description: "Build only this CPU variant"
         required: false
         default: all
         type: choice
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
       - id: config
         env:
-          AVX_FLAG: ${{ inputs.avx_flag || 'all' }}
+          AVX_FLAG: ${{ github.event.inputs.avx_flag || 'all' }}
         run: |
           python -m pip install packaging pyyaml
           python src/simtools/applications/dependency_versions.py --format github-output > dependency-output

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -232,7 +232,7 @@ jobs:
     permissions:
       contents: read
     needs: build-simtools-prod
-    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || inputs.avx_flag == 'all' || inputs.avx_flag == 'generic') }}
+    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","generic"]'), github.event.inputs.avx_flag || 'all')) }}
     uses: ./.github/workflows/CI-integrationtests.yml
     secrets: inherit
     with:

--- a/docs/changes/2417.feature.md
+++ b/docs/changes/2417.feature.md
@@ -1,0 +1,1 @@
+Allow to select avx type for manual trigger of production image building.

--- a/docs/changes/2417.feature.md
+++ b/docs/changes/2417.feature.md
@@ -1,1 +1,1 @@
-Allow to select avx type for manual trigger of production image building.
+Allow selecting a CPU variant when manually triggering production image builds.


### PR DESCRIPTION
Add option to build only one variant when triggering manually build-simulate-prod (makes development/debugging more efficient).

<img width="688" height="832" alt="Screenshot from 2026-08-07 09-54-11" src="https://github.com/user-attachments/assets/f382a89a-88ec-46af-97fe-c38a7a6caa68" />
