### PR TITLE
Upgrade pip for simtools container

### DIFF
--- a/docker/Dockerfile-simtools-dev
+++ b/docker/Dockerfile-simtools-dev
@@ -59,6 +59,7 @@ RUN python"${PYTHON_VERSION}" -m pip install --no-cache-dir packaging pyyaml && 
       --extras dev doc tests > /workdir/requirements-dev.txt && \
     python"${PYTHON_VERSION}" -m venv env && \
     . env/bin/activate && \
+    python -m pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir --requirement /workdir/requirements-dev.txt && \
     SIMTOOLS_CONTAINER_BUILD=1 \
       SIMTOOLS_GIT_REVISION="${SIMTOOLS_GIT_REVISION}" \

--- a/docker/Dockerfile-simtools-prod
+++ b/docker/Dockerfile-simtools-prod
@@ -59,6 +59,7 @@ ENV SIMTOOLS_SIMTEL_IMAGE=${SIMTEL_IMAGE}
 # hadolint ignore=DL4006
 RUN python"${PYTHON_VERSION}" -m venv env \
   && . env/bin/activate \
+  && python -m pip install --no-cache-dir --upgrade pip \
   && SETUPTOOLS_SCM_PRETEND_VERSION_FOR_GAMMASIMTOOLS="${SIMTOOLS_VERSION}" \
     pip install --no-cache-dir /workdir/simtools \
   && SIMTOOLS_CONTAINER_BUILD=1 simtools-dependency-manifest \


### PR DESCRIPTION
Add a `pip upgrade pip` to the simtools-dev and simtools-prod Docker file to ensure that images contain newest pip version.