### PR TITLE
Align error message for reading simulation model from path and from DB

### DIFF
--- a/docs/changes/2467.bugfix.md
+++ b/docs/changes/2467.bugfix.md
@@ -1,0 +1,1 @@
+Fix local-filesystem compatibility for calibration and simtel-array reports by normalizing missing-table errors and propagating telescope context to plotting lookups.

--- a/src/simtools/db/file_system_model.py
+++ b/src/simtools/db/file_system_model.py
@@ -82,10 +82,8 @@ class FileSystemModelHandler:
         try:
             return deepcopy(self.production_tables_cached[cache_key][collection_name])
         except KeyError as exc:
-            raise ValueError(
-                f"No production table for collection {collection_name} and model version "
-                f"{model_version} in {self.source_name}"
-            ) from exc
+            query = {"model_version": str(model_version), "collection": collection_name}
+            raise ValueError(f"The following query returned zero results: {query}") from exc
 
     def query_model_parameters(self, query, collection_name):
         """Read parameter JSON files matching a DatabaseHandler query."""

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -299,10 +299,14 @@ class ReadParameters:
 
         return True
 
-    def _generate_plots(self, parameter, parameter_version, input_file, outpath, telescope=None):
+    def _generate_plots(
+        self, parameter, parameter_version, input_file, outpath, telescope=None, site=None
+    ):
         """Generate plots based on the parameter type."""
         plot_names = []
-        telescope_kwargs = {"telescope": telescope} if telescope else {}
+        plot_kwargs = {
+            key: value for key, value in (("telescope", telescope), ("site", site)) if value
+        }
 
         if parameter == "camera_config_file":
             plot_names = self._plot_camera_config(
@@ -310,7 +314,7 @@ class ReadParameters:
                 parameter_version,
                 input_file,
                 outpath,
-                **telescope_kwargs,
+                **plot_kwargs,
             )
         elif parameter in (
             "mirror_list",
@@ -322,26 +326,27 @@ class ReadParameters:
                 parameter_version,
                 input_file,
                 outpath,
-                **telescope_kwargs,
+                **plot_kwargs,
             )
         elif parameter_version:
             plot_names = self._plot_parameter_tables(
                 parameter,
                 parameter_version,
                 outpath,
-                **telescope_kwargs,
+                **plot_kwargs,
             )
 
         return plot_names
 
     def _plot_camera_config(
-        self, parameter, parameter_version, input_file, outpath, telescope=None
+        self, parameter, parameter_version, input_file, outpath, telescope=None, site=None
     ):
         """Generate plots for camera configuration files."""
         if not parameter_version:
             return []
 
         telescope = telescope or self.array_element
+        site = site or self.site
         plot_names = []
         plot_name = input_file.stem.replace(".", "-")
         plot_path = Path(f"{outpath}/{plot_name}").with_suffix(".png")
@@ -351,7 +356,7 @@ class ReadParameters:
                 "file_name": input_file.name,
                 "telescope": telescope,
                 "parameter_version": parameter_version,
-                "site": self.site,
+                "site": site,
                 "model_version": self.model_version,
                 "parameter": parameter,
             }
@@ -371,13 +376,14 @@ class ReadParameters:
         return plot_names
 
     def _plot_mirror_config(
-        self, parameter, parameter_version, input_file, outpath, telescope=None
+        self, parameter, parameter_version, input_file, outpath, telescope=None, site=None
     ):
         """Generate plots for mirror configuration files."""
         if not parameter_version:
             return []
 
         telescope = telescope or self.array_element
+        site = site or self.site
         plot_names = []
         plot_name = input_file.stem.replace(".", "-")
         plot_path = Path(f"{outpath}/{plot_name}").with_suffix(".png")
@@ -387,7 +393,7 @@ class ReadParameters:
                 "parameter": parameter,
                 "telescope": telescope,
                 "parameter_version": parameter_version,
-                "site": self.site,
+                "site": site,
                 "model_version": self.model_version,
             }
 
@@ -405,14 +411,17 @@ class ReadParameters:
 
         return plot_names
 
-    def _plot_parameter_tables(self, parameter, parameter_version, outpath, telescope=None):
+    def _plot_parameter_tables(
+        self, parameter, parameter_version, outpath, telescope=None, site=None
+    ):
         """Generate plots for parameter tables."""
