### PR TITLE
Correct treatment of `ct` vs `count` for simulation models.

### DIFF
--- a/docs/changes/2451.bugfix.md
+++ b/docs/changes/2451.bugfix.md
@@ -1,0 +1,1 @@
+Correct treatment of `ct` vs `count` for simulation models.

--- a/src/simtools/model/model_repository.py
+++ b/src/simtools/model/model_repository.py
@@ -806,9 +806,12 @@ def _validate_existing_model_parameter_file(target_file, telescope, param, param
 def _normalize_units_for_comparison(unit):
     """Normalize equivalent scalar and per-value unit representations."""
     unit = value_conversion.normalize_dimensionless_unit(unit)
-    if isinstance(unit, list) and unit and all(entry == unit[0] for entry in unit):
-        return unit[0]
-    return unit
+    if isinstance(unit, list):
+        unit = [_normalize_units_for_comparison(entry) for entry in unit]
+        if unit and all(entry == unit[0] for entry in unit):
+            return unit[0]
+        return unit
+    return value_conversion.normalize_model_parameter_unit(0, unit)
 
 
 def _get_latest_model_parameter_file(directory, parameter, max_version):

--- a/tests/unit_tests/model/test_model_repository.py
+++ b/tests/unit_tests/model/test_model_repository.py
@@ -958,7 +958,12 @@ def test_create_new_model_parameter_entry_rejects_mismatching_existing_file(
 
 @pytest.mark.parametrize(
     ("unit", "expected"),
-    [(["cm", "cm"], "cm"), (["null", "null"], None), (["null", "cm"], [None, "cm"])],
+    [
+        (["cm", "cm"], "cm"),
+        (["null", "null"], None),
+        (["null", "cm"], [None, "cm"]),
+        ("count", "ct"),
+    ],
 )
 def test_normalize_units_for_comparison(unit, expected):
     assert model_repository._normalize_units_for_comparison(unit) == expected


### PR DESCRIPTION
see simulation-models pipeline failure https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models/-/jobs/830425