### PR TITLE
Round the view cone values in the metadata to two decimal points

### DIFF
--- a/docs/changes/2462.maintenance.md
+++ b/docs/changes/2462.maintenance.md
@@ -1,0 +1,1 @@
+View cone values printed in the job metadata are now rounded to two decimal places. This change ensures that the view cone values are consistently formatted and avoids potential issues with floating-point precision in the metadata.

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -51,9 +51,10 @@ def _has_sct(array_models):
 
 def _format_view_cone(view_cone_min, view_cone_max):
     """Format view-cone bounds in the catalog convention."""
-    return (f"{view_cone_min.to_value(u.deg)}_deg_{view_cone_max.to_value(u.deg)}_deg").replace(
-        " ", "_"
-    )
+    return (
+        f"{round(view_cone_min.to_value(u.deg), 2)}_deg_"
+        f"{round(view_cone_max.to_value(u.deg), 2)}_deg"
+    ).replace(" ", "_")
 
 
 def _add_optional_coordinate(metadata, key, value):

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -5,7 +5,10 @@ from types import SimpleNamespace
 import astropy.units as u
 import pytest
 
-from simtools.production_configuration.job_metadata import build_simulation_job_metadata
+from simtools.production_configuration.job_metadata import (
+    _format_view_cone,
+    build_simulation_job_metadata,
+)
 
 
 def _args(**updates):
@@ -73,3 +76,8 @@ def test_build_simulation_job_metadata_omits_missing_coordinates_and_sets_sct_fa
     assert metadata["runNumber"] == 5
     assert "dec" not in metadata
     assert "ha" not in metadata
+
+
+def test_format_view_cone_rounds_to_two_decimal_places():
+    result = _format_view_cone(0.12345 * u.deg, 5.6789 * u.deg)
+    assert result == "0.12_deg_5.68_deg"


### PR DESCRIPTION
I will probably also split the view cone to two entries in the metadata soon (requires changes in DIRAC File Catalogue), but for now, this is at least better.