### PR TITLE
Improve error messaging for integration tests when comparison with reference files fail.

### DIFF
--- a/docs/changes/2485.feature.md
+++ b/docs/changes/2485.feature.md
@@ -1,0 +1,1 @@
+Improve error messaging of integration test when comparison with reference files fail.

--- a/docs/changes/2485.feature.md
+++ b/docs/changes/2485.feature.md
@@ -1,1 +1,1 @@
-Improve error messaging of integration test when comparison with reference files fail.
+Improve error messaging for integration tests when comparisons with reference files fail.

--- a/src/simtools/testing/output_validation/reference.py
+++ b/src/simtools/testing/output_validation/reference.py
@@ -182,8 +182,18 @@ def compare_files(
 
 def difference_report(reference_file, output_file):
     """Return a unified diff between a reference file and generated output."""
-    reference_lines = Path(reference_file).read_text(encoding="utf-8").splitlines(keepends=True)
-    output_lines = Path(output_file).read_text(encoding="utf-8").splitlines(keepends=True)
+    try:
+        reference_lines = (
+            Path(reference_file)
+            .read_text(encoding="utf-8", errors="replace")
+            .splitlines(keepends=True)
+        )
+        output_lines = (
+            Path(output_file).read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+        )
+    except OSError as exc:
+        return f"(Unable to read files for diff: {exc})"
+
     return "".join(
         difflib.unified_diff(
             reference_lines,

--- a/src/simtools/testing/output_validation/reference.py
+++ b/src/simtools/testing/output_validation/reference.py
@@ -189,7 +189,9 @@ def difference_report(reference_file, output_file):
             .splitlines(keepends=True)
         )
         output_lines = (
-            Path(output_file).read_text(encoding="utf-8", errors="replace").splitlines(keepends=True)
+            Path(output_file)
+            .read_text(encoding="utf-8", errors="replace")
+            .splitlines(keepends=True)
         )
     except OSError as exc:
         return f"(Unable to read files for diff: {exc})"

--- a/src/simtools/testing/output_validation/reference.py
+++ b/src/simtools/testing/output_validation/reference.py
@@ -1,5 +1,6 @@
 """Reference-file comparison validators."""
 
+import difflib
 import logging
 from pathlib import Path
 
@@ -177,3 +178,17 @@ def compare_files(
         return compare_json_or_yaml_files(first_file, second_file, tolerance)
     _logger.warning(f"Unknown file type for files: {first_file} and {second_file}")
     return False
+
+
+def difference_report(reference_file, output_file):
+    """Return a unified diff between a reference file and generated output."""
+    reference_lines = Path(reference_file).read_text(encoding="utf-8").splitlines(keepends=True)
+    output_lines = Path(output_file).read_text(encoding="utf-8").splitlines(keepends=True)
+    return "".join(
+        difflib.unified_diff(
+            reference_lines,
+            output_lines,
+            fromfile=f"reference: {reference_file}",
+            tofile=f"generated: {output_file}",
+        )
+    )

--- a/src/simtools/testing/output_validation/registry.py
+++ b/src/simtools/testing/output_validation/registry.py
@@ -22,7 +22,10 @@ def validate_reference(artifact, rule, _context):
         rule.get("filters"),
         rule.get("key_columns"),
     ):
-        raise AssertionError(f"Output '{artifact.path}' differs from reference '{reference_file}'.")
+        raise AssertionError(
+            f"Output '{artifact.path}' differs from reference '{reference_file}'.\n"
+            f"{reference.difference_report(reference_file, artifact.path)}"
+        )
 
 
 def validate_data_schema(artifact, rule, _context):

--- a/tests/unit_tests/testing/output_validation/test_reference.py
+++ b/tests/unit_tests/testing/output_validation/test_reference.py
@@ -102,8 +102,8 @@ def test_json_difference_report_identifies_generated_values(tmp_test_directory):
 
     assert "--- reference:" in report
     assert "+++ generated:" in report
-    assert "-  \"value\": 1.0" in report
-    assert "+  \"value\": 2.0" in report
+    assert '-  "value": 1.0' in report
+    assert '+  "value": 2.0' in report
 
 
 def test_reference_resolve_path_handles_absolute_and_repository_relative_paths():

--- a/tests/unit_tests/testing/output_validation/test_reference.py
+++ b/tests/unit_tests/testing/output_validation/test_reference.py
@@ -91,6 +91,21 @@ def test_json_reference_comparison_ignores_schema_version(tmp_test_directory):
     assert reference.compare_json_or_yaml_files(first, second)
 
 
+def test_json_difference_report_identifies_generated_values(tmp_test_directory):
+    """Report generated and reference lines in a unified diff."""
+    reference_file = Path(tmp_test_directory) / "reference.json"
+    output_file = Path(tmp_test_directory) / "output.json"
+    reference_file.write_text(json.dumps({"value": 1.0}, indent=2) + "\n", encoding="utf-8")
+    output_file.write_text(json.dumps({"value": 2.0}, indent=2) + "\n", encoding="utf-8")
+
+    report = reference.difference_report(reference_file, output_file)
+
+    assert "--- reference:" in report
+    assert "+++ generated:" in report
+    assert '-  "value": 1.0' in report
+    assert '+  "value": 2.0' in report
+
+
 def test_reference_resolve_path_handles_absolute_and_repository_relative_paths():
     """Resolve absolute paths unchanged and relative paths from the repository root."""
     absolute = Path.cwd() / "reference.json"

--- a/tests/unit_tests/testing/output_validation/test_reference.py
+++ b/tests/unit_tests/testing/output_validation/test_reference.py
@@ -102,8 +102,8 @@ def test_json_difference_report_identifies_generated_values(tmp_test_directory):
 
     assert "--- reference:" in report
     assert "+++ generated:" in report
-    assert '-  "value": 1.0' in report
-    assert '+  "value": 2.0' in report
+    assert "-  \"value\": 1.0" in report
+    assert "+  \"value\": 2.0" in report
 
 
 def test_reference_resolve_path_handles_absolute_and_repository_relative_paths():

--- a/tests/unit_tests/testing/output_validation/test_registry.py
+++ b/tests/unit_tests/testing/output_validation/test_registry.py
@@ -91,10 +91,12 @@ def test_registry_reference_validator(mocker):
 def test_registry_reference_validator_reports_difference(mocker):
     """Report a reference comparison failure."""
     artifact = OutputArtifact(Path("output.json"), {})
-    mocker.patch.object(registry.reference, "resolve_path", return_value=Path("reference.json"))
+    reference_file = Path("reference.json")
+    mocker.patch.object(registry.reference, "resolve_path", return_value=reference_file)
     mocker.patch.object(registry.reference, "compare_files", return_value=False)
+    mocker.patch.object(registry.reference, "difference_report", return_value="- changed value")
 
-    with pytest.raises(AssertionError, match="differs from reference"):
+    with pytest.raises(AssertionError, match="changed value"):
         registry.validate_reference(artifact, {"file": "reference.json"}, {})
 
 


### PR DESCRIPTION
This is hard to disentangle otherwise, see e.g., https://github.com/gammasim/simtools/actions/runs/33351225395/job/99365702929