### PR TITLE
Replace telescope by array layout name

### DIFF
--- a/docs/changes/2420.api.md
+++ b/docs/changes/2420.api.md
@@ -1,0 +1,9 @@
+Remove 'telescope' command line parameter and replace it by `array_layout_name for
+the following applications:
+
+- generate_bias_curve_submissions.py
+- production_generate_grid.py
+- simulate_pedestals.py
+- simulate_prod.py
+
+This resolves the ambiguous usage of single-telescope layout names.

--- a/docs/changes/2420.api.md
+++ b/docs/changes/2420.api.md
@@ -1,4 +1,4 @@
-Remove 'telescope' command line parameter and replace it by `array_layout_name for
+Remove 'telescope' command line parameter and replace it by `array_layout_name` for
 the following applications:
 
 - generate_bias_curve_submissions.py

--- a/src/simtools/applications/generate_bias_curve_submissions.py
+++ b/src/simtools/applications/generate_bias_curve_submissions.py
@@ -24,8 +24,8 @@ site (str, required)
     Observation site (e.g., North, South).
 model_version (str, required)
     Simulation model version.
-telescope (str, required)
-    Telescope name for simulations.
+array_layout_name (str, required)
+    Single-telescope array layout name for simulations.
 simulation_software (str)
     Simulation software (default: corsika_sim_telarray).
 azimuth_angle (float, required)
@@ -68,7 +68,7 @@ Example
     simtools-generate-bias-curve-submissions \
         --site North \
         --model_version 7.0.0 \
-        --telescope LSTN-01 \
+        --array_layout_name LSTN-01 \
         --azimuth_angle 0.0 \
         --zenith_angle 20.0 \
         --showers_per_run 10000 \
