### PR TITLE
Allow to configure figure DPI

### DIFF
--- a/docs/changes/2490.feature.md
+++ b/docs/changes/2490.feature.md
@@ -1,1 +1,1 @@
-Add a `--figure_dpi <dpi>` command line parameter to change resolution of generated figures (default is 300).
+Add a `--figure_dpi <dpi>` command line parameter to change resolution of generated PNG figures (default is 300).

--- a/docs/changes/2490.feature.md
+++ b/docs/changes/2490.feature.md
@@ -1,0 +1,1 @@
+Add a `--figure_dpi <dpi>` command line parameter to change resolution of generated figures (default is 300).

--- a/src/simtools/configuration/arguments.py
+++ b/src/simtools/configuration/arguments.py
@@ -304,6 +304,14 @@ FIGURE_FORMAT = _argument(
     default=["png"],
 )
 
+FIGURE_DPI = _argument(
+    "figure_dpi",
+    "execution",
+    help="PNG figure resolution in DPI",
+    type=int,
+    default=300,
+)
+
 EXPORT_BUILD_INFO = _argument(
     "export_build_info",
     "execution",
@@ -343,6 +351,7 @@ EXECUTION_ARGUMENTS = (
     LOG_FILE_PATH,
     DISABLE_LOG_FILE,
     FIGURE_FORMAT,
+    FIGURE_DPI,
     EXPORT_BUILD_INFO,
     IGNORE_EXISTING_PARAMETER_VERSION,
     VERSION,

--- a/src/simtools/visualization/visualize.py
+++ b/src/simtools/visualization/visualize.py
@@ -670,7 +670,8 @@ def save_figure(fig, output_file, figure_format=None, log_title="", dpi="figure"
     log_title: str
         Title of the figure to be added to the log message.
     dpi : str or int, optional
-        DPI passed to ``fig.savefig``. Defaults to ``"figure"``.
+        DPI passed to ``fig.savefig`` unless saving a PNG and ``figure_dpi`` is
+        configured. Defaults to ``"figure"``.
     close : bool, optional
         Close the figure after saving. Defaults to False.
     """

--- a/src/simtools/visualization/visualize.py
+++ b/src/simtools/visualization/visualize.py
@@ -675,12 +675,14 @@ def save_figure(fig, output_file, figure_format=None, log_title="", dpi="figure"
         Close the figure after saving. Defaults to False.
     """
     configured_formats = config.args.get("figure_format")
+    configured_dpi = config.args.get("figure_dpi")
 
     figure_format = figure_format or configured_formats or ["png"]
 
     for fmt in gen.ensure_list(figure_format):
         _file = Path(output_file).with_suffix(f".{fmt}")
-        fig.savefig(_file, format=fmt, bbox_inches="tight", dpi=dpi)
+        save_dpi = configured_dpi if fmt == "png" and configured_dpi is not None else dpi
+        fig.savefig(_file, format=fmt, bbox_inches="tight", dpi=save_dpi)
         logging.info(f"Saved plot {log_title} to {_file}")
 
     fig.clf()

--- a/tests/unit_tests/configuration/test_commandline_parser.py
+++ b/tests/unit_tests/configuration/test_commandline_parser.py
@@ -3,6 +3,7 @@
 import pytest
 
 from simtools.configuration.arguments import (
+    FIGURE_DPI,
     ArgumentDefinition,
 )
 from simtools.configuration.commandline_parser import CommandLineParser
@@ -21,3 +22,11 @@ def test_add_argument_definitions_rejects_conflicting_exclusive_group_state():
                 ),
             )
         )
+
+
+def test_figure_dpi_defaults_and_accepts_cli_value():
+    parser = CommandLineParser()
+    parser.add_argument_definitions((FIGURE_DPI,))
+
+    assert parser.parse_args([]).figure_dpi == 300
+    assert parser.parse_args(["--figure_dpi", "123"]).figure_dpi == 123

--- a/tests/unit_tests/visualization/test_visualize.py
+++ b/tests/unit_tests/visualization/test_visualize.py
@@ -149,6 +149,19 @@ def test_save_figure_closes_when_requested(io_handler, mocker):
     mock_close.assert_called_once_with(fig)
 
 
+def test_save_figure_uses_configured_dpi_for_png_only(tmp_test_directory, mocker):
+    fig = mocker.Mock()
+    mocker.patch.object(visualize, "config").args = {"figure_dpi": 123}
+    output_file = Path(tmp_test_directory) / "figure"
+
+    visualize.save_figure(fig, output_file, figure_format=["pdf", "png"], dpi=150)
+
+    assert fig.savefig.call_args_list == [
+        mocker.call(output_file.with_suffix(".pdf"), format="pdf", bbox_inches="tight", dpi=150),
+        mocker.call(output_file.with_suffix(".png"), format="png", bbox_inches="tight", dpi=123),
+    ]
+
+
 def test_plot_histogram_uses_existing_axes():
     data = np.array([0.0, 1.0, 1.0])
     fig, ax = plt.subplots()


### PR DESCRIPTION
Add a `--figure_dpi <dpi>` command line parameter to change resolution of generated figures (default is 300).