### PR TITLE
Add metaparameter as an input argument

### DIFF
--- a/docs/changes/2442.maintenance.md
+++ b/docs/changes/2442.maintenance.md
@@ -1,0 +1,1 @@
+Add the meta_parameter input argument to submit_model_parameter_from_external.py to allow setting the meta parameter flag when submitting a model parameter from an external source.

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -49,6 +49,12 @@ _ARGUMENTS = (
         help="Check if the parameter version exists in the database",
         action="store_true",
     ),
+    cli.ArgumentDefinition(
+        "meta_parameter",
+        help="Set if this is should be saved in the sim_telarray meta parameters.",
+        action="store_true",
+        default=False,
+    ),
 )
 
 
@@ -101,6 +107,7 @@ def main():
         metadata_input_dict=app_context.args,
         check_db_for_existing_parameter=app_context.args.get("check_parameter_version", False),
         model_parameter_schema_version=model_parameter_schema_version,
+        meta_parameter=app_context.args.get("meta_parameter", False),
     )
 
 

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -52,7 +52,8 @@ _ARGUMENTS = (
     cli.ArgumentDefinition(
         "meta_parameter",
         help=(
-            "If set, treat the submitted parameter as a sim_telarray metaparameter (written into sim_telarray metadata)."
+            "If set, treat the submitted parameter as a sim_telarray metaparameter "
+            "(written into sim_telarray metadata)."
         ),
         action="store_true",
     ),

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -51,9 +51,10 @@ _ARGUMENTS = (
     ),
     cli.ArgumentDefinition(
         "meta_parameter",
-        help="Set if this is should be saved in the sim_telarray meta parameters.",
+        help=(
+            "If set, treat the submitted parameter as a sim_telarray metaparameter (written into sim_telarray metadata)."
+        ),
         action="store_true",
-        default=False,
     ),
 )
 


### PR DESCRIPTION
The submit parameter from external did not have the option to set if the parameter is a meta parameter and therefore defaulted to false. This PR adds that argument.