@@ -102,7 +102,7 @@ from simtools.job_execution import bias_curve_submissions
 _ARGUMENTS = (
     cli.SITE(required=True),
     cli.MODEL_VERSION(required=True, nargs=None),
-    cli.TELESCOPE(required=True),
+    cli.ARRAY_LAYOUT_NAME(required=True),
     cli.SIMULATION_SOFTWARE,
     cli.AZIMUTH_ANGLE(required=True, action="store", nargs=None, default=None),
     cli.ZENITH_ANGLE(required=True, action="store", nargs=None, default=None),

--- a/src/simtools/applications/production_generate_grid.py
+++ b/src/simtools/applications/production_generate_grid.py
@@ -130,7 +130,6 @@ APPLICATION = ApplicationDefinition.for_module(
         cli.MODEL_VERSION(required=True),
         cli.OVERWRITE_MODEL_PARAMETERS,
         cli.SITE(required=True),
-        cli.TELESCOPE,
         cli.ARRAY_LAYOUT_NAME(required=True),
         cli.SIMULATION_SOFTWARE,
         cli.PRIMARY,

--- a/src/simtools/applications/simulate_pedestals.py
+++ b/src/simtools/applications/simulate_pedestals.py
@@ -92,7 +92,6 @@ APPLICATION = ApplicationDefinition.for_module(
         cli.MODEL_VERSION,
         cli.OVERWRITE_MODEL_PARAMETERS,
         cli.SITE,
-        cli.TELESCOPE,
         *cli.layout_selection_arguments(),
         cli.RUN_NUMBER,
         cli.AZIMUTH_ANGLE,

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -172,7 +172,6 @@ APPLICATION = ApplicationDefinition.for_module(
         cli.MODEL_VERSION,
         cli.OVERWRITE_MODEL_PARAMETERS,
         cli.SITE,
-        cli.TELESCOPE,
         *cli.layout_selection_arguments(),
         cli.SIMULATION_SOFTWARE,
         *cli.corsika_configuration_arguments(primary_required=False),

--- a/src/simtools/job_execution/bias_curve_submissions.py
+++ b/src/simtools/job_execution/bias_curve_submissions.py
@@ -18,6 +18,7 @@ trigger response in both simulations.
 
 from simtools.io import ascii_handler
 from simtools.job_execution import parameter_scan_generator
+from simtools.layout.array_layout_utils import resolve_array_layout_name
 from simtools.model.telescope_model import TelescopeModel
 from simtools.production_configuration.simulation_jobs import generate_job_grid
 
@@ -43,7 +44,7 @@ def _threshold_param_name(args):
     """Return the threshold parameter selected by the telescope model."""
     telescope_model = TelescopeModel(
         site=args["site"],
-        telescope_name=args["telescope"],
+        telescope_name=_telescope_from_layout(args),
         model_version=args["model_version"],
     )
     if telescope_model.get_parameter_value("default_trigger") == "AnalogSum":
@@ -138,7 +139,7 @@ def _production_grid_configuration(args, curve_definition, curve_label):
     }
     configuration.update(
         {
-            "array_layout_name": args["telescope"],
+            "array_layout_name": args["array_layout_name"],
             "primary": curve_definition["primary"],
             "energy_range": curve_definition["energy_range"],
             "label": curve_label,
@@ -151,7 +152,7 @@ def _generate_scan_grid(curve_name, curve_definition, args, io_handler):
     """Generate base grid, scan config, and scan grid for one curve."""
     curve_directory = io_handler.get_output_directory(sub_dir=curve_name)
 
-    telescope = args["telescope"]
+    telescope = _telescope_from_layout(args)
     base_grid_file = curve_directory / "base_grid.ecsv"
     scan_config_file = curve_directory / "scan_config.yaml"
     scan_grid_file = curve_directory / "scan_grid.ecsv"
@@ -175,7 +176,7 @@ def _validate_required_args(args):
     required_args = [
         "site",
         "model_version",
-        "telescope",
+        "array_layout_name",
         "azimuth_angle",
         "zenith_angle",
         "showers_per_run",
@@ -187,6 +188,11 @@ def _validate_required_args(args):
     for key in required_args:
         if args.get(key) in (None, ""):
             raise ValueError(f"Missing required argument: --{key}")
+
+
+def _telescope_from_layout(args):
+    """Resolve the single-telescope layout name used for trigger scans."""
+    return resolve_array_layout_name(args["array_layout_name"], args["model_version"])
 
 
 def _curve_definitions(args):

--- a/src/simtools/job_execution/bias_curve_submissions.py
+++ b/src/simtools/job_execution/bias_curve_submissions.py
@@ -125,7 +125,6 @@ def _scan_config(curve_name, telescope, args):
                     args.get("trigger_thresholds"),
                 )
             ],
-            "job_grid_updates": {"telescope": telescope},
         },
     }
 

--- a/src/simtools/job_execution/htcondor_script_generator.py
+++ b/src/simtools/job_execution/htcondor_script_generator.py
@@ -38,7 +38,6 @@ _OPTIONAL_QUEUE_FIELDS = (
     "corsika_hadronic_transition_energy",
     "overwrite_model_parameters",
     "scan_label",
-    "telescope",
 )
 
 _PARAMS_JOB_SPEC_FIELDS = {field: field for field in _PARAMS_FIELDS}
@@ -343,18 +342,6 @@ def _get_submit_script(args_dict, params_fields=None):
         )
         transition_energy_argument = '"${corsika_hadronic_transition_energy_args[@]}"'
 
-    telescope_block = ""
-    telescope_argument = ""
-    if "telescope" in params_fields:
-        telescope_block = (
-            f'telescope="{bash_indices["telescope"]}"\n'
-            "telescope_args=()\n"
-            'if [ -n "$telescope" ]; then\n'
-            '    telescope_args+=(--telescope "$telescope")\n'
-            "fi\n"
-        )
-        telescope_argument = '"${telescope_args[@]}"'
-
     job_label = (
         f"{label}_{bash_indices['corsika_he_interaction']}_"
         f"{bash_indices['corsika_le_interaction']}_"
@@ -394,8 +381,6 @@ def _get_submit_script(args_dict, params_fields=None):
         command_parts.append("--save_file_lists")
     if transition_energy_argument:
         command_parts.append(transition_energy_argument.rstrip())
-    if telescope_argument:
-        command_parts.append(telescope_argument.rstrip())
     if overwrite_parameters_argument:
         command_parts.append(overwrite_parameters_argument.rstrip())
     command_parts.extend(
@@ -414,7 +399,6 @@ def _get_submit_script(args_dict, params_fields=None):
         scan_label_block.rstrip(),
         transition_energy_block.rstrip(),
         overwrite_parameters_block.rstrip(),
-        telescope_block.rstrip(),
         "",
         "simtools-simulate-prod \\",
         *_format_multiline_command(command_parts),
@@ -447,7 +431,7 @@ def _add_optional_job_spec_field(job_spec, field_name, value):
         job_spec[field_name] = value
 
 
-def _build_job_spec(row, label, base_pack_dir, args_dict):
+def _build_job_spec(row, label, base_pack_dir):
     """Build one job spec from one job-grid row and one image label."""
     job_spec = {
         "image_label": str(label),
@@ -455,11 +439,6 @@ def _build_job_spec(row, label, base_pack_dir, args_dict):
         "grid_output_path": f"{base_pack_dir}/{label!s}",
     }
 
-    _add_optional_job_spec_field(
-        job_spec,
-        "telescope",
-        row.get("telescope") or args_dict.get("telescope"),
-    )
     _add_optional_job_spec_field(job_spec, "scan_label", row.get("scan_label"))
     _add_optional_job_spec_field(
         job_spec,
@@ -478,7 +457,7 @@ def build_job_specs(args_dict, image_labels):
     _validate_job_grid_metadata(job_grid_metadata)
 
     job_specs = [
-        _build_job_spec(row, label, base_pack_dir, args_dict)
+        _build_job_spec(row, label, base_pack_dir)
         for label in image_labels
         for row in normalized_rows
     ]

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -20,7 +20,7 @@ _ECSV_SUFFIX = ".ecsv"
 _ECSV_FORMAT = "ascii.ecsv"
 _JOB_GRID_SCHEMA_FILE = "job_grid_density.schema.yml"
 _JOB_GRID_SCHEMA_URL = SCHEMA_URL + "/" + _JOB_GRID_SCHEMA_FILE
-_OPTIONAL_STRING_FIELDS = ("overwrite_model_parameters", "scan_label", "telescope")
+_OPTIONAL_STRING_FIELDS = ("overwrite_model_parameters", "scan_label")
 _MISSING = object()
 SIMULATE_PROD_JOB_GRID_EXCLUSIVE_FIELDS = frozenset(
     {
@@ -58,6 +58,8 @@ class JobGridSchema:
 def _load_job_grid_schema():
     """Load the job-grid format definition from its YAML schema."""
     schema = collect_data_from_file(SCHEMA_PATH / _JOB_GRID_SCHEMA_FILE)
+    if isinstance(schema, list):
+        schema = schema[0]
     table_definition = next(item for item in schema["data"] if item["type"] == "data_table")
     column_definitions = table_definition["table_columns"]
     column_units = {

--- a/src/simtools/schemas/job_grid_density.schema.yml
+++ b/src/simtools/schemas/job_grid_density.schema.yml
@@ -1,6 +1,114 @@
 %YAML 1.2
 ---
 title: Schema for production_generate_grid density output
+schema_version: 0.4.0
+meta_schema: simpipe-schema
+meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml
+meta_schema_version: 0.1.0
+name: production_generate_grid_density
+description: |-
+  Job grid for simulation production (including CORSIKA/sim_telarray) with
+  configuration parameters.
+data:
+  - type: data_table
+    table_columns:
+      - name: run_number
+        description: Run index within each grid point.
+        required: true
+        type: int64
+      - name: primary
+        description: Primary particle type.
+        required: true
+        type: string
+      - name: azimuth_angle
+        description: Azimuth pointing angle.
+        required: true
+        type: float64
+        unit: deg
+      - name: zenith_angle
+        description: Zenith pointing angle.
+        required: true
+        type: float64
+        unit: deg
+      - name: ha
+        description: Hour angle coordinate value in degrees (positive westward).
+        required: false
+        type: float64
+        unit: deg
+      - name: dec
+        description: Declination coordinate value in degrees.
+        required: false
+        type: float64
+        unit: deg
+      - name: energy_min
+        description: Minimum primary energy.
+        required: true
+        type: float64
+        unit: GeV
+      - name: energy_max
+        description: Maximum primary energy.
+        required: true
+        type: float64
+        unit: GeV
+      - name: cores_per_shower
+        description: Number of core scatter samples per shower.
+        required: true
+        type: int64
+      - name: core_scatter_max
+        description: Maximum core scatter radius.
+        required: true
+        type: float64
+        unit: m
+      - name: view_cone_min
+        description: Minimum view cone radius.
+        required: true
+        type: float64
+        unit: deg
+      - name: view_cone_max
+        description: Maximum view cone radius.
+        required: true
+        type: float64
+        unit: deg
+      - name: showers_per_run
+        description: Number of showers simulated per run.
+        required: true
+        type: int64
+      - name: nsb_rate
+        description: Integrated night-sky-background flux from the site model.
+        required: true
+        type: float64
+        unit: 1 / (cm2 ns sr)
+      - name: model_version
+        description: Simulation model version.
+        required: true
+        type: string
+      - name: array_layout_name
+        description: Array layout identifier.
+        required: true
+        type: string
+      - name: corsika_le_interaction
+        description: CORSIKA low-energy interaction model.
+        required: true
+        type: string
+      - name: corsika_he_interaction
+        description: CORSIKA high-energy interaction model.
+        required: true
+        type: string
+      - name: corsika_hadronic_transition_energy
+        description: Transition energy between low- and high-energy hadronic models.
+        required: false
+        type: float64
+        unit: GeV
+      - name: overwrite_model_parameters
+        description: File containing model parameter values that overwrite production defaults.
+        required: false
+        type: string
+      - name: scan_label
+        description: Label identifying a parameter-scan grid point.
+        required: false
+        type: string
+---
+title: Schema for production_generate_grid density output
 schema_version: 0.3.0
 meta_schema: simpipe-schema
 meta_schema_url: https://raw.githubusercontent.com/gammasim/simtools/main/src/simtools/schemas/model_parameter_and_data_schema.metaschema.yml

--- a/tests/integration_tests/config/generate_bias_curve_submissions_lstn-01.yml
+++ b/tests/integration_tests/config/generate_bias_curve_submissions_lstn-01.yml
@@ -4,7 +4,7 @@ applications:
   configuration:
     site: North
     model_version: 7.0.0
-    telescope: LSTN-01
+    array_layout_name: LSTN-01
     azimuth_angle: 0.0
     zenith_angle: 20.0
     showers_per_run: 5

--- a/tests/integration_tests/config/generate_bias_curve_submissions_lstn-01.yml
+++ b/tests/integration_tests/config/generate_bias_curve_submissions_lstn-01.yml
@@ -95,8 +95,6 @@ applications:
           allowed_values: [gamma]
         scan_label:
           allowed_values: [asum220]
-        telescope:
-          allowed_values: [LSTN-01]
       metadata:
         required_keys:
         - job_grid_summary
@@ -112,8 +110,6 @@ applications:
           allowed_values: [proton]
         scan_label:
           allowed_values: [asum220]
-        telescope:
-          allowed_values: [LSTN-01]
       metadata:
         required_keys:
         - job_grid_summary

--- a/tests/unit_tests/applications/test_generate_bias_curve_submissions.py
+++ b/tests/unit_tests/applications/test_generate_bias_curve_submissions.py
@@ -10,7 +10,7 @@ def _required_arguments():
         "North",
         "--model_version",
         "7.0.0",
-        "--telescope",
+        "--array_layout_name",
         "LSTN-01",
         "--azimuth_angle",
         "0",
@@ -39,3 +39,5 @@ def test_add_arguments_uses_bias_curve_defaults():
     assert args.trigger_thresholds is None
     assert args.core_scatter == (20, 1900 * u.m)
     assert args.view_cone == (0 * u.deg, 5 * u.deg)
+    assert args.array_layout_name == ["LSTN-01"]
+    assert not hasattr(args, "telescope")

--- a/tests/unit_tests/applications/test_production_generate_grid.py
+++ b/tests/unit_tests/applications/test_production_generate_grid.py
@@ -63,7 +63,6 @@ def test_full_parser_retains_supported_shared_arguments():
         "showers_per_run",
         "show_options",
         "site",
-        "telescope",
         "view_cone",
         "zenith_angle",
     }
@@ -98,6 +97,7 @@ def test_full_parser_accepts_minimum_direct_configuration():
     assert args.model_version == ["7.0.0"]
     assert args.site == "North"
     assert args.array_layout_name == ["LSTN-01"]
+    assert not hasattr(args, "telescope")
     assert args.output_file == "job_grid.ecsv"
 
 

--- a/tests/unit_tests/applications/test_simulate_pedestals.py
+++ b/tests/unit_tests/applications/test_simulate_pedestals.py
@@ -1,0 +1,10 @@
+"""Tests for the simulate_pedestals application."""
+
+import simtools.applications.simulate_pedestals as app
+
+
+def test_parser_excludes_redundant_telescope_argument():
+    actions = {action.dest for action in app.APPLICATION.build_parser()._actions}
+
+    assert "array_layout_name" in actions
+    assert "telescope" not in actions

--- a/tests/unit_tests/applications/test_simulate_prod.py
+++ b/tests/unit_tests/applications/test_simulate_prod.py
@@ -146,6 +146,13 @@ def test_sim_telarray_only_does_not_require_primary(monkeypatch):
     assert args["primary"] is None
 
 
+def test_parser_excludes_redundant_telescope_argument():
+    actions = {action.dest for action in app.APPLICATION.build_parser()._actions}
+
+    assert "array_layout_name" in actions
+    assert "telescope" not in actions
+
+
 def test_corsika_requires_primary(monkeypatch, capsys):
     with pytest.raises(SystemExit):
         _parse_with_args(

--- a/tests/unit_tests/job_execution/test_bias_curve_submissions.py
+++ b/tests/unit_tests/job_execution/test_bias_curve_submissions.py
@@ -12,7 +12,7 @@ def _base_args(tmp_test_directory):
     return {
         "site": "North",
         "model_version": "7.0.0",
-        "telescope": "LSTN-01",
+        "array_layout_name": "LSTN-01",
         "threshold_parameter": "asum_threshold",
         "simulation_software": "corsika_sim_telarray",
         "azimuth_angle": 0.0,
@@ -54,7 +54,7 @@ def test_generate_scan_grids_uses_configured_curve_definitions_without_mutating_
         "proton",
     ]
     assert all(
-        item.kwargs["args"]["telescope"] == "LSTN-01"
+        item.kwargs["args"]["array_layout_name"] == "LSTN-01"
         for item in mock_generate_scan_grid.call_args_list
     )
     assert (

--- a/tests/unit_tests/job_execution/test_bias_curve_submissions.py
+++ b/tests/unit_tests/job_execution/test_bias_curve_submissions.py
@@ -150,7 +150,7 @@ def test_scan_config_contains_nsb_base_overwrite_and_trigger_scan(tmp_test_direc
     assert scan_config["parameter_scan"]["parameters"] == [
         bias_curve_submissions._parameter_scan_entry("LSTN-01", "asum_threshold")
     ]
-    assert scan_config["parameter_scan"]["job_grid_updates"] == {"telescope": "LSTN-01"}
+    assert "job_grid_updates" not in scan_config["parameter_scan"]
 
 
 def test_scan_config_contains_proton_base_overwrite_and_trigger_scan(tmp_test_directory):
@@ -244,7 +244,7 @@ def test_generate_scan_grid_generates_and_expands_grid(tmp_test_directory):
     assert scan_config["label"] == "nsb"
     assert scan_config["parameter_scan"]["parameters"][0]["label"] == "asum"
     assert scan_config["parameter_scan"]["parameters"][0]["label_separator"] == ""
-    assert scan_config["parameter_scan"]["job_grid_updates"] == {"telescope": "LSTN-01"}
+    assert "job_grid_updates" not in scan_config["parameter_scan"]
 
     mock_generate_job_grid.assert_called_once_with(
         bias_curve_submissions._production_grid_configuration(

--- a/tests/unit_tests/job_execution/test_htcondor_script_generator.py
+++ b/tests/unit_tests/job_execution/test_htcondor_script_generator.py
@@ -259,7 +259,6 @@ def _base_job_row_for_optional_fields():
 def test_format_param_value_optional_missing_is_empty():
     assert htg._format_param_value(None, "overwrite_model_parameters") == ""
     assert htg._format_param_value(None, "scan_label") == ""
-    assert htg._format_param_value(None, "telescope") == ""
 
 
 def test_write_params_file_includes_optional_queue_fields(tmp_test_directory):
@@ -273,13 +272,12 @@ def test_write_params_file_includes_optional_queue_fields(tmp_test_directory):
         "corsika_hadronic_transition_energy": 120 * u.GeV,
         "overwrite_model_parameters": "overwrite.yaml",
         "scan_label": "asum 220",
-        "telescope": "LSTN-01",
     }
 
     htg._write_params_file(params_file_path, [job_spec], params_fields=params_fields)
 
     row = params_file_path.read_text(encoding="utf-8").strip().split()
-    assert row[-4:] == ["120.0", "overwrite.yaml", "asum_220", "LSTN-01"]
+    assert row[-3:] == ["120.0", "overwrite.yaml", "asum_220"]
 
 
 def test_write_params_file_preserves_missing_optional_queue_field_in_mixed_rows(
@@ -344,12 +342,6 @@ def test_get_submit_script_with_optional_queue_fields():
     assert 'scan_label="${20}"' in script
     assert 'job_label="${job_label}_${scan_label}"' in script
 
-    assert 'telescope="${21}"' in script
-    assert "telescope_args=()" in script
-    assert 'telescope_args+=(--telescope "$telescope")' in script
-    assert '    "${telescope_args[@]}" \\' in script
-    assert '    "${telescope_args[@]}" \\\n    "${overwrite_model_parameters_args[@]}" \\' in script
-
 
 @mock.patch("simtools.job_execution.htcondor_script_generator.read_job_grid")
 @mock.patch("simtools.job_execution.htcondor_script_generator.Path.mkdir")
@@ -368,7 +360,6 @@ def test_generate_submission_script_detects_optional_queue_fields(
         **_base_job_row_for_optional_fields(),
         "overwrite_model_parameters": "overwrite.yaml",
         "scan_label": "asum220",
-        "telescope": "LSTN-01",
     }
     metadata = {"site": "North", "simulation_software": "corsika_sim_telarray"}
     mock_read_job_grid.return_value = ([row], metadata)
@@ -390,5 +381,5 @@ def test_generate_submission_script_detects_optional_queue_fields(
     written_text = "".join(call.args[0] for call in mock_open().write.call_args_list)
     assert "overwrite_model_parameters" in written_text
     assert "scan_label" in written_text
-    assert "telescope" in written_text
+    assert "telescope" not in written_text
     mock_chmod.assert_called_once_with(0o755)

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -4,6 +4,8 @@ import astropy.units as u
 import pytest
 from astropy.table import Table
 
+from simtools.constants import SCHEMA_PATH
+from simtools.io.ascii_handler import collect_data_from_file
 from simtools.production_configuration import job_grid_io
 
 
@@ -40,6 +42,14 @@ def _metadata():
     }
 
 
+def test_job_grid_schema_keeps_previous_format_document():
+    schemas = collect_data_from_file(SCHEMA_PATH / "job_grid_density.schema.yml")
+
+    assert [schema["schema_version"] for schema in schemas] == ["0.4.0", "0.3.0"]
+    assert "telescope" not in job_grid_io.JOB_GRID_SCHEMA.columns
+    assert "telescope" in {column["name"] for column in schemas[1]["data"][0]["table_columns"]}
+
+
 def test_serialize_job_grid_writes_empty_grid_header(tmp_test_directory):
     output_file = Path(tmp_test_directory) / "empty_job_grid.ecsv"
 
@@ -51,6 +61,8 @@ def test_serialize_job_grid_writes_empty_grid_header(tmp_test_directory):
         *job_grid_io.JOB_GRID_SCHEMA.optional_columns,
     ]
     assert output_table.meta["job_grid_summary"]["simulation_rows"] == 0
+    assert output_table.meta["job_grid_format_version"] == "0.4.0"
+    assert "telescope" not in output_table.colnames
 
 
 def test_serialize_and_read_job_grid_with_optional_string_fields(tmp_test_directory):
@@ -62,7 +74,6 @@ def test_serialize_and_read_job_grid_with_optional_string_fields(tmp_test_direct
             "run_number": 11,
             "overwrite_model_parameters": "overwrite file.yaml",
             "scan_label": "asum220",
-            "telescope": "LSTN-01",
         }
     )
 
@@ -72,7 +83,6 @@ def test_serialize_and_read_job_grid_with_optional_string_fields(tmp_test_direct
     assert "overwrite_model_parameters" not in read_rows[0]
     assert read_rows[1]["overwrite_model_parameters"] == "overwrite file.yaml"
     assert read_rows[1]["scan_label"] == "asum220"
-    assert read_rows[1]["telescope"] == "LSTN-01"
 
 
 def test_serialize_job_grid_rejects_non_ecsv_output(tmp_test_directory):


### PR DESCRIPTION
Remove 'telescope' command line parameter and replace it by `array_layout_name for
the following applications:

- generate_bias_curve_submissions.py
- production_generate_grid.py
- simulate_pedestals.py
- simulate_prod.py

This resolves the ambiguous usage of single-telescope layout names.