+        site = site or self.site
         tel = self._get_telescope_identifier(telescope=telescope)
 
         config_data = plot_tables.generate_plot_configurations(
             parameter=parameter,
             parameter_version=parameter_version,
-            site=self.site,
+            site=site,
             telescope=tel,
             output_path=outpath,
             plot_type="all",
@@ -448,7 +457,7 @@ class ReadParameters:
             return telescope_design
         return telescope
 
-    def _convert_to_md(self, parameter, parameter_version, input_file, telescope=None):
+    def _convert_to_md(self, parameter, parameter_version, input_file, telescope=None, site=None):
         """Convert a file to a Markdown file, preserving formatting."""
         input_file = Path(input_file)
 
@@ -466,9 +475,11 @@ class ReadParameters:
             outpath = io_handler.IOHandler().get_output_directory("_images")
             outpath.mkdir(parents=True, exist_ok=True)
 
-            telescope_kwargs = {"telescope": telescope} if telescope else {}
+            plot_kwargs = {
+                key: value for key, value in (("telescope", telescope), ("site", site)) if value
+            }
             plot_names = self._generate_plots(
-                parameter, parameter_version, input_file, outpath, **telescope_kwargs
+                parameter, parameter_version, input_file, outpath, **plot_kwargs
             )
             # Write markdown file using the stored path
             file_contents = ascii_handler.read_file_encoded_in_utf_or_latin(input_file)
@@ -494,7 +505,14 @@ class ReadParameters:
         return relative_path
 
     def _format_parameter_value(
-        self, parameter, value_data, unit, file_flag, parameter_version=None, telescope=None
+        self,
+        parameter,
+        value_data,
+        unit,
+        file_flag,
+        parameter_version=None,
+        telescope=None,
+        site=None,
     ):
         """Format parameter value based on type."""
         if file_flag:
@@ -505,9 +523,11 @@ class ReadParameters:
                     f"/simulation-model/simulation-models/-/blob/main/"
                     f"simulation-models/model_parameters/Files/{value_data})"
                 ).strip()
-            telescope_kwargs = {"telescope": telescope} if telescope else {}
+            plot_kwargs = {
+                key: value for key, value in (("telescope", telescope), ("site", site)) if value
+            }
             output_file_name = self._convert_to_md(
-                parameter, parameter_version, input_file_name, **telescope_kwargs
+                parameter, parameter_version, input_file_name, **plot_kwargs
             )
             return f"[{Path(value_data).name}]({output_file_name})".strip()
 
@@ -835,7 +855,13 @@ class ReadParameters:
             file_flag = parameter_data.get("file", False)
             parameter_version = parameter_data.get("parameter_version")
             value = self._format_parameter_value(
-                parameter, value_data, unit, file_flag, parameter_version, telescope=telescope
+                parameter,
+                value_data,
+                unit,
+                file_flag,
+                parameter_version,
+                telescope=telescope,
+                site=site,
             )
 
             if self._is_list_of_dicts(value_data):

--- a/src/simtools/reporting/docs_read_parameters.py
+++ b/src/simtools/reporting/docs_read_parameters.py
@@ -299,9 +299,10 @@ class ReadParameters:
 
         return True
 
-    def _generate_plots(self, parameter, parameter_version, input_file, outpath):
+    def _generate_plots(self, parameter, parameter_version, input_file, outpath, telescope=None):
         """Generate plots based on the parameter type."""
         plot_names = []
+        telescope_kwargs = {"telescope": telescope} if telescope else {}
 
         if parameter == "camera_config_file":
             plot_names = self._plot_camera_config(
@@ -309,6 +310,7 @@ class ReadParameters:
                 parameter_version,
                 input_file,
                 outpath,
+                **telescope_kwargs,
             )
         elif parameter in (
             "mirror_list",
@@ -320,21 +322,26 @@ class ReadParameters:
                 parameter_version,
                 input_file,
                 outpath,
+                **telescope_kwargs,
             )
         elif parameter_version:
             plot_names = self._plot_parameter_tables(
                 parameter,
                 parameter_version,
                 outpath,
+                **telescope_kwargs,
             )
 
         return plot_names
 
-    def _plot_camera_config(self, parameter, parameter_version, input_file, outpath):
+    def _plot_camera_config(
+        self, parameter, parameter_version, input_file, outpath, telescope=None
+    ):
         """Generate plots for camera configuration files."""
         if not parameter_version:
             return []
 
