### PR TITLE
Fix instrument name stripped of OBS- prefix when writing model parameter JSON

### DIFF
--- a/docs/changes/2444.maintenance.md
+++ b/docs/changes/2444.maintenance.md
@@ -1,0 +1,1 @@
+Fix instrument name stripping of OBS- prefix when writing the model parameter JSON.

--- a/src/simtools/applications/submit_model_parameter_from_external.py
+++ b/src/simtools/applications/submit_model_parameter_from_external.py
@@ -52,7 +52,8 @@ _ARGUMENTS = (
     cli.ArgumentDefinition(
         "meta_parameter",
         help=(
-            "If set, treat the submitted parameter as a sim_telarray metaparameter (written into sim_telarray metadata)."
+            "If set, treat the submitted parameter as a sim_telarray metaparameter "
+            " (written into sim_telarray metadata)."
         ),
         action="store_true",
     ),

--- a/src/simtools/utils/names.py
+++ b/src/simtools/utils/names.py
@@ -389,7 +389,7 @@ def validate_array_element_name(array_element_name):
         msg = f"Invalid name {array_element_name}"
         raise ValueError(msg) from exc
     if _array_element_type == "OBS":
-        return validate_site_name(_array_element_id)
+        return f"OBS-{validate_site_name(_array_element_id)}"
     return (
         _validate_name(_array_element_type, array_elements())
         + "-"

--- a/tests/unit_tests/configuration/test_argument_helpers.py
+++ b/tests/unit_tests/configuration/test_argument_helpers.py
@@ -74,8 +74,8 @@ def test_telescope():
 
 
 def test_instrument():
-    assert helpers.instrument("OBS-North") == "North"
-    assert helpers.instrument("OBS-South") == "South"
+    assert helpers.instrument("OBS-North") == "OBS-North"
+    assert helpers.instrument("OBS-South") == "OBS-South"
     assert helpers.instrument("LSTN-01") == "LSTN-01"
     assert helpers.instrument("LSTN-design") == "LSTN-design"
     assert helpers.instrument("MSTS-FlashCam") == "MSTS-FlashCam"


### PR DESCRIPTION
`validate_array_element_name("OBS-North")` was returning `"North"` instead of `"OBS-North"`. 
This caused the `instrument` field in output JSON files to be written as `"North"`, which fails schema validation since `telescope_name_pattern` requires the `OBS-(North|South)` format.

Note, @GernotMaier implemented this way intentionally not so long ago. I don't entirely remember why, but it would be good to double check before accepting this change.