### PR TITLE
Keep consistent UUIDs for temporary files when writing reduced event lists.

### DIFF
--- a/docs/changes/2452.feature.md
+++ b/docs/changes/2452.feature.md
@@ -1,0 +1,1 @@
+Keep consistent UUIDs when writing reduced events list between temporary files and log files.

--- a/docs/changes/2452.feature.md
+++ b/docs/changes/2452.feature.md
@@ -1,1 +1,1 @@
-Keep consistent UUIDs when writing reduced events list between temporary files and log files.
+Keep consistent UUIDs when writing reduced event lists between temporary files and log files.

--- a/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
+++ b/docs/source/user-guide/applications/simtools-write-reduced-event-lists.md
@@ -44,6 +44,10 @@ columns carrying their Astropy units.
 Provide either `input_files` or `input_file_list`, but not both. Use `max_workers` to control
 parallel output-file processing.
 
+If an HDF5 write fails, the retained incomplete file includes the application activity ID and
+the per-write staging ID in its name. The activity ID matches the UUID in the generated
+`write_reduced_event_lists_<activity_id>.log` file.
+
 ## Command line arguments
 
 ```{eval-rst}

--- a/src/simtools/io/table_handler.py
+++ b/src/simtools/io/table_handler.py
@@ -333,12 +333,40 @@ def write_tables(
         fits.HDUList(hdus).writeto(output_file, checksum=False)
 
 
-def write_table_chunks(table_chunks, output_file, overwrite_existing=True, metadata_documents=None):
-    """Write table chunks and optional JSON documents to atomic HDF5 output."""
+def write_table_chunks(
+    table_chunks,
+    output_file,
+    overwrite_existing=True,
+    metadata_documents=None,
+    activity_id=None,
+):
+    """Write table chunks and optional JSON documents to atomic HDF5 output.
+
+    Parameters
+    ----------
+    table_chunks : iterable
+        Tables to write, grouped into chunks.
+    output_file : str or Path
+        Path of the published HDF5 output file.
+    overwrite_existing : bool, optional
+        Whether an existing output file may be replaced.
+    metadata_documents : dict or callable, optional
+        Named JSON documents to embed in the HDF5 output.
+    activity_id : str, optional
+        Application activity identifier. If supplied, it is included in the
+        incomplete-file name to correlate failed writes with the application log.
+    """
     output_file = Path(output_file)
     if output_file.exists() and not overwrite_existing:
         raise FileExistsError(f"Output file {output_file} already exists.")
-    incomplete_file = output_file.with_name(f"{output_file.name}.incomplete-{general.get_uuid()}")
+    write_id = general.get_uuid()
+    activity_suffix = ""
+    if activity_id is not None:
+        safe_activity_id = str(activity_id).replace("/", "_").replace("\\", "_")
+        activity_suffix = f"{safe_activity_id}-"
+    incomplete_file = output_file.with_name(
+        f"{output_file.name}.incomplete-{activity_suffix}{write_id}"
+    )
     expected_tables = {}
     metadata_names = set()
 

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -44,6 +44,7 @@ def _write_reduced_event_list_batch(job_spec):
         output_file=Path(output_file),
         overwrite_existing=True,
         metadata_documents=build_metadata_documents,
+        activity_id=metadata_args.get("activity_id") if metadata_args else None,
     )
 
 

--- a/tests/unit_tests/io/test_table_handler.py
+++ b/tests/unit_tests/io/test_table_handler.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import astropy.units as u
 import h5py
 import numpy as np
@@ -348,6 +350,29 @@ def test_write_tables_hdf5_failure_preserves_existing_output(tmp_path, mock_tabl
         assert hdf5_file.attrs["simtools_write_status"] == "incomplete"
         assert TEST_TABLE_NAME in hdf5_file
         assert "second_table" not in hdf5_file
+
+
+def test_write_table_chunks_includes_activity_id_in_incomplete_filename(
+    tmp_test_directory, mock_table, mocker
+):
+    """Retained incomplete files can be matched to the application log."""
+    output_file = Path(tmp_test_directory) / TEST_H5
+    activity_id = "019d85b6-1f98-715b-b92b-bfbcd06d7cd8"
+    write_id = "019d85b6-1f98-715b-b92b-bfbcd06d7cd9"
+
+    mocker.patch(f"{TABLE_HANDLER_PATH}.general.get_uuid", return_value=write_id)
+
+    def failing_chunks():
+        yield [mock_table]
+        raise RuntimeError("injected chunk failure")
+
+    with pytest.raises(RuntimeError, match="injected chunk failure"):
+        write_table_chunks(failing_chunks(), output_file, activity_id=activity_id)
+
+    incomplete_file = output_file.with_name(
+        f"{output_file.name}.incomplete-{activity_id}-{write_id}"
+    )
+    assert incomplete_file.is_file()
 
 
 def test_write_tables_existing_file(tmp_path, mocker):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -503,6 +503,21 @@ def test_write_reduced_event_lists_derives_output_files(mocker, tmp_test_directo
     }
 
 
+def test_write_reduced_event_lists_passes_activity_id_to_hdf5_writer(mocker, tmp_test_directory):
+    """Pass the application activity ID to retained incomplete HDF5 filenames."""
+    input_file = Path(tmp_test_directory) / "output_file.simtel.zst"
+    activity_id = "019d85b6-1f98-715b-b92b-bfbcd06d7cd8"
+    mocker.patch("simtools.sim_events.writer.EventDataWriter", return_value=mocker.MagicMock())
+    mock_table_handler = _mock_reduced_event_table_writer(mocker)
+
+    Simulator.write_reduced_event_lists(
+        input_files=[input_file],
+        metadata_args={"activity_id": activity_id},
+    )
+
+    assert mock_table_handler.write_table_chunks.call_args.kwargs["activity_id"] == activity_id
+
+
 def test_write_reduced_event_lists_derives_output_to_input_directory(mocker, tmp_test_directory):
     data_dir = Path(str(tmp_test_directory)) / "data"
     input_file = str(data_dir / "output_file3.simtel")


### PR DESCRIPTION
When running write_reduced_event_lists.py, a temporary HDF5 file written with a UUID in its file name. Only after validation at the end of writing, the UUID is removed from the file name. This PR fixes an issue that this UUID was different from the activity ID of the process and therefore didn't help at all when debugging (meaning: there was no way to relate a log file to an unfinished file when processing many files).