### PR TITLE
Separate the view cone metadata entry

### DIFF
--- a/docs/changes/2486.api.md
+++ b/docs/changes/2486.api.md
@@ -1,0 +1,1 @@
+Separate the view cone metadata entry into two separate entries for the minimum and maximum view cone angles. This entry is used by the DIRAC file catalog. This change improves clarity and allows for more precise specification of the view cone range when searching for output files.

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -31,7 +31,8 @@ def build_simulation_job_metadata(args_dict, simulator):
         "phiP": round((azimuth_angle + 180.0) % 360.0, 2),
         "thetaP": round(float(args_dict["zenith_angle"].to_value(u.deg)), 2),
         "sct": str(_has_sct(simulator.array_models)),
-        "view_cone": _format_view_cone(view_cone_min, view_cone_max),
+        "view_cone_min": round(float(view_cone_min.to_value(u.deg)), 2),
+        "view_cone_max": round(float(view_cone_max.to_value(u.deg)), 2),
         "runNumber": int(simulator.run_number),
         "model_version": str(args_dict["model_version"]),
     }
@@ -47,14 +48,6 @@ def _has_sct(array_models):
         for array_model in array_models
         for element_name in array_model.array_elements
     )
-
-
-def _format_view_cone(view_cone_min, view_cone_max):
-    """Format view-cone bounds in the catalog convention."""
-    return (
-        f"{round(view_cone_min.to_value(u.deg), 2)}_deg_"
-        f"{round(view_cone_max.to_value(u.deg), 2)}_deg"
-    ).replace(" ", "_")
 
 
 def _add_optional_coordinate(metadata, key, value):

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -5,10 +5,7 @@ from types import SimpleNamespace
 import astropy.units as u
 import pytest
 
-from simtools.production_configuration.job_metadata import (
-    _format_view_cone,
-    build_simulation_job_metadata,
-)
+from simtools.production_configuration.job_metadata import build_simulation_job_metadata
 
 
 def _args(**updates):
@@ -45,7 +42,8 @@ def test_build_simulation_job_metadata_uses_catalog_conventions():
         "phiP": 10.0,
         "thetaP": 20.0,
         "sct": "True",
-        "view_cone": "0.0_deg_1.5_deg",
+        "view_cone_min": 0.0,
+        "view_cone_max": 1.5,
         "runNumber": 12,
         "model_version": "7.0.0",
         "dec": -45.0,
@@ -78,6 +76,11 @@ def test_build_simulation_job_metadata_omits_missing_coordinates_and_sets_sct_fa
     assert "ha" not in metadata
 
 
-def test_format_view_cone_rounds_to_two_decimal_places():
-    result = _format_view_cone(0.12345 * u.deg, 5.6789 * u.deg)
-    assert result == "0.12_deg_5.68_deg"
+def test_build_simulation_job_metadata_rounds_view_cone_to_two_decimal_places():
+    metadata = build_simulation_job_metadata(
+        _args(view_cone=(0.12345 * u.deg, 5.6789 * u.deg)),
+        _simulator("MSTS-01"),
+    )
+
+    assert metadata["view_cone_min"] == pytest.approx(0.12)
+    assert metadata["view_cone_max"] == pytest.approx(5.68)


### PR DESCRIPTION
Separate the view cone metadata entry written for DIRAC to two separate min/max entries.