+        telescope = telescope or self.array_element
         plot_names = []
         plot_name = input_file.stem.replace(".", "-")
         plot_path = Path(f"{outpath}/{plot_name}").with_suffix(".png")
@@ -342,7 +349,7 @@ class ReadParameters:
         if not plot_path.exists():
             plot_config = {
                 "file_name": input_file.name,
-                "telescope": self.array_element,
+                "telescope": telescope,
                 "parameter_version": parameter_version,
                 "site": self.site,
                 "model_version": self.model_version,
@@ -363,11 +370,14 @@ class ReadParameters:
 
         return plot_names
 
-    def _plot_mirror_config(self, parameter, parameter_version, input_file, outpath):
+    def _plot_mirror_config(
+        self, parameter, parameter_version, input_file, outpath, telescope=None
+    ):
         """Generate plots for mirror configuration files."""
         if not parameter_version:
             return []
 
+        telescope = telescope or self.array_element
         plot_names = []
         plot_name = input_file.stem.replace(".", "-")
         plot_path = Path(f"{outpath}/{plot_name}").with_suffix(".png")
@@ -375,7 +385,7 @@ class ReadParameters:
         if not plot_path.exists():
             plot_config = {
                 "parameter": parameter,
-                "telescope": self.array_element,
+                "telescope": telescope,
                 "parameter_version": parameter_version,
                 "site": self.site,
                 "model_version": self.model_version,
@@ -395,9 +405,9 @@ class ReadParameters:
 
         return plot_names
 
-    def _plot_parameter_tables(self, parameter, parameter_version, outpath):
+    def _plot_parameter_tables(self, parameter, parameter_version, outpath, telescope=None):
         """Generate plots for parameter tables."""
-        tel = self._get_telescope_identifier()
+        tel = self._get_telescope_identifier(telescope=telescope)
 
         config_data = plot_tables.generate_plot_configurations(
             parameter=parameter,
@@ -424,20 +434,21 @@ class ReadParameters:
 
         return plot_names
 
-    def _get_telescope_identifier(self, model_version=None):
+    def _get_telescope_identifier(self, model_version=None, telescope=None):
         """Get the appropriate telescope design type for file naming (e.g., LSTN-design)."""
         model_version = model_version or self.model_version
+        telescope = telescope or self.array_element
         telescope_design = self.db.get_design_model(
-            model_version, self.array_element, collection="telescopes"
+            model_version, telescope, collection="telescopes"
         )
 
-        if not self.array_element:
+        if not telescope:
             return None
-        if not names.is_design_type(self.array_element):
+        if not names.is_design_type(telescope):
             return telescope_design
-        return self.array_element
+        return telescope
 
-    def _convert_to_md(self, parameter, parameter_version, input_file):
+    def _convert_to_md(self, parameter, parameter_version, input_file, telescope=None):
         """Convert a file to a Markdown file, preserving formatting."""
         input_file = Path(input_file)
 
@@ -455,7 +466,10 @@ class ReadParameters:
             outpath = io_handler.IOHandler().get_output_directory("_images")
             outpath.mkdir(parents=True, exist_ok=True)
 
-            plot_names = self._generate_plots(parameter, parameter_version, input_file, outpath)
+            telescope_kwargs = {"telescope": telescope} if telescope else {}
+            plot_names = self._generate_plots(
+                parameter, parameter_version, input_file, outpath, **telescope_kwargs
+            )
             # Write markdown file using the stored path
             file_contents = ascii_handler.read_file_encoded_in_utf_or_latin(input_file)
 
@@ -480,7 +494,7 @@ class ReadParameters:
         return relative_path
 
     def _format_parameter_value(
-        self, parameter, value_data, unit, file_flag, parameter_version=None
+        self, parameter, value_data, unit, file_flag, parameter_version=None, telescope=None
     ):
         """Format parameter value based on type."""
         if file_flag:
@@ -491,7 +505,10 @@ class ReadParameters:
                     f"/simulation-model/simulation-models/-/blob/main/"
                     f"simulation-models/model_parameters/Files/{value_data})"
                 ).strip()
-            output_file_name = self._convert_to_md(parameter, parameter_version, input_file_name)
+            telescope_kwargs = {"telescope": telescope} if telescope else {}
+            output_file_name = self._convert_to_md(
+                parameter, parameter_version, input_file_name, **telescope_kwargs
+            )
             return f"[{Path(value_data).name}]({output_file_name})".strip()
 
         if isinstance(value_data, (str, int, float, dict)):
@@ -818,7 +835,7 @@ class ReadParameters:
             file_flag = parameter_data.get("file", False)
             parameter_version = parameter_data.get("parameter_version")
             value = self._format_parameter_value(
-                parameter, value_data, unit, file_flag, parameter_version
+                parameter, value_data, unit, file_flag, parameter_version, telescope=telescope
             )
 
             if self._is_list_of_dicts(value_data):

--- a/tests/unit_tests/db/test_file_system_model.py
+++ b/tests/unit_tests/db/test_file_system_model.py
@@ -354,7 +354,11 @@ def test_missing_model_data_reports_source(simulation_models_path):
 
     with pytest.raises(ValueError, match=r"Model version 2\.0\.0 not found"):
         handler.read_production_table("telescopes", "2.0.0")
-    with pytest.raises(ValueError, match="No production table for collection"):
+    with pytest.raises(
+        ValueError,
+        match=r"The following query returned zero results: "
+        r"\{'model_version': '1\.0\.0', 'collection': 'calibration_devices'\}",
+    ):
         handler.read_production_table("calibration_devices", "1.0.0")
     with pytest.raises(ValueError, match="returned zero results"):
         handler.query_model_parameters(

--- a/tests/unit_tests/reporting/test_docs_read_parameters.py
+++ b/tests/unit_tests/reporting/test_docs_read_parameters.py
@@ -723,6 +723,7 @@ def test_get_simulation_configuration_data_passes_telescope_to_plotting(tmp_test
         "6.0.0", "LSTN-01", collection="telescopes"
     )
     assert generate_plot_configurations.call_args.kwargs["telescope"] == "LSTN-design"
+    assert generate_plot_configurations.call_args.kwargs["site"] == "North"
 
 
 def test__write_to_file(telescope_model_lst, tmp_path):

--- a/tests/unit_tests/reporting/test_docs_read_parameters.py
+++ b/tests/unit_tests/reporting/test_docs_read_parameters.py
@@ -677,6 +677,54 @@ def test_get_simulation_configuration_data(simulation_software, tmp_path):
     assert dict_tables == []
 
 
+def test_get_simulation_configuration_data_passes_telescope_to_plotting(tmp_test_directory, mocker):
+    """Pass the loop telescope to plotting for all-telescope reports."""
+    output_path = Path(tmp_test_directory)
+    read_parameters = ReadParameters(
+        args={
+            "model_version": "6.0.0",
+            "simulation_software": "sim_telarray",
+            "all_model_versions": True,
+        },
+        output_path=output_path,
+    )
+    read_parameters.db.get_array_elements = Mock(return_value=["LSTN-01"])
+    read_parameters.db.get_design_model = Mock(return_value="LSTN-design")
+    read_parameters.db.get_simulation_configuration_parameters = Mock(
+        return_value={
+            "pm_photoelectron_spectrum": {
+                "value": "pe-spectrum.dat",
+                "unit": " ",
+                "file": True,
+                "parameter_version": "1.0.0",
+            }
+        }
+    )
+    read_parameters.db.export_model_files.side_effect = lambda parameters, dest: (
+        Path(dest).mkdir(parents=True, exist_ok=True),
+        (Path(dest) / "pe-spectrum.dat").write_text("table data\n", encoding="utf-8"),
+    )
+    read_parameters.get_all_parameter_descriptions = Mock(
+        return_value={
+            "pm_photoelectron_spectrum": {
+                "description": "Photoelectron spectrum",
+                "short_description": "Spectrum",
+            }
+        }
+    )
+    generate_plot_configurations = mocker.patch(
+        "simtools.reporting.docs_read_parameters.plot_tables.generate_plot_configurations",
+        return_value=None,
+    )
+
+    read_parameters.get_simulation_configuration_data()
+
+    read_parameters.db.get_design_model.assert_called_once_with(
+        "6.0.0", "LSTN-01", collection="telescopes"
+    )
+    assert generate_plot_configurations.call_args.kwargs["telescope"] == "LSTN-design"
+
+
 def test__write_to_file(telescope_model_lst, tmp_path):
     args = {
         "telescope": telescope_model_lst.name,


### PR DESCRIPTION
Fix local-filesystem compatibility for calibration and simtel-array reports by normalizing missing-table errors and propagating telescope context to plotting lookups. 