### PR TITLE
Allow to plot PSF images also in degrees and add the name of the telescope to the annotation

### DIFF
--- a/docs/changes/2461.feature.md
+++ b/docs/changes/2461.feature.md
@@ -1,1 +1,3 @@
-Add functionality to plot PSF images in degrees instead of cm, using the effective focal length. This is controlled by the new `plot_images_in_degrees` argument in the optics validation application. The plots include as well the name of the telescope in the annotation box.
+Add functionality to plot PSF images in degrees instead of cm, using the effective focal length.
+This is controlled by the new `plot_images_in_degrees` argument in the optics validation application.
+The plots include as well the name of the telescope in the annotation box.

--- a/docs/changes/2461.feature.md
+++ b/docs/changes/2461.feature.md
@@ -1,0 +1,1 @@
+Add functionality to plot PSF images in degrees instead of cm, using the effective focal length. This is controlled by the new `plot_images_in_degrees` argument in the optics validation application. The plots include as well the name of the telescope in the annotation box.

--- a/src/simtools/applications/validate_optics.py
+++ b/src/simtools/applications/validate_optics.py
@@ -35,6 +35,14 @@ _ARGUMENTS = (
         action="store_true",
     ),
     cli.ArgumentDefinition(
+        "plot_images_in_degrees",
+        help=(
+            "When plotting PSF images, convert X/Y positions from cm to degrees "
+            "using the effective focal length. Requires --plot_images."
+        ),
+        action="store_true",
+    ),
+    cli.ArgumentDefinition(
         "save_photons",
         help="Retain compressed photon list files after analysis.",
         action="store_true",

--- a/src/simtools/ray_tracing/optics_validation.py
+++ b/src/simtools/ray_tracing/optics_validation.py
@@ -129,7 +129,7 @@ def validate_cumulative_psf(app_context):
     data_to_plot = image.get_image_data()
     fig, _ = plot_ray_tracing_psf.create_psf_image_figure(
         data_to_plot,
-        containment_radius_cm=image.get_psf(0.8) / 2,
+        containment_radius=image.get_psf(0.8) / 2,
         center=(0, 0),
         bins=80,
         cmap="gist_heat_r",
@@ -265,7 +265,6 @@ def _plot_psf_images(ray, telescope_name, plot_file, plot_in_degrees=False):
     eff_flen_cm = _eff_flen_cm_for_degree_conversion(ray) if plot_in_degrees else None
 
     max_extent_rounded = _max_image_extent(images_dict)
-    logger.info(f"Setting consistent image axes: x,y range = +-{max_extent_rounded} cm")
 
     figures = []
     for (off_x, off_y), image in images_dict.items():

--- a/src/simtools/ray_tracing/optics_validation.py
+++ b/src/simtools/ray_tracing/optics_validation.py
@@ -186,20 +186,7 @@ def validate_optics(app_context):
     ray.simulate(test=args_dict["test"], force=False)
     ray.analyze(force=True, save_photons=args_dict.get("save_photons", False))
 
-    for key in ["psf_deg", "psf_cm", "eff_area", "eff_flen"]:
-        plot_kwargs = {"marker": "o", "linestyle": "none", "color": "k"}
-        if key == "eff_flen":
-            plot_kwargs.update(
-                {
-                    "error_type": "errorbar",
-                    "error_label": "Uncertainty",
-                    "markersize": 4,
-                }
-            )
-        fig = ray.plot(key, **plot_kwargs)
-        plot_file_name = "_".join((label, tel_model.name, key))
-        plot_file = io_handler.get_output_file(plot_file_name)
-        visualize.save_figure(fig, plot_file, close=True)
+    _plot_psf_summary(ray, label, tel_model.name, io_handler)
 
     _export_effective_focal_length_model_parameter(
         ray=ray,
@@ -211,47 +198,175 @@ def validate_optics(app_context):
     )
 
     if args_dict["plot_images"]:
-        plot_file_name = "_".join((label, tel_model.name, "images.pdf"))
-        plot_file = io_handler.get_output_file(plot_file_name)
+        plot_file = io_handler.get_output_file("_".join((label, tel_model.name, "images.pdf")))
+        _plot_psf_images(
+            ray,
+            tel_model.name,
+            plot_file,
+            plot_in_degrees=args_dict.get("plot_images_in_degrees", False),
+        )
 
-        logger.info(f"Plotting images into {plot_file}")
 
-        images_dict = ray.psf_images
-        max_x_extent = 0.0
-        max_y_extent = 0.0
-
-        for image in images_dict.values():
-            data = image.get_image_data(centralized=True)
-            if len(data) > 0:
-                x_extent = np.max(np.abs(data["X"]))
-                y_extent = np.max(np.abs(data["Y"]))
-                max_x_extent = max(max_x_extent, x_extent)
-                max_y_extent = max(max_y_extent, y_extent)
-
-        max_extent = max(max_x_extent, max_y_extent)
-        max_extent_rounded = np.ceil(max_extent * 2) / 2
-
-        logger.info(f"Setting consistent image axes: x,y range = +-{max_extent_rounded} cm")
-
-        figures = []
-        for (off_x, off_y), image in images_dict.items():
-            psf_cm = image.get_psf(fraction=0.8, unit="cm")
-            figures.append(
-                plot_ray_tracing_psf.create_annotated_psf_image_figure(
-                    image.get_image_data(centralized=True),
-                    off_x=off_x,
-                    off_y=off_y,
-                    psf_cm=psf_cm,
-                    image_range=[
-                        [-max_extent_rounded, max_extent_rounded],
-                        [-max_extent_rounded, max_extent_rounded],
-                    ],
-                    bins=150,
-                    cmap="gist_heat_r",
-                    psf_kwargs={"color": "k", "fill": False, "lw": 2, "ls": "--"},
-                )
+def _plot_psf_summary(ray, label, telescope_name, io_handler):
+    """Plot PSF, effective area, and effective focal length vs off-axis angle."""
+    for key in ["psf_deg", "psf_cm", "eff_area", "eff_flen"]:
+        plot_kwargs = {"marker": "o", "linestyle": "none", "color": "k"}
+        if key == "eff_flen":
+            plot_kwargs.update(
+                {
+                    "error_type": "errorbar",
+                    "error_label": "Uncertainty",
+                    "markersize": 4,
+                }
             )
-        visualize.save_figures_to_single_document(figures, plot_file, close=True)
+        fig = ray.plot(key, **plot_kwargs)
+        plot_file = io_handler.get_output_file("_".join((label, telescope_name, key)))
+        visualize.save_figure(fig, plot_file, close=True)
+
+
+def _eff_flen_cm_for_degree_conversion(ray):
+    """
+    Return the median effective focal length in cm for image unit conversion.
+
+    Reads ``ray._results`` and delegates to ``_median_effective_focal_length``.
+    Returns None when results are unavailable or contain no valid values.
+    """
+    results = getattr(ray, "_results", None)
+    if results is None or "eff_flen" not in results.colnames:
+        return None
+    eff_flen_cm = _median_effective_focal_length(results)
+    if eff_flen_cm is not None:
+        logger.info(
+            f"Using median effective focal length for degree conversion: {eff_flen_cm:.2f} cm"
+        )
+    return eff_flen_cm
+
+
+def _max_image_extent(images_dict):
+    """Return the rounded half-range of all image X/Y positions in cm."""
+    max_x_extent = 0.0
+    max_y_extent = 0.0
+    for image in images_dict.values():
+        data = image.get_image_data(centralized=True)
+        if len(data) > 0:
+            max_x_extent = max(max_x_extent, np.max(np.abs(data["X"])))
+            max_y_extent = max(max_y_extent, np.max(np.abs(data["Y"])))
+    return np.ceil(max(max_x_extent, max_y_extent) * 2) / 2
+
+
+def _plot_psf_images(ray, telescope_name, plot_file, plot_in_degrees=False):
+    """Render one PSF image per off-axis angle and save them to a single PDF."""
+    logger.info(f"Plotting images into {plot_file}")
+
+    images_dict = ray.psf_images
+    # Compute a single representative effective focal length from all non-zero-offset
+    # rows (eff_flen is undefined / NaN at zero offset).  The value is stable across
+    # off-axis angles, so using the median is sufficient.
+    eff_flen_cm = _eff_flen_cm_for_degree_conversion(ray) if plot_in_degrees else None
+
+    max_extent_rounded = _max_image_extent(images_dict)
+    logger.info(f"Setting consistent image axes: x,y range = +-{max_extent_rounded} cm")
+
+    figures = []
+    for (off_x, off_y), image in images_dict.items():
+        psf_cm_val = image.get_psf(fraction=0.8, unit="cm")
+        converted_data, psf_quantity, containment_radius, plot_extent = _prepare_image_for_plotting(
+            image.get_image_data(centralized=True),
+            psf_cm_val,
+            max_extent_rounded,
+            eff_flen_cm,
+        )
+        figures.append(
+            plot_ray_tracing_psf.create_annotated_psf_image_figure(
+                converted_data,
+                off_x=off_x,
+                off_y=off_y,
+                psf=psf_quantity,
+                containment_radius=containment_radius,
+                image_range=[
+                    [-plot_extent, plot_extent],
+                    [-plot_extent, plot_extent],
+                ],
+                bins=150,
+                cmap="gist_heat_r",
+                psf_kwargs={"color": "k", "fill": False, "lw": 2, "ls": "--"},
+                telescope_name=telescope_name,
+            )
+        )
+    visualize.save_figures_to_single_document(figures, plot_file, close=True)
+
+
+def _median_effective_focal_length(results):
+    """
+    Return median effective focal length in cm from ray-tracing results.
+
+    The effective focal length is undefined (NaN) at zero off-axis angle and is
+    stable across non-zero off-axis angles, so the median over those rows is a
+    sufficient single representative value.
+
+    Parameters
+    ----------
+    results : astropy.table.QTable
+        Ray-tracing results table with columns ``off_x``, ``off_y``, and
+        ``eff_flen``.
+
+    Returns
+    -------
+    float or None
+        Median effective focal length in cm, or None if no valid values exist.
+    """
+    off_x_vals = np.asarray(results["off_x"].to_value(), dtype=float)
+    off_y_vals = np.asarray(results["off_y"].to_value(), dtype=float)
+    eff_flen_vals = np.asarray(results["eff_flen"], dtype=float)
+    non_zero = ~(np.isclose(off_x_vals, 0.0) & np.isclose(off_y_vals, 0.0))
+    valid = eff_flen_vals[non_zero]
+    valid = valid[~np.isnan(valid)]
+    if valid.size == 0:
+        return None
+    return float(np.median(valid))
+
+
+def _prepare_image_for_plotting(image_data, psf_cm, max_extent_cm, eff_flen_cm=None):
+    """
+    Prepare image data and quantities for ``create_annotated_psf_image_figure``.
+
+    If ``eff_flen_cm`` is given, converts X/Y positions, PSF, containment
+    radius, and image extent from cm to degrees using the small-angle
+    approximation ``deg = rad2deg(cm / eff_flen_cm)``.  Otherwise returns
+    unchanged data and cm quantities.
+
+    Parameters
+    ----------
+    image_data : numpy.ndarray
+        Structured array with ``X`` and ``Y`` columns in cm.
+    psf_cm : float
+        PSF diameter in cm.
+    max_extent_cm : float
+        Half-range of the image axes in cm.
+    eff_flen_cm : float, optional
+        Median effective focal length in cm.  When provided the returned
+        quantities use degrees.
+
+    Returns
+    -------
+    tuple
+        ``(converted_data, psf_quantity, containment_radius, plot_extent)``
+        where ``psf_quantity`` and ``containment_radius`` are astropy
+        ``Quantity`` objects.
+    """
+    if eff_flen_cm is not None:
+        converted_data = image_data.copy()
+        converted_data["X"] = np.rad2deg(image_data["X"] / eff_flen_cm)
+        converted_data["Y"] = np.rad2deg(image_data["Y"] / eff_flen_cm)
+        psf_quantity = np.rad2deg(psf_cm / eff_flen_cm) * u.deg
+        containment_radius = np.rad2deg(psf_cm / 2 / eff_flen_cm) * u.deg
+        plot_extent = np.rad2deg(max_extent_cm / eff_flen_cm)
+    else:
+        converted_data = image_data
+        psf_quantity = psf_cm * u.cm
+        containment_radius = (psf_cm / 2) * u.cm
+        plot_extent = max_extent_cm
+    return converted_data, psf_quantity, containment_radius, plot_extent
 
 
 def _effective_focal_length_value_from_results(results):

--- a/src/simtools/ray_tracing/psf_analysis.py
+++ b/src/simtools/ray_tracing/psf_analysis.py
@@ -553,7 +553,7 @@ class PSFImage:
         center = (0, 0) if centralized else (self.centroid_x, self.centroid_y)
         fig, _ = plot_ray_tracing_psf.create_psf_image_figure(
             data,
-            containment_radius_cm=self.get_psf(fraction) / 2,
+            containment_radius=self.get_psf(fraction) / 2,
             center=center,
             psf_kwargs=kwargs_for_psf,
             use_current_axes=True,

--- a/src/simtools/visualization/plot_ray_tracing_psf.py
+++ b/src/simtools/visualization/plot_ray_tracing_psf.py
@@ -59,7 +59,7 @@ def create_cumulative_psf_figure(
 
 def create_psf_image_figure(
     data,
-    containment_radius_cm,
+    containment_radius,
     center,
     ax=None,
     psf_kwargs=None,
@@ -74,10 +74,10 @@ def create_psf_image_figure(
     ----------
     data : numpy.ndarray
         Structured array with ``X`` and ``Y`` columns.
-    containment_radius_cm : float
-        Radius of the containment circle in cm.
+    containment_radius : float
+        Radius of the containment circle, assumed to be in the same unit as the data.
     center : tuple
-        Center of the PSF circle in cm.
+        Center of the PSF circle in the same unit as the data.
     ax : matplotlib.axes.Axes, optional
         Existing axes to draw on.
     psf_kwargs : dict, optional
@@ -102,9 +102,7 @@ def create_psf_image_figure(
 
     fig = visualize.plot_hist_2d(data, ax=ax, **hist_kwargs)
     ax = fig.gca() if ax is None else ax
-    ax.set_xlabel("X Position (cm)")
-    ax.set_ylabel("Y Position (cm)")
-    circle = plt.Circle(center, containment_radius_cm, **(psf_kwargs or {}))
+    circle = plt.Circle(center, containment_radius, **(psf_kwargs or {}))
     ax.add_artist(circle)
 
     if show_reference_axes:
@@ -166,7 +164,7 @@ def create_annotated_psf_image_figure(
     fig, ax = plt.subplots(figsize=(8, 6), tight_layout=True)
     create_psf_image_figure(
         data,
-        containment_radius_cm=containment_radius.value,
+        containment_radius=containment_radius.to(psf.unit).value,
         center=(0, 0),
         ax=ax,
         image_range=image_range,

--- a/src/simtools/visualization/plot_ray_tracing_psf.py
+++ b/src/simtools/visualization/plot_ray_tracing_psf.py
@@ -102,6 +102,8 @@ def create_psf_image_figure(
 
     fig = visualize.plot_hist_2d(data, ax=ax, **hist_kwargs)
     ax = fig.gca() if ax is None else ax
+    ax.set_xlabel("X Position (cm)")
+    ax.set_ylabel("Y Position (cm)")
     circle = plt.Circle(center, containment_radius, **(psf_kwargs or {}))
     ax.add_artist(circle)
 

--- a/src/simtools/visualization/plot_ray_tracing_psf.py
+++ b/src/simtools/visualization/plot_ray_tracing_psf.py
@@ -1,5 +1,6 @@
 """Shared PSF plotting helpers for ray-tracing workflows."""
 
+import astropy.units as u
 import matplotlib.pyplot as plt
 
 from simtools.visualization import visualize
@@ -117,11 +118,13 @@ def create_annotated_psf_image_figure(
     data,
     off_x,
     off_y,
-    psf_cm,
+    psf,
+    containment_radius,
     image_range,
     bins=150,
     cmap=None,
     psf_kwargs=None,
+    telescope_name=None,
 ):
     """
     Create a PSF image figure annotated with offset and PSF information.
@@ -129,13 +132,17 @@ def create_annotated_psf_image_figure(
     Parameters
     ----------
     data : numpy.ndarray
-        Structured array with ``X`` and ``Y`` columns.
+        Structured array with ``X`` and ``Y`` columns, already in the
+        desired display unit.
     off_x : float
         Off-axis x component in degrees.
     off_y : float
         Off-axis y component in degrees.
-    psf_cm : float
-        PSF diameter in cm.
+    psf : astropy.units.Quantity
+        PSF diameter as an astropy quantity (e.g. ``1.2 * u.cm`` or
+        ``0.05 * u.deg``).  Its unit is used for axis labels and annotation.
+    containment_radius : astropy.units.Quantity
+        Containment radius in the same unit as ``psf``.
     image_range : list
         Range passed to ``Axes.hist2d``.
     bins : int
@@ -144,16 +151,22 @@ def create_annotated_psf_image_figure(
         Colormap passed to ``Axes.hist2d``.
     psf_kwargs : dict, optional
         Keyword arguments passed to ``matplotlib.patches.Circle``.
+    telescope_name : str, optional
+        Telescope name shown in the annotation box above the offset.
 
     Returns
     -------
     matplotlib.figure.Figure
         Created figure.
     """
+    unit_str = psf.unit.to_string()
+    psf_fmt = ".4f" if psf.unit == u.deg else ".2f"
+    psf_annotation = f"PSF: {psf.value:{psf_fmt}} {unit_str}"
+
     fig, ax = plt.subplots(figsize=(8, 6), tight_layout=True)
     create_psf_image_figure(
         data,
-        containment_radius_cm=psf_cm / 2,
+        containment_radius_cm=containment_radius.value,
         center=(0, 0),
         ax=ax,
         image_range=image_range,
@@ -161,7 +174,16 @@ def create_annotated_psf_image_figure(
         cmap=cmap,
         psf_kwargs=psf_kwargs,
     )
-    text_str = f"Offset: ({off_x:+.2f} deg, {off_y:+.2f} deg)\nPSF: {psf_cm:.2f} cm"
+    ax.set_xlabel(f"X Position ({unit_str})")
+    ax.set_ylabel(f"Y Position ({unit_str})")
+
+    annotation_lines = []
+    if telescope_name:
+        annotation_lines.append(telescope_name)
+    annotation_lines.append(f"Offset: ({off_x:+.2f} deg, {off_y:+.2f} deg)")
+    annotation_lines.append(psf_annotation)
+    text_str = "\n".join(annotation_lines)
+
     ax.text(
         0.02,
         0.98,

--- a/tests/unit_tests/ray_tracing/test_optics_validation.py
+++ b/tests/unit_tests/ray_tracing/test_optics_validation.py
@@ -461,3 +461,195 @@ def test_prepare_image_for_plotting_does_not_mutate_original():
     optics_validation._prepare_image_for_plotting(image_data, 1.0, 5.0, eff_flen_cm=1000.0)
 
     np.testing.assert_array_equal(image_data["X"], original_x)
+
+
+# ---------------------------------------------------------------------------
+# _plot_psf_summary
+# ---------------------------------------------------------------------------
+
+
+def test_plot_psf_summary_saves_four_figures():
+    mock_ray = MagicMock()
+    mock_ray.plot.return_value = MagicMock()
+    mock_io = MagicMock()
+
+    with patch("simtools.ray_tracing.optics_validation.visualize.save_figure") as mock_save:
+        optics_validation._plot_psf_summary(mock_ray, "validate_optics", "LSTN-01", mock_io)
+
+    assert mock_ray.plot.call_count == 4
+    assert mock_save.call_count == 4
+    plotted_keys = [call.args[0] for call in mock_ray.plot.call_args_list]
+    assert plotted_keys == ["psf_deg", "psf_cm", "eff_area", "eff_flen"]
+
+
+def test_plot_psf_summary_adds_errorbar_kwargs_for_eff_flen():
+    mock_ray = MagicMock()
+    mock_ray.plot.return_value = MagicMock()
+    mock_io = MagicMock()
+
+    with patch("simtools.ray_tracing.optics_validation.visualize.save_figure"):
+        optics_validation._plot_psf_summary(mock_ray, "label", "TEL", mock_io)
+
+    eff_flen_call = mock_ray.plot.call_args_list[3]
+    assert eff_flen_call.kwargs.get("error_type") == "errorbar"
+
+
+# ---------------------------------------------------------------------------
+# _eff_flen_cm_for_degree_conversion
+# ---------------------------------------------------------------------------
+
+
+def test_eff_flen_cm_for_degree_conversion_returns_median():
+    mock_ray = MagicMock()
+    mock_ray._results = _make_results(
+        off_x=[0.0, 1.0, -1.0],
+        off_y=[0.0, 0.0, 0.0],
+        eff_flen=[np.nan, 2900.0, 2950.0],
+    )
+
+    value = optics_validation._eff_flen_cm_for_degree_conversion(mock_ray)
+
+    assert value == pytest.approx(2925.0)
+
+
+def test_eff_flen_cm_for_degree_conversion_returns_none_when_no_results():
+    mock_ray = MagicMock(spec=[])  # no _results attribute
+
+    value = optics_validation._eff_flen_cm_for_degree_conversion(mock_ray)
+
+    assert value is None
+
+
+def test_eff_flen_cm_for_degree_conversion_returns_none_when_column_missing():
+    mock_ray = MagicMock()
+    mock_ray._results = QTable({"off_x": [1.0] * u.deg, "off_y": [0.0] * u.deg})
+
+    value = optics_validation._eff_flen_cm_for_degree_conversion(mock_ray)
+
+    assert value is None
+
+
+def test_eff_flen_cm_for_degree_conversion_returns_none_when_all_nan():
+    mock_ray = MagicMock()
+    mock_ray._results = _make_results(off_x=[1.0], off_y=[0.0], eff_flen=[np.nan])
+
+    value = optics_validation._eff_flen_cm_for_degree_conversion(mock_ray)
+
+    assert value is None
+
+
+# ---------------------------------------------------------------------------
+# _max_image_extent
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_image(x_vals, y_vals):
+    image = MagicMock()
+    image.get_image_data.return_value = _make_image_data(x_vals, y_vals)
+    return image
+
+
+def test_max_image_extent_returns_rounded_half_range():
+    images_dict = {
+        (0.0, 0.0): _make_mock_image([-3.0, 1.0], [2.0, -1.0]),
+        (1.0, 0.0): _make_mock_image([0.5, -0.5], [4.1, -0.5]),
+    }
+
+    result = optics_validation._max_image_extent(images_dict)
+
+    # max abs is 4.1; ceil(4.1*2)/2 = ceil(8.2)/2 = 9/2 = 4.5
+    assert result == pytest.approx(4.5)
+
+
+def test_max_image_extent_ignores_empty_images():
+    images_dict = {
+        (0.0, 0.0): _make_mock_image([], []),
+        (1.0, 0.0): _make_mock_image([2.0], [-1.0]),
+    }
+
+    result = optics_validation._max_image_extent(images_dict)
+
+    # max abs is 2.0; ceil(2.0*2)/2 = ceil(4.0)/2 = 2.0
+    assert result == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# _plot_psf_images
+# ---------------------------------------------------------------------------
+
+
+def test_plot_psf_images_calls_create_figure_per_image_and_saves_pdf():
+    image_a = _make_mock_image([-1.0, 1.0], [-1.0, 1.0])
+    image_a.get_psf.return_value = 2.0
+    image_b = _make_mock_image([0.5], [-0.5])
+    image_b.get_psf.return_value = 1.5
+
+    mock_ray = MagicMock()
+    mock_ray.psf_images = {(0.0, 0.0): image_a, (1.0, 0.0): image_b}
+    mock_ray._results = None
+
+    with (
+        patch(
+            "simtools.ray_tracing.optics_validation.plot_ray_tracing_psf"
+            ".create_annotated_psf_image_figure",
+            return_value=MagicMock(),
+        ) as mock_create,
+        patch(
+            "simtools.ray_tracing.optics_validation.visualize.save_figures_to_single_document"
+        ) as mock_save,
+    ):
+        optics_validation._plot_psf_images(mock_ray, "LSTN-01", Path("out.pdf"))
+
+    assert mock_create.call_count == 2
+    mock_save.assert_called_once()
+    assert mock_save.call_args.kwargs["close"] is True
+
+
+def test_plot_psf_images_passes_telescope_name_to_figure():
+    image = _make_mock_image([1.0], [-1.0])
+    image.get_psf.return_value = 2.0
+
+    mock_ray = MagicMock()
+    mock_ray.psf_images = {(0.5, 0.0): image}
+    mock_ray._results = None
+
+    with (
+        patch(
+            "simtools.ray_tracing.optics_validation.plot_ray_tracing_psf"
+            ".create_annotated_psf_image_figure",
+            return_value=MagicMock(),
+        ) as mock_create,
+        patch("simtools.ray_tracing.optics_validation.visualize.save_figures_to_single_document"),
+    ):
+        optics_validation._plot_psf_images(mock_ray, "MSTS-01", Path("out.pdf"))
+
+    assert mock_create.call_args.kwargs["telescope_name"] == "MSTS-01"
+
+
+def test_plot_psf_images_in_degrees_uses_eff_flen():
+    image = _make_mock_image([100.0, -100.0], [50.0, -50.0])
+    image.get_psf.return_value = 4.0
+
+    mock_ray = MagicMock()
+    mock_ray.psf_images = {(1.0, 0.0): image}
+    mock_ray._results = _make_results(off_x=[0.0, 1.0], off_y=[0.0, 0.0], eff_flen=[np.nan, 2000.0])
+
+    captured = {}
+
+    def capture_figure(data, **kwargs):
+        captured["psf_unit"] = kwargs["psf"].unit
+        return MagicMock()
+
+    with (
+        patch(
+            "simtools.ray_tracing.optics_validation.plot_ray_tracing_psf"
+            ".create_annotated_psf_image_figure",
+            side_effect=capture_figure,
+        ),
+        patch("simtools.ray_tracing.optics_validation.visualize.save_figures_to_single_document"),
+    ):
+        optics_validation._plot_psf_images(
+            mock_ray, "LSTN-01", Path("out.pdf"), plot_in_degrees=True
+        )
+
+    assert captured["psf_unit"] == u.deg

--- a/tests/unit_tests/ray_tracing/test_optics_validation.py
+++ b/tests/unit_tests/ray_tracing/test_optics_validation.py
@@ -343,3 +343,121 @@ def test_export_effective_focal_length_model_parameter_without_results(caplog):
     )
 
     assert "No ray-tracing results available to export effective_focal_length" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _median_effective_focal_length
+# ---------------------------------------------------------------------------
+
+
+def _make_results(off_x, off_y, eff_flen):
+    """Build a minimal QTable matching the ray-tracing results schema."""
+    return QTable(
+        {
+            "off_x": off_x * u.deg,
+            "off_y": off_y * u.deg,
+            "eff_flen": np.asarray(eff_flen, dtype=float),
+        }
+    )
+
+
+def test_median_effective_focal_length_returns_median_of_nonzero_rows():
+    results = _make_results(
+        off_x=[0.0, 1.0, -1.0, 0.0, 0.0],
+        off_y=[0.0, 0.0, 0.0, 1.0, -1.0],
+        eff_flen=[np.nan, 2900.0, 2950.0, 2920.0, 2940.0],
+    )
+
+    value = optics_validation._median_effective_focal_length(results)
+
+    assert value == pytest.approx(2930.0)
+
+
+def test_median_effective_focal_length_excludes_zero_offset_nan():
+    # Only the zero-offset row; eff_flen is NaN there -> no valid values
+    results = _make_results(off_x=[0.0], off_y=[0.0], eff_flen=[np.nan])
+
+    value = optics_validation._median_effective_focal_length(results)
+
+    assert value is None
+
+
+def test_median_effective_focal_length_all_nonzero_nan_returns_none():
+    results = _make_results(
+        off_x=[1.0, -1.0],
+        off_y=[0.0, 0.0],
+        eff_flen=[np.nan, np.nan],
+    )
+
+    value = optics_validation._median_effective_focal_length(results)
+
+    assert value is None
+
+
+def test_median_effective_focal_length_single_valid_value():
+    results = _make_results(off_x=[0.0, 1.0], off_y=[0.0, 0.0], eff_flen=[np.nan, 2800.0])
+
+    value = optics_validation._median_effective_focal_length(results)
+
+    assert value == pytest.approx(2800.0)
+
+
+# ---------------------------------------------------------------------------
+# _prepare_image_for_plotting
+# ---------------------------------------------------------------------------
+
+_IMAGE_DTYPE = [("X", "f8"), ("Y", "f8")]
+
+
+def _make_image_data(x_vals, y_vals):
+    data = np.zeros(len(x_vals), dtype=_IMAGE_DTYPE)
+    data["X"] = x_vals
+    data["Y"] = y_vals
+    return data
+
+
+def test_prepare_image_for_plotting_returns_cm_when_no_eff_flen():
+    image_data = _make_image_data([1.0, -2.0], [3.0, -4.0])
+    psf_cm = 2.0
+    max_extent_cm = 5.0
+
+    converted, psf_q, cont_r, plot_extent = optics_validation._prepare_image_for_plotting(
+        image_data, psf_cm, max_extent_cm
+    )
+
+    assert converted is image_data
+    assert psf_q.unit == u.cm
+    assert psf_q.value == pytest.approx(2.0)
+    assert cont_r.unit == u.cm
+    assert cont_r.value == pytest.approx(1.0)
+    assert plot_extent == pytest.approx(5.0)
+
+
+def test_prepare_image_for_plotting_converts_to_degrees():
+    image_data = _make_image_data([100.0, -200.0], [50.0, -50.0])
+    psf_cm = 4.0
+    max_extent_cm = 200.0
+    eff_flen_cm = 2000.0
+
+    converted, psf_q, cont_r, plot_extent = optics_validation._prepare_image_for_plotting(
+        image_data, psf_cm, max_extent_cm, eff_flen_cm
+    )
+
+    expected_x = np.rad2deg(np.array([100.0, -200.0]) / eff_flen_cm)
+    expected_y = np.rad2deg(np.array([50.0, -50.0]) / eff_flen_cm)
+    np.testing.assert_allclose(converted["X"], expected_x)
+    np.testing.assert_allclose(converted["Y"], expected_y)
+    assert psf_q.unit == u.deg
+    assert psf_q.value == pytest.approx(np.rad2deg(psf_cm / eff_flen_cm))
+    assert cont_r.unit == u.deg
+    assert cont_r.value == pytest.approx(np.rad2deg(psf_cm / 2 / eff_flen_cm))
+    assert plot_extent == pytest.approx(np.rad2deg(max_extent_cm / eff_flen_cm))
+
+
+def test_prepare_image_for_plotting_does_not_mutate_original():
+    image_data = _make_image_data([10.0], [20.0])
+    original_x = image_data["X"].copy()
+
+    optics_validation._prepare_image_for_plotting(image_data, 1.0, 5.0, eff_flen_cm=1000.0)
+
+    np.testing.assert_array_equal(image_data["X"], original_x)

--- a/tests/unit_tests/visualization/test_plot_ray_tracing_psf.py
+++ b/tests/unit_tests/visualization/test_plot_ray_tracing_psf.py
@@ -46,7 +46,7 @@ def test_create_psf_image_figure_draws_histogram_circle_and_axes():
     ) as mock_plot_hist:
         fig, ax = plot_ray_tracing_psf.create_psf_image_figure(
             data,
-            containment_radius_cm=2.0,
+            containment_radius=2.0,
             center=(0.0, 0.0),
             bins=80,
             image_range=[[-1.0, 1.0], [-1.0, 1.0]],
@@ -89,3 +89,31 @@ def test_create_annotated_psf_image_figure_adds_text():
 
     assert fig == mock_fig
     mock_ax.text.assert_called_once()
+    annotation_text = mock_ax.text.call_args.args[2]
+    assert "Offset" in annotation_text
+    assert "PSF" in annotation_text
+
+
+def test_create_annotated_psf_image_figure_includes_telescope_name():
+    data = np.array([(0.0, 0.0)], dtype=[("X", "f8"), ("Y", "f8")])
+    mock_fig = MagicMock()
+    mock_ax = MagicMock()
+
+    with patch("simtools.visualization.plot_ray_tracing_psf.plt.subplots") as mock_subplots:
+        mock_subplots.return_value = (mock_fig, mock_ax)
+        with patch(
+            "simtools.visualization.plot_ray_tracing_psf.visualize.plot_hist_2d",
+            return_value=mock_fig,
+        ):
+            plot_ray_tracing_psf.create_annotated_psf_image_figure(
+                data,
+                off_x=0.0,
+                off_y=0.0,
+                psf=2.0 * u.cm,
+                containment_radius=1.0 * u.cm,
+                image_range=[[-1.0, 1.0], [-1.0, 1.0]],
+                telescope_name="LSTN-01",
+            )
+
+    annotation_text = mock_ax.text.call_args.args[2]
+    assert "LSTN-01" in annotation_text

--- a/tests/unit_tests/visualization/test_plot_ray_tracing_psf.py
+++ b/tests/unit_tests/visualization/test_plot_ray_tracing_psf.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import astropy.units as u
 import numpy as np
 
 from simtools.visualization import plot_ray_tracing_psf
@@ -80,7 +81,8 @@ def test_create_annotated_psf_image_figure_adds_text():
                 data,
                 off_x=0.5,
                 off_y=-0.5,
-                psf_cm=4.2,
+                psf=4.2 * u.cm,
+                containment_radius=2.1 * u.cm,
                 image_range=[[-1.0, 1.0], [-1.0, 1.0]],
                 cmap="gist_heat_r",
             )


### PR DESCRIPTION
Refactored as well the `validate_optics` function since the linter complained about complexity.