### PR TITLE
Round pointing angles to two digits in metadata file

### DIFF
--- a/docs/changes/2427.maintenance.md
+++ b/docs/changes/2427.maintenance.md
@@ -1,0 +1,1 @@
+Round pointing angles to two digits in metadata file which is written out for the sake of the DIRAC interface.

--- a/docs/changes/2427.maintenance.md
+++ b/docs/changes/2427.maintenance.md
@@ -1,1 +1,1 @@
-Round pointing angles to two digits in metadata file which is written out for the sake of the DIRAC interface.
+Round pointing angles to two decimal places in the metadata file written for the DIRAC interface.

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -29,7 +29,7 @@ def build_simulation_job_metadata(args_dict, simulator):
         "site": CATALOG_SITE_NAMES[args_dict["site"]],
         "particle": args_dict["primary"].lower(),
         "phiP": round((azimuth_angle + 180.0) % 360.0, 2),
-        "thetaP": float(args_dict["zenith_angle"].to_value(u.deg)),
+        "thetaP": round(float(args_dict["zenith_angle"].to_value(u.deg)), 2),
         "sct": str(_has_sct(simulator.array_models)),
         "view_cone": _format_view_cone(view_cone_min, view_cone_max),
         "runNumber": int(simulator.run_number),
@@ -59,4 +59,4 @@ def _format_view_cone(view_cone_min, view_cone_max):
 def _add_optional_coordinate(metadata, key, value):
     """Add one optional angular coordinate in degrees to metadata."""
     if value is not None:
-        metadata[key] = float(value.to_value(u.deg))
+        metadata[key] = round(float(value.to_value(u.deg)), 2)

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -50,6 +50,17 @@ def test_build_simulation_job_metadata_uses_catalog_conventions():
     }
 
 
+def test_build_simulation_job_metadata_rounds_angles_to_two_decimal_places():
+    metadata = build_simulation_job_metadata(
+        _args(zenith_angle=20.123 * u.deg, dec=-45.987 * u.deg, ha=10.0056 * u.deg),
+        _simulator("MSTS-01"),
+    )
+
+    assert metadata["thetaP"] == pytest.approx(20.12)
+    assert metadata["dec"] == pytest.approx(-45.99)
+    assert metadata["ha"] == pytest.approx(10.01)
+
+
 def test_build_simulation_job_metadata_omits_missing_coordinates_and_sets_sct_false():
     metadata = build_simulation_job_metadata(
         _args(site="North", azimuth_angle=180 * u.deg),


### PR DESCRIPTION
No need to keep too many digits in the DIRAC  metadata dictionary.