### PR TITLE
Improve production metadata and accessing of production in file-based systems

### DIFF
--- a/docs/changes/2496.feature.md
+++ b/docs/changes/2496.feature.md
@@ -1,0 +1,1 @@
+Improve simulation production metadata and accessing of production files in file-based systems.

--- a/docs/source/api-reference/production_configuration.md
+++ b/docs/source/api-reference/production_configuration.md
@@ -61,6 +61,13 @@ related production-configuration helpers used by the supported workflows.
    :members:
 ```
 
+## production_file_selection
+
+```{eval-rst}
+.. automodule:: production_configuration.production_file_selection
+   :members:
+```
+
 
 (angle-ranges)=
 

--- a/docs/source/api-reference/production_configuration.md
+++ b/docs/source/api-reference/production_configuration.md
@@ -68,6 +68,20 @@ related production-configuration helpers used by the supported workflows.
    :members:
 ```
 
+## production_comparison
+
+```{eval-rst}
+.. automodule:: production_configuration.production_comparison
+   :members:
+```
+
+## production_metadata
+
+```{eval-rst}
+.. automodule:: production_configuration.production_metadata
+   :members:
+```
+
 
 (angle-ranges)=
 

--- a/docs/source/user-guide/applications.md
+++ b/docs/source/user-guide/applications.md
@@ -106,6 +106,7 @@ simtools-plot-simulated-event-distributions <applications/simtools-plot-simulate
 simtools-production-derive-corsika-limits <applications/simtools-production-derive-corsika-limits>
 simtools-production-derive-monte-carlo-statistics <applications/simtools-production-derive-monte-carlo-statistics>
 simtools-production-generate-grid <applications/simtools-production-generate-grid>
+simtools-production-select-files <applications/simtools-production-select-files>
 simtools-resources-test-generate <applications/simtools-resources-test-generate>
 simtools-run-application <applications/simtools-run-application>
 simtools-simulate-flasher <applications/simtools-simulate-flasher>
@@ -120,5 +121,6 @@ simtools-validate-camera-fov <applications/simtools-validate-camera-fov>
 simtools-validate-cumulative-psf <applications/simtools-validate-cumulative-psf>
 simtools-validate-file-using-schema <applications/simtools-validate-file-using-schema>
 simtools-validate-optics <applications/simtools-validate-optics>
+simtools-write-production-metadata <applications/simtools-write-production-metadata>
 simtools-write-reduced-event-lists <applications/simtools-write-reduced-event-lists>
 simtools-write-trigger-histograms <applications/simtools-write-trigger-histograms>

--- a/docs/source/user-guide/applications/simtools-compare-productions.md
+++ b/docs/source/user-guide/applications/simtools-compare-productions.md
@@ -25,6 +25,21 @@ array-layout references found in the input files are aggregated into one compari
 selected layouts, each layout is compared independently and written to its own directory below
 `output_path/<layout-name>/`.
 
+For production metadata manifests, pass the baseline and candidate metadata directories instead of
+legacy file descriptors. Repeated `select` expressions choose configurations, while `compare_by`
+lists configuration fields that are allowed to differ. Each matched configuration is written below
+`output_path/comparison-<configuration-hash>/`.
+
+```console
+simtools-compare-productions \
+    --baseline_path /data/baseline/trigger_histograms \
+    --candidate_path /data/candidate/trigger_histograms \
+    --select configuration.primary=gamma \
+    --compare_by configuration.atmosphere \
+    --array_layout_name CTAO-North-Alpha \
+    --output_path comparisons
+```
+
 ## Input and output
 
 | Role | Argument or file | Format | Description |

--- a/docs/source/user-guide/applications/simtools-production-select-files.md
+++ b/docs/source/user-guide/applications/simtools-production-select-files.md
@@ -1,0 +1,44 @@
+# simtools-production-select-files
+
+```{eval-rst}
+.. automodule:: simtools.applications.production_select_files
+   :members:
+   :exclude-members: main
+```
+
+## Overview
+
+The application selects production files from the
+`simulate_prod_job_metadata.yml` manifests written for completed simulation jobs. Selection
+expressions address manifest fields using dotted paths, for example
+`configuration.zenith_angle=20 deg`.
+
+The selected files are grouped by their simulation configuration. Use
+`--require_complete_runs` to reject groups with missing run numbers.
+
+## Input and output
+
+| Role | Argument | Format | Description |
+| --- | --- | --- | --- |
+| Input | `production_path` | Directory | Directory containing `job-*` output directories. |
+| Input | `select` | `KEY=VALUE` | Optional selection expression; may be repeated. |
+| Output | `output_file` | YAML | Optional file containing the selected groups. |
+
+## Command line arguments
+
+```{eval-rst}
+.. simtools-cli-help::
+   :application: production_select_files
+   :no-heading:
+```
+
+## Example
+
+```console
+simtools-production-select-files \
+    --production_path /data/production \
+    --select configuration.zenith_angle="20 deg" \
+    --select configuration.primary=gamma \
+    --file_type reduced_event_data \
+    --output_file selected_files.yml
+```

--- a/docs/source/user-guide/applications/simtools-simulate-prod.md
+++ b/docs/source/user-guide/applications/simtools-simulate-prod.md
@@ -14,6 +14,12 @@ The application produces multipipe scripts and runs array-layout simulations tha
 and detector simulations. It can execute only the CORSIKA shower simulation or pipe CORSIKA output
 directly to sim_telarray using the sim_telarray multipipe mechanism.
 
+After a successful job, the application writes `simulate_prod_job_metadata.yml` to the job output
+directory. The manifest records the resolved configuration and the generated production files,
+including files in the standard `sim_telarray/runNNNNNN` and `corsika/runNNNNNN` subdirectories.
+When `--grid_output_path` is used, the manifest is written alongside the files packed for grid
+registration.
+
 The installed CORSIKA build determines which hadronic interaction-model combinations are
 available. Use `--list_available_corsika_models` to inspect them. For simulations that run
 CORSIKA, `--corsika_hadronic_transition_energy` controls the `HILOW` transition between the

--- a/docs/source/user-guide/applications/simtools-write-production-metadata.md
+++ b/docs/source/user-guide/applications/simtools-write-production-metadata.md
@@ -1,0 +1,42 @@
+# simtools-write-production-metadata
+
+```{eval-rst}
+.. automodule:: simtools.applications.write_production_metadata
+   :members:
+   :exclude-members: main
+```
+
+## Overview
+
+The application writes job-level metadata manifests for an existing simulation production. It
+uses the authoritative ECSV job grid to reconstruct each job configuration and discovers output
+files below each `job-*` directory, including the standard `sim_telarray/runNNNNNN` and
+`corsika/runNNNNNN` subdirectories.
+
+Use `--check` to validate manifests that already exist. In write mode, use `--overwrite` to
+replace existing manifests.
+
+## Input and output
+
+| Role | Argument | Format | Description |
+| --- | --- | --- | --- |
+| Input | `production_path` | Directory | Directory containing `job-*` output directories. |
+| Input | `job_grid_file` | ECSV | Job grid used to resolve the production configuration. |
+| Output | `simulate_prod_job_metadata.yml` | YAML | One manifest per job directory. |
+
+## Command line arguments
+
+```{eval-rst}
+.. simtools-cli-help::
+   :application: write_production_metadata
+   :no-heading:
+```
+
+## Example
+
+```console
+simtools-write-production-metadata \
+    --production_path /data/production \
+    --job_grid_file /data/production_grid.ecsv \
+    --overwrite
+```

--- a/docs/source/user-guide/applications/simtools-write-trigger-histograms.md
+++ b/docs/source/user-guide/applications/simtools-write-trigger-histograms.md
@@ -26,11 +26,20 @@ direct-child `*.reduced_event_data.hdf5` files and groups files whose names diff
 `output_path`. With the `htcondor` backend, one job is submitted per group and the command returns
 after writing the submission manifest.
 
+For a completed `simulate_prod` production, use `production_path` and one or more `select`
+expressions. The application reads the job manifests, groups reduced event-data files by their
+recorded configuration, and writes one trigger-histogram product per group. The site, model
+version, and array layout are read from each selected manifest; explicit layout or model options
+must agree with that metadata.
+
 ## Input and output
 
 | Role | Argument | Format | Description |
 | --- | --- | --- | --- |
 | Input | `event_data_files` | HDF5 | Reduced event-data files or glob patterns. |
+| Input | `event_data_directory` | Directory | Direct-child reduced event-data files. |
+| Input | `production_path` | Directory | Production job manifests and their reduced event-data files. |
+| Input | `select` | `KEY=VALUE` | Optional repeated metadata selection. |
 | Output | `output_file` | HDF5 | Trigger-histogram product. |
 
 The output can be passed to the CORSIKA-limit and Monte Carlo-statistics applications.
@@ -60,4 +69,14 @@ invalid files, and use `max_workers` to control parallel processing.
 ```{eval-rst}
 .. simtools-integration-example::
     :file: write_trigger_histograms_from_directory.yml
+```
+
+### Production metadata
+
+```console
+simtools-write-trigger-histograms \
+    --production_path /data/production \
+    --select configuration.zenith_angle="20 deg" \
+    --select configuration.energy_min="1 TeV" \
+    --output_path trigger_histograms
 ```

--- a/docs/source/user-guide/productions/run-productions.md
+++ b/docs/source/user-guide/productions/run-productions.md
@@ -21,6 +21,7 @@ Typical outputs are:
 - CORSIKA, sim_telarray, and simtools log files
 - sim_telarray eventio files and histogram files
 - reduced event-data HDF5 files (enabled by default; disable with `--reduced_event_lists`)
+- `simulate_prod_job_metadata.yml`, containing the resolved job configuration and output inventory
 - output and log file lists when `--save_file_lists` is used
 - copied grid output files, including logs, histogram files, model archives, moved event files,
   and `simtools.log.gz`, when `--grid_output_path` is configured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ scripts.simtools-plot-tabular-data-for-model-parameter = "simtools.applications.
 scripts.simtools-production-derive-corsika-limits = "simtools.applications.production_derive_corsika_limits:main"
 scripts.simtools-production-derive-monte-carlo-statistics = "simtools.applications.production_derive_monte_carlo_statistics:main"
 scripts.simtools-production-generate-grid = "simtools.applications.production_generate_grid:main"
+scripts.simtools-production-select-files = "simtools.applications.production_select_files:main"
 scripts.simtools-resources-test-generate = "simtools.applications.resources_test_generate:main"
 scripts.simtools-run-application = "simtools.applications.run_application:main"
 scripts.simtools-simulate-flasher = "simtools.applications.simulate_flasher:main"
@@ -139,6 +140,7 @@ scripts.simtools-validate-camera-fov = "simtools.applications.validate_camera_fo
 scripts.simtools-validate-cumulative-psf = "simtools.applications.validate_cumulative_psf:main"
 scripts.simtools-validate-file-using-schema = "simtools.applications.validate_file_using_schema:main"
 scripts.simtools-validate-optics = "simtools.applications.validate_optics:main"
+scripts.simtools-write-production-metadata = "simtools.applications.write_production_metadata:main"
 scripts.simtools-write-reduced-event-lists = "simtools.applications.write_reduced_event_lists:main"
 scripts.simtools-write-trigger-histograms = "simtools.applications.write_trigger_histograms:main"
 

--- a/src/simtools/applications/compare_productions.py
+++ b/src/simtools/applications/compare_productions.py
@@ -2,11 +2,21 @@
 
 """Compare trigger-histogram products from simulation productions."""
 
+from pathlib import Path
+
 from simtools.application.definition import ApplicationDefinition
 from simtools.configuration import arguments as cli
 from simtools.constants import SCHEMA_PATH
 from simtools.data_model.metadata_collector import MetadataCollector
+from simtools.production_configuration.production_file_selection import (
+    check_manifest,
+    discover_product_manifests,
+    filter_manifests,
+    normalize_for_comparison,
+    stable_configuration_hash,
+)
 from simtools.sim_events.production_comparison import (
+    ProductionDescriptor,
     collect_production_metrics,
     parse_production_arguments,
 )
@@ -18,11 +28,35 @@ _ARGUMENTS = (
         action="append",
         nargs="+",
         metavar=("LABEL", "TRIGGER_HISTOGRAM_PATTERNS"),
-        required=True,
+        required=False,
         help=(
             "Production descriptor: --production <label> <comma-separated file patterns>. "
             "Repeat for each production; the first production is the baseline."
         ),
+    ),
+    cli.ArgumentDefinition(
+        "baseline_path",
+        help="Directory containing baseline trigger-histogram metadata YAML files.",
+        type=str,
+        required=False,
+    ),
+    cli.ArgumentDefinition(
+        "candidate_path",
+        help="Directory containing candidate trigger-histogram metadata YAML files.",
+        type=str,
+        required=False,
+    ),
+    cli.ArgumentDefinition(
+        "select",
+        help="Selection expression as dotted.path=value. Can be repeated.",
+        action="append",
+        default=[],
+    ),
+    cli.ArgumentDefinition(
+        "compare_by",
+        help="Configuration field allowed to differ between baseline and candidate.",
+        action="append",
+        default=[],
     ),
     cli.ArgumentDefinition(
         "comparison_level",
@@ -39,6 +73,18 @@ _ARGUMENTS = (
 )
 
 
+def _post_parse(args_dict, _config_sources, parser):
+    """Validate legacy and metadata-based production input modes."""
+    has_legacy_input = bool(args_dict.get("production"))
+    has_metadata_input = bool(args_dict.get("baseline_path") or args_dict.get("candidate_path"))
+    if has_legacy_input == has_metadata_input:
+        parser.error("Use either '--production' or '--baseline_path' with '--candidate_path'.")
+    if has_metadata_input and not (
+        args_dict.get("baseline_path") and args_dict.get("candidate_path")
+    ):
+        parser.error("'--baseline_path' and '--candidate_path' must be used together.")
+
+
 APPLICATION = ApplicationDefinition.for_module(
     __name__,
     arguments=(
@@ -47,6 +93,7 @@ APPLICATION = ApplicationDefinition.for_module(
     ),
     initialize_output=False,
     excluded_standard_arguments=("test", "ignore_existing_parameter_version"),
+    post_parse=_post_parse,
 )
 
 
@@ -57,17 +104,34 @@ def main():
     if comparison_level != "events":
         raise NotImplementedError(f"Comparison level '{comparison_level}' is not implemented yet.")
 
-    production_descriptors = parse_production_arguments(app_context.args["production"])
     array_layout_names = app_context.args.get("array_layout_name") or [None]
+    if app_context.args.get("baseline_path"):
+        descriptor_pairs = _production_descriptor_pairs_from_metadata(app_context.args)
+        for pairing_key, production_descriptors in descriptor_pairs:
+            pair_output_directory = (
+                app_context.io_handler.get_output_directory()
+                / f"comparison-{stable_configuration_hash(pairing_key)}"
+            )
+            for array_layout_name in array_layout_names:
+                _compare_array_layout(
+                    production_descriptors,
+                    app_context,
+                    array_layout_name,
+                    output_directory=pair_output_directory,
+                )
+        return
+
+    production_descriptors = parse_production_arguments(app_context.args["production"])
     for array_layout_name in array_layout_names:
-        _compare_array_layout(
-            production_descriptors,
-            app_context,
-            array_layout_name,
-        )
+        _compare_array_layout(production_descriptors, app_context, array_layout_name)
 
 
-def _compare_array_layout(production_descriptors, app_context, array_layout_name):
+def _compare_array_layout(
+    production_descriptors,
+    app_context,
+    array_layout_name,
+    output_directory=None,
+):
     """Compare one selected array layout and write its statistics metadata."""
     metrics_per_production = collect_production_metrics(
         production_descriptors,
@@ -75,7 +139,7 @@ def _compare_array_layout(production_descriptors, app_context, array_layout_name
     )
     comparison_statistics_file = plot_event_level_production_comparison.plot(
         metrics_per_production,
-        output_path=app_context.io_handler.get_output_directory(),
+        output_path=output_directory or app_context.io_handler.get_output_directory(),
         array_layout_name=array_layout_name,
         figure_format=app_context.args.get("figure_format"),
     )
@@ -90,6 +154,101 @@ def _compare_array_layout(production_descriptors, app_context, array_layout_name
         }
     )
     MetadataCollector.dump(metadata_args, comparison_statistics_file)
+
+
+def _production_descriptor_pairs_from_metadata(args_dict):
+    """Build one descriptor pair per matched trigger-histogram configuration."""
+    baseline = _selected_trigger_histogram_manifests(
+        args_dict["baseline_path"], args_dict.get("select")
+    )
+    candidate = _selected_trigger_histogram_manifests(
+        args_dict["candidate_path"], args_dict.get("select")
+    )
+    compare_by = {field.removeprefix("configuration.") for field in args_dict.get("compare_by", [])}
+    baseline_by_key = _unique_manifests_by_pairing_key(baseline, compare_by, "baseline")
+    candidate_by_key = _unique_manifests_by_pairing_key(candidate, compare_by, "candidate")
+
+    missing_candidates = sorted(set(baseline_by_key) - set(candidate_by_key))
+    missing_baselines = sorted(set(candidate_by_key) - set(baseline_by_key))
+    if missing_candidates or missing_baselines:
+        raise ValueError(
+            "Trigger-histogram metadata pairing failed: "
+            f"missing candidates={len(missing_candidates)}, "
+            f"missing baselines={len(missing_baselines)}."
+        )
+
+    return [
+        (
+            key,
+            [
+                ProductionDescriptor(
+                    label="baseline",
+                    trigger_histogram_files=[
+                        str(_single_trigger_histogram_file(baseline_by_key[key]))
+                    ],
+                ),
+                ProductionDescriptor(
+                    label="candidate",
+                    trigger_histogram_files=[
+                        str(_single_trigger_histogram_file(candidate_by_key[key]))
+                    ],
+                ),
+            ],
+        )
+        for key in sorted(baseline_by_key, key=str)
+    ]
+
+
+def _selected_trigger_histogram_manifests(path, selections):
+    """Return checked trigger-histogram manifests matching selections."""
+    manifests = discover_product_manifests(path, "trigger_histograms")
+    selected = filter_manifests(manifests, selections or [])
+    if not selected:
+        raise ValueError(f"No trigger-histogram metadata files matched in {path}.")
+    for manifest in selected:
+        check_manifest(manifest)
+    return selected
+
+
+def _unique_manifests_by_pairing_key(manifests, compare_by, label):
+    """Return manifests keyed by comparable simulation configuration."""
+    keyed = {}
+    for manifest in manifests:
+        key = _pairing_key(manifest.data, compare_by)
+        if key in keyed:
+            raise ValueError(
+                f"More than one {label} trigger-histogram file matches configuration {key}."
+            )
+        keyed[key] = manifest
+    return keyed
+
+
+def _pairing_key(manifest, compare_by):
+    """Return normalized configuration fields used for baseline/candidate pairing."""
+    configuration = manifest.get("configuration", {})
+    paired_configuration = {
+        key: value for key, value in configuration.items() if key not in compare_by
+    }
+    return normalize_for_comparison(
+        {
+            "configuration": paired_configuration,
+            "histogram_settings": manifest.get("histogram_settings", {}),
+            "array_selection": manifest.get("array_selection", []),
+        }
+    )
+
+
+def _single_trigger_histogram_file(manifest):
+    """Return the single trigger-histogram file referenced by a manifest."""
+    files = manifest.data.get("files", {}).get("trigger_histograms", [])
+    if len(files) != 1:
+        raise ValueError(
+            f"Expected exactly one trigger-histogram file in {manifest.path}, found {len(files)}."
+        )
+    path = Path(files[0])
+    if path.is_absolute():
+        return path
+    return manifest.directory / path
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/compare_productions.py
+++ b/src/simtools/applications/compare_productions.py
@@ -2,25 +2,9 @@
 
 """Compare trigger-histogram products from simulation productions."""
 
-from pathlib import Path
-
 from simtools.application.definition import ApplicationDefinition
 from simtools.configuration import arguments as cli
-from simtools.constants import SCHEMA_PATH
-from simtools.data_model.metadata_collector import MetadataCollector
-from simtools.production_configuration.production_file_selection import (
-    check_manifest,
-    discover_product_manifests,
-    filter_manifests,
-    normalize_for_comparison,
-    stable_configuration_hash,
-)
-from simtools.sim_events.production_comparison import (
-    ProductionDescriptor,
-    collect_production_metrics,
-    parse_production_arguments,
-)
-from simtools.visualization import plot_event_level_production_comparison
+from simtools.production_configuration.production_comparison import write_production_comparison
 
 _ARGUMENTS = (
     cli.ArgumentDefinition(
@@ -104,151 +88,10 @@ def main():
     if comparison_level != "events":
         raise NotImplementedError(f"Comparison level '{comparison_level}' is not implemented yet.")
 
-    array_layout_names = app_context.args.get("array_layout_name") or [None]
-    if app_context.args.get("baseline_path"):
-        descriptor_pairs = _production_descriptor_pairs_from_metadata(app_context.args)
-        for pairing_key, production_descriptors in descriptor_pairs:
-            pair_output_directory = (
-                app_context.io_handler.get_output_directory()
-                / f"comparison-{stable_configuration_hash(pairing_key)}"
-            )
-            for array_layout_name in array_layout_names:
-                _compare_array_layout(
-                    production_descriptors,
-                    app_context,
-                    array_layout_name,
-                    output_directory=pair_output_directory,
-                )
-        return
-
-    production_descriptors = parse_production_arguments(app_context.args["production"])
-    for array_layout_name in array_layout_names:
-        _compare_array_layout(production_descriptors, app_context, array_layout_name)
-
-
-def _compare_array_layout(
-    production_descriptors,
-    app_context,
-    array_layout_name,
-    output_directory=None,
-):
-    """Compare one selected array layout and write its statistics metadata."""
-    metrics_per_production = collect_production_metrics(
-        production_descriptors,
-        array_names=array_layout_name,
+    write_production_comparison(
+        app_context.args,
+        app_context.io_handler.get_output_directory(),
     )
-    comparison_statistics_file = plot_event_level_production_comparison.plot(
-        metrics_per_production,
-        output_path=output_directory or app_context.io_handler.get_output_directory(),
-        array_layout_name=array_layout_name,
-        figure_format=app_context.args.get("figure_format"),
-    )
-    metadata_args = dict(app_context.args)
-    metadata_args.update(
-        {
-            "array_layout_name": array_layout_name,
-            "output_file": str(comparison_statistics_file),
-            "output_file_format": "JSON",
-            "metadata_product_data_name": "production_comparison_statistics",
-            "schema_file": str(SCHEMA_PATH / "production_comparison_statistics.schema.yml"),
-        }
-    )
-    MetadataCollector.dump(metadata_args, comparison_statistics_file)
-
-
-def _production_descriptor_pairs_from_metadata(args_dict):
-    """Build one descriptor pair per matched trigger-histogram configuration."""
-    baseline = _selected_trigger_histogram_manifests(
-        args_dict["baseline_path"], args_dict.get("select")
-    )
-    candidate = _selected_trigger_histogram_manifests(
-        args_dict["candidate_path"], args_dict.get("select")
-    )
-    compare_by = {field.removeprefix("configuration.") for field in args_dict.get("compare_by", [])}
-    baseline_by_key = _unique_manifests_by_pairing_key(baseline, compare_by, "baseline")
-    candidate_by_key = _unique_manifests_by_pairing_key(candidate, compare_by, "candidate")
-
-    missing_candidates = sorted(set(baseline_by_key) - set(candidate_by_key))
-    missing_baselines = sorted(set(candidate_by_key) - set(baseline_by_key))
-    if missing_candidates or missing_baselines:
-        raise ValueError(
-            "Trigger-histogram metadata pairing failed: "
-            f"missing candidates={len(missing_candidates)}, "
-            f"missing baselines={len(missing_baselines)}."
-        )
-
-    return [
-        (
-            key,
-            [
-                ProductionDescriptor(
-                    label="baseline",
-                    trigger_histogram_files=[
-                        str(_single_trigger_histogram_file(baseline_by_key[key]))
-                    ],
-                ),
-                ProductionDescriptor(
-                    label="candidate",
-                    trigger_histogram_files=[
-                        str(_single_trigger_histogram_file(candidate_by_key[key]))
-                    ],
-                ),
-            ],
-        )
-        for key in sorted(baseline_by_key, key=str)
-    ]
-
-
-def _selected_trigger_histogram_manifests(path, selections):
-    """Return checked trigger-histogram manifests matching selections."""
-    manifests = discover_product_manifests(path, "trigger_histograms")
-    selected = filter_manifests(manifests, selections or [])
-    if not selected:
-        raise ValueError(f"No trigger-histogram metadata files matched in {path}.")
-    for manifest in selected:
-        check_manifest(manifest)
-    return selected
-
-
-def _unique_manifests_by_pairing_key(manifests, compare_by, label):
-    """Return manifests keyed by comparable simulation configuration."""
-    keyed = {}
-    for manifest in manifests:
-        key = _pairing_key(manifest.data, compare_by)
-        if key in keyed:
-            raise ValueError(
-                f"More than one {label} trigger-histogram file matches configuration {key}."
-            )
-        keyed[key] = manifest
-    return keyed
-
-
-def _pairing_key(manifest, compare_by):
-    """Return normalized configuration fields used for baseline/candidate pairing."""
-    configuration = manifest.get("configuration", {})
-    paired_configuration = {
-        key: value for key, value in configuration.items() if key not in compare_by
-    }
-    return normalize_for_comparison(
-        {
-            "configuration": paired_configuration,
-            "histogram_settings": manifest.get("histogram_settings", {}),
-            "array_selection": manifest.get("array_selection", []),
-        }
-    )
-
-
-def _single_trigger_histogram_file(manifest):
-    """Return the single trigger-histogram file referenced by a manifest."""
-    files = manifest.data.get("files", {}).get("trigger_histograms", [])
-    if len(files) != 1:
-        raise ValueError(
-            f"Expected exactly one trigger-histogram file in {manifest.path}, found {len(files)}."
-        )
-    path = Path(files[0])
-    if path.is_absolute():
-        return path
-    return manifest.directory / path
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/production_select_files.py
+++ b/src/simtools/applications/production_select_files.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+"""Select production files from production metadata manifests."""
+
+import sys
+
+from simtools.application.definition import ApplicationDefinition
+from simtools.configuration import arguments as cli
+from simtools.production_configuration.production_file_selection import (
+    select_file_groups,
+    selection_summary,
+    write_selection_file,
+)
+
+_ARGUMENTS = (
+    cli.ArgumentDefinition(
+        "production_path",
+        help="Directory containing simulate_prod job output directories.",
+        type=str,
+        required=True,
+    ),
+    cli.ArgumentDefinition(
+        "select",
+        help="Selection expression as dotted.path=value. Can be repeated.",
+        action="append",
+        default=[],
+    ),
+    cli.ArgumentDefinition(
+        "file_type",
+        help="Manifest file type to select.",
+        type=str,
+        default="reduced_event_data",
+    ),
+    cli.ArgumentDefinition(
+        "require_complete_runs",
+        help="Fail when selected run numbers are not contiguous within each group.",
+        action="store_true",
+        default=False,
+    ),
+)
+
+
+APPLICATION = ApplicationDefinition.for_module(
+    __name__,
+    arguments=(*_ARGUMENTS, *cli.OUTPUT_ARGUMENTS),
+    initialize_output=False,
+)
+
+
+def main():
+    """Run the production-file selection CLI application."""
+    app_context = APPLICATION.start()
+    result = select_file_groups(
+        app_context.args["production_path"],
+        selections=app_context.args.get("select"),
+        file_type=app_context.args["file_type"],
+        require_complete_runs=app_context.args.get("require_complete_runs", False),
+    )
+    sys.stdout.write(selection_summary(result) + "\n")
+    if app_context.args.get("output_file") and not app_context.args.get("output_file_from_default"):
+        write_selection_file(result, app_context.args["output_file"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -234,6 +234,20 @@ def _validate_simulation_arguments(args_dict, parser):
         parser.error("the following argument is required for CORSIKA: --primary")
 
 
+def _write_job_metadata(args_dict, simulator, output_directory):
+    """Write and validate metadata for a completed simulation job."""
+    output_directory = Path(output_directory)
+    manifest_path = output_directory / _JOB_METADATA_FILE
+    manifest = build_production_job_manifest(args_dict, simulator, output_directory)
+    validate_required_production_outputs(
+        manifest["files"],
+        manifest["configuration"]["simulation_software"],
+        output_directory,
+    )
+    check_manifest(ProductionManifest(path=manifest_path, data=manifest))
+    write_data_to_file(manifest, manifest_path)
+
+
 APPLICATION = ApplicationDefinition.for_module(
     __name__,
     arguments=(
@@ -280,25 +294,12 @@ def main():
     if app_context.args["save_file_lists"]:
         simulator.save_file_lists()
 
+    metadata_output_path = Path(app_context.args["output_path"])
     if app_context.args.get("grid_output_path"):
-        grid_output_path = Path(app_context.args["grid_output_path"])
-        simulator.pack_for_register(grid_output_path)
-        manifest_path = grid_output_path / _JOB_METADATA_FILE
-        manifest = build_production_job_manifest(
-            app_context.args,
-            simulator,
-            grid_output_path,
-        )
-        validate_required_production_outputs(
-            manifest["files"],
-            manifest["configuration"]["simulation_software"],
-            grid_output_path,
-        )
-        check_manifest(ProductionManifest(path=manifest_path, data=manifest))
-        write_data_to_file(
-            manifest,
-            manifest_path,
-        )
+        metadata_output_path = Path(app_context.args["grid_output_path"])
+        simulator.pack_for_register(metadata_output_path)
+
+    _write_job_metadata(app_context.args, simulator, metadata_output_path)
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/simulate_prod.py
+++ b/src/simtools/applications/simulate_prod.py
@@ -19,7 +19,12 @@ from simtools.production_configuration.job_grid_io import (
     job_grid_row_to_simulate_prod_args,
     read_job_grid,
 )
-from simtools.production_configuration.job_metadata import build_simulation_job_metadata
+from simtools.production_configuration.job_metadata import build_production_job_manifest
+from simtools.production_configuration.production_file_selection import (
+    ProductionManifest,
+    check_manifest,
+    validate_required_production_outputs,
+)
 from simtools.simulator import Simulator
 
 _JOB_METADATA_FILE = "simulate_prod_job_metadata.yml"
@@ -278,9 +283,21 @@ def main():
     if app_context.args.get("grid_output_path"):
         grid_output_path = Path(app_context.args["grid_output_path"])
         simulator.pack_for_register(grid_output_path)
+        manifest_path = grid_output_path / _JOB_METADATA_FILE
+        manifest = build_production_job_manifest(
+            app_context.args,
+            simulator,
+            grid_output_path,
+        )
+        validate_required_production_outputs(
+            manifest["files"],
+            manifest["configuration"]["simulation_software"],
+            grid_output_path,
+        )
+        check_manifest(ProductionManifest(path=manifest_path, data=manifest))
         write_data_to_file(
-            build_simulation_job_metadata(app_context.args, simulator),
-            grid_output_path / _JOB_METADATA_FILE,
+            manifest,
+            manifest_path,
         )
 
 

--- a/src/simtools/applications/write_production_metadata.py
+++ b/src/simtools/applications/write_production_metadata.py
@@ -2,28 +2,9 @@
 
 """Write or check production-job metadata manifests."""
 
-from pathlib import Path
-from types import SimpleNamespace
-
 from simtools.application.definition import ApplicationDefinition
 from simtools.configuration import arguments as cli
-from simtools.io.ascii_handler import write_data_to_file
-from simtools.model.model_utils import read_overwrite_model_parameter_dict
-from simtools.production_configuration.job_grid_io import (
-    job_grid_row_to_simulate_prod_args,
-    read_job_grid,
-)
-from simtools.production_configuration.job_metadata import (
-    build_production_job_manifest,
-    build_simulation_job_metadata,
-)
-from simtools.production_configuration.production_file_selection import (
-    SIMULATE_PROD_JOB_METADATA,
-    ProductionManifest,
-    check_manifest,
-    inventory_production_files,
-    validate_required_production_outputs,
-)
+from simtools.production_configuration.production_metadata import write_production_metadata
 
 _ARGUMENTS = (
     cli.ArgumentDefinition(
@@ -73,122 +54,7 @@ APPLICATION = ApplicationDefinition.for_module(
 def main():
     """Run the production metadata writer/checker."""
     app_context = APPLICATION.start()
-    production_path = Path(app_context.args["production_path"])
-    if app_context.args.get("check"):
-        _check_existing_manifests(production_path)
-    else:
-        _write_manifests(production_path, app_context.args["job_grid_file"], app_context.args)
-
-
-def _check_existing_manifests(production_path):
-    """Check all existing simulate_prod job manifests below a production path."""
-    job_directories = _job_directories(production_path)
-    if not job_directories:
-        raise FileNotFoundError(f"No production job directories found in {production_path}.")
-    missing = [
-        directory / SIMULATE_PROD_JOB_METADATA
-        for directory in job_directories
-        if not (directory / SIMULATE_PROD_JOB_METADATA).is_file()
-    ]
-    if missing:
-        raise FileNotFoundError(
-            "Missing production metadata manifest(s): " + ", ".join(map(str, missing))
-        )
-    for job_directory in job_directories:
-        check_manifest(job_directory / SIMULATE_PROD_JOB_METADATA)
-
-
-def _write_manifests(production_path, job_grid_file, args_dict):
-    """Write manifests for job directories described by a job grid."""
-    rows, metadata = read_job_grid(job_grid_file)
-    for index, row in enumerate(rows):
-        job_directory = production_path / f"job-{index + 1:06d}"
-        if not job_directory.is_dir():
-            raise FileNotFoundError(f"Production job directory not found: {job_directory}")
-        manifest_path = job_directory / SIMULATE_PROD_JOB_METADATA
-        if manifest_path.exists() and not args_dict.get("overwrite"):
-            raise FileExistsError(
-                f"Metadata manifest already exists: {manifest_path}. Use --overwrite to replace it."
-            )
-        resolved_args = job_grid_row_to_simulate_prod_args(row, metadata)
-        resolved_args.setdefault("simulation_software", "corsika_sim_telarray")
-        resolved_args.setdefault("eslope", -2.0)
-        _validate_resolved_configuration(resolved_args, job_grid_file)
-        overwrite_parameter_file = resolved_args.get("overwrite_model_parameters")
-        overwrite_parameters = (
-            read_overwrite_model_parameter_dict(overwrite_parameter_file)
-            if overwrite_parameter_file
-            else {}
-        )
-        array_model = SimpleNamespace(
-            model_version=resolved_args["model_version"],
-            overwrite_model_parameter_dict=overwrite_parameters,
-            array_elements={},
-            site_model=SimpleNamespace(parameters={}),
-        )
-        simulator = SimpleNamespace(
-            run_number=resolved_args["run_number"],
-            array_models=[array_model],
-            corsika_configurations=[],
-        )
-        file_inventory = inventory_production_files(job_directory)
-        validate_required_production_outputs(
-            file_inventory,
-            resolved_args["simulation_software"],
-            job_directory,
-        )
-        manifest = build_production_job_manifest(
-            resolved_args,
-            simulator,
-            job_directory,
-            file_inventory=file_inventory,
-            catalog_metadata=build_simulation_job_metadata(
-                resolved_args, simulator, include_sct=False
-            ),
-            atmosphere_configuration=_backfilled_atmosphere_configuration(resolved_args),
-        )
-        check_manifest(ProductionManifest(path=manifest_path, data=manifest))
-        write_data_to_file(manifest, manifest_path)
-
-
-def _backfilled_atmosphere_configuration(args_dict):
-    """Return only atmosphere values known from the authoritative job grid."""
-    threshold = args_dict.get("curved_atmosphere_min_zenith_angle")
-    return {"curved_atmosphere_min_zenith_angle": threshold} if threshold is not None else {}
-
-
-def _validate_resolved_configuration(args_dict, job_grid_file):
-    """Require fields needed to write truthful production metadata."""
-    missing = [
-        key
-        for key in (
-            "primary",
-            "azimuth_angle",
-            "zenith_angle",
-            "energy_range",
-            "core_scatter",
-            "view_cone",
-            "showers_per_run",
-            "model_version",
-            "array_layout_name",
-            "site",
-            "simulation_software",
-        )
-        if args_dict.get(key) is None
-    ]
-    if missing:
-        raise ValueError(
-            f"Job grid {job_grid_file} does not provide required resolved configuration "
-            "field(s): " + ", ".join(missing)
-        )
-
-
-def _job_directories(production_path):
-    """Return sorted direct production job directories."""
-    production_path = Path(production_path)
-    if not production_path.is_dir():
-        raise FileNotFoundError(f"Production path not found: {production_path}")
-    return sorted(path for path in production_path.glob("job-*") if path.is_dir())
+    write_production_metadata(app_context.args)
 
 
 if __name__ == "__main__":

--- a/src/simtools/applications/write_production_metadata.py
+++ b/src/simtools/applications/write_production_metadata.py
@@ -5,18 +5,18 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-import astropy.units as u
-
 from simtools.application.definition import ApplicationDefinition
 from simtools.configuration import arguments as cli
-from simtools.configuration import defaults
 from simtools.io.ascii_handler import write_data_to_file
 from simtools.model.model_utils import read_overwrite_model_parameter_dict
 from simtools.production_configuration.job_grid_io import (
     job_grid_row_to_simulate_prod_args,
     read_job_grid,
 )
-from simtools.production_configuration.job_metadata import build_production_job_manifest
+from simtools.production_configuration.job_metadata import (
+    build_production_job_manifest,
+    build_simulation_job_metadata,
+)
 from simtools.production_configuration.production_file_selection import (
     SIMULATE_PROD_JOB_METADATA,
     ProductionManifest,
@@ -112,10 +112,6 @@ def _write_manifests(production_path, job_grid_file, args_dict):
             )
         resolved_args = job_grid_row_to_simulate_prod_args(row, metadata)
         resolved_args.setdefault("simulation_software", "corsika_sim_telarray")
-        resolved_args.setdefault(
-            "curved_atmosphere_min_zenith_angle",
-            defaults.CURVED_ATMOSPHERE_MIN_ZENITH_ANGLE_DEG * u.deg,
-        )
         resolved_args.setdefault("eslope", -2.0)
         _validate_resolved_configuration(resolved_args, job_grid_file)
         overwrite_parameter_file = resolved_args.get("overwrite_model_parameters")
@@ -123,9 +119,6 @@ def _write_manifests(production_path, job_grid_file, args_dict):
             read_overwrite_model_parameter_dict(overwrite_parameter_file)
             if overwrite_parameter_file
             else {}
-        )
-        use_curved_atmosphere = (
-            resolved_args["zenith_angle"] >= resolved_args["curved_atmosphere_min_zenith_angle"]
         )
         array_model = SimpleNamespace(
             model_version=resolved_args["model_version"],
@@ -136,7 +129,7 @@ def _write_manifests(production_path, job_grid_file, args_dict):
         simulator = SimpleNamespace(
             run_number=resolved_args["run_number"],
             array_models=[array_model],
-            corsika_configurations=SimpleNamespace(use_curved_atmosphere=use_curved_atmosphere),
+            corsika_configurations=[],
         )
         file_inventory = inventory_production_files(job_directory)
         validate_required_production_outputs(
@@ -149,9 +142,19 @@ def _write_manifests(production_path, job_grid_file, args_dict):
             simulator,
             job_directory,
             file_inventory=file_inventory,
+            catalog_metadata=build_simulation_job_metadata(
+                resolved_args, simulator, include_sct=False
+            ),
+            atmosphere_configuration=_backfilled_atmosphere_configuration(resolved_args),
         )
         check_manifest(ProductionManifest(path=manifest_path, data=manifest))
         write_data_to_file(manifest, manifest_path)
+
+
+def _backfilled_atmosphere_configuration(args_dict):
+    """Return only atmosphere values known from the authoritative job grid."""
+    threshold = args_dict.get("curved_atmosphere_min_zenith_angle")
+    return {"curved_atmosphere_min_zenith_angle": threshold} if threshold is not None else {}
 
 
 def _validate_resolved_configuration(args_dict, job_grid_file):

--- a/src/simtools/applications/write_production_metadata.py
+++ b/src/simtools/applications/write_production_metadata.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python3
+
+"""Write or check production-job metadata manifests."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import astropy.units as u
+
+from simtools.application.definition import ApplicationDefinition
+from simtools.configuration import arguments as cli
+from simtools.configuration import defaults
+from simtools.io.ascii_handler import write_data_to_file
+from simtools.model.model_utils import read_overwrite_model_parameter_dict
+from simtools.production_configuration.job_grid_io import (
+    job_grid_row_to_simulate_prod_args,
+    read_job_grid,
+)
+from simtools.production_configuration.job_metadata import build_production_job_manifest
+from simtools.production_configuration.production_file_selection import (
+    SIMULATE_PROD_JOB_METADATA,
+    ProductionManifest,
+    check_manifest,
+    inventory_production_files,
+    validate_required_production_outputs,
+)
+
+_ARGUMENTS = (
+    cli.ArgumentDefinition(
+        "production_path",
+        help="Directory containing production job output directories.",
+        type=str,
+        required=True,
+    ),
+    cli.ArgumentDefinition(
+        "job_grid_file",
+        help="Authoritative job grid used to reconstruct resolved production configuration.",
+        type=str,
+        required=False,
+    ),
+    cli.ArgumentDefinition(
+        "check",
+        help="Validate existing manifests without writing files.",
+        action="store_true",
+        default=False,
+    ),
+    cli.ArgumentDefinition(
+        "overwrite",
+        help="Overwrite existing metadata manifests in write mode.",
+        action="store_true",
+        default=False,
+    ),
+)
+
+
+def _post_parse(args_dict, _config_sources, parser):
+    """Validate write/check mode arguments."""
+    if not args_dict.get("check") and not args_dict.get("job_grid_file"):
+        parser.error(
+            "'--job_grid_file' is required when writing production metadata; "
+            "filenames alone are not an authoritative configuration source."
+        )
+
+
+APPLICATION = ApplicationDefinition.for_module(
+    __name__,
+    arguments=_ARGUMENTS,
+    initialize_output=False,
+    post_parse=_post_parse,
+)
+
+
+def main():
+    """Run the production metadata writer/checker."""
+    app_context = APPLICATION.start()
+    production_path = Path(app_context.args["production_path"])
+    if app_context.args.get("check"):
+        _check_existing_manifests(production_path)
+    else:
+        _write_manifests(production_path, app_context.args["job_grid_file"], app_context.args)
+
+
+def _check_existing_manifests(production_path):
+    """Check all existing simulate_prod job manifests below a production path."""
+    job_directories = _job_directories(production_path)
+    if not job_directories:
+        raise FileNotFoundError(f"No production job directories found in {production_path}.")
+    missing = [
+        directory / SIMULATE_PROD_JOB_METADATA
+        for directory in job_directories
+        if not (directory / SIMULATE_PROD_JOB_METADATA).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "Missing production metadata manifest(s): " + ", ".join(map(str, missing))
+        )
+    for job_directory in job_directories:
+        check_manifest(job_directory / SIMULATE_PROD_JOB_METADATA)
+
+
+def _write_manifests(production_path, job_grid_file, args_dict):
+    """Write manifests for job directories described by a job grid."""
+    rows, metadata = read_job_grid(job_grid_file)
+    for index, row in enumerate(rows):
+        job_directory = production_path / f"job-{index + 1:06d}"
+        if not job_directory.is_dir():
+            raise FileNotFoundError(f"Production job directory not found: {job_directory}")
+        manifest_path = job_directory / SIMULATE_PROD_JOB_METADATA
+        if manifest_path.exists() and not args_dict.get("overwrite"):
+            raise FileExistsError(
+                f"Metadata manifest already exists: {manifest_path}. Use --overwrite to replace it."
+            )
+        resolved_args = job_grid_row_to_simulate_prod_args(row, metadata)
+        resolved_args.setdefault("simulation_software", "corsika_sim_telarray")
+        resolved_args.setdefault(
+            "curved_atmosphere_min_zenith_angle",
+            defaults.CURVED_ATMOSPHERE_MIN_ZENITH_ANGLE_DEG * u.deg,
+        )
+        resolved_args.setdefault("eslope", -2.0)
+        _validate_resolved_configuration(resolved_args, job_grid_file)
+        overwrite_parameter_file = resolved_args.get("overwrite_model_parameters")
+        overwrite_parameters = (
+            read_overwrite_model_parameter_dict(overwrite_parameter_file)
+            if overwrite_parameter_file
+            else {}
+        )
+        use_curved_atmosphere = (
+            resolved_args["zenith_angle"] >= resolved_args["curved_atmosphere_min_zenith_angle"]
+        )
+        array_model = SimpleNamespace(
+            model_version=resolved_args["model_version"],
+            overwrite_model_parameter_dict=overwrite_parameters,
+            array_elements={},
+            site_model=SimpleNamespace(parameters={}),
+        )
+        simulator = SimpleNamespace(
+            run_number=resolved_args["run_number"],
+            array_models=[array_model],
+            corsika_configurations=SimpleNamespace(use_curved_atmosphere=use_curved_atmosphere),
+        )
+        file_inventory = inventory_production_files(job_directory)
+        validate_required_production_outputs(
+            file_inventory,
+            resolved_args["simulation_software"],
+            job_directory,
+        )
+        manifest = build_production_job_manifest(
+            resolved_args,
+            simulator,
+            job_directory,
+            file_inventory=file_inventory,
+        )
+        check_manifest(ProductionManifest(path=manifest_path, data=manifest))
+        write_data_to_file(manifest, manifest_path)
+
+
+def _validate_resolved_configuration(args_dict, job_grid_file):
+    """Require fields needed to write truthful production metadata."""
+    missing = [
+        key
+        for key in (
+            "primary",
+            "azimuth_angle",
+            "zenith_angle",
+            "energy_range",
+            "core_scatter",
+            "view_cone",
+            "showers_per_run",
+            "model_version",
+            "array_layout_name",
+            "site",
+            "simulation_software",
+        )
+        if args_dict.get(key) is None
+    ]
+    if missing:
+        raise ValueError(
+            f"Job grid {job_grid_file} does not provide required resolved configuration "
+            "field(s): " + ", ".join(missing)
+        )
+
+
+def _job_directories(production_path):
+    """Return sorted direct production job directories."""
+    production_path = Path(production_path)
+    if not production_path.is_dir():
+        raise FileNotFoundError(f"Production path not found: {production_path}")
+    return sorted(path for path in production_path.glob("job-*") if path.is_dir())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simtools/applications/write_trigger_histograms.py
+++ b/src/simtools/applications/write_trigger_histograms.py
@@ -32,6 +32,31 @@ _ARGUMENTS = (
         exclusive_group_required=True,
     ),
     cli.ArgumentDefinition(
+        "production_path",
+        help="Directory containing production job metadata manifests to select input files from.",
+        type=str,
+        exclusive_group="event_data_input",
+        exclusive_group_required=True,
+    ),
+    cli.ArgumentDefinition(
+        "select",
+        help="Selection expression as dotted.path=value. Can be repeated.",
+        action="append",
+        default=[],
+    ),
+    cli.ArgumentDefinition(
+        "file_type",
+        help="Manifest file type selected from production metadata.",
+        type=str,
+        default="reduced_event_data",
+    ),
+    cli.ArgumentDefinition(
+        "require_complete_runs",
+        help="Fail when selected run numbers are not contiguous within each configuration group.",
+        action="store_true",
+        default=False,
+    ),
+    cli.ArgumentDefinition(
         "energy_bins_per_decade",
         help="Number of logarithmic energy bins per decade.",
         type=int,
@@ -87,7 +112,7 @@ def _post_parse(args_dict, config_sources, parser):
     if args_dict.get("minimum_triggered_telescopes", 2) < 1:
         parser.error("'--minimum_triggered_telescopes' must be at least 1.")
 
-    if args_dict.get("event_data_directory"):
+    if args_dict.get("event_data_directory") or args_dict.get("production_path"):
         explicit_output_path_sources = set().union(
             *(
                 config_sources.get(source, set())
@@ -95,10 +120,12 @@ def _post_parse(args_dict, config_sources, parser):
             )
         )
         if "output_path" not in explicit_output_path_sources:
-            parser.error("'--output_path' is required with '--event_data_directory'.")
+            parser.error("'--output_path' is required with directory or production metadata input.")
 
         if args_dict.get("output_file") and not args_dict.get("output_file_from_default"):
-            parser.error("'--output_file' cannot be used with '--event_data_directory'.")
+            parser.error(
+                "'--output_file' cannot be used with directory or production metadata input."
+            )
 
 
 APPLICATION = ApplicationDefinition.for_module(

--- a/src/simtools/applications/write_trigger_histograms.py
+++ b/src/simtools/applications/write_trigger_histograms.py
@@ -45,12 +45,6 @@ _ARGUMENTS = (
         default=[],
     ),
     cli.ArgumentDefinition(
-        "file_type",
-        help="Manifest file type selected from production metadata.",
-        type=str,
-        default="reduced_event_data",
-    ),
-    cli.ArgumentDefinition(
         "require_complete_runs",
         help="Fail when selected run numbers are not contiguous within each configuration group.",
         action="store_true",
@@ -127,6 +121,11 @@ def _post_parse(args_dict, config_sources, parser):
                 "'--output_file' cannot be used with directory or production metadata input."
             )
 
+    if not args_dict.get("production_path") and not (
+        args_dict.get("array_layout_name") or args_dict.get("array_element_list")
+    ):
+        parser.error("Use one of --array_layout_name or --array_element_list.")
+
 
 APPLICATION = ApplicationDefinition.for_module(
     __name__,
@@ -136,7 +135,7 @@ APPLICATION = ApplicationDefinition.for_module(
         cli.MODEL_VERSION,
         cli.OVERWRITE_MODEL_PARAMETERS,
         cli.SITE,
-        *cli.layout_selection_arguments(),
+        *cli.layout_selection_arguments(required=False),
         *cli.OUTPUT_PATH_ARGUMENTS,
         *cli.OUTPUT_ARGUMENTS,
     ),

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -403,7 +403,7 @@ class Configurator:
             return boolean_tokens
 
         if isinstance(value, list):
-            return [option, *map(str, value)]
+            return [option, *map(str, value)] if value else []
 
         if Configurator._is_scalar_config_value(value):
             return [option, *Configurator._normalize_scalar_config_value(key, value, parser=parser)]

--- a/src/simtools/configuration/configurator.py
+++ b/src/simtools/configuration/configurator.py
@@ -403,7 +403,9 @@ class Configurator:
             return boolean_tokens
 
         if isinstance(value, list):
-            return [option, *map(str, value)] if value else []
+            if value:
+                return [option, *map(str, value)]
+            return [option] if action is not None and action.nargs == "*" else []
 
         if Configurator._is_scalar_config_value(value):
             return [option, *Configurator._normalize_scalar_config_value(key, value, parser=parser)]

--- a/src/simtools/production_configuration/job_grid_io.py
+++ b/src/simtools/production_configuration/job_grid_io.py
@@ -422,11 +422,12 @@ def build_simulate_prod_job_specs(args_dict, rows, parser, metadata=None):
 def _build_simulate_prod_job_spec(args_dict, row, index, output_root, parser, metadata):
     """Build one local command job for a production-grid row."""
     job_args = _job_args_for_simulate_prod(args_dict, row, parser, metadata)
-    output_path = output_root / f"job-{index:06d}"
+    job_name = f"job-{index + 1:06d}"
+    output_path = output_root / job_name
     job_args["output_path"] = str(output_path)
     mount_paths = [output_path]
     output_paths = [output_path]
-    _add_grid_output_path(job_args, index, mount_paths, output_paths)
+    _add_grid_output_path(job_args, job_name, mount_paths, output_paths)
     _add_scan_label(job_args, row)
     _normalize_simulate_prod_paths(job_args, args_dict)
     _add_simulate_prod_input_mount_paths(job_args, mount_paths)
@@ -443,7 +444,7 @@ def _build_simulate_prod_job_spec(args_dict, row, index, output_root, parser, me
     ]
     command.extend(Configurator.arglist_from_dict(job_args, parser=parser))
     return JobSpec(
-        f"job-{index:06d}",
+        job_name,
         index,
         command=tuple(command),
         mount_paths=tuple(mount_paths),
@@ -467,11 +468,11 @@ def _job_args_for_simulate_prod(args_dict, row, parser, metadata):
     }
 
 
-def _add_grid_output_path(job_args, index, mount_paths, output_paths):
+def _add_grid_output_path(job_args, job_name, mount_paths, output_paths):
     """Add a per-job grid output path and its expected output mount."""
     if not job_args.get("grid_output_path"):
         return
-    grid_output_path = Path(job_args["grid_output_path"]) / f"job-{index:06d}"
+    grid_output_path = Path(job_args["grid_output_path"]) / job_name
     job_args["grid_output_path"] = str(grid_output_path)
     mount_paths.append(grid_output_path)
     output_paths.append(grid_output_path)

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -177,14 +177,18 @@ def _add_optional_configuration_value(configuration, key, value):
 
 def _build_output_file_inventory(simulator, output_directory):
     """Return output files grouped by manifest file type."""
-    output_directory = Path(output_directory)
+    output_directory = Path(output_directory).resolve()
     inventory = {}
     for simulator_file_type, manifest_file_type in _FILE_TYPE_ALIASES.items():
         files = []
         for file_path in _ensure_list(simulator.get_files(file_type=simulator_file_type)):
-            packaged_file = output_directory / Path(file_path).name
-            if packaged_file.exists():
-                files.append(packaged_file.relative_to(output_directory).as_posix())
+            file_path = Path(file_path).resolve()
+            try:
+                relative_path = file_path.relative_to(output_directory)
+            except ValueError:
+                relative_path = Path(file_path.name)
+            if (output_directory / relative_path).exists():
+                files.append(relative_path.as_posix())
         if files:
             inventory[manifest_file_type] = sorted(files)
     return inventory

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -56,7 +56,7 @@ def build_simulation_job_metadata(args_dict, simulator, include_sct=True):
         "view_cone_min": round(float(view_cone_min.to_value(u.deg)), 2),
         "view_cone_max": round(float(view_cone_max.to_value(u.deg)), 2),
         "runNumber": int(simulator.run_number),
-        "model_version": str(args_dict["model_version"]),
+        "model_version": _scalar_or_list(args_dict["model_version"]),
     }
     if include_sct:
         metadata["sct"] = str(_has_sct(simulator.array_models))
@@ -128,7 +128,7 @@ def _build_selection_configuration(args_dict, simulator, atmosphere_configuratio
         "primary": _primary_name(args_dict, simulator),
         "site": args_dict["site"],
         "array_layout_name": args_dict["array_layout_name"],
-        "model_version": str(args_dict["model_version"]),
+        "model_version": _scalar_or_list(args_dict["model_version"]),
         "simulation_software": args_dict["simulation_software"],
         "azimuth_angle": args_dict["azimuth_angle"],
         "zenith_angle": args_dict["zenith_angle"],
@@ -150,6 +150,16 @@ def _build_selection_configuration(args_dict, simulator, atmosphere_configuratio
     }
     _add_optional_configuration_value(configuration, "dec", args_dict.get("dec"))
     _add_optional_configuration_value(configuration, "ha", args_dict.get("ha"))
+    for key in (
+        "corsika_seeds",
+        "event_number_first_shower",
+        "correct_for_b_field_alignment",
+        "sim_telarray_instrument_seed",
+        "sim_telarray_random_instrument_instances",
+        "sim_telarray_seed",
+        "sim_telarray_seed_file",
+    ):
+        _add_optional_configuration_value(configuration, key, args_dict.get(key))
     return {key: value for key, value in configuration.items() if value is not None}
 
 
@@ -222,6 +232,13 @@ def _primary_name(args_dict, simulator):
             return str(primary_name).lower()
 
     raise ValueError("Unable to determine the primary particle for production metadata.")
+
+
+def _scalar_or_list(value):
+    """Return model-version values without converting lists to pseudo-scalars."""
+    if isinstance(value, list | tuple):
+        return [str(item) for item in value]
+    return str(value)
 
 
 def _showers_per_run(args_dict, simulator):

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -19,6 +19,19 @@ _FILE_TYPE_ALIASES = {
     "corsika_output": "corsika",
     "corsika_log": "corsika_log",
 }
+REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS = (
+    "primary",
+    "azimuth_angle",
+    "zenith_angle",
+    "energy_range",
+    "core_scatter",
+    "view_cone",
+    "showers_per_run",
+    "model_version",
+    "array_layout_name",
+    "site",
+    "simulation_software",
+)
 
 
 def build_simulation_job_metadata(args_dict, simulator, include_sct=True):

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -7,7 +7,7 @@ from astropy import units as u
 
 from simtools.production_configuration.production_file_selection import (
     get_manifest_schema_metadata,
-    get_simulation_file_type_aliases,
+    inventory_production_files,
 )
 from simtools.utils import names
 from simtools.utils.geometry import geographic_to_corsika_azimuth
@@ -50,7 +50,7 @@ def build_simulation_job_metadata(args_dict, simulator, include_sct=True):
     metadata = {
         "array_layout": args_dict["array_layout_name"],
         "site": CATALOG_SITE_NAMES[args_dict["site"]],
-        "particle": args_dict["primary"].lower(),
+        "particle": _primary_name(args_dict, simulator),
         "phiP": round(geographic_to_corsika_azimuth(azimuth_angle), 2),
         "thetaP": round(float(args_dict["zenith_angle"].to_value(u.deg)), 2),
         "view_cone_min": round(float(view_cone_min.to_value(u.deg)), 2),
@@ -110,7 +110,11 @@ def build_production_job_manifest(
             simulator,
             atmosphere_configuration=atmosphere_configuration,
         ),
-        "files": file_inventory or _build_output_file_inventory(simulator, output_directory),
+        "files": (
+            file_inventory
+            if file_inventory is not None
+            else inventory_production_files(output_directory)
+        ),
     }
 
 
@@ -121,7 +125,7 @@ def _build_selection_configuration(args_dict, simulator, atmosphere_configuratio
     cores_per_shower, core_scatter_max = args_dict["core_scatter"]
     configuration = {
         "run_number": int(simulator.run_number),
-        "primary": str(args_dict["primary"]).lower(),
+        "primary": _primary_name(args_dict, simulator),
         "site": args_dict["site"],
         "array_layout_name": args_dict["array_layout_name"],
         "model_version": str(args_dict["model_version"]),
@@ -134,7 +138,7 @@ def _build_selection_configuration(args_dict, simulator, atmosphere_configuratio
         "view_cone_max": view_cone_max,
         "cores_per_shower": int(cores_per_shower),
         "core_scatter_max": core_scatter_max,
-        "showers_per_run": args_dict.get("showers_per_run"),
+        "showers_per_run": _showers_per_run(args_dict, simulator),
         "eslope": args_dict.get("eslope"),
         "corsika_he_interaction": args_dict.get("corsika_he_interaction"),
         "corsika_le_interaction": args_dict.get("corsika_le_interaction"),
@@ -203,32 +207,40 @@ def _add_optional_configuration_value(configuration, key, value):
         configuration[key] = value
 
 
-def _build_output_file_inventory(simulator, output_directory):
-    """Return output files grouped by manifest file type."""
-    output_directory = Path(output_directory).resolve()
-    inventory = {}
-    for simulator_file_type, manifest_file_type in get_simulation_file_type_aliases().items():
-        files = []
-        for file_path in _ensure_list(simulator.get_files(file_type=simulator_file_type)):
-            file_path = Path(file_path).resolve()
-            try:
-                relative_path = file_path.relative_to(output_directory)
-            except ValueError:
-                relative_path = Path(file_path.name)
-            if (output_directory / relative_path).exists():
-                files.append(relative_path.as_posix())
-        if files:
-            inventory[manifest_file_type] = sorted(files)
-    return inventory
+def _primary_name(args_dict, simulator):
+    """Return the resolved primary name, including sim_telarray-only inputs."""
+    if args_dict.get("primary") is not None:
+        return str(args_dict["primary"]).lower()
+
+    corsika_configurations = getattr(simulator, "corsika_configurations", [])
+    if not isinstance(corsika_configurations, list):
+        corsika_configurations = [corsika_configurations]
+    for configuration in corsika_configurations:
+        primary_particle = getattr(configuration, "primary_particle", None)
+        primary_name = getattr(primary_particle, "name", None)
+        if primary_name:
+            return str(primary_name).lower()
+
+    raise ValueError("Unable to determine the primary particle for production metadata.")
 
 
-def _ensure_list(value):
-    """Return value as list, preserving empty values."""
-    if value is None:
-        return []
-    if isinstance(value, list | tuple | set):
-        return list(value)
-    return [value]
+def _showers_per_run(args_dict, simulator):
+    """Return the configured shower count, including for sim_telarray-only inputs."""
+    if args_dict.get("showers_per_run") is not None:
+        return args_dict["showers_per_run"]
+
+    corsika_configurations = getattr(simulator, "corsika_configurations", [])
+    if not isinstance(corsika_configurations, list):
+        corsika_configurations = [corsika_configurations]
+    shower_counts = {
+        configuration.shower_events
+        for configuration in corsika_configurations
+        if configuration is not None and getattr(configuration, "shower_events", None) is not None
+    }
+    if len(shower_counts) == 1:
+        return shower_counts.pop()
+
+    raise ValueError("Unable to determine the number of showers for production metadata.")
 
 
 def _has_sct(array_models):

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -1,10 +1,23 @@
-"""Build catalog metadata for completed simulation-production jobs."""
+"""Build metadata for completed simulation-production jobs."""
+
+from copy import deepcopy
+from pathlib import Path
 
 from astropy import units as u
 
 from simtools.utils import names
 
 CATALOG_SITE_NAMES = {"North": "LaPalma", "South": "Paranal"}
+PRODUCTION_JOB_MANIFEST_VERSION = "1.0.0"
+
+_FILE_TYPE_ALIASES = {
+    "sim_telarray_output": "sim_telarray",
+    "sim_telarray_event_data": "reduced_event_data",
+    "sim_telarray_log": "sim_telarray_log",
+    "sim_telarray_histogram": "sim_telarray_histogram",
+    "corsika_output": "corsika",
+    "corsika_log": "corsika_log",
+}
 
 
 def build_simulation_job_metadata(args_dict, simulator):
@@ -38,6 +51,150 @@ def build_simulation_job_metadata(args_dict, simulator):
     _add_optional_coordinate(metadata, "dec", args_dict.get("dec"))
     _add_optional_coordinate(metadata, "ha", args_dict.get("ha"))
     return metadata
+
+
+def build_production_job_manifest(args_dict, simulator, output_directory, file_inventory=None):
+    """Build a versioned production-job manifest from resolved simulation output.
+
+    Parameters
+    ----------
+    args_dict : dict
+        Resolved ``simulate_prod`` application arguments.
+    simulator : simtools.simulator.Simulator
+        Simulator for the completed and validated run.
+    output_directory : str or pathlib.Path
+        Directory containing the packaged output files.
+    file_inventory : dict, optional
+        Precomputed manifest file inventory. Used when backfilling existing jobs.
+
+    Returns
+    -------
+    dict
+        Versioned production-job manifest used for downstream file selection.
+    """
+    catalog_metadata = build_simulation_job_metadata(args_dict, simulator)
+    return {
+        "schema_name": "simulate_prod_job_metadata",
+        "schema_version": PRODUCTION_JOB_MANIFEST_VERSION,
+        "product_type": "simulate_prod_job",
+        "production_id": args_dict.get("production_id") or args_dict.get("label"),
+        "job_id": Path(output_directory).name,
+        "status": "complete",
+        "catalog_metadata": catalog_metadata,
+        "configuration": _build_selection_configuration(args_dict, simulator),
+        "files": file_inventory or _build_output_file_inventory(simulator, output_directory),
+    }
+
+
+def _build_selection_configuration(args_dict, simulator):
+    """Return stable simulation configuration fields used for selection and grouping."""
+    energy_min, energy_max = args_dict["energy_range"]
+    view_cone_min, view_cone_max = args_dict["view_cone"]
+    cores_per_shower, core_scatter_max = args_dict["core_scatter"]
+    configuration = {
+        "run_number": int(simulator.run_number),
+        "primary": str(args_dict["primary"]).lower(),
+        "site": args_dict["site"],
+        "array_layout_name": args_dict["array_layout_name"],
+        "model_version": str(args_dict["model_version"]),
+        "simulation_software": args_dict["simulation_software"],
+        "azimuth_angle": args_dict["azimuth_angle"],
+        "zenith_angle": args_dict["zenith_angle"],
+        "energy_min": energy_min,
+        "energy_max": energy_max,
+        "view_cone_min": view_cone_min,
+        "view_cone_max": view_cone_max,
+        "cores_per_shower": int(cores_per_shower),
+        "core_scatter_max": core_scatter_max,
+        "showers_per_run": args_dict.get("showers_per_run"),
+        "eslope": args_dict.get("eslope"),
+        "corsika_he_interaction": args_dict.get("corsika_he_interaction"),
+        "corsika_le_interaction": args_dict.get("corsika_le_interaction"),
+        "corsika_hadronic_transition_energy": args_dict.get("corsika_hadronic_transition_energy"),
+        "model_parameter_overrides": _resolved_model_parameter_overrides(simulator),
+        "atmosphere": _resolved_atmosphere_configuration(args_dict, simulator),
+    }
+    _add_optional_configuration_value(configuration, "dec", args_dict.get("dec"))
+    _add_optional_configuration_value(configuration, "ha", args_dict.get("ha"))
+    return {key: value for key, value in configuration.items() if value is not None}
+
+
+def _resolved_model_parameter_overrides(simulator):
+    """Return resolved model-parameter overrides without source file paths."""
+    overrides_by_version = {
+        str(model.model_version): deepcopy(model.overwrite_model_parameter_dict)
+        for model in simulator.array_models
+        if getattr(model, "overwrite_model_parameter_dict", None)
+    }
+    if not overrides_by_version:
+        return {}
+    if len(overrides_by_version) == 1:
+        return next(iter(overrides_by_version.values()))
+    return overrides_by_version
+
+
+def _resolved_atmosphere_configuration(args_dict, simulator):
+    """Return resolved atmosphere settings used by the simulation."""
+    atmosphere = {}
+    threshold = args_dict.get("curved_atmosphere_min_zenith_angle")
+    if threshold is not None:
+        atmosphere["curved_atmosphere_min_zenith_angle"] = threshold
+
+    corsika_configurations = getattr(simulator, "corsika_configurations", [])
+    if not isinstance(corsika_configurations, list):
+        corsika_configurations = [corsika_configurations]
+    curved_values = {
+        bool(configuration.use_curved_atmosphere)
+        for configuration in corsika_configurations
+        if configuration is not None
+    }
+    if len(curved_values) == 1:
+        atmosphere["use_curved_atmosphere"] = curved_values.pop()
+
+    site_parameters = {}
+    for model in simulator.array_models:
+        site_model = getattr(model, "site_model", None)
+        parameters = getattr(site_model, "parameters", {})
+        for name in (
+            "atmospheric_profile",
+            "atmospheric_transmission",
+            "reference_point_altitude",
+        ):
+            if name in parameters:
+                site_parameters[name] = deepcopy(parameters[name].get("value"))
+    if site_parameters:
+        atmosphere["site_parameters"] = site_parameters
+    return atmosphere
+
+
+def _add_optional_configuration_value(configuration, key, value):
+    """Add an optional resolved configuration value."""
+    if value is not None:
+        configuration[key] = value
+
+
+def _build_output_file_inventory(simulator, output_directory):
+    """Return output files grouped by manifest file type."""
+    output_directory = Path(output_directory)
+    inventory = {}
+    for simulator_file_type, manifest_file_type in _FILE_TYPE_ALIASES.items():
+        files = []
+        for file_path in _ensure_list(simulator.get_files(file_type=simulator_file_type)):
+            packaged_file = output_directory / Path(file_path).name
+            if packaged_file.exists():
+                files.append(packaged_file.relative_to(output_directory).as_posix())
+        if files:
+            inventory[manifest_file_type] = sorted(files)
+    return inventory
+
+
+def _ensure_list(value):
+    """Return value as list, preserving empty values."""
+    if value is None:
+        return []
+    if isinstance(value, list | tuple | set):
+        return list(value)
+    return [value]
 
 
 def _has_sct(array_models):

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -5,20 +5,14 @@ from pathlib import Path
 
 from astropy import units as u
 
+from simtools.production_configuration.production_file_selection import (
+    get_manifest_schema_metadata,
+    get_simulation_file_type_aliases,
+)
 from simtools.utils import names
 from simtools.utils.geometry import geographic_to_corsika_azimuth
 
 CATALOG_SITE_NAMES = {"North": "LaPalma", "South": "Paranal"}
-PRODUCTION_JOB_MANIFEST_VERSION = "1.0.0"
-
-_FILE_TYPE_ALIASES = {
-    "sim_telarray_output": "sim_telarray",
-    "sim_telarray_event_data": "reduced_event_data",
-    "sim_telarray_log": "sim_telarray_log",
-    "sim_telarray_histogram": "sim_telarray_histogram",
-    "corsika_output": "corsika",
-    "corsika_log": "corsika_log",
-}
 REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS = (
     "primary",
     "azimuth_angle",
@@ -103,9 +97,9 @@ def build_production_job_manifest(
     """
     if catalog_metadata is None:
         catalog_metadata = build_simulation_job_metadata(args_dict, simulator)
+    manifest_schema = get_manifest_schema_metadata("simulate_prod_job")
     return {
-        "schema_name": "simulate_prod_job_metadata",
-        "schema_version": PRODUCTION_JOB_MANIFEST_VERSION,
+        **manifest_schema,
         "product_type": "simulate_prod_job",
         "production_id": args_dict.get("production_id") or args_dict.get("label"),
         "job_id": Path(output_directory).name,
@@ -213,7 +207,7 @@ def _build_output_file_inventory(simulator, output_directory):
     """Return output files grouped by manifest file type."""
     output_directory = Path(output_directory).resolve()
     inventory = {}
-    for simulator_file_type, manifest_file_type in _FILE_TYPE_ALIASES.items():
+    for simulator_file_type, manifest_file_type in get_simulation_file_type_aliases().items():
         files = []
         for file_path in _ensure_list(simulator.get_files(file_type=simulator_file_type)):
             file_path = Path(file_path).resolve()

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -21,7 +21,7 @@ _FILE_TYPE_ALIASES = {
 }
 
 
-def build_simulation_job_metadata(args_dict, simulator):
+def build_simulation_job_metadata(args_dict, simulator, include_sct=True):
     """Build DIRAC catalog metadata from resolved simulation configuration.
 
     Parameters
@@ -30,6 +30,8 @@ def build_simulation_job_metadata(args_dict, simulator):
         Resolved ``simulate_prod`` application arguments.
     simulator : simtools.simulator.Simulator
         Simulator for the completed run.
+    include_sct : bool, optional
+        Include the SCT-presence catalog field when the resolved array elements are available.
 
     Returns
     -------
@@ -44,18 +46,26 @@ def build_simulation_job_metadata(args_dict, simulator):
         "particle": args_dict["primary"].lower(),
         "phiP": round(geographic_to_corsika_azimuth(azimuth_angle), 2),
         "thetaP": round(float(args_dict["zenith_angle"].to_value(u.deg)), 2),
-        "sct": str(_has_sct(simulator.array_models)),
         "view_cone_min": round(float(view_cone_min.to_value(u.deg)), 2),
         "view_cone_max": round(float(view_cone_max.to_value(u.deg)), 2),
         "runNumber": int(simulator.run_number),
         "model_version": str(args_dict["model_version"]),
     }
+    if include_sct:
+        metadata["sct"] = str(_has_sct(simulator.array_models))
     _add_optional_coordinate(metadata, "dec", args_dict.get("dec"))
     _add_optional_coordinate(metadata, "ha", args_dict.get("ha"))
     return metadata
 
 
-def build_production_job_manifest(args_dict, simulator, output_directory, file_inventory=None):
+def build_production_job_manifest(
+    args_dict,
+    simulator,
+    output_directory,
+    file_inventory=None,
+    catalog_metadata=None,
+    atmosphere_configuration=None,
+):
     """Build a versioned production-job manifest from resolved simulation output.
 
     Parameters
@@ -68,13 +78,18 @@ def build_production_job_manifest(args_dict, simulator, output_directory, file_i
         Directory containing the packaged output files.
     file_inventory : dict, optional
         Precomputed manifest file inventory. Used when backfilling existing jobs.
+    catalog_metadata : dict, optional
+        Catalog metadata to store instead of deriving it from the simulator.
+    atmosphere_configuration : dict, optional
+        Resolved atmosphere configuration to store instead of deriving it from the simulator.
 
     Returns
     -------
     dict
         Versioned production-job manifest used for downstream file selection.
     """
-    catalog_metadata = build_simulation_job_metadata(args_dict, simulator)
+    if catalog_metadata is None:
+        catalog_metadata = build_simulation_job_metadata(args_dict, simulator)
     return {
         "schema_name": "simulate_prod_job_metadata",
         "schema_version": PRODUCTION_JOB_MANIFEST_VERSION,
@@ -83,12 +98,16 @@ def build_production_job_manifest(args_dict, simulator, output_directory, file_i
         "job_id": Path(output_directory).name,
         "status": "complete",
         "catalog_metadata": catalog_metadata,
-        "configuration": _build_selection_configuration(args_dict, simulator),
+        "configuration": _build_selection_configuration(
+            args_dict,
+            simulator,
+            atmosphere_configuration=atmosphere_configuration,
+        ),
         "files": file_inventory or _build_output_file_inventory(simulator, output_directory),
     }
 
 
-def _build_selection_configuration(args_dict, simulator):
+def _build_selection_configuration(args_dict, simulator, atmosphere_configuration=None):
     """Return stable simulation configuration fields used for selection and grouping."""
     energy_min, energy_max = args_dict["energy_range"]
     view_cone_min, view_cone_max = args_dict["view_cone"]
@@ -114,7 +133,9 @@ def _build_selection_configuration(args_dict, simulator):
         "corsika_le_interaction": args_dict.get("corsika_le_interaction"),
         "corsika_hadronic_transition_energy": args_dict.get("corsika_hadronic_transition_energy"),
         "model_parameter_overrides": _resolved_model_parameter_overrides(simulator),
-        "atmosphere": _resolved_atmosphere_configuration(args_dict, simulator),
+        "atmosphere": atmosphere_configuration
+        if atmosphere_configuration is not None
+        else _resolved_atmosphere_configuration(args_dict, simulator),
     }
     _add_optional_configuration_value(configuration, "dec", args_dict.get("dec"))
     _add_optional_configuration_value(configuration, "ha", args_dict.get("ha"))

--- a/src/simtools/production_configuration/job_metadata.py
+++ b/src/simtools/production_configuration/job_metadata.py
@@ -8,7 +8,7 @@ from astropy import units as u
 from simtools.utils import names
 from simtools.utils.geometry import geographic_to_corsika_azimuth
 
-CATALOG_SITE_NAMES = {"North": "North", "South": "South"}
+CATALOG_SITE_NAMES = {"North": "LaPalma", "South": "Paranal"}
 PRODUCTION_JOB_MANIFEST_VERSION = "1.0.0"
 
 _FILE_TYPE_ALIASES = {

--- a/src/simtools/production_configuration/production_comparison.py
+++ b/src/simtools/production_configuration/production_comparison.py
@@ -1,0 +1,186 @@
+"""Compare trigger-histogram products from simulation productions."""
+
+from pathlib import Path
+
+from simtools.constants import SCHEMA_PATH
+from simtools.data_model.metadata_collector import MetadataCollector
+from simtools.production_configuration.production_file_selection import (
+    check_manifest,
+    discover_product_manifests,
+    filter_manifests,
+    normalize_for_comparison,
+    stable_configuration_hash,
+)
+from simtools.sim_events.production_comparison import (
+    ProductionDescriptor,
+    collect_production_metrics,
+    parse_production_arguments,
+)
+from simtools.visualization import plot_event_level_production_comparison
+
+
+def write_production_comparison(args_dict, output_directory):
+    """Compare selected trigger-histogram productions and write their statistics.
+
+    Parameters
+    ----------
+    args_dict : dict
+        Application arguments, including either explicit production descriptors or metadata paths.
+    output_directory : pathlib.Path
+        Directory in which comparison products are written.
+    """
+    array_layout_names = args_dict.get("array_layout_name") or [None]
+    if args_dict.get("baseline_path"):
+        descriptor_pairs = _production_descriptor_pairs_from_metadata(args_dict)
+        for pairing_key, production_descriptors in descriptor_pairs:
+            pair_output_directory = (
+                output_directory / f"comparison-{stable_configuration_hash(pairing_key)}"
+            )
+            _write_array_layout_comparisons(
+                production_descriptors,
+                args_dict,
+                pair_output_directory,
+                array_layout_names,
+            )
+        return
+
+    production_descriptors = parse_production_arguments(args_dict["production"])
+    _write_array_layout_comparisons(
+        production_descriptors,
+        args_dict,
+        output_directory,
+        array_layout_names,
+    )
+
+
+def _write_array_layout_comparisons(
+    production_descriptors, args_dict, output_directory, array_layout_names
+):
+    """Write comparison products for all selected array layouts."""
+    for array_layout_name in array_layout_names:
+        _compare_array_layout(
+            production_descriptors,
+            args_dict,
+            array_layout_name,
+            output_directory,
+        )
+
+
+def _compare_array_layout(production_descriptors, args_dict, array_layout_name, output_directory):
+    """Compare one selected array layout and write its statistics metadata."""
+    metrics_per_production = collect_production_metrics(
+        production_descriptors,
+        array_names=array_layout_name,
+    )
+    comparison_statistics_file = plot_event_level_production_comparison.plot(
+        metrics_per_production,
+        output_path=output_directory,
+        array_layout_name=array_layout_name,
+        figure_format=args_dict.get("figure_format"),
+    )
+    metadata_args = dict(args_dict)
+    metadata_args.update(
+        {
+            "array_layout_name": array_layout_name,
+            "output_file": str(comparison_statistics_file),
+            "output_file_format": "JSON",
+            "metadata_product_data_name": "production_comparison_statistics",
+            "schema_file": str(SCHEMA_PATH / "production_comparison_statistics.schema.yml"),
+        }
+    )
+    MetadataCollector.dump(metadata_args, comparison_statistics_file)
+
+
+def _production_descriptor_pairs_from_metadata(args_dict):
+    """Build one descriptor pair per matched trigger-histogram configuration."""
+    baseline = _selected_trigger_histogram_manifests(
+        args_dict["baseline_path"], args_dict.get("select")
+    )
+    candidate = _selected_trigger_histogram_manifests(
+        args_dict["candidate_path"], args_dict.get("select")
+    )
+    compare_by = {field.removeprefix("configuration.") for field in args_dict.get("compare_by", [])}
+    baseline_by_key = _unique_manifests_by_pairing_key(baseline, compare_by, "baseline")
+    candidate_by_key = _unique_manifests_by_pairing_key(candidate, compare_by, "candidate")
+
+    missing_candidates = sorted(set(baseline_by_key) - set(candidate_by_key))
+    missing_baselines = sorted(set(candidate_by_key) - set(baseline_by_key))
+    if missing_candidates or missing_baselines:
+        raise ValueError(
+            "Trigger-histogram metadata pairing failed: "
+            f"missing candidates={len(missing_candidates)}, "
+            f"missing baselines={len(missing_baselines)}."
+        )
+
+    return [
+        (
+            key,
+            [
+                ProductionDescriptor(
+                    label="baseline",
+                    trigger_histogram_files=[
+                        str(_single_trigger_histogram_file(baseline_by_key[key]))
+                    ],
+                ),
+                ProductionDescriptor(
+                    label="candidate",
+                    trigger_histogram_files=[
+                        str(_single_trigger_histogram_file(candidate_by_key[key]))
+                    ],
+                ),
+            ],
+        )
+        for key in sorted(baseline_by_key, key=str)
+    ]
+
+
+def _selected_trigger_histogram_manifests(path, selections):
+    """Return checked trigger-histogram manifests matching selections."""
+    manifests = discover_product_manifests(path, "trigger_histograms")
+    selected = filter_manifests(manifests, selections or [])
+    if not selected:
+        raise ValueError(f"No trigger-histogram metadata files matched in {path}.")
+    for manifest in selected:
+        check_manifest(manifest)
+    return selected
+
+
+def _unique_manifests_by_pairing_key(manifests, compare_by, label):
+    """Return manifests keyed by comparable simulation configuration."""
+    keyed = {}
+    for manifest in manifests:
+        key = _pairing_key(manifest.data, compare_by)
+        if key in keyed:
+            raise ValueError(
+                f"More than one {label} trigger-histogram file matches configuration {key}."
+            )
+        keyed[key] = manifest
+    return keyed
+
+
+def _pairing_key(manifest, compare_by):
+    """Return normalized configuration fields used for baseline/candidate pairing."""
+    configuration = manifest.get("configuration", {})
+    paired_configuration = {
+        key: value for key, value in configuration.items() if key not in compare_by
+    }
+    return normalize_for_comparison(
+        {
+            "configuration": paired_configuration,
+            "histogram_settings": manifest.get("histogram_settings", {}),
+            "array_selection": manifest.get("array_selection", []),
+        }
+    )
+
+
+def _single_trigger_histogram_file(manifest):
+    """Return the single trigger-histogram file referenced by a manifest."""
+    files = manifest.data.get("files", {}).get("trigger_histograms", [])
+    if len(files) != 1:
+        raise ValueError(
+            f"Expected exactly one trigger-histogram file in {manifest.path}, found {len(files)}."
+        )
+    path = Path(files[0])
+    if path.is_absolute():
+        return path
+    return manifest.directory / path

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -1,0 +1,539 @@
+"""Discover, filter, group, and validate production metadata manifests."""
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from math import isclose
+from pathlib import Path
+
+import astropy.units as u
+
+from simtools.constants import SCHEMA_PATH
+from simtools.data_model import schema
+from simtools.io import ascii_handler
+from simtools.simtel.simtel_io_metadata import read_sim_telarray_metadata
+
+SIMULATE_PROD_JOB_METADATA = "simulate_prod_job_metadata.yml"
+SUPPORTED_SCHEMA_VERSIONS = {"1.0.0"}
+
+_RUN_NUMBER_PATTERN = re.compile(r"(?:^|_)run0*([0-9]+)(?:_|\.|$)")
+_FILE_TYPE_SUFFIXES = {
+    "reduced_event_data": (".reduced_event_data.hdf5",),
+    "sim_telarray": (".simtel.zst", ".simtel.gz", ".simtel"),
+    "sim_telarray_log": (".simtel.log.gz", ".simtel.log"),
+    "sim_telarray_histogram": (".histogram.hdf5", ".histogram.gz", ".histogram"),
+    "corsika": (".corsika.zst", ".corsika.gz", ".corsika"),
+    "corsika_log": (".corsika.log.gz", ".corsika.log"),
+    "trigger_histograms": (".trigger_histograms.hdf5",),
+}
+_MANIFEST_SCHEMAS = {
+    "simulate_prod_job": "simulate_prod_job_metadata.schema.yml",
+    "trigger_histograms": "trigger_histograms_metadata.schema.yml",
+}
+_GROUPING_EXCLUDE_KEYS = {
+    "run_number",
+    "random_seed",
+    "corsika_seeds",
+    "sim_telarray_seed",
+    "sim_telarray_seed_file",
+    "sim_telarray_instrument_seed",
+    "sim_telarray_random_instrument_instances",
+    "output_path",
+    "grid_output_path",
+}
+_SIMTEL_METADATA_MANIFEST_KEYS = {
+    "primary": ("primary", "primary_particle", "particle"),
+    "azimuth_angle": ("azimuth", "azimuth_angle"),
+    "zenith_angle": ("zenith", "zenith_angle"),
+    "energy_min": ("energy_min",),
+    "energy_max": ("energy_max",),
+    "view_cone_min": ("viewcone_min", "view_cone_min"),
+    "view_cone_max": ("viewcone_max", "view_cone_max"),
+    "core_scatter_max": ("core_scatter_max",),
+}
+
+
+@dataclass(frozen=True)
+class ProductionManifest:
+    """A loaded production metadata manifest and its file path."""
+
+    path: Path
+    data: dict
+
+    @property
+    def directory(self):
+        """Return the manifest parent directory."""
+        return self.path.parent
+
+    @property
+    def run_number(self):
+        """Return the run number recorded in this manifest."""
+        return int(self.data.get("configuration", {})["run_number"])
+
+
+@dataclass
+class ProductionFileGroup:
+    """Selected production files sharing one simulation configuration."""
+
+    configuration: dict
+    run_numbers: list[int] = field(default_factory=list)
+    file_paths: list[Path] = field(default_factory=list)
+    missing_run_numbers: list[int] = field(default_factory=list)
+    duplicate_run_numbers: list[int] = field(default_factory=list)
+
+
+def find_manifests(production_path, manifest_name=SIMULATE_PROD_JOB_METADATA):
+    """Return sorted production metadata manifests below a directory."""
+    production_path = Path(production_path)
+    if not production_path.is_dir():
+        raise FileNotFoundError(f"Production path not found: {production_path}")
+    return sorted(path for path in production_path.rglob(manifest_name) if path.is_file())
+
+
+def load_manifest(manifest_path):
+    """Load and validate one production manifest YAML file."""
+    manifest_path = Path(manifest_path)
+    data = ascii_handler.collect_data_from_file(manifest_path)
+    _validate_manifest_structure(data, manifest_path)
+    return ProductionManifest(path=manifest_path, data=data)
+
+
+def discover_manifests(production_path, manifest_name=SIMULATE_PROD_JOB_METADATA):
+    """Load all production metadata manifests below a directory."""
+    return [load_manifest(path) for path in find_manifests(production_path, manifest_name)]
+
+
+def discover_product_manifests(production_path, product_type, manifest_pattern="*.yml"):
+    """Load all manifests of one product type below a directory."""
+    production_path = Path(production_path)
+    if not production_path.is_dir():
+        raise FileNotFoundError(f"Production path not found: {production_path}")
+    manifests = []
+    for path in sorted(production_path.rglob(manifest_pattern)):
+        data = ascii_handler.collect_data_from_file(path)
+        if not isinstance(data, dict) or data.get("product_type") != product_type:
+            continue
+        _validate_manifest_structure(data, path)
+        manifests.append(ProductionManifest(path=path, data=data))
+    return manifests
+
+
+def select_file_groups(
+    production_path,
+    selections=None,
+    file_type="reduced_event_data",
+    require_complete_runs=False,
+    manifest_name=SIMULATE_PROD_JOB_METADATA,
+):
+    """Discover manifests, filter jobs, and group selected files by configuration."""
+    manifests = discover_manifests(production_path, manifest_name=manifest_name)
+    selected = filter_manifests(manifests, selections or [])
+    groups = group_selected_files(selected, file_type=file_type)
+    if require_complete_runs:
+        incomplete = [group for group in groups if group.missing_run_numbers]
+        if incomplete:
+            raise ValueError(
+                "Missing run numbers in selected production groups: "
+                + "; ".join(",".join(map(str, group.missing_run_numbers)) for group in incomplete)
+            )
+    return {
+        "metadata_files_read": len(manifests),
+        "matching_jobs": len(selected),
+        "configuration_groups": len(groups),
+        "groups": groups,
+    }
+
+
+def filter_manifests(manifests, selections):
+    """Return manifests matching all selection expressions."""
+    parsed = [_parse_selection(selection) for selection in selections]
+    return [
+        manifest
+        for manifest in manifests
+        if all(_selection_matches(manifest.data, key, expected) for key, expected in parsed)
+    ]
+
+
+def group_selected_files(manifests, file_type="reduced_event_data"):
+    """Group selected files by all configuration fields except the run number."""
+    groups = {}
+    for manifest in manifests:
+        check_manifest(manifest)
+        files = _manifest_files(manifest, file_type)
+        if not files:
+            raise ValueError(f"Manifest {manifest.path} lists no files of type '{file_type}'.")
+        key = _normalized_group_key(manifest.data.get("configuration", {}))
+        group = groups.setdefault(
+            key,
+            ProductionFileGroup(
+                configuration=_configuration_without_excluded_keys(
+                    manifest.data.get("configuration", {})
+                )
+            ),
+        )
+        for file_path in files:
+            group.run_numbers.append(manifest.run_number)
+            group.file_paths.append(file_path)
+
+    grouped = list(groups.values())
+    for group in grouped:
+        _sort_group_by_run_number(group)
+        group.duplicate_run_numbers = _duplicate_run_numbers(group.run_numbers)
+        if group.duplicate_run_numbers:
+            raise ValueError(
+                "Duplicate run numbers in selected production group: "
+                + ", ".join(map(str, group.duplicate_run_numbers))
+            )
+        group.missing_run_numbers = _missing_run_numbers(group.run_numbers)
+    return grouped
+
+
+def check_manifest(manifest):
+    """Validate a manifest against its output directory and listed files."""
+    if not isinstance(manifest, ProductionManifest):
+        manifest = load_manifest(manifest)
+
+    _validate_manifest_structure(manifest.data, manifest.path)
+    seen_paths = set()
+    unverifiable_fields = sorted(manifest.data.get("configuration", {}))
+    for file_type, relative_paths in manifest.data.get("files", {}).items():
+        for relative_path in relative_paths:
+            file_path = _resolve_relative_manifest_path(manifest.directory, relative_path)
+            if file_path in seen_paths:
+                raise ValueError(
+                    f"Duplicate output file listed in {manifest.path}: {relative_path}"
+                )
+            seen_paths.add(file_path)
+            if not file_path.exists():
+                raise FileNotFoundError(
+                    f"Manifest {manifest.path} references missing file: {relative_path}"
+                )
+            _validate_file_type(file_path, file_type, manifest.path)
+            _validate_filename_run_number(file_path, manifest)
+            if file_type == "sim_telarray":
+                unverifiable_fields = _compare_simtel_metadata(
+                    file_path,
+                    manifest,
+                    unverifiable_fields,
+                )
+    if manifest.data["product_type"] == "simulate_prod_job":
+        _check_declared_production_inventory(manifest, seen_paths)
+
+    return {"valid": True, "unverifiable_fields": unverifiable_fields}
+
+
+def inventory_production_files(job_directory):
+    """Return nested production outputs grouped by manifest file type.
+
+    Paths in the returned inventory are relative to ``job_directory`` so that
+    manifests can describe the standard ``sim_telarray/runNNNNNN`` and
+    ``corsika/runNNNNNN`` output layout.
+    """
+    job_directory = Path(job_directory)
+    inventory = {}
+    for file_path in sorted(path for path in job_directory.rglob("*") if path.is_file()):
+        file_type = _production_file_type(file_path)
+        if file_type is not None:
+            relative_path = file_path.relative_to(job_directory).as_posix()
+            inventory.setdefault(file_type, []).append(relative_path)
+    return inventory
+
+
+def validate_required_production_outputs(file_inventory, simulation_software, job_directory):
+    """Require the principal simulation output before marking a job complete."""
+    required_type = "corsika" if simulation_software == "corsika" else "sim_telarray"
+    if not file_inventory.get(required_type):
+        raise ValueError(
+            f"Incomplete production job {job_directory}: no '{required_type}' output file found."
+        )
+
+
+def stable_configuration_hash(value, length=8):
+    """Return a short stable hash for normalized configuration data."""
+    normalized = normalize_for_comparison(value)
+    payload = json.dumps(normalized, sort_keys=True, default=str).encode()
+    return hashlib.sha1(payload).hexdigest()[:length]
+
+
+def write_selection_file(selection_result, output_file):
+    """Write selected file groups to a YAML file."""
+    output = {
+        "schema_version": "1.0.0",
+        "product_type": "production_file_selection",
+        "metadata_files_read": selection_result["metadata_files_read"],
+        "matching_jobs": selection_result["matching_jobs"],
+        "configuration_groups": selection_result["configuration_groups"],
+        "groups": [
+            {
+                "configuration": group.configuration,
+                "run_numbers": group.run_numbers,
+                "missing_run_numbers": group.missing_run_numbers,
+                "files": [str(path) for path in group.file_paths],
+            }
+            for group in selection_result["groups"]
+        ],
+    }
+    ascii_handler.write_data_to_file(output, output_file)
+
+
+def selection_summary(selection_result):
+    """Return a compact summary string for logging or console output."""
+    missing = sorted(
+        {
+            run_number
+            for group in selection_result["groups"]
+            for run_number in group.missing_run_numbers
+        }
+    )
+    return (
+        f"Metadata files read: {selection_result['metadata_files_read']}\n"
+        f"Matching jobs: {selection_result['matching_jobs']}\n"
+        f"Configuration groups: {selection_result['configuration_groups']}\n"
+        f"Missing runs: {', '.join(map(str, missing)) if missing else 'none'}"
+    )
+
+
+def normalize_for_comparison(value):
+    """Normalize quantities and containers for exact matching and grouping."""
+    if isinstance(value, u.Quantity):
+        return _quantity_comparison_value(value.value, value.unit)
+    if isinstance(value, dict) and set(value) == {"value", "unit"}:
+        return _quantity_comparison_value(value["value"], value["unit"])
+    if isinstance(value, dict):
+        return tuple(
+            (key, normalize_for_comparison(value[key]))
+            for key in sorted(value)
+            if key not in _GROUPING_EXCLUDE_KEYS
+        )
+    if isinstance(value, list | tuple):
+        return tuple(normalize_for_comparison(item) for item in value)
+    return value
+
+
+def _validate_manifest_structure(data, manifest_path):
+    """Validate required manifest fields and supported version."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Malformed metadata in {manifest_path}: expected a mapping.")
+    for key in ("schema_version", "product_type", "status", "configuration", "files"):
+        if key not in data:
+            raise ValueError(f"Malformed metadata in {manifest_path}: missing '{key}'.")
+    if str(data["schema_version"]) not in SUPPORTED_SCHEMA_VERSIONS:
+        raise ValueError(
+            f"Unsupported production metadata schema version in {manifest_path}: "
+            f"{data['schema_version']}"
+        )
+    if data["status"] != "complete":
+        raise ValueError(f"Production job is not complete in {manifest_path}.")
+    if not isinstance(data["configuration"], dict):
+        raise ValueError(f"Malformed metadata in {manifest_path}: configuration is not a mapping.")
+    if data["product_type"] == "simulate_prod_job" and "run_number" not in data["configuration"]:
+        raise ValueError(
+            f"Malformed metadata in {manifest_path}: missing configuration.run_number."
+        )
+    if not isinstance(data["files"], dict):
+        raise ValueError(f"Malformed metadata in {manifest_path}: files is not a mapping.")
+    schema_file = _MANIFEST_SCHEMAS.get(data["product_type"])
+    if schema_file is not None:
+        schema.validate_dict_using_schema(
+            ascii_handler.to_builtin(data),
+            schema_file=SCHEMA_PATH / schema_file,
+            offline=True,
+        )
+
+
+def _parse_selection(selection):
+    """Parse a KEY=VALUE selection expression."""
+    if "=" not in selection:
+        raise ValueError(f"Selection must use KEY=VALUE syntax: {selection}")
+    key, expected = selection.split("=", maxsplit=1)
+    if not key:
+        raise ValueError(f"Selection key is empty: {selection}")
+    return key, expected.strip().strip("\"'")
+
+
+def _selection_matches(data, key, expected):
+    """Return whether one dotted-path selection matches."""
+    value = _get_dotted_value(data, key)
+    if value is None and "." not in key:
+        value = _get_dotted_value(data, f"configuration.{key}")
+    return _values_match(value, expected)
+
+
+def _get_dotted_value(data, key):
+    """Return a nested value addressed by a dotted key path."""
+    value = data
+    for part in key.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def _values_match(value, expected):
+    """Return whether a manifest value matches a command-line selection value."""
+    if value is None:
+        return False
+    if isinstance(value, dict) and set(value) == {"value", "unit"}:
+        return _quantity_matches(value, expected)
+    return str(value) == expected
+
+
+def _quantity_matches(value, expected):
+    """Return whether a stored quantity matches a textual quantity exactly after conversion."""
+    stored = float(value["value"]) * u.Unit(value["unit"])
+    try:
+        expected_quantity = u.Quantity(expected)
+    except TypeError, ValueError:
+        return str(value) == expected
+    if expected_quantity.unit == u.dimensionless_unscaled:
+        expected_quantity = expected_quantity.value * stored.unit
+    return stored.unit.is_equivalent(expected_quantity.unit) and isclose(
+        stored.to_value(expected_quantity.unit), expected_quantity.value
+    )
+
+
+def _quantity_comparison_value(value, unit):
+    """Return a normalized comparable representation of a quantity."""
+    quantity = float(value) * u.Unit(unit)
+    return (round(float(quantity.si.value), 12), str(quantity.si.unit))
+
+
+def _configuration_without_excluded_keys(configuration):
+    """Return configuration fields used for grouping."""
+    return {key: value for key, value in configuration.items() if key not in _GROUPING_EXCLUDE_KEYS}
+
+
+def _normalized_group_key(configuration):
+    """Return a stable normalized grouping key for a configuration."""
+    return normalize_for_comparison(_configuration_without_excluded_keys(configuration))
+
+
+def _manifest_files(manifest, file_type):
+    """Return absolute paths for files of the requested manifest file type."""
+    return [
+        _resolve_relative_manifest_path(manifest.directory, relative_path)
+        for relative_path in manifest.data.get("files", {}).get(file_type, [])
+    ]
+
+
+def _resolve_relative_manifest_path(directory, relative_path):
+    """Resolve one manifest-relative path and reject paths escaping the job directory."""
+    path = Path(relative_path)
+    if path.is_absolute():
+        raise ValueError(f"Manifest file path must be relative: {relative_path}")
+    resolved = (directory / path).resolve()
+    try:
+        resolved.relative_to(directory.resolve())
+    except ValueError as exc:
+        raise ValueError(f"Manifest file path escapes job directory: {relative_path}") from exc
+    return resolved
+
+
+def _validate_file_type(file_path, file_type, manifest_path):
+    """Validate a file suffix for known manifest file types."""
+    suffixes = _FILE_TYPE_SUFFIXES.get(file_type)
+    if suffixes and not any(file_path.name.endswith(suffix) for suffix in suffixes):
+        raise ValueError(
+            f"Manifest {manifest_path} lists {file_path.name} as '{file_type}', "
+            "but its suffix is inconsistent."
+        )
+
+
+def _production_file_type(file_path):
+    """Return the manifest type for a recognized production output file."""
+    for file_type, suffixes in _FILE_TYPE_SUFFIXES.items():
+        if file_type == "trigger_histograms":
+            continue
+        if any(file_path.name.endswith(suffix) for suffix in suffixes):
+            return file_type
+    return None
+
+
+def _check_declared_production_inventory(manifest, declared_paths):
+    """Require the manifest to list every recognized production output."""
+    actual_paths = {
+        (manifest.directory / relative_path).resolve()
+        for paths in inventory_production_files(manifest.directory).values()
+        for relative_path in paths
+    }
+    unexpected = sorted(path.name for path in actual_paths - declared_paths)
+    if unexpected:
+        raise ValueError(
+            f"Unexpected production files not listed in {manifest.path}: " + ", ".join(unexpected)
+        )
+
+
+def _validate_filename_run_number(file_path, manifest):
+    """Validate encoded run numbers when the filename contains one."""
+    if "run_number" not in manifest.data.get("configuration", {}):
+        return
+    match = _RUN_NUMBER_PATTERN.search(file_path.name)
+    if match and int(match.group(1)) != manifest.run_number:
+        raise ValueError(
+            f"Run number mismatch for {file_path.name}: filename encodes "
+            f"{int(match.group(1))}, manifest records {manifest.run_number}."
+        )
+
+
+def _compare_simtel_metadata(file_path, manifest, unverifiable_fields):
+    """Compare manifest configuration with matching embedded sim_telarray metadata."""
+    try:
+        metadata, _ = read_sim_telarray_metadata(file_path)
+    except OSError, ValueError, AttributeError:
+        return unverifiable_fields
+
+    remaining = set(unverifiable_fields)
+    configuration = manifest.data.get("configuration", {})
+    for manifest_key, metadata_keys in _SIMTEL_METADATA_MANIFEST_KEYS.items():
+        if manifest_key not in configuration:
+            continue
+        metadata_key = next((key for key in metadata_keys if key in metadata), None)
+        if metadata_key is None:
+            continue
+        if not _embedded_metadata_matches(configuration[manifest_key], metadata[metadata_key]):
+            raise ValueError(
+                f"Manifest {manifest.path} field configuration.{manifest_key} does not match "
+                f"embedded sim_telarray metadata in {file_path.name}."
+            )
+        remaining.discard(manifest_key)
+    return sorted(remaining)
+
+
+def _embedded_metadata_matches(manifest_value, metadata_value):
+    """Return whether one embedded metadata value matches a manifest value."""
+    if isinstance(manifest_value, u.Quantity):
+        manifest_value = {"value": manifest_value.value, "unit": manifest_value.unit}
+    if isinstance(manifest_value, dict) and set(manifest_value) == {"value", "unit"}:
+        return _quantity_matches(manifest_value, str(metadata_value))
+    return str(manifest_value).lower() == str(metadata_value).lower()
+
+
+def _sort_group_by_run_number(group):
+    """Sort grouped run numbers and files by run number."""
+    ordered = sorted(zip(group.run_numbers, group.file_paths), key=lambda item: item[0])
+    group.run_numbers = [run_number for run_number, _ in ordered]
+    group.file_paths = [file_path for _, file_path in ordered]
+
+
+def _duplicate_run_numbers(run_numbers):
+    """Return sorted duplicate run numbers."""
+    seen = set()
+    duplicates = set()
+    for run_number in run_numbers:
+        if run_number in seen:
+            duplicates.add(run_number)
+        seen.add(run_number)
+    return sorted(duplicates)
+
+
+def _missing_run_numbers(run_numbers):
+    """Return missing run numbers between the minimum and maximum selected run."""
+    if not run_numbers:
+        return []
+    present = set(run_numbers)
+    return [
+        run_number
+        for run_number in range(min(present), max(present) + 1)
+        if run_number not in present
+    ]

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -67,19 +67,6 @@ def _get_registered_manifest_schema_versions():
     }
 
 
-def get_simulation_file_type_aliases():
-    """Return simulator file types mapped to their manifest file types."""
-    special_cases = {
-        "sim_telarray": "sim_telarray_output",
-        "reduced_event_data": "sim_telarray_event_data",
-    }
-    return {
-        special_cases.get(manifest_file_type, manifest_file_type): manifest_file_type
-        for manifest_file_type in _FILE_TYPE_SUFFIXES
-        if manifest_file_type != "trigger_histograms"
-    }
-
-
 _GROUPING_EXCLUDE_KEYS = {
     "run_number",
     "random_seed",

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -75,6 +75,8 @@ _GROUPING_EXCLUDE_KEYS = {
     "sim_telarray_seed_file",
     "sim_telarray_instrument_seed",
     "sim_telarray_random_instrument_instances",
+    "event_number_first_shower",
+    "correct_for_b_field_alignment",
     "output_path",
     "grid_output_path",
 }

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -253,7 +253,7 @@ def stable_configuration_hash(value, length=8):
     """Return a short stable hash for normalized configuration data."""
     normalized = normalize_for_comparison(value)
     payload = json.dumps(normalized, sort_keys=True, default=str).encode()
-    return hashlib.sha1(payload).hexdigest()[:length]
+    return hashlib.sha256(payload).hexdigest()[:length]
 
 
 def write_selection_file(selection_result, output_file):

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -81,6 +81,7 @@ class ProductionFileGroup:
     file_paths: list[Path] = field(default_factory=list)
     missing_run_numbers: list[int] = field(default_factory=list)
     duplicate_run_numbers: list[int] = field(default_factory=list)
+    files_by_run_number: dict[int, list[Path]] = field(default_factory=dict, repr=False)
 
 
 def find_manifests(production_path, manifest_name=SIMULATE_PROD_JOB_METADATA):
@@ -172,9 +173,8 @@ def group_selected_files(manifests, file_type="reduced_event_data"):
                 )
             ),
         )
-        for file_path in files:
-            group.run_numbers.append(manifest.run_number)
-            group.file_paths.append(file_path)
+        group.run_numbers.append(manifest.run_number)
+        group.files_by_run_number.setdefault(manifest.run_number, []).extend(files)
 
     grouped = list(groups.values())
     for group in grouped:
@@ -511,9 +511,12 @@ def _embedded_metadata_matches(manifest_value, metadata_value):
 
 def _sort_group_by_run_number(group):
     """Sort grouped run numbers and files by run number."""
-    ordered = sorted(zip(group.run_numbers, group.file_paths), key=lambda item: item[0])
-    group.run_numbers = [run_number for run_number, _ in ordered]
-    group.file_paths = [file_path for _, file_path in ordered]
+    group.run_numbers.sort()
+    group.file_paths = [
+        file_path
+        for run_number in group.run_numbers
+        for file_path in group.files_by_run_number[run_number]
+    ]
 
 
 def _duplicate_run_numbers(run_numbers):

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -17,15 +17,30 @@ from simtools.simtel.simtel_io_metadata import read_sim_telarray_metadata
 SIMULATE_PROD_JOB_METADATA = "simulate_prod_job_metadata.yml"
 SUPPORTED_SCHEMA_VERSIONS = {"1.0.0"}
 
-_RUN_NUMBER_PATTERN = re.compile(r"(?:^|_)run0*([0-9]+)(?:_|\.|$)")
+_RUN_NUMBER_PATTERN = re.compile(r"(?:^|_)run0*(\d+)(?:_|\.|$)")
+
+
+def _with_compression_suffixes(*suffixes):
+    """Return suffixes with supported compression extensions."""
+    return tuple(
+        compressed_suffix
+        for suffix in suffixes
+        for compressed_suffix in (f"{suffix}.zst", f"{suffix}.gz", suffix)
+    )
+
+
 _FILE_TYPE_SUFFIXES = {
-    "reduced_event_data": (".reduced_event_data.hdf5",),
-    "sim_telarray": (".simtel.zst", ".simtel.gz", ".simtel"),
-    "sim_telarray_log": (".simtel.log.gz", ".simtel.log"),
-    "sim_telarray_histogram": (".histogram.hdf5", ".histogram.gz", ".histogram"),
-    "corsika": (".corsika.zst", ".corsika.gz", ".corsika"),
-    "corsika_log": (".corsika.log.gz", ".corsika.log"),
-    "trigger_histograms": (".trigger_histograms.hdf5",),
+    "reduced_event_data": _with_compression_suffixes(".reduced_event_data.hdf5"),
+    "sim_telarray": _with_compression_suffixes(".simtel"),
+    "sim_telarray_log": _with_compression_suffixes(".simtel.log"),
+    "sim_telarray_histogram": _with_compression_suffixes(
+        ".hdata",
+        ".histogram",
+        ".histogram.hdf5",
+    ),
+    "corsika": _with_compression_suffixes(".corsika"),
+    "corsika_log": _with_compression_suffixes(".corsika.log"),
+    "trigger_histograms": _with_compression_suffixes(".trigger_histograms.hdf5"),
 }
 _MANIFEST_SCHEMAS = {
     "simulate_prod_job": "simulate_prod_job_metadata.schema.yml",

--- a/src/simtools/production_configuration/production_file_selection.py
+++ b/src/simtools/production_configuration/production_file_selection.py
@@ -15,7 +15,6 @@ from simtools.io import ascii_handler
 from simtools.simtel.simtel_io_metadata import read_sim_telarray_metadata
 
 SIMULATE_PROD_JOB_METADATA = "simulate_prod_job_metadata.yml"
-SUPPORTED_SCHEMA_VERSIONS = {"1.0.0"}
 
 _RUN_NUMBER_PATTERN = re.compile(r"(?:^|_)run0*(\d+)(?:_|\.|$)")
 
@@ -46,6 +45,41 @@ _MANIFEST_SCHEMAS = {
     "simulate_prod_job": "simulate_prod_job_metadata.schema.yml",
     "trigger_histograms": "trigger_histograms_metadata.schema.yml",
 }
+
+
+def get_manifest_schema_metadata(product_type):
+    """Return the current schema name and version for a manifest product type."""
+    schema_file = _MANIFEST_SCHEMAS.get(product_type)
+    if schema_file is None:
+        raise ValueError(f"Unknown production manifest product type: {product_type}")
+    definition = schema.load_schema(SCHEMA_PATH / schema_file, "latest")
+    return {
+        "schema_name": str(definition["schema_name"]).removesuffix(".schema"),
+        "schema_version": str(definition["schema_version"]),
+    }
+
+
+def _get_registered_manifest_schema_versions():
+    """Return schema versions registered for known manifest product types."""
+    return {
+        get_manifest_schema_metadata(product_type)["schema_version"]
+        for product_type in _MANIFEST_SCHEMAS
+    }
+
+
+def get_simulation_file_type_aliases():
+    """Return simulator file types mapped to their manifest file types."""
+    special_cases = {
+        "sim_telarray": "sim_telarray_output",
+        "reduced_event_data": "sim_telarray_event_data",
+    }
+    return {
+        special_cases.get(manifest_file_type, manifest_file_type): manifest_file_type
+        for manifest_file_type in _FILE_TYPE_SUFFIXES
+        if manifest_file_type != "trigger_histograms"
+    }
+
+
 _GROUPING_EXCLUDE_KEYS = {
     "run_number",
     "random_seed",
@@ -274,7 +308,6 @@ def stable_configuration_hash(value, length=8):
 def write_selection_file(selection_result, output_file):
     """Write selected file groups to a YAML file."""
     output = {
-        "schema_version": "1.0.0",
         "product_type": "production_file_selection",
         "metadata_files_read": selection_result["metadata_files_read"],
         "matching_jobs": selection_result["matching_jobs"],
@@ -333,7 +366,18 @@ def _validate_manifest_structure(data, manifest_path):
     for key in ("schema_version", "product_type", "status", "configuration", "files"):
         if key not in data:
             raise ValueError(f"Malformed metadata in {manifest_path}: missing '{key}'.")
-    if str(data["schema_version"]) not in SUPPORTED_SCHEMA_VERSIONS:
+    product_type = data["product_type"]
+    expected_version = (
+        get_manifest_schema_metadata(product_type)["schema_version"]
+        if product_type in _MANIFEST_SCHEMAS
+        else None
+    )
+    if str(data["schema_version"]) not in _get_registered_manifest_schema_versions():
+        raise ValueError(
+            f"Unsupported production metadata schema version in {manifest_path}: "
+            f"{data['schema_version']}"
+        )
+    if expected_version is not None and str(data["schema_version"]) != expected_version:
         raise ValueError(
             f"Unsupported production metadata schema version in {manifest_path}: "
             f"{data['schema_version']}"

--- a/src/simtools/production_configuration/production_metadata.py
+++ b/src/simtools/production_configuration/production_metadata.py
@@ -59,10 +59,8 @@ def _check_existing_manifests(production_path):
 def _write_manifests(production_path, job_grid_file, args_dict):
     """Write manifests for job directories described by a job grid."""
     rows, metadata = read_job_grid(job_grid_file)
-    for index, row in enumerate(rows):
-        job_directory = production_path / f"job-{index + 1:06d}"
-        if not job_directory.is_dir():
-            raise FileNotFoundError(f"Production job directory not found: {job_directory}")
+    job_directories = _job_directories_for_rows(production_path, len(rows))
+    for row, job_directory in zip(rows, job_directories):
         manifest_path = job_directory / SIMULATE_PROD_JOB_METADATA
         if manifest_path.exists() and not args_dict.get("overwrite"):
             raise FileExistsError(
@@ -135,3 +133,30 @@ def _job_directories(production_path):
     if not production_path.is_dir():
         raise FileNotFoundError(f"Production path not found: {production_path}")
     return sorted(path for path in production_path.glob("job-*") if path.is_dir())
+
+
+def _job_directories_for_rows(production_path, row_count):
+    """Resolve a complete zero- or one-based job-directory mapping."""
+    job_directories = _job_directories(production_path)
+    if not job_directories:
+        raise FileNotFoundError(
+            f"Production job directory not found: {production_path / 'job-000001'}"
+        )
+    numbers = {
+        int(directory.name.removeprefix("job-"))
+        for directory in job_directories
+        if directory.name.removeprefix("job-").isdigit()
+    }
+    if 0 in numbers:
+        offset = 0
+    else:
+        offset = 1
+    expected_numbers = set(range(offset, offset + row_count))
+    if numbers != expected_numbers:
+        expected = ", ".join(f"job-{number:06d}" for number in sorted(expected_numbers))
+        found = ", ".join(directory.name for directory in job_directories)
+        raise FileNotFoundError(
+            f"Production job directories do not match the {row_count}-row job grid. "
+            f"Expected: {expected}; found: {found or 'none'}."
+        )
+    return [production_path / f"job-{number:06d}" for number in sorted(expected_numbers)]

--- a/src/simtools/production_configuration/production_metadata.py
+++ b/src/simtools/production_configuration/production_metadata.py
@@ -1,0 +1,137 @@
+"""Write and validate metadata manifests for completed simulation production jobs."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from simtools.io.ascii_handler import write_data_to_file
+from simtools.model.model_utils import read_overwrite_model_parameter_dict
+from simtools.production_configuration.job_grid_io import (
+    job_grid_row_to_simulate_prod_args,
+    read_job_grid,
+)
+from simtools.production_configuration.job_metadata import (
+    REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS,
+    build_production_job_manifest,
+    build_simulation_job_metadata,
+)
+from simtools.production_configuration.production_file_selection import (
+    SIMULATE_PROD_JOB_METADATA,
+    ProductionManifest,
+    check_manifest,
+    inventory_production_files,
+    validate_required_production_outputs,
+)
+
+
+def write_production_metadata(args_dict):
+    """Write or validate production job metadata manifests.
+
+    Parameters
+    ----------
+    args_dict : dict
+        Application arguments containing ``production_path`` and, in write mode, ``job_grid_file``.
+    """
+    production_path = Path(args_dict["production_path"])
+    if args_dict.get("check"):
+        _check_existing_manifests(production_path)
+        return
+    _write_manifests(production_path, args_dict["job_grid_file"], args_dict)
+
+
+def _check_existing_manifests(production_path):
+    """Check all existing simulate_prod job manifests below a production path."""
+    job_directories = _job_directories(production_path)
+    if not job_directories:
+        raise FileNotFoundError(f"No production job directories found in {production_path}.")
+    missing = [
+        directory / SIMULATE_PROD_JOB_METADATA
+        for directory in job_directories
+        if not (directory / SIMULATE_PROD_JOB_METADATA).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "Missing production metadata manifest(s): " + ", ".join(map(str, missing))
+        )
+    for job_directory in job_directories:
+        check_manifest(job_directory / SIMULATE_PROD_JOB_METADATA)
+
+
+def _write_manifests(production_path, job_grid_file, args_dict):
+    """Write manifests for job directories described by a job grid."""
+    rows, metadata = read_job_grid(job_grid_file)
+    for index, row in enumerate(rows):
+        job_directory = production_path / f"job-{index + 1:06d}"
+        if not job_directory.is_dir():
+            raise FileNotFoundError(f"Production job directory not found: {job_directory}")
+        manifest_path = job_directory / SIMULATE_PROD_JOB_METADATA
+        if manifest_path.exists() and not args_dict.get("overwrite"):
+            raise FileExistsError(
+                f"Metadata manifest already exists: {manifest_path}. Use --overwrite to replace it."
+            )
+        resolved_args = job_grid_row_to_simulate_prod_args(row, metadata)
+        resolved_args.setdefault("simulation_software", "corsika_sim_telarray")
+        resolved_args.setdefault("eslope", -2.0)
+        _validate_resolved_configuration(resolved_args, job_grid_file)
+        overwrite_parameter_file = resolved_args.get("overwrite_model_parameters")
+        overwrite_parameters = (
+            read_overwrite_model_parameter_dict(overwrite_parameter_file)
+            if overwrite_parameter_file
+            else {}
+        )
+        array_model = SimpleNamespace(
+            model_version=resolved_args["model_version"],
+            overwrite_model_parameter_dict=overwrite_parameters,
+            array_elements={},
+            site_model=SimpleNamespace(parameters={}),
+        )
+        simulator = SimpleNamespace(
+            run_number=resolved_args["run_number"],
+            array_models=[array_model],
+            corsika_configurations=[],
+        )
+        file_inventory = inventory_production_files(job_directory)
+        validate_required_production_outputs(
+            file_inventory,
+            resolved_args["simulation_software"],
+            job_directory,
+        )
+        manifest = build_production_job_manifest(
+            resolved_args,
+            simulator,
+            job_directory,
+            file_inventory=file_inventory,
+            catalog_metadata=build_simulation_job_metadata(
+                resolved_args, simulator, include_sct=False
+            ),
+            atmosphere_configuration=_backfilled_atmosphere_configuration(resolved_args),
+        )
+        check_manifest(ProductionManifest(path=manifest_path, data=manifest))
+        write_data_to_file(manifest, manifest_path)
+
+
+def _backfilled_atmosphere_configuration(args_dict):
+    """Return only atmosphere values known from the authoritative job grid."""
+    threshold = args_dict.get("curved_atmosphere_min_zenith_angle")
+    return {"curved_atmosphere_min_zenith_angle": threshold} if threshold is not None else {}
+
+
+def _validate_resolved_configuration(args_dict, job_grid_file):
+    """Require fields needed to write truthful production metadata."""
+    missing = [
+        key
+        for key in ("run_number", *REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS)
+        if args_dict.get(key) is None
+    ]
+    if missing:
+        raise ValueError(
+            f"Job grid {job_grid_file} does not provide required resolved configuration "
+            "field(s): " + ", ".join(missing)
+        )
+
+
+def _job_directories(production_path):
+    """Return sorted direct production job directories."""
+    production_path = Path(production_path)
+    if not production_path.is_dir():
+        raise FileNotFoundError(f"Production path not found: {production_path}")
+    return sorted(path for path in production_path.glob("job-*") if path.is_dir())

--- a/src/simtools/production_configuration/trigger_histograms.py
+++ b/src/simtools/production_configuration/trigger_histograms.py
@@ -702,11 +702,13 @@ def _write_directory_products(args_dict):
 
 def _write_production_selection_products(args_dict):
     """Submit one trigger-histogram product per selected production configuration group."""
+    if args_dict.get("file_type", "reduced_event_data") != "reduced_event_data":
+        raise ValueError("Production metadata input requires file_type='reduced_event_data'.")
     output_directory = io_handler.IOHandler().get_output_directory()
     selection_result = select_file_groups(
         args_dict["production_path"],
         selections=args_dict.get("select"),
-        file_type=args_dict.get("file_type", "reduced_event_data"),
+        file_type="reduced_event_data",
         require_complete_runs=args_dict.get("require_complete_runs", False),
     )
     _logger.info("\n%s", selection_summary(selection_result))
@@ -718,13 +720,13 @@ def _write_production_selection_products(args_dict):
         dict(settings_config.args) if args_dict.get("backend", "local") != "local" else None
     )
     runtime_db_config = dict(settings_config.db_config) if runtime_args is not None else None
-    telescope_configs = _resolve_telescope_configs(args_dict)
-    product_identity = {
-        "histogram_settings": _histogram_settings(args_dict),
-        "array_selection": telescope_configs,
-    }
     jobs = []
     for index, group in enumerate(selection_result["groups"]):
+        telescope_configs = _resolve_group_telescope_configs(args_dict, group.configuration)
+        product_identity = {
+            "histogram_settings": _histogram_settings(args_dict),
+            "array_selection": telescope_configs,
+        }
         output_file = validate_file_type(
             output_directory
             / f"{_group_output_stem(group, product_identity)}.trigger_histograms.hdf5",
@@ -838,6 +840,38 @@ def _resolve_telescope_configs(args_dict):
     return _use_readable_inline_array_names(
         normalize_telescope_configs(resolve_telescope_configs(args_dict))
     )
+
+
+def _resolve_group_telescope_configs(args_dict, configuration):
+    """Resolve telescope configurations from one selected production configuration."""
+    group_args = dict(args_dict)
+    _set_group_argument(group_args, configuration, "site")
+    _set_group_argument(group_args, configuration, "model_version", list_value=True)
+    if group_args.get("array_element_list"):
+        return _resolve_telescope_configs(group_args)
+    _set_group_argument(group_args, configuration, "array_layout_name", list_value=True)
+    return _resolve_telescope_configs(group_args)
+
+
+def _set_group_argument(args_dict, configuration, key, list_value=False):
+    """Set one telescope-resolution argument from metadata or reject an incompatible override."""
+    if key not in configuration:
+        raise ValueError(f"Selected production metadata is missing configuration.{key}.")
+    metadata_value = configuration[key]
+    expected = _as_argument_value(metadata_value, list_value)
+    provided = args_dict.get(key)
+    if provided is not None and provided != expected:
+        raise ValueError(
+            f"Explicit --{key}={provided} does not match selected production metadata {expected}."
+        )
+    args_dict[key] = expected
+
+
+def _as_argument_value(value, list_value):
+    """Return manifest values in the form accepted by the command-line resolver."""
+    if not list_value:
+        return value
+    return value if isinstance(value, list) else [value]
 
 
 def _histogram_settings(args_dict):

--- a/src/simtools/production_configuration/trigger_histograms.py
+++ b/src/simtools/production_configuration/trigger_histograms.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+import os
 import re
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from astropy.table import Table, vstack
 
 import simtools.utils.general as gen
 from simtools.io import io_handler, table_handler
+from simtools.io.ascii_handler import write_data_to_file
 from simtools.io.file_type import validate_file_type
 from simtools.job_execution.execution import map_ordered, options_from_args, submit_jobs
 from simtools.job_execution.job import JobSpec
@@ -19,6 +21,13 @@ from simtools.production_configuration.production_event_data_helpers import (
     accumulate_histograms_by_telescope_config,
     normalize_telescope_configs,
     resolve_telescope_configs,
+)
+from simtools.production_configuration.production_file_selection import (
+    ProductionManifest,
+    check_manifest,
+    select_file_groups,
+    selection_summary,
+    stable_configuration_hash,
 )
 from simtools.settings import config as settings_config
 from simtools.sim_events.histograms import EventDataHistograms
@@ -543,11 +552,15 @@ def discover_event_data_groups(event_data_directory):
     return [(group_name, groups[group_name]) for group_name in sorted(groups)]
 
 
-def _write_trigger_histogram_product(args_dict, production_patterns, output_file):
+def _write_trigger_histogram_product(
+    args_dict,
+    production_patterns,
+    output_file,
+    product_metadata=None,
+    telescope_configs=None,
+):
     """Build and write one trigger-histogram product from production sources."""
-    telescope_configs = _use_readable_inline_array_names(
-        normalize_telescope_configs(resolve_telescope_configs(args_dict))
-    )
+    telescope_configs = telescope_configs or _resolve_telescope_configs(args_dict)
     output_file = validate_file_type(output_file, file_type="hdf5")
 
     reference_specs = []
@@ -602,7 +615,36 @@ def _write_trigger_histogram_product(args_dict, production_patterns, output_file
         },
     )
     _write_dense_histogram_payload(reference_specs, output_file)
+    if product_metadata is not None:
+        _write_trigger_histogram_metadata(args_dict, output_file, product_metadata)
     return metadata_table, bin_table
+
+
+def _write_trigger_histogram_metadata(args_dict, output_file, product_metadata):
+    """Write a neighboring YAML manifest for a trigger-histogram product."""
+    output_file = Path(output_file)
+    metadata_file = output_file.with_suffix(".yml")
+    manifest = {
+        "schema_name": "trigger_histograms_metadata",
+        "schema_version": "1.0.0",
+        "product_type": "trigger_histograms",
+        "status": "complete",
+        "configuration": product_metadata["configuration"],
+        "histogram_settings": _histogram_settings(args_dict),
+        "array_selection": product_metadata["array_selection"],
+        "input_run_numbers": product_metadata["run_numbers"],
+        "input_files": {
+            "reduced_event_data": [
+                _relative_to_directory(path, metadata_file.parent)
+                for path in product_metadata["input_files"]
+            ],
+        },
+        "files": {
+            "trigger_histograms": [_relative_to_directory(output_file, metadata_file.parent)],
+        },
+    }
+    check_manifest(ProductionManifest(path=metadata_file, data=manifest))
+    write_data_to_file(manifest, metadata_file)
 
 
 def _write_directory_group_job(job_spec):
@@ -614,7 +656,11 @@ def _write_directory_group_job(job_spec):
         "max_workers": 1,
     }
     _write_trigger_histogram_product(
-        args_dict, [job_spec["event_data_files"]], job_spec["output_file"]
+        args_dict,
+        [job_spec["event_data_files"]],
+        job_spec["output_file"],
+        product_metadata=job_spec.get("product_metadata"),
+        telescope_configs=job_spec.get("telescope_configs"),
     )
     return str(job_spec["output_file"])
 
@@ -654,6 +700,66 @@ def _write_directory_products(args_dict):
     return submit_jobs(jobs, options_from_args(args_dict, max_workers=args_dict.get("max_workers")))
 
 
+def _write_production_selection_products(args_dict):
+    """Submit one trigger-histogram product per selected production configuration group."""
+    output_directory = io_handler.IOHandler().get_output_directory()
+    selection_result = select_file_groups(
+        args_dict["production_path"],
+        selections=args_dict.get("select"),
+        file_type=args_dict.get("file_type", "reduced_event_data"),
+        require_complete_runs=args_dict.get("require_complete_runs", False),
+    )
+    _logger.info("\n%s", selection_summary(selection_result))
+    if not selection_result["groups"]:
+        raise ValueError("Production metadata selection did not match any files.")
+
+    production_path = Path(args_dict["production_path"]).resolve()
+    runtime_args = (
+        dict(settings_config.args) if args_dict.get("backend", "local") != "local" else None
+    )
+    runtime_db_config = dict(settings_config.db_config) if runtime_args is not None else None
+    telescope_configs = _resolve_telescope_configs(args_dict)
+    product_identity = {
+        "histogram_settings": _histogram_settings(args_dict),
+        "array_selection": telescope_configs,
+    }
+    jobs = []
+    for index, group in enumerate(selection_result["groups"]):
+        output_file = validate_file_type(
+            output_directory
+            / f"{_group_output_stem(group, product_identity)}.trigger_histograms.hdf5",
+            file_type="hdf5",
+        )
+        metadata_file = output_file.with_suffix(".yml")
+        if output_file.exists() or metadata_file.exists():
+            raise FileExistsError(f"Trigger-histogram output already exists: {output_file}")
+        jobs.append(
+            JobSpec(
+                job_id=f"trigger-histograms-{index:06d}",
+                index=index,
+                function=_write_directory_group_job,
+                item={
+                    "args_dict": args_dict,
+                    "event_data_files": [str(file_path) for file_path in group.file_paths],
+                    "output_file": output_file,
+                    "product_metadata": {
+                        "configuration": group.configuration,
+                        "run_numbers": group.run_numbers,
+                        "input_files": group.file_paths,
+                        "array_selection": telescope_configs,
+                    },
+                    "telescope_configs": telescope_configs,
+                },
+                runtime_args=runtime_args,
+                runtime_db_config=runtime_db_config,
+                mount_paths=(production_path,),
+                output_paths=(output_file, metadata_file),
+            )
+        )
+    _logger.info("Submitting %d trigger-histogram production metadata group(s)", len(jobs))
+    return submit_jobs(jobs, options_from_args(args_dict, max_workers=args_dict.get("max_workers")))
+
+
 def write_trigger_histograms(args_dict):
     """
     Build trigger histograms and write them to file.
@@ -677,10 +783,71 @@ def write_trigger_histograms(args_dict):
     """
     if args_dict.get("event_data_directory"):
         return _write_directory_products(args_dict)
+    if args_dict.get("production_path"):
+        return _write_production_selection_products(args_dict)
 
     production_patterns = gen.ensure_string_lists(args_dict["event_data_files"])
     output_file = io_handler.IOHandler().get_output_file(args_dict["output_file"])
     return _write_trigger_histogram_product(args_dict, production_patterns, output_file)
+
+
+def _group_output_stem(group, product_identity=None):
+    """Return a readable, stable output stem for a selected production group."""
+    configuration = group.configuration
+    parts = [
+        _safe_stem_part(configuration.get("primary", "production")),
+        _angle_stem_part("za", configuration.get("zenith_angle")),
+        _safe_stem_part(configuration.get("corsika_he_interaction")),
+    ]
+    parts = [part for part in parts if part]
+    parts.append(
+        stable_configuration_hash(
+            {
+                "configuration": configuration,
+                **(product_identity or {}),
+            }
+        )
+    )
+    return "_".join(parts)
+
+
+def _angle_stem_part(prefix, value):
+    """Return an angle value formatted for an output file stem."""
+    if isinstance(value, dict) and set(value) == {"value", "unit"}:
+        quantity = float(value["value"]) * u.Unit(value["unit"])
+        return f"{prefix}{quantity.to_value(u.deg):g}"
+    return None
+
+
+def _safe_stem_part(value):
+    """Return a filesystem-safe output stem component."""
+    if value is None:
+        return None
+    return re.sub(r"[^A-Za-z0-9]+", "-", str(value)).strip("-").lower()
+
+
+def _relative_to_directory(path, directory):
+    """Return a portable path relative to a metadata directory."""
+    path = Path(path).resolve()
+    directory = Path(directory).resolve()
+    return Path(os.path.relpath(path, directory)).as_posix()
+
+
+def _resolve_telescope_configs(args_dict):
+    """Return normalized resolved telescope configurations."""
+    return _use_readable_inline_array_names(
+        normalize_telescope_configs(resolve_telescope_configs(args_dict))
+    )
+
+
+def _histogram_settings(args_dict):
+    """Return settings that define a trigger-histogram product."""
+    return {
+        "energy_bins_per_decade": args_dict["energy_bins_per_decade"],
+        "angular_distance_bin_width": args_dict["angular_distance_bin_width"],
+        "core_distance_bin_width": args_dict.get("core_distance_bin_width"),
+        "minimum_triggered_telescopes": args_dict.get("minimum_triggered_telescopes", 2),
+    }
 
 
 def load_trigger_histograms(reference_file):

--- a/src/simtools/production_configuration/trigger_histograms.py
+++ b/src/simtools/production_configuration/trigger_histograms.py
@@ -25,6 +25,7 @@ from simtools.production_configuration.production_event_data_helpers import (
 from simtools.production_configuration.production_file_selection import (
     ProductionManifest,
     check_manifest,
+    get_manifest_schema_metadata,
     select_file_groups,
     selection_summary,
     stable_configuration_hash,
@@ -624,9 +625,9 @@ def _write_trigger_histogram_metadata(args_dict, output_file, product_metadata):
     """Write a neighboring YAML manifest for a trigger-histogram product."""
     output_file = Path(output_file)
     metadata_file = output_file.with_suffix(".yml")
+    manifest_schema = get_manifest_schema_metadata("trigger_histograms")
     manifest = {
-        "schema_name": "trigger_histograms_metadata",
-        "schema_version": "1.0.0",
+        **manifest_schema,
         "product_type": "trigger_histograms",
         "status": "complete",
         "configuration": product_metadata["configuration"],

--- a/src/simtools/schemas/simulate_prod_job_metadata.schema.yml
+++ b/src/simtools/schemas/simulate_prod_job_metadata.schema.yml
@@ -49,8 +49,14 @@ properties:
               type: string
               minLength: 1
       model_version:
-        type: string
-        minLength: 1
+        oneOf:
+          - type: string
+            minLength: 1
+          - type: array
+            minItems: 1
+            items:
+              type: string
+              minLength: 1
       simulation_software:
         type: string
         enum: [corsika, sim_telarray, corsika_sim_telarray]

--- a/src/simtools/schemas/simulate_prod_job_metadata.schema.yml
+++ b/src/simtools/schemas/simulate_prod_job_metadata.schema.yml
@@ -1,0 +1,151 @@
+---
+$schema: http://json-schema.org/draft-06/schema#
+title: simulate_prod job metadata
+description: Versioned manifest for one completed simulate_prod job.
+schema_version: 1.0.0
+schema_name: simulate_prod_job_metadata.schema
+type: object
+additionalProperties: false
+properties:
+  schema_name:
+    type: string
+    enum: [simulate_prod_job_metadata]
+  schema_version:
+    type: string
+    enum: [1.0.0]
+  product_type:
+    type: string
+    enum: [simulate_prod_job]
+  production_id:
+    type: [string, 'null']
+  job_id:
+    type: string
+  status:
+    type: string
+    enum: [complete]
+  catalog_metadata:
+    type: object
+    additionalProperties: true
+  configuration:
+    type: object
+    additionalProperties: true
+    properties:
+      run_number:
+        type: integer
+        minimum: 0
+      primary:
+        type: string
+        minLength: 1
+      site:
+        type: string
+        enum: [North, South]
+      array_layout_name:
+        oneOf:
+          - type: string
+            minLength: 1
+          - type: array
+            minItems: 1
+            items:
+              type: string
+              minLength: 1
+      model_version:
+        type: string
+        minLength: 1
+      simulation_software:
+        type: string
+        enum: [corsika, sim_telarray, corsika_sim_telarray]
+      azimuth_angle:
+        $ref: '#/definitions/Quantity'
+      zenith_angle:
+        $ref: '#/definitions/Quantity'
+      energy_min:
+        $ref: '#/definitions/Quantity'
+      energy_max:
+        $ref: '#/definitions/Quantity'
+      view_cone_min:
+        $ref: '#/definitions/Quantity'
+      view_cone_max:
+        $ref: '#/definitions/Quantity'
+      cores_per_shower:
+        type: integer
+        minimum: 1
+      core_scatter_max:
+        $ref: '#/definitions/Quantity'
+      showers_per_run:
+        type: integer
+        minimum: 1
+      corsika_hadronic_transition_energy:
+        $ref: '#/definitions/Quantity'
+      model_parameter_overrides:
+        type: object
+      atmosphere:
+        type: object
+    required:
+      - run_number
+      - primary
+      - site
+      - array_layout_name
+      - model_version
+      - simulation_software
+      - azimuth_angle
+      - zenith_angle
+      - energy_min
+      - energy_max
+      - view_cone_min
+      - view_cone_max
+      - cores_per_shower
+      - core_scatter_max
+      - showers_per_run
+      - model_parameter_overrides
+      - atmosphere
+  files:
+    type: object
+    additionalProperties: false
+    minProperties: 1
+    properties:
+      sim_telarray:
+        $ref: '#/definitions/FileList'
+      reduced_event_data:
+        $ref: '#/definitions/FileList'
+      sim_telarray_log:
+        $ref: '#/definitions/FileList'
+      sim_telarray_histogram:
+        $ref: '#/definitions/FileList'
+      corsika:
+        $ref: '#/definitions/FileList'
+      corsika_log:
+        $ref: '#/definitions/FileList'
+    anyOf:
+      - required: [sim_telarray]
+      - required: [corsika]
+required:
+  - schema_name
+  - schema_version
+  - product_type
+  - job_id
+  - status
+  - catalog_metadata
+  - configuration
+  - files
+
+definitions:
+  Quantity:
+    type: object
+    additionalProperties: false
+    properties:
+      value:
+        type: number
+      unit:
+        type: string
+        minLength: 1
+    required:
+      - value
+      - unit
+
+  FileList:
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1

--- a/src/simtools/schemas/trigger_histograms_metadata.schema.yml
+++ b/src/simtools/schemas/trigger_histograms_metadata.schema.yml
@@ -1,0 +1,116 @@
+---
+$schema: http://json-schema.org/draft-06/schema#
+title: Trigger histogram product metadata
+description: Metadata manifest for one trigger-histogram product.
+schema_version: 1.0.0
+schema_name: trigger_histograms_metadata.schema
+type: object
+additionalProperties: false
+properties:
+  schema_name:
+    type: string
+    enum: [trigger_histograms_metadata]
+  schema_version:
+    type: string
+    enum: [1.0.0]
+  product_type:
+    type: string
+    enum: [trigger_histograms]
+  status:
+    type: string
+    enum: [complete]
+  configuration:
+    type: object
+    minProperties: 1
+  histogram_settings:
+    type: object
+    additionalProperties: false
+    properties:
+      energy_bins_per_decade:
+        type: integer
+        minimum: 1
+      angular_distance_bin_width:
+        $ref: '#/definitions/Quantity'
+      core_distance_bin_width:
+        $ref: '#/definitions/Quantity'
+      minimum_triggered_telescopes:
+        type: integer
+        minimum: 1
+    required:
+      - energy_bins_per_decade
+      - angular_distance_bin_width
+      - core_distance_bin_width
+      - minimum_triggered_telescopes
+  array_selection:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      additionalProperties: false
+      properties:
+        array_name:
+          type: string
+          minLength: 1
+        telescope_ids:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      required:
+        - array_name
+        - telescope_ids
+  input_run_numbers:
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: integer
+  input_files:
+    type: object
+    additionalProperties: false
+    properties:
+      reduced_event_data:
+        $ref: '#/definitions/FileList'
+    required:
+      - reduced_event_data
+  files:
+    type: object
+    additionalProperties: false
+    properties:
+      trigger_histograms:
+        $ref: '#/definitions/FileList'
+    required:
+      - trigger_histograms
+required:
+  - schema_name
+  - schema_version
+  - product_type
+  - status
+  - configuration
+  - histogram_settings
+  - array_selection
+  - input_run_numbers
+  - input_files
+  - files
+
+definitions:
+  Quantity:
+    type: object
+    additionalProperties: false
+    properties:
+      value:
+        type: number
+      unit:
+        type: string
+        minLength: 1
+    required:
+      - value
+      - unit
+
+  FileList:
+    type: array
+    minItems: 1
+    uniqueItems: true
+    items:
+      type: string
+      minLength: 1

--- a/tests/unit_tests/applications/test_compare_productions.py
+++ b/tests/unit_tests/applications/test_compare_productions.py
@@ -6,8 +6,6 @@ import pytest
 import simtools.sim_events.production_comparison as production_comparison
 from simtools.applications import compare_productions
 from simtools.configuration.commandline_parser import CommandLineParser
-from simtools.constants import SCHEMA_PATH
-from simtools.production_configuration.production_file_selection import ProductionManifest
 
 
 def test_parse_production_arguments_requires_baseline_and_candidate(mocker):
@@ -90,9 +88,8 @@ def test_parse_production_arguments_accepts_nested_flattened_strings(mocker):
     assert [descriptor.label for descriptor in descriptors] == ["baseline", "candidate"]
 
 
-def test_main_writes_comparison_statistics_metadata(mocker, tmp_test_directory):
+def test_main_delegates_to_production_comparison_workflow(mocker, tmp_test_directory):
     output_directory = Path(tmp_test_directory) / "comparison"
-    statistics_file = output_directory / "comparison_statistics.json"
     app_context = mocker.MagicMock()
     app_context.args = {
         "comparison_level": "events",
@@ -108,85 +105,13 @@ def test_main_writes_comparison_statistics_metadata(mocker, tmp_test_directory):
     app_context.io_handler.get_output_directory.return_value = output_directory
     mock_application = mocker.patch("simtools.applications.compare_productions.APPLICATION")
     mock_application.start.return_value = app_context
-    mocker.patch("simtools.applications.compare_productions.parse_production_arguments")
-    mocker.patch("simtools.applications.compare_productions.collect_production_metrics")
-    mock_plot = mocker.patch(
-        "simtools.applications.compare_productions.plot_event_level_production_comparison.plot",
-        return_value=statistics_file,
+    mock_write = mocker.patch(
+        "simtools.applications.compare_productions.write_production_comparison"
     )
-    mock_dump = mocker.patch("simtools.applications.compare_productions.MetadataCollector.dump")
 
     compare_productions.main()
 
-    mock_plot.assert_called_once_with(
-        mocker.ANY,
-        output_path=output_directory,
-        array_layout_name="CTAO-North-Alpha",
-        figure_format=["pdf"],
-    )
-    metadata_args, metadata_file = mock_dump.call_args.args
-    assert metadata_file == statistics_file
-    assert metadata_args["output_file"] == str(statistics_file)
-    assert metadata_args["output_file_format"] == "JSON"
-    assert metadata_args["metadata_product_data_name"] == "production_comparison_statistics"
-    assert metadata_args["schema_file"] == str(
-        SCHEMA_PATH / "production_comparison_statistics.schema.yml"
-    )
-
-
-def test_main_compares_each_selected_array_layout_separately(mocker, tmp_test_directory):
-    output_directory = Path(tmp_test_directory) / "comparison"
-    first_statistics_file = output_directory / "first" / "comparison_statistics.json"
-    second_statistics_file = output_directory / "second" / "comparison_statistics.json"
-    app_context = mocker.MagicMock()
-    app_context.args = {
-        "comparison_level": "events",
-        "production": ["baseline", "baseline.hdf5", "candidate", "candidate.hdf5"],
-        "array_layout_name": ["first", "second"],
-        "figure_format": ["png"],
-    }
-    app_context.io_handler.get_output_directory.return_value = output_directory
-    mock_application = mocker.patch("simtools.applications.compare_productions.APPLICATION")
-    mock_application.start.return_value = app_context
-    descriptors = mocker.sentinel.production_descriptors
-    mocker.patch(
-        "simtools.applications.compare_productions.parse_production_arguments",
-        return_value=descriptors,
-    )
-    mock_collect = mocker.patch(
-        "simtools.applications.compare_productions.collect_production_metrics",
-        side_effect=[mocker.sentinel.first_metrics, mocker.sentinel.second_metrics],
-    )
-    mock_plot = mocker.patch(
-        "simtools.applications.compare_productions.plot_event_level_production_comparison.plot",
-        side_effect=[first_statistics_file, second_statistics_file],
-    )
-    mock_dump = mocker.patch("simtools.applications.compare_productions.MetadataCollector.dump")
-
-    compare_productions.main()
-
-    assert mock_collect.call_args_list == [
-        mocker.call(descriptors, array_names="first"),
-        mocker.call(descriptors, array_names="second"),
-    ]
-    assert mock_plot.call_args_list == [
-        mocker.call(
-            mocker.sentinel.first_metrics,
-            output_path=output_directory,
-            array_layout_name="first",
-            figure_format=["png"],
-        ),
-        mocker.call(
-            mocker.sentinel.second_metrics,
-            output_path=output_directory,
-            array_layout_name="second",
-            figure_format=["png"],
-        ),
-    ]
-    assert [call.args[0]["array_layout_name"] for call in mock_dump.call_args_list] == [
-        "first",
-        "second",
-    ]
+    mock_write.assert_called_once_with(app_context.args, output_directory)
 
 
 def test_application_exposes_events_comparison_level_without_unused_output_arguments():
@@ -252,52 +177,3 @@ def test_main_rejects_unimplemented_comparison_level(mocker):
 
     with pytest.raises(NotImplementedError, match="Comparison level 'signals' is not implemented"):
         compare_productions.main()
-
-
-def test_metadata_comparison_builds_one_descriptor_pair_per_configuration(
-    mocker,
-    tmp_test_directory,
-):
-    base_directory = Path(tmp_test_directory)
-
-    def manifest(directory, interaction, zenith):
-        return ProductionManifest(
-            path=base_directory / directory / f"{zenith}.yml",
-            data={
-                "configuration": {
-                    "primary": "gamma",
-                    "zenith_angle": {"value": zenith, "unit": "deg"},
-                    "corsika_he_interaction": interaction,
-                },
-                "histogram_settings": {"minimum_triggered_telescopes": 2},
-                "array_selection": [{"array_name": "alpha", "telescope_ids": ["LSTN-01"]}],
-                "files": {
-                    "trigger_histograms": [f"{interaction}_{zenith}.trigger_histograms.hdf5"]
-                },
-            },
-        )
-
-    mocker.patch(
-        "simtools.applications.compare_productions._selected_trigger_histogram_manifests",
-        side_effect=[
-            [manifest("baseline", "qgs3", 20), manifest("baseline", "qgs3", 40)],
-            [manifest("candidate", "epos", 20), manifest("candidate", "epos", 40)],
-        ],
-    )
-
-    pairs = compare_productions._production_descriptor_pairs_from_metadata(
-        {
-            "baseline_path": base_directory / "baseline",
-            "candidate_path": base_directory / "candidate",
-            "select": [],
-            "compare_by": ["corsika_he_interaction"],
-        }
-    )
-
-    assert len(pairs) == 2
-    assert all(len(descriptors) == 2 for _, descriptors in pairs)
-    assert all(
-        len(descriptor.trigger_histogram_files) == 1
-        for _, descriptors in pairs
-        for descriptor in descriptors
-    )

--- a/tests/unit_tests/applications/test_compare_productions.py
+++ b/tests/unit_tests/applications/test_compare_productions.py
@@ -6,6 +6,7 @@ import simtools.sim_events.production_comparison as production_comparison
 from simtools.applications import compare_productions
 from simtools.configuration.commandline_parser import CommandLineParser
 from simtools.constants import SCHEMA_PATH
+from simtools.production_configuration.production_file_selection import ProductionManifest
 
 
 def test_parse_production_arguments_requires_baseline_and_candidate(mocker):
@@ -228,3 +229,52 @@ def test_main_rejects_unimplemented_comparison_level(mocker):
 
     with pytest.raises(NotImplementedError, match="Comparison level 'signals' is not implemented"):
         compare_productions.main()
+
+
+def test_metadata_comparison_builds_one_descriptor_pair_per_configuration(
+    mocker,
+    tmp_test_directory,
+):
+    base_directory = Path(tmp_test_directory)
+
+    def manifest(directory, interaction, zenith):
+        return ProductionManifest(
+            path=base_directory / directory / f"{zenith}.yml",
+            data={
+                "configuration": {
+                    "primary": "gamma",
+                    "zenith_angle": {"value": zenith, "unit": "deg"},
+                    "corsika_he_interaction": interaction,
+                },
+                "histogram_settings": {"minimum_triggered_telescopes": 2},
+                "array_selection": [{"array_name": "alpha", "telescope_ids": ["LSTN-01"]}],
+                "files": {
+                    "trigger_histograms": [f"{interaction}_{zenith}.trigger_histograms.hdf5"]
+                },
+            },
+        )
+
+    mocker.patch(
+        "simtools.applications.compare_productions._selected_trigger_histogram_manifests",
+        side_effect=[
+            [manifest("baseline", "qgs3", 20), manifest("baseline", "qgs3", 40)],
+            [manifest("candidate", "epos", 20), manifest("candidate", "epos", 40)],
+        ],
+    )
+
+    pairs = compare_productions._production_descriptor_pairs_from_metadata(
+        {
+            "baseline_path": base_directory / "baseline",
+            "candidate_path": base_directory / "candidate",
+            "select": [],
+            "compare_by": ["corsika_he_interaction"],
+        }
+    )
+
+    assert len(pairs) == 2
+    assert all(len(descriptors) == 2 for _, descriptors in pairs)
+    assert all(
+        len(descriptor.trigger_histogram_files) == 1
+        for _, descriptors in pairs
+        for descriptor in descriptors
+    )

--- a/tests/unit_tests/applications/test_compare_productions.py
+++ b/tests/unit_tests/applications/test_compare_productions.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 import pytest
@@ -219,6 +220,28 @@ def test_comparison_level_argument_accepts_events():
     )
 
     assert args.comparison_level == "events"
+
+
+def test_application_parses_productions_without_select(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "compare_productions.py",
+            "--production",
+            "baseline",
+            "baseline.hdf5",
+            "--production",
+            "candidate",
+            "candidate.hdf5",
+            "--output_path",
+            "output",
+        ],
+    )
+
+    args, _ = compare_productions.APPLICATION._parse()
+
+    assert args["select"] == []
 
 
 def test_main_rejects_unimplemented_comparison_level(mocker):

--- a/tests/unit_tests/applications/test_production_select_files.py
+++ b/tests/unit_tests/applications/test_production_select_files.py
@@ -1,0 +1,73 @@
+"""Tests for the production-file selection application."""
+
+import sys
+from pathlib import Path
+
+from simtools.applications import production_select_files
+from simtools.configuration.commandline_parser import CommandLineParser
+
+
+def test_application_parser_accepts_selection_options():
+    parser = CommandLineParser()
+    parser.add_argument_definitions(production_select_files.APPLICATION.all_arguments)
+
+    args = parser.parse_args(
+        [
+            "--production_path",
+            "production",
+            "--select",
+            "configuration.primary=gamma",
+            "--file_type",
+            "reduced_event_data",
+            "--require_complete_runs",
+        ]
+    )
+
+    assert args.production_path == "production"
+    assert args.select == ["configuration.primary=gamma"]
+    assert args.file_type == "reduced_event_data"
+    assert args.require_complete_runs is True
+
+
+def test_main_prints_selection_summary_and_writes_explicit_output(
+    mocker, capsys, tmp_test_directory
+):
+    output_file = Path(tmp_test_directory) / "selected.yml"
+    app_context = mocker.MagicMock()
+    app_context.args = {
+        "production_path": "production",
+        "select": [],
+        "file_type": "reduced_event_data",
+        "require_complete_runs": False,
+        "output_file": str(output_file),
+        "output_file_from_default": False,
+    }
+    mocker.patch(
+        "simtools.applications.production_select_files.APPLICATION"
+    ).start.return_value = app_context
+    mocker.patch(
+        "simtools.applications.production_select_files.select_file_groups",
+        return_value={"matching_jobs": 1},
+    )
+    mocker.patch(
+        "simtools.applications.production_select_files.selection_summary",
+        return_value="Matching jobs: 1",
+    )
+    mock_write = mocker.patch("simtools.applications.production_select_files.write_selection_file")
+
+    production_select_files.main()
+
+    assert capsys.readouterr().out == "Matching jobs: 1\n"
+    mock_write.assert_called_once_with({"matching_jobs": 1}, str(output_file))
+
+
+def test_application_parser_does_not_require_output_file(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["production_select_files.py", "--production_path", "production"],
+    )
+
+    args, _ = production_select_files.APPLICATION._parse()
+
+    assert args["output_file"] is None

--- a/tests/unit_tests/applications/test_simulate_prod.py
+++ b/tests/unit_tests/applications/test_simulate_prod.py
@@ -88,6 +88,7 @@ def _mock_application_context(mock_application_start, label="test"):
             "label": label,
             "reduced_event_lists": True,
             "save_file_lists": False,
+            "output_path": Path("output"),
             "grid_output_path": None,
         }
     )
@@ -373,12 +374,14 @@ def test_main_uses_explicit_application_definition(mock_application_start, mock_
     _mock_application_context(mock_application_start)
     mock_simulator_class.return_value = MagicMock()
 
-    app.main()
+    with patch("simtools.applications.simulate_prod._write_job_metadata") as mock_write_metadata:
+        app.main()
 
     mock_application_start.assert_called_once_with()
     assert app.APPLICATION.setup_io_handler is False
     assert app.APPLICATION.validate_simulation_dependencies is True
     assert app.APPLICATION.post_parse == app._post_parse
+    mock_write_metadata.assert_called_once()
 
 
 @patch("simtools.applications.simulate_prod.Simulator")
@@ -388,12 +391,57 @@ def test_main_runs_simulator_and_reports(mock_application_start, mock_simulator_
     mock_simulator = MagicMock()
     mock_simulator_class.return_value = mock_simulator
 
-    app.main()
+    with patch("simtools.applications.simulate_prod._write_job_metadata") as mock_write_metadata:
+        app.main()
 
     mock_simulator_class.assert_called_once_with(label="myprod")
     mock_simulator.simulate.assert_called_once()
     mock_simulator.validate_simulations.assert_called_once()
     mock_simulator.report.assert_called_once()
+    mock_write_metadata.assert_called_once()
+
+
+@patch("simtools.applications.simulate_prod.write_data_to_file")
+@patch("simtools.applications.simulate_prod.check_manifest")
+@patch("simtools.applications.simulate_prod.validate_required_production_outputs")
+@patch("simtools.applications.simulate_prod.build_production_job_manifest")
+@patch("simtools.applications.simulate_prod.Simulator")
+@patch("simtools.application.definition.ApplicationDefinition.start")
+def test_main_writes_job_metadata_to_output_path(
+    mock_application_start,
+    mock_simulator_class,
+    mock_build_metadata,
+    mock_validate_outputs,
+    mock_check_manifest,
+    mock_write_data,
+):
+    _mock_application_context(mock_application_start)
+    mock_simulator = MagicMock()
+    mock_simulator_class.return_value = mock_simulator
+    manifest = {
+        "configuration": {
+            "run_number": 7,
+            "simulation_software": "corsika_sim_telarray",
+        },
+        "files": {"sim_telarray": ["gamma.simtel.zst"]},
+    }
+    mock_build_metadata.return_value = manifest
+
+    app.main()
+
+    mock_build_metadata.assert_called_once_with(
+        mock_application_start.return_value.args,
+        mock_simulator,
+        Path("output"),
+    )
+    mock_simulator.pack_for_register.assert_not_called()
+    mock_validate_outputs.assert_called_once_with(
+        manifest["files"],
+        "corsika_sim_telarray",
+        Path("output"),
+    )
+    assert mock_check_manifest.call_args.args[0].data == manifest
+    mock_write_data.assert_called_once_with(manifest, Path("output") / app._JOB_METADATA_FILE)
 
 
 @patch("simtools.applications.simulate_prod.write_data_to_file")

--- a/tests/unit_tests/applications/test_simulate_prod.py
+++ b/tests/unit_tests/applications/test_simulate_prod.py
@@ -397,30 +397,47 @@ def test_main_runs_simulator_and_reports(mock_application_start, mock_simulator_
 
 
 @patch("simtools.applications.simulate_prod.write_data_to_file")
-@patch("simtools.applications.simulate_prod.build_simulation_job_metadata")
+@patch("simtools.applications.simulate_prod.check_manifest")
+@patch("simtools.applications.simulate_prod.validate_required_production_outputs")
+@patch("simtools.applications.simulate_prod.build_production_job_manifest")
 @patch("simtools.applications.simulate_prod.Simulator")
 @patch("simtools.application.definition.ApplicationDefinition.start")
 def test_main_writes_job_metadata_to_grid_output_path(
     mock_application_start,
     mock_simulator_class,
     mock_build_metadata,
+    mock_validate_outputs,
+    mock_check_manifest,
     mock_write_data,
 ):
     _mock_application_context(mock_application_start)
     mock_application_start.return_value.args["grid_output_path"] = Path("grid-output")
     mock_simulator = MagicMock()
     mock_simulator_class.return_value = mock_simulator
-    mock_build_metadata.return_value = {"runNumber": 7}
+    manifest = {
+        "configuration": {
+            "run_number": 7,
+            "simulation_software": "corsika_sim_telarray",
+        },
+        "files": {"sim_telarray": ["gamma.simtel.zst"]},
+    }
+    mock_build_metadata.return_value = manifest
 
     app.main()
 
     mock_build_metadata.assert_called_once_with(
-        mock_application_start.return_value.args, mock_simulator
+        mock_application_start.return_value.args,
+        mock_simulator,
+        Path("grid-output"),
     )
     mock_simulator.pack_for_register.assert_called_once_with(Path("grid-output"))
-    mock_write_data.assert_called_once_with(
-        {"runNumber": 7}, Path("grid-output") / app._JOB_METADATA_FILE
+    mock_validate_outputs.assert_called_once_with(
+        manifest["files"],
+        "corsika_sim_telarray",
+        Path("grid-output"),
     )
+    assert mock_check_manifest.call_args.args[0].data == manifest
+    mock_write_data.assert_called_once_with(manifest, Path("grid-output") / app._JOB_METADATA_FILE)
 
 
 @patch("simtools.applications.simulate_prod.write_data_to_file")

--- a/tests/unit_tests/applications/test_write_production_metadata.py
+++ b/tests/unit_tests/applications/test_write_production_metadata.py
@@ -60,3 +60,28 @@ def test_write_manifests_does_not_mark_incomplete_job_complete(
         )
 
     write_file.assert_not_called()
+
+
+def test_write_manifests_omits_unknown_catalog_and_atmosphere_values(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    job_directory = production_path / "job-000001"
+    job_directory.mkdir()
+    (job_directory / "gamma_run000001.simtel.zst").touch()
+    mocker.patch(
+        "simtools.applications.write_production_metadata.read_job_grid",
+        return_value=(
+            [_job_grid_row()],
+            {"site": "North", "simulation_software": "corsika_sim_telarray"},
+        ),
+    )
+    write_file = mocker.patch("simtools.applications.write_production_metadata.write_data_to_file")
+
+    write_production_metadata._write_manifests(
+        production_path,
+        "job-grid.ecsv",
+        {"overwrite": False},
+    )
+
+    manifest = write_file.call_args.args[0]
+    assert "sct" not in manifest["catalog_metadata"]
+    assert manifest["configuration"]["atmosphere"] == {}

--- a/tests/unit_tests/applications/test_write_production_metadata.py
+++ b/tests/unit_tests/applications/test_write_production_metadata.py
@@ -1,0 +1,62 @@
+"""Tests for the production metadata backfill and check application."""
+
+from pathlib import Path
+
+import astropy.units as u
+import pytest
+
+from simtools.applications import write_production_metadata
+
+
+def _job_grid_row():
+    """Return one complete authoritative job-grid row."""
+    return {
+        "run_number": 1,
+        "primary": "gamma",
+        "azimuth_angle": 180 * u.deg,
+        "zenith_angle": 20 * u.deg,
+        "energy_min": 0.03 * u.TeV,
+        "energy_max": 300 * u.TeV,
+        "cores_per_shower": 10,
+        "core_scatter_max": 500 * u.m,
+        "view_cone_min": 0 * u.deg,
+        "view_cone_max": 10 * u.deg,
+        "showers_per_run": 100,
+        "model_version": "7.0.0",
+        "array_layout_name": "CTAO-North-Alpha",
+        "corsika_le_interaction": "urqmd",
+        "corsika_he_interaction": "qgs3",
+    }
+
+
+def test_check_existing_manifests_reports_missing_job_manifest(tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    (production_path / "job-000001").mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Missing production metadata manifest"):
+        write_production_metadata._check_existing_manifests(production_path)
+
+
+def test_write_manifests_does_not_mark_incomplete_job_complete(
+    mocker,
+    tmp_test_directory,
+):
+    production_path = Path(tmp_test_directory)
+    (production_path / "job-000001").mkdir()
+    mocker.patch(
+        "simtools.applications.write_production_metadata.read_job_grid",
+        return_value=(
+            [_job_grid_row()],
+            {"site": "North", "simulation_software": "corsika_sim_telarray"},
+        ),
+    )
+    write_file = mocker.patch("simtools.applications.write_production_metadata.write_data_to_file")
+
+    with pytest.raises(ValueError, match="Incomplete production job"):
+        write_production_metadata._write_manifests(
+            production_path,
+            "job-grid.ecsv",
+            {"overwrite": False},
+        )
+
+    write_file.assert_not_called()

--- a/tests/unit_tests/applications/test_write_production_metadata.py
+++ b/tests/unit_tests/applications/test_write_production_metadata.py
@@ -15,3 +15,19 @@ def test_main_delegates_to_production_metadata_workflow(mocker):
     write_production_metadata.main()
 
     mock_write.assert_called_once_with(app_context.args)
+
+
+def test_post_parse_allows_check_without_job_grid(mocker):
+    parser = mocker.Mock()
+
+    write_production_metadata._post_parse({"check": True}, {}, parser)
+
+    parser.error.assert_not_called()
+
+
+def test_post_parse_requires_job_grid_when_writing(mocker):
+    parser = mocker.Mock()
+
+    write_production_metadata._post_parse({"check": False}, {}, parser)
+
+    parser.error.assert_called_once()

--- a/tests/unit_tests/applications/test_write_production_metadata.py
+++ b/tests/unit_tests/applications/test_write_production_metadata.py
@@ -1,87 +1,17 @@
-"""Tests for the production metadata backfill and check application."""
-
-from pathlib import Path
-
-import astropy.units as u
-import pytest
+"""Tests for the production metadata application."""
 
 from simtools.applications import write_production_metadata
 
 
-def _job_grid_row():
-    """Return one complete authoritative job-grid row."""
-    return {
-        "run_number": 1,
-        "primary": "gamma",
-        "azimuth_angle": 180 * u.deg,
-        "zenith_angle": 20 * u.deg,
-        "energy_min": 0.03 * u.TeV,
-        "energy_max": 300 * u.TeV,
-        "cores_per_shower": 10,
-        "core_scatter_max": 500 * u.m,
-        "view_cone_min": 0 * u.deg,
-        "view_cone_max": 10 * u.deg,
-        "showers_per_run": 100,
-        "model_version": "7.0.0",
-        "array_layout_name": "CTAO-North-Alpha",
-        "corsika_le_interaction": "urqmd",
-        "corsika_he_interaction": "qgs3",
-    }
-
-
-def test_check_existing_manifests_reports_missing_job_manifest(tmp_test_directory):
-    production_path = Path(tmp_test_directory)
-    (production_path / "job-000001").mkdir()
-
-    with pytest.raises(FileNotFoundError, match="Missing production metadata manifest"):
-        write_production_metadata._check_existing_manifests(production_path)
-
-
-def test_write_manifests_does_not_mark_incomplete_job_complete(
-    mocker,
-    tmp_test_directory,
-):
-    production_path = Path(tmp_test_directory)
-    (production_path / "job-000001").mkdir()
-    mocker.patch(
-        "simtools.applications.write_production_metadata.read_job_grid",
-        return_value=(
-            [_job_grid_row()],
-            {"site": "North", "simulation_software": "corsika_sim_telarray"},
-        ),
-    )
-    write_file = mocker.patch("simtools.applications.write_production_metadata.write_data_to_file")
-
-    with pytest.raises(ValueError, match="Incomplete production job"):
-        write_production_metadata._write_manifests(
-            production_path,
-            "job-grid.ecsv",
-            {"overwrite": False},
-        )
-
-    write_file.assert_not_called()
-
-
-def test_write_manifests_omits_unknown_catalog_and_atmosphere_values(mocker, tmp_test_directory):
-    production_path = Path(tmp_test_directory)
-    job_directory = production_path / "job-000001"
-    job_directory.mkdir()
-    (job_directory / "gamma_run000001.simtel.zst").touch()
-    mocker.patch(
-        "simtools.applications.write_production_metadata.read_job_grid",
-        return_value=(
-            [_job_grid_row()],
-            {"site": "North", "simulation_software": "corsika_sim_telarray"},
-        ),
-    )
-    write_file = mocker.patch("simtools.applications.write_production_metadata.write_data_to_file")
-
-    write_production_metadata._write_manifests(
-        production_path,
-        "job-grid.ecsv",
-        {"overwrite": False},
+def test_main_delegates_to_production_metadata_workflow(mocker):
+    app_context = mocker.MagicMock()
+    app_context.args = {"production_path": "production"}
+    mock_application = mocker.patch("simtools.applications.write_production_metadata.APPLICATION")
+    mock_application.start.return_value = app_context
+    mock_write = mocker.patch(
+        "simtools.applications.write_production_metadata.write_production_metadata"
     )
 
-    manifest = write_file.call_args.args[0]
-    assert "sct" not in manifest["catalog_metadata"]
-    assert manifest["configuration"]["atmosphere"] == {}
+    write_production_metadata.main()
+
+    mock_write.assert_called_once_with(app_context.args)

--- a/tests/unit_tests/applications/test_write_trigger_histograms.py
+++ b/tests/unit_tests/applications/test_write_trigger_histograms.py
@@ -81,7 +81,6 @@ def test_add_arguments_accepts_production_path_and_selection():
         "configuration.corsika_he_interaction=qgs3",
         "configuration.zenith_angle=20 deg",
     ]
-    assert args.file_type == "reduced_event_data"
 
 
 def test_post_parse_rejects_default_output_path_for_directory_mode(mocker):
@@ -90,6 +89,7 @@ def test_post_parse_rejects_default_output_path_for_directory_mode(mocker):
     write_trigger_histograms._post_parse(
         {
             "event_data_directory": "reduced_event_data",
+            "array_layout_name": ["CTAO-North-Alpha"],
             "output_file": "write_trigger_histograms.hdf5",
             "output_file_from_default": True,
         },
@@ -109,6 +109,7 @@ def test_post_parse_accepts_explicit_output_path_for_directory_mode(mocker, sour
     write_trigger_histograms._post_parse(
         {
             "event_data_directory": "reduced_event_data",
+            "array_layout_name": ["CTAO-North-Alpha"],
             "output_file": "write_trigger_histograms.hdf5",
             "output_file_from_default": True,
         },
@@ -125,6 +126,7 @@ def test_post_parse_rejects_explicit_output_file_for_directory_mode(mocker):
     write_trigger_histograms._post_parse(
         {
             "event_data_directory": "reduced_event_data",
+            "array_layout_name": ["CTAO-North-Alpha"],
             "output_file": "trigger_histograms.hdf5",
             "output_file_from_default": False,
         },
@@ -135,3 +137,19 @@ def test_post_parse_rejects_explicit_output_file_for_directory_mode(mocker):
     parser.error.assert_called_once_with(
         "'--output_file' cannot be used with directory or production metadata input."
     )
+
+
+def test_post_parse_allows_production_metadata_without_layout_selection(mocker):
+    parser = mocker.Mock()
+
+    write_trigger_histograms._post_parse(
+        {
+            "production_path": "production",
+            "output_file": "write_trigger_histograms.hdf5",
+            "output_file_from_default": True,
+        },
+        {"cli": {"output_path"}},
+        parser,
+    )
+
+    parser.error.assert_not_called()

--- a/tests/unit_tests/applications/test_write_trigger_histograms.py
+++ b/tests/unit_tests/applications/test_write_trigger_histograms.py
@@ -61,6 +61,29 @@ def test_add_arguments_accepts_event_data_directory():
     assert args.event_data_files is None
 
 
+def test_add_arguments_accepts_production_path_and_selection():
+    parser = CommandLineParser()
+    parser.add_argument_definitions(write_trigger_histograms._ARGUMENTS)
+
+    args = parser.parse_args(
+        [
+            "--production_path",
+            "grid-output",
+            "--select",
+            "configuration.corsika_he_interaction=qgs3",
+            "--select",
+            "configuration.zenith_angle=20 deg",
+        ]
+    )
+
+    assert args.production_path == "grid-output"
+    assert args.select == [
+        "configuration.corsika_he_interaction=qgs3",
+        "configuration.zenith_angle=20 deg",
+    ]
+    assert args.file_type == "reduced_event_data"
+
+
 def test_post_parse_rejects_default_output_path_for_directory_mode(mocker):
     parser = mocker.Mock()
 
@@ -75,7 +98,7 @@ def test_post_parse_rejects_default_output_path_for_directory_mode(mocker):
     )
 
     parser.error.assert_called_once_with(
-        "'--output_path' is required with '--event_data_directory'."
+        "'--output_path' is required with directory or production metadata input."
     )
 
 
@@ -110,5 +133,5 @@ def test_post_parse_rejects_explicit_output_file_for_directory_mode(mocker):
     )
 
     parser.error.assert_called_once_with(
-        "'--output_file' cannot be used with '--event_data_directory'."
+        "'--output_file' cannot be used with directory or production metadata input."
     )

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -16,6 +16,7 @@ from simtools.configuration.arguments import (
     OUTPUT_ARGUMENTS,
     OUTPUT_PATH_ARGUMENTS,
     STANDARD_ARGUMENTS,
+    ArgumentDefinition,
 )
 from simtools.configuration.configurator import Configurator
 
@@ -394,6 +395,17 @@ def test_database_tag_cli_aliases_reject_conflicting_values(configurator):
 def test_canonical_database_tag_argument_is_available():
     """The canonical database tag argument is part of the shared definitions."""
     assert DB_SIMULATION_MODEL_TAG.name == "db_simulation_model_tag"
+
+
+def test_arglist_from_dict_preserves_bare_star_argument():
+    parser = Configurator().parser
+    parser.add_argument_definitions(
+        (ArgumentDefinition("plot_histograms", nargs="*", action="store"),)
+    )
+
+    assert Configurator.arglist_from_dict({"plot_histograms": []}, parser=parser) == [
+        "--plot_histograms"
+    ]
 
 
 def test_initialize(configurator):

--- a/tests/unit_tests/configuration/test_configurator.py
+++ b/tests/unit_tests/configuration/test_configurator.py
@@ -175,6 +175,7 @@ def test_arglist_from_config():
     ] == Configurator._arglist_from_config(_tmp_dict)
 
     assert [] == Configurator._arglist_from_config({})
+    assert [] == Configurator._arglist_from_config({"select": []})
 
     assert [] == Configurator._arglist_from_config(None)
     assert [] == Configurator._arglist_from_config(5.0)

--- a/tests/unit_tests/production_configuration/test_job_grid_io.py
+++ b/tests/unit_tests/production_configuration/test_job_grid_io.py
@@ -235,21 +235,21 @@ def test_build_simulate_prod_job_specs_creates_local_commands(tmp_test_directory
     assert "prod_high_nsb" in command
     assert str(overwrite_path) in command
     assert str(model_path) in command
-    assert str(tmp_test_directory / "output" / "job-000000") in command
-    assert str(tmp_test_directory / "grid" / "job-000000") in command
+    assert str(tmp_test_directory / "output" / "job-000001") in command
+    assert str(tmp_test_directory / "grid" / "job-000001") in command
     assert "--no-reduced_event_lists" in command
     assert "--no-correct_for_b_field_alignment" in command
     assert str(corsika_path) in command
     assert jobs[0].mount_paths == (
-        tmp_test_directory / "output" / "job-000000",
-        tmp_test_directory / "grid" / "job-000000",
+        tmp_test_directory / "output" / "job-000001",
+        tmp_test_directory / "grid" / "job-000001",
         corsika_path.parent,
         model_path,
         overwrite_path.parent,
     )
     assert jobs[0].output_paths == (
-        tmp_test_directory / "output" / "job-000000",
-        tmp_test_directory / "grid" / "job-000000",
+        tmp_test_directory / "output" / "job-000001",
+        tmp_test_directory / "grid" / "job-000001",
     )
     nested_args = app.APPLICATION.build_parser().parse_args(command[5:])
     assert nested_args.reduced_event_lists is False
@@ -261,6 +261,35 @@ def test_build_simulate_prod_job_specs_creates_local_commands(tmp_test_directory
     assert command[core_scatter_index + 1] == "10 200.0 m"
     view_cone_index = command.index("--view_cone")
     assert command[view_cone_index + 1] == "0.0 deg 5.0 deg"
+
+
+def test_build_simulate_prod_job_specs_uses_one_based_job_names(tmp_test_directory):
+    """Use one-based names for job IDs and both production output directories."""
+    args = {
+        "output_path": tmp_test_directory / "output",
+        "grid_output_path": tmp_test_directory / "grid",
+    }
+    rows = _job_rows()
+    rows.append({**rows[0], "run_number": 11})
+
+    jobs = job_grid_io.build_simulate_prod_job_specs(
+        args,
+        rows,
+        app.APPLICATION.build_parser(),
+        _metadata(),
+    )
+
+    assert [job.job_id for job in jobs] == ["job-000001", "job-000002"]
+    assert [job.output_paths for job in jobs] == [
+        (
+            tmp_test_directory / "output" / "job-000001",
+            tmp_test_directory / "grid" / "job-000001",
+        ),
+        (
+            tmp_test_directory / "output" / "job-000002",
+            tmp_test_directory / "grid" / "job-000002",
+        ),
+    ]
 
 
 def test_build_simulate_prod_job_specs_uses_remote_environment_paths(tmp_test_directory):

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -169,6 +169,32 @@ def test_build_production_job_manifest_records_resolved_overrides_and_atmosphere
     )
 
 
+def test_build_production_job_manifest_keeps_nested_output_paths(tmp_test_directory):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    simtel_directory = output_directory / "sim_telarray" / "run000012"
+    simtel_directory.mkdir(parents=True)
+    simtel_file = simtel_directory / "gamma_run000012.simtel.zst"
+    simtel_file.touch()
+    simulator = _simulator("MSTS-01", run_number=12)
+    simulator.get_files = lambda file_type: (
+        [simtel_file] if file_type == "sim_telarray_output" else []
+    )
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            simulation_software="sim_telarray",
+        ),
+        simulator,
+        output_directory,
+    )
+
+    assert manifest["files"] == {
+        "sim_telarray": ["sim_telarray/run000012/gamma_run000012.simtel.zst"]
+    }
+
+
 def test_build_simulation_job_metadata_rounds_view_cone_to_two_decimal_places():
     metadata = build_simulation_job_metadata(
         _args(view_cone=(0.12345 * u.deg, 5.6789 * u.deg)),

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -41,7 +41,7 @@ def test_build_simulation_job_metadata_uses_catalog_conventions():
 
     assert metadata == {
         "array_layout": "CTAO-South-Alpha",
-        "site": "South",
+        "site": "Paranal",
         "particle": "gamma",
         "phiP": 350.0,
         "thetaP": 20.0,
@@ -72,7 +72,7 @@ def test_build_simulation_job_metadata_omits_missing_coordinates_and_sets_sct_fa
         _simulator("LSTN-01", run_number=5),
     )
 
-    assert metadata["site"] == "North"
+    assert metadata["site"] == "LaPalma"
     assert metadata["phiP"] == pytest.approx(0.0)
     assert metadata["sct"] == "False"
     assert metadata["runNumber"] == 5

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -9,7 +9,6 @@ import pytest
 from simtools.production_configuration.job_metadata import (
     REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS,
     _add_optional_configuration_value,
-    _ensure_list,
     _resolved_model_parameter_overrides,
     build_production_job_manifest,
     build_simulation_job_metadata,
@@ -139,6 +138,64 @@ def test_build_production_job_manifest_contains_selection_fields(tmp_test_direct
     }
 
 
+def test_build_production_job_manifest_discovers_all_packaged_outputs(tmp_test_directory):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    output_directory.mkdir()
+    for name in (
+        "gamma_run000012.simtel.zst",
+        "gamma_run000012.corsika.zst",
+        "gamma_run000012.simtel.log.gz",
+    ):
+        (output_directory / name).touch()
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
+            simulation_software="corsika_sim_telarray",
+        ),
+        _simulator("MSTS-01", run_number=12),
+        output_directory,
+    )
+
+    assert manifest["files"] == {
+        "corsika": ["gamma_run000012.corsika.zst"],
+        "sim_telarray": ["gamma_run000012.simtel.zst"],
+        "sim_telarray_log": ["gamma_run000012.simtel.log.gz"],
+    }
+
+
+def test_build_production_job_manifest_reads_primary_from_corsika_input(
+    tmp_test_directory,
+):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    output_directory.mkdir()
+    (output_directory / "gamma_run000012.simtel.zst").touch()
+    simulator = _simulator("MSTS-01", run_number=12)
+    simulator.corsika_configurations = SimpleNamespace(
+        primary_particle=SimpleNamespace(name="gamma"),
+        use_curved_atmosphere=False,
+        shower_events=10,
+    )
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=None,
+            primary=None,
+            simulation_software="sim_telarray",
+        ),
+        simulator,
+        output_directory,
+    )
+
+    assert manifest["catalog_metadata"]["particle"] == "gamma"
+    assert manifest["configuration"]["primary"] == "gamma"
+    assert manifest["configuration"]["showers_per_run"] == 10
+
+
 def test_build_production_job_manifest_preserves_truthful_backfill_metadata(tmp_test_directory):
     output_directory = Path(tmp_test_directory) / "job-000012"
     output_directory.mkdir()
@@ -238,9 +295,6 @@ def test_optional_configuration_values_and_file_lists():
     _add_optional_configuration_value(configuration, "missing", None)
 
     assert configuration == {"present": 1}
-    assert _ensure_list(None) == []
-    assert _ensure_list((1, 2)) == [1, 2]
-    assert _ensure_list("one") == ["one"]
 
 
 def test_build_production_job_manifest_keeps_nested_output_paths(tmp_test_directory):
@@ -258,6 +312,7 @@ def test_build_production_job_manifest_keeps_nested_output_paths(tmp_test_direct
         _args(
             energy_range=(0.03 * u.TeV, 300 * u.TeV),
             core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
             simulation_software="sim_telarray",
         ),
         simulator,

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -1,5 +1,6 @@
 """Tests for simulation job metadata generation."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import astropy.units as u
@@ -7,6 +8,7 @@ import pytest
 
 from simtools.production_configuration.job_metadata import (
     _format_view_cone,
+    build_production_job_manifest,
     build_simulation_job_metadata,
 )
 
@@ -81,3 +83,92 @@ def test_build_simulation_job_metadata_omits_missing_coordinates_and_sets_sct_fa
 def test_format_view_cone_rounds_to_two_decimal_places():
     result = _format_view_cone(0.12345 * u.deg, 5.6789 * u.deg)
     assert result == "0.12_deg_5.68_deg"
+
+
+def test_build_production_job_manifest_contains_selection_fields(tmp_test_directory):
+    tmp_test_directory = Path(tmp_test_directory)
+    output_directory = tmp_test_directory / "job-000001"
+    output_directory.mkdir()
+    simtel_file = output_directory / "gamma_run000012.simtel.zst"
+    event_data_file = output_directory / "gamma_run000012.reduced_event_data.hdf5"
+    simtel_file.touch()
+    event_data_file.touch()
+    simulator = _simulator("MSTS-01", run_number=12)
+    simulator.get_files = lambda file_type: {
+        "sim_telarray_output": [tmp_test_directory / simtel_file.name],
+        "sim_telarray_event_data": [tmp_test_directory / event_data_file.name],
+    }.get(file_type, [])
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
+            simulation_software="corsika_sim_telarray",
+            corsika_he_interaction="qgs3",
+            corsika_le_interaction="urqmd",
+        ),
+        simulator,
+        output_directory,
+    )
+
+    assert manifest["schema_version"] == "1.0.0"
+    assert manifest["product_type"] == "simulate_prod_job"
+    assert manifest["catalog_metadata"]["runNumber"] == 12
+    assert manifest["configuration"]["run_number"] == 12
+    assert manifest["configuration"]["zenith_angle"] == 20 * u.deg
+    assert manifest["configuration"]["cores_per_shower"] == 10
+    assert manifest["files"] == {
+        "reduced_event_data": ["gamma_run000012.reduced_event_data.hdf5"],
+        "sim_telarray": ["gamma_run000012.simtel.zst"],
+    }
+
+
+def test_build_production_job_manifest_records_resolved_overrides_and_atmosphere(
+    tmp_test_directory,
+):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    output_directory.mkdir()
+    simtel_file = output_directory / "gamma_run000012.simtel.zst"
+    simtel_file.touch()
+    site_model = SimpleNamespace(
+        parameters={
+            "atmospheric_profile": {"value": "prod-atmosphere"},
+            "reference_point_altitude": {"value": 2150 * u.m},
+        }
+    )
+    array_model = SimpleNamespace(
+        array_elements={},
+        model_version="7.0.0",
+        overwrite_model_parameter_dict={"LSTN-design": {"mirror_area": {"value": 400}}},
+        site_model=site_model,
+    )
+    simulator = SimpleNamespace(
+        array_models=[array_model],
+        corsika_configurations=SimpleNamespace(use_curved_atmosphere=True),
+        run_number=12,
+        get_files=lambda file_type: [simtel_file] if file_type == "sim_telarray_output" else [],
+    )
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
+            simulation_software="corsika_sim_telarray",
+            curved_atmosphere_min_zenith_angle=70 * u.deg,
+            overwrite_model_parameters="/submission/path/overrides.yml",
+        ),
+        simulator,
+        output_directory,
+    )
+
+    configuration = manifest["configuration"]
+    assert configuration["model_parameter_overrides"] == {
+        "LSTN-design": {"mirror_area": {"value": 400}}
+    }
+    assert "overwrite_model_parameters" not in configuration
+    assert configuration["atmosphere"]["use_curved_atmosphere"] is True
+    assert configuration["atmosphere"]["site_parameters"]["atmospheric_profile"] == (
+        "prod-atmosphere"
+    )

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -122,6 +122,31 @@ def test_build_production_job_manifest_contains_selection_fields(tmp_test_direct
     }
 
 
+def test_build_production_job_manifest_preserves_truthful_backfill_metadata(tmp_test_directory):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    output_directory.mkdir()
+    simulator = _simulator("MSTS-01", run_number=12)
+    catalog_metadata = {"runNumber": 12, "particle": "gamma"}
+    atmosphere = {"curved_atmosphere_min_zenith_angle": 70 * u.deg}
+
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
+            simulation_software="corsika_sim_telarray",
+        ),
+        simulator,
+        output_directory,
+        file_inventory={"sim_telarray": ["gamma_run000012.simtel.zst"]},
+        catalog_metadata=catalog_metadata,
+        atmosphere_configuration=atmosphere,
+    )
+
+    assert manifest["catalog_metadata"] == catalog_metadata
+    assert manifest["configuration"]["atmosphere"] == atmosphere
+
+
 def test_build_production_job_manifest_records_resolved_overrides_and_atmosphere(
     tmp_test_directory,
 ):

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -196,6 +196,26 @@ def test_build_production_job_manifest_reads_primary_from_corsika_input(
     assert manifest["configuration"]["showers_per_run"] == 10
 
 
+def test_build_production_job_manifest_preserves_multiple_model_versions(tmp_test_directory):
+    output_directory = Path(tmp_test_directory) / "job-000012"
+    output_directory.mkdir()
+    (output_directory / "gamma_run000012.simtel.zst").touch()
+    manifest = build_production_job_manifest(
+        _args(
+            energy_range=(0.03 * u.TeV, 300 * u.TeV),
+            core_scatter=(10, 500 * u.m),
+            showers_per_run=100,
+            model_version=["6.0.2", "7.0.0"],
+            simulation_software="sim_telarray",
+        ),
+        _simulator("MSTS-01", run_number=12),
+        output_directory,
+    )
+
+    assert manifest["configuration"]["model_version"] == ["6.0.2", "7.0.0"]
+    assert manifest["catalog_metadata"]["model_version"] == ["6.0.2", "7.0.0"]
+
+
 def test_build_production_job_manifest_preserves_truthful_backfill_metadata(tmp_test_directory):
     output_directory = Path(tmp_test_directory) / "job-000012"
     output_directory.mkdir()

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -7,6 +7,9 @@ import astropy.units as u
 import pytest
 
 from simtools.production_configuration.job_metadata import (
+    _add_optional_configuration_value,
+    _ensure_list,
+    _resolved_model_parameter_overrides,
     build_production_job_manifest,
     build_simulation_job_metadata,
 )
@@ -167,6 +170,35 @@ def test_build_production_job_manifest_records_resolved_overrides_and_atmosphere
     assert configuration["atmosphere"]["site_parameters"]["atmospheric_profile"] == (
         "prod-atmosphere"
     )
+
+
+def test_resolved_model_parameter_overrides_keeps_values_by_model_version():
+    models = [
+        SimpleNamespace(
+            model_version="7.0.0",
+            overwrite_model_parameter_dict={"first": 1},
+        ),
+        SimpleNamespace(
+            model_version="7.1.0",
+            overwrite_model_parameter_dict={"second": 2},
+        ),
+    ]
+
+    assert _resolved_model_parameter_overrides(SimpleNamespace(array_models=models)) == {
+        "7.0.0": {"first": 1},
+        "7.1.0": {"second": 2},
+    }
+
+
+def test_optional_configuration_values_and_file_lists():
+    configuration = {}
+    _add_optional_configuration_value(configuration, "present", 1)
+    _add_optional_configuration_value(configuration, "missing", None)
+
+    assert configuration == {"present": 1}
+    assert _ensure_list(None) == []
+    assert _ensure_list((1, 2)) == [1, 2]
+    assert _ensure_list("one") == ["one"]
 
 
 def test_build_production_job_manifest_keeps_nested_output_paths(tmp_test_directory):

--- a/tests/unit_tests/production_configuration/test_job_metadata.py
+++ b/tests/unit_tests/production_configuration/test_job_metadata.py
@@ -7,6 +7,7 @@ import astropy.units as u
 import pytest
 
 from simtools.production_configuration.job_metadata import (
+    REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS,
     _add_optional_configuration_value,
     _ensure_list,
     _resolved_model_parameter_overrides,
@@ -33,6 +34,22 @@ def _simulator(*array_elements, run_number=12):
     return SimpleNamespace(
         array_models=[SimpleNamespace(array_elements=dict.fromkeys(array_elements))],
         run_number=run_number,
+    )
+
+
+def test_required_simulation_job_metadata_arguments_cover_manifest_inputs():
+    assert REQUIRED_SIMULATION_JOB_METADATA_ARGUMENTS == (
+        "primary",
+        "azimuth_angle",
+        "zenith_angle",
+        "energy_range",
+        "core_scatter",
+        "view_cone",
+        "showers_per_run",
+        "model_version",
+        "array_layout_name",
+        "site",
+        "simulation_software",
     )
 
 

--- a/tests/unit_tests/production_configuration/test_production_comparison.py
+++ b/tests/unit_tests/production_configuration/test_production_comparison.py
@@ -1,0 +1,220 @@
+"""Tests for production comparison workflows."""
+
+from pathlib import Path
+
+import pytest
+
+from simtools.constants import SCHEMA_PATH
+from simtools.production_configuration import production_comparison
+from simtools.production_configuration.production_file_selection import ProductionManifest
+
+
+def test_write_production_comparison_writes_each_selected_array_layout(mocker, tmp_test_directory):
+    output_directory = Path(tmp_test_directory) / "comparison"
+    first_statistics_file = output_directory / "first" / "comparison_statistics.json"
+    second_statistics_file = output_directory / "second" / "comparison_statistics.json"
+    descriptors = mocker.sentinel.production_descriptors
+    mocker.patch(
+        "simtools.production_configuration.production_comparison.parse_production_arguments",
+        return_value=descriptors,
+    )
+    mock_collect = mocker.patch(
+        "simtools.production_configuration.production_comparison.collect_production_metrics",
+        side_effect=[mocker.sentinel.first_metrics, mocker.sentinel.second_metrics],
+    )
+    mock_plot = mocker.patch(
+        "simtools.production_configuration.production_comparison."
+        "plot_event_level_production_comparison.plot",
+        side_effect=[first_statistics_file, second_statistics_file],
+    )
+    mock_dump = mocker.patch(
+        "simtools.production_configuration.production_comparison.MetadataCollector.dump"
+    )
+
+    production_comparison.write_production_comparison(
+        {
+            "production": ["baseline", "baseline.hdf5", "candidate", "candidate.hdf5"],
+            "array_layout_name": ["first", "second"],
+            "figure_format": ["png"],
+        },
+        output_directory,
+    )
+
+    assert mock_collect.call_args_list == [
+        mocker.call(descriptors, array_names="first"),
+        mocker.call(descriptors, array_names="second"),
+    ]
+    assert mock_plot.call_args_list == [
+        mocker.call(
+            mocker.sentinel.first_metrics,
+            output_path=output_directory,
+            array_layout_name="first",
+            figure_format=["png"],
+        ),
+        mocker.call(
+            mocker.sentinel.second_metrics,
+            output_path=output_directory,
+            array_layout_name="second",
+            figure_format=["png"],
+        ),
+    ]
+    assert [call.args[0]["array_layout_name"] for call in mock_dump.call_args_list] == [
+        "first",
+        "second",
+    ]
+    assert mock_dump.call_args.args[0]["schema_file"] == str(
+        SCHEMA_PATH / "production_comparison_statistics.schema.yml"
+    )
+
+
+def test_production_descriptor_pairs_from_metadata_matches_configurations(
+    mocker, tmp_test_directory
+):
+    base_directory = Path(tmp_test_directory)
+
+    def manifest(directory, interaction, zenith):
+        return ProductionManifest(
+            path=base_directory / directory / f"{zenith}.yml",
+            data={
+                "configuration": {
+                    "primary": "gamma",
+                    "zenith_angle": {"value": zenith, "unit": "deg"},
+                    "corsika_he_interaction": interaction,
+                },
+                "histogram_settings": {"minimum_triggered_telescopes": 2},
+                "array_selection": [{"array_name": "alpha", "telescope_ids": ["LSTN-01"]}],
+                "files": {
+                    "trigger_histograms": [f"{interaction}_{zenith}.trigger_histograms.hdf5"]
+                },
+            },
+        )
+
+    mocker.patch(
+        "simtools.production_configuration.production_comparison."
+        "_selected_trigger_histogram_manifests",
+        side_effect=[
+            [manifest("baseline", "qgs3", 20), manifest("baseline", "qgs3", 40)],
+            [manifest("candidate", "epos", 20), manifest("candidate", "epos", 40)],
+        ],
+    )
+
+    pairs = production_comparison._production_descriptor_pairs_from_metadata(
+        {
+            "baseline_path": base_directory / "baseline",
+            "candidate_path": base_directory / "candidate",
+            "select": [],
+            "compare_by": ["corsika_he_interaction"],
+        }
+    )
+
+    assert len(pairs) == 2
+    assert all(len(descriptors) == 2 for _, descriptors in pairs)
+    assert all(
+        len(descriptor.trigger_histogram_files) == 1
+        for _, descriptors in pairs
+        for descriptor in descriptors
+    )
+
+
+def test_write_production_comparison_uses_metadata_pair_output_directory(
+    mocker, tmp_test_directory
+):
+    output_directory = Path(tmp_test_directory) / "comparison"
+    pairing_key = {"configuration": {"primary": "gamma"}}
+    descriptors = [mocker.sentinel.baseline, mocker.sentinel.candidate]
+    mocker.patch(
+        "simtools.production_configuration.production_comparison."
+        "_production_descriptor_pairs_from_metadata",
+        return_value=[(pairing_key, descriptors)],
+    )
+    mock_write = mocker.patch(
+        "simtools.production_configuration.production_comparison._write_array_layout_comparisons"
+    )
+
+    production_comparison.write_production_comparison(
+        {"baseline_path": "baseline", "array_layout_name": ["alpha"]},
+        output_directory,
+    )
+
+    assert mock_write.call_args.args[:2] == (
+        descriptors,
+        {"baseline_path": "baseline", "array_layout_name": ["alpha"]},
+    )
+    assert mock_write.call_args.args[2].parent == output_directory
+    assert mock_write.call_args.args[3] == ["alpha"]
+
+
+def test_production_descriptor_pairs_rejects_unmatched_metadata(mocker, tmp_test_directory):
+    manifest = ProductionManifest(
+        path=Path(tmp_test_directory) / "baseline.yml",
+        data={"configuration": {}, "files": {"trigger_histograms": ["baseline.hdf5"]}},
+    )
+    mocker.patch(
+        "simtools.production_configuration.production_comparison."
+        "_selected_trigger_histogram_manifests",
+        side_effect=[[manifest], []],
+    )
+
+    with pytest.raises(ValueError, match="pairing failed"):
+        production_comparison._production_descriptor_pairs_from_metadata(
+            {"baseline_path": "baseline", "candidate_path": "candidate"}
+        )
+
+
+def test_selected_trigger_histogram_manifests_checks_matches(mocker):
+    manifest = mocker.sentinel.manifest
+    mocker.patch(
+        "simtools.production_configuration.production_comparison.discover_product_manifests",
+        return_value=[manifest],
+    )
+    mocker.patch(
+        "simtools.production_configuration.production_comparison.filter_manifests",
+        return_value=[manifest],
+    )
+    mock_check = mocker.patch(
+        "simtools.production_configuration.production_comparison.check_manifest"
+    )
+
+    selected = production_comparison._selected_trigger_histogram_manifests("production", [])
+
+    assert selected == [manifest]
+    mock_check.assert_called_once_with(manifest)
+
+
+def test_selected_trigger_histogram_manifests_rejects_empty_selection(mocker):
+    mocker.patch(
+        "simtools.production_configuration.production_comparison.discover_product_manifests",
+        return_value=[],
+    )
+    mocker.patch(
+        "simtools.production_configuration.production_comparison.filter_manifests",
+        return_value=[],
+    )
+
+    with pytest.raises(ValueError, match="No trigger-histogram metadata"):
+        production_comparison._selected_trigger_histogram_manifests("production", [])
+
+
+def test_unique_manifests_by_pairing_key_rejects_duplicates(tmp_test_directory):
+    manifest = ProductionManifest(
+        path=Path(tmp_test_directory) / "first.yml",
+        data={"configuration": {}},
+    )
+
+    with pytest.raises(ValueError, match="More than one baseline"):
+        production_comparison._unique_manifests_by_pairing_key(
+            [manifest, manifest], set(), "baseline"
+        )
+
+
+def test_single_trigger_histogram_file_handles_absolute_and_invalid_manifests(tmp_test_directory):
+    absolute_file = Path(tmp_test_directory) / "trigger_histograms.hdf5"
+    manifest = ProductionManifest(
+        path=Path(tmp_test_directory) / "manifest.yml",
+        data={"files": {"trigger_histograms": [str(absolute_file)]}},
+    )
+    assert production_comparison._single_trigger_histogram_file(manifest) == absolute_file
+
+    empty_manifest = ProductionManifest(path=manifest.path, data={"files": {}})
+    with pytest.raises(ValueError, match="Expected exactly one"):
+        production_comparison._single_trigger_histogram_file(empty_manifest)

--- a/tests/unit_tests/production_configuration/test_production_file_selection.py
+++ b/tests/unit_tests/production_configuration/test_production_file_selection.py
@@ -131,6 +131,23 @@ def test_select_file_groups_reports_missing_runs(tmp_test_directory):
     assert result["groups"][0].missing_run_numbers == [2]
 
 
+def test_select_file_groups_keeps_multiple_files_from_one_run(tmp_test_directory):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    second_file = manifest_path.parent / "gamma_run000001.part0002.reduced_event_data.hdf5"
+    second_file.touch()
+    manifest = collect_data_from_file(manifest_path)
+    manifest["files"]["reduced_event_data"].append(second_file.name)
+    write_data_to_file(manifest, manifest_path)
+
+    result = select_file_groups(tmp_test_directory)
+
+    assert result["groups"][0].run_numbers == [1]
+    assert [path.name for path in result["groups"][0].file_paths] == [
+        "gamma_run000001.reduced_event_data.hdf5",
+        "gamma_run000001.part0002.reduced_event_data.hdf5",
+    ]
+
+
 def test_select_file_groups_can_require_complete_runs(tmp_test_directory):
     _write_manifest(tmp_test_directory, "job-000001", 1)
     _write_manifest(tmp_test_directory, "job-000003", 3)

--- a/tests/unit_tests/production_configuration/test_production_file_selection.py
+++ b/tests/unit_tests/production_configuration/test_production_file_selection.py
@@ -510,6 +510,29 @@ def test_manifest_path_and_file_suffix_validation(tmp_test_directory):
         _validate_file_type(Path(tmp_test_directory) / "file.txt", "sim_telarray", "manifest.yml")
 
 
+@pytest.mark.parametrize(
+    ("file_type", "suffix"),
+    [
+        ("reduced_event_data", ".reduced_event_data.hdf5"),
+        ("sim_telarray", ".simtel"),
+        ("sim_telarray_log", ".simtel.log"),
+        ("sim_telarray_histogram", ".hdata"),
+        ("corsika", ".corsika"),
+        ("corsika_log", ".corsika.log"),
+        ("trigger_histograms", ".trigger_histograms.hdf5"),
+    ],
+)
+@pytest.mark.parametrize("compression", ["", ".gz", ".zst"])
+def test_all_production_file_types_accept_compression_suffixes(
+    file_type, suffix, compression, tmp_test_directory
+):
+    _validate_file_type(
+        Path(tmp_test_directory) / f"run000001{suffix}{compression}",
+        file_type,
+        "manifest.yml",
+    )
+
+
 def test_filename_run_number_validation_allows_unencoded_names_and_rejects_mismatch():
     no_run_manifest = ProductionManifest(Path("manifest.yml"), {"configuration": {}})
     _validate_filename_run_number(Path("output.simtel"), no_run_manifest)

--- a/tests/unit_tests/production_configuration/test_production_file_selection.py
+++ b/tests/unit_tests/production_configuration/test_production_file_selection.py
@@ -1,0 +1,204 @@
+"""Tests for production metadata file discovery, filtering, and grouping."""
+
+from pathlib import Path
+
+import astropy.units as u
+import pytest
+
+from simtools.io.ascii_handler import write_data_to_file
+from simtools.production_configuration.production_file_selection import (
+    SIMULATE_PROD_JOB_METADATA,
+    _embedded_metadata_matches,
+    check_manifest,
+    inventory_production_files,
+    select_file_groups,
+    validate_required_production_outputs,
+)
+
+
+def _write_manifest(base, job_name, run_number, he_interaction="qgs3", zenith=None):
+    base = Path(base)
+    job_directory = base / job_name
+    job_directory.mkdir()
+    data_file = job_directory / f"gamma_run{run_number:06d}.reduced_event_data.hdf5"
+    simtel_file = job_directory / f"gamma_run{run_number:06d}.simtel.zst"
+    data_file.touch()
+    simtel_file.touch()
+    manifest = {
+        "schema_name": "simulate_prod_job_metadata",
+        "schema_version": "1.0.0",
+        "product_type": "simulate_prod_job",
+        "job_id": job_name,
+        "status": "complete",
+        "catalog_metadata": {"runNumber": run_number},
+        "configuration": {
+            "run_number": run_number,
+            "primary": "gamma",
+            "site": "North",
+            "array_layout_name": "CTAO-North-Alpha",
+            "model_version": "7.0.0",
+            "simulation_software": "corsika_sim_telarray",
+            "corsika_he_interaction": he_interaction,
+            "azimuth_angle": {"value": 180.0, "unit": "deg"},
+            "zenith_angle": zenith or {"value": 20.0, "unit": "deg"},
+            "energy_min": {"value": 0.03, "unit": "TeV"},
+            "energy_max": {"value": 300.0, "unit": "TeV"},
+            "view_cone_min": {"value": 0.0, "unit": "deg"},
+            "view_cone_max": {"value": 10.0, "unit": "deg"},
+            "cores_per_shower": 10,
+            "core_scatter_max": {"value": 500.0, "unit": "m"},
+            "showers_per_run": 100,
+            "model_parameter_overrides": {},
+            "atmosphere": {},
+        },
+        "files": {
+            "reduced_event_data": [data_file.name],
+            "sim_telarray": [simtel_file.name],
+        },
+    }
+    manifest_path = job_directory / SIMULATE_PROD_JOB_METADATA
+    write_data_to_file(manifest, manifest_path)
+    return manifest_path
+
+
+def test_select_file_groups_filters_quantities_and_orders_runs(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000002", 2, he_interaction="qgs3")
+    _write_manifest(tmp_test_directory, "job-000001", 1, he_interaction="qgs3")
+    _write_manifest(tmp_test_directory, "job-000003", 3, he_interaction="epos")
+
+    result = select_file_groups(
+        tmp_test_directory,
+        selections=[
+            "configuration.corsika_he_interaction=qgs3",
+            "configuration.zenith_angle=20 deg",
+        ],
+        file_type="reduced_event_data",
+    )
+
+    assert result["metadata_files_read"] == 3
+    assert result["matching_jobs"] == 2
+    assert result["configuration_groups"] == 1
+    assert result["groups"][0].run_numbers == [1, 2]
+    assert [path.name for path in result["groups"][0].file_paths] == [
+        "gamma_run000001.reduced_event_data.hdf5",
+        "gamma_run000002.reduced_event_data.hdf5",
+    ]
+
+
+def test_select_file_groups_separates_different_configurations(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000001", 1, he_interaction="qgs3")
+    _write_manifest(
+        tmp_test_directory,
+        "job-000002",
+        2,
+        he_interaction="qgs3",
+        zenith={"value": 0.3490658503988659, "unit": "rad"},
+    )
+
+    result = select_file_groups(tmp_test_directory)
+
+    assert result["configuration_groups"] == 1
+    assert result["groups"][0].run_numbers == [1, 2]
+
+
+def test_select_file_groups_reports_missing_runs(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000001", 1)
+    _write_manifest(tmp_test_directory, "job-000003", 3)
+
+    result = select_file_groups(tmp_test_directory)
+
+    assert result["groups"][0].missing_run_numbers == [2]
+
+
+def test_select_file_groups_rejects_duplicate_runs(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000001", 1)
+    _write_manifest(tmp_test_directory, "job-000002", 1)
+
+    with pytest.raises(ValueError, match="Duplicate run numbers"):
+        select_file_groups(tmp_test_directory)
+
+
+def test_check_manifest_rejects_paths_outside_job_directory(tmp_test_directory):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    manifest = {
+        "schema_name": "simulate_prod_job_metadata",
+        "schema_version": "1.0.0",
+        "product_type": "simulate_prod_job",
+        "job_id": "job-000001",
+        "status": "complete",
+        "catalog_metadata": {"runNumber": 1},
+        "configuration": {
+            "run_number": 1,
+            "primary": "gamma",
+            "site": "North",
+            "array_layout_name": "CTAO-North-Alpha",
+            "model_version": "7.0.0",
+            "simulation_software": "corsika_sim_telarray",
+            "azimuth_angle": {"value": 180.0, "unit": "deg"},
+            "zenith_angle": {"value": 20.0, "unit": "deg"},
+            "energy_min": {"value": 0.03, "unit": "TeV"},
+            "energy_max": {"value": 300.0, "unit": "TeV"},
+            "view_cone_min": {"value": 0.0, "unit": "deg"},
+            "view_cone_max": {"value": 10.0, "unit": "deg"},
+            "cores_per_shower": 10,
+            "core_scatter_max": {"value": 500.0, "unit": "m"},
+            "showers_per_run": 100,
+            "model_parameter_overrides": {},
+            "atmosphere": {},
+        },
+        "files": {"sim_telarray": ["../gamma_run000001.simtel.zst"]},
+    }
+    write_data_to_file(manifest, manifest_path)
+
+    with pytest.raises(ValueError, match="escapes job directory"):
+        check_manifest(manifest_path)
+
+
+def test_check_manifest_rejects_missing_files(tmp_test_directory):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    (manifest_path.parent / "gamma_run000001.reduced_event_data.hdf5").unlink()
+
+    with pytest.raises(FileNotFoundError, match="references missing file"):
+        check_manifest(manifest_path)
+
+
+def test_check_manifest_rejects_unlisted_production_files(tmp_test_directory):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    (manifest_path.parent / "gamma_run000001.simtel.log.gz").touch()
+
+    with pytest.raises(ValueError, match="Unexpected production files"):
+        check_manifest(manifest_path)
+
+
+def test_inventory_production_files_discovers_nested_simulation_outputs(tmp_test_directory):
+    job_directory = Path(tmp_test_directory)
+    simtel_file = job_directory / "sim_telarray" / "run000001" / "gamma_run000001.simtel.zst"
+    log_file = job_directory / "sim_telarray" / "run000001" / "gamma_run000001.simtel.log.gz"
+    reduced_file = (
+        job_directory / "sim_telarray" / "run000001" / "gamma_run000001.reduced_event_data.hdf5"
+    )
+    simtel_file.parent.mkdir(parents=True)
+    simtel_file.touch()
+    log_file.touch()
+    reduced_file.touch()
+
+    assert inventory_production_files(job_directory) == {
+        "reduced_event_data": ["sim_telarray/run000001/gamma_run000001.reduced_event_data.hdf5"],
+        "sim_telarray": ["sim_telarray/run000001/gamma_run000001.simtel.zst"],
+        "sim_telarray_log": ["sim_telarray/run000001/gamma_run000001.simtel.log.gz"],
+    }
+
+
+def test_embedded_metadata_matches_in_memory_and_serialized_quantities():
+    assert _embedded_metadata_matches(0 * u.deg, "0.0")
+    assert _embedded_metadata_matches({"value": 20.0, "unit": "deg"}, "20")
+    assert not _embedded_metadata_matches(20 * u.deg, "21")
+
+
+def test_validate_required_production_outputs_rejects_incomplete_job(tmp_test_directory):
+    with pytest.raises(ValueError, match="no 'sim_telarray' output"):
+        validate_required_production_outputs(
+            {"reduced_event_data": ["gamma.reduced_event_data.hdf5"]},
+            "corsika_sim_telarray",
+            tmp_test_directory,
+        )

--- a/tests/unit_tests/production_configuration/test_production_file_selection.py
+++ b/tests/unit_tests/production_configuration/test_production_file_selection.py
@@ -5,14 +5,35 @@ from pathlib import Path
 import astropy.units as u
 import pytest
 
-from simtools.io.ascii_handler import write_data_to_file
+from simtools.io.ascii_handler import collect_data_from_file, write_data_to_file
 from simtools.production_configuration.production_file_selection import (
     SIMULATE_PROD_JOB_METADATA,
+    ProductionFileGroup,
+    ProductionManifest,
+    _compare_simtel_metadata,
     _embedded_metadata_matches,
+    _get_dotted_value,
+    _missing_run_numbers,
+    _parse_selection,
+    _production_file_type,
+    _quantity_matches,
+    _resolve_relative_manifest_path,
+    _validate_file_type,
+    _validate_filename_run_number,
+    _validate_manifest_structure,
     check_manifest,
+    discover_product_manifests,
+    filter_manifests,
+    find_manifests,
+    group_selected_files,
     inventory_production_files,
+    load_manifest,
+    normalize_for_comparison,
     select_file_groups,
+    selection_summary,
+    stable_configuration_hash,
     validate_required_production_outputs,
+    write_selection_file,
 )
 
 
@@ -110,6 +131,23 @@ def test_select_file_groups_reports_missing_runs(tmp_test_directory):
     assert result["groups"][0].missing_run_numbers == [2]
 
 
+def test_select_file_groups_can_require_complete_runs(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000001", 1)
+    _write_manifest(tmp_test_directory, "job-000003", 3)
+
+    with pytest.raises(ValueError, match=r"Missing run numbers.*2"):
+        select_file_groups(tmp_test_directory, require_complete_runs=True)
+
+
+def test_select_file_groups_accepts_complete_runs(tmp_test_directory):
+    _write_manifest(tmp_test_directory, "job-000001", 1)
+    _write_manifest(tmp_test_directory, "job-000002", 2)
+
+    result = select_file_groups(tmp_test_directory, require_complete_runs=True)
+
+    assert result["groups"][0].missing_run_numbers == []
+
+
 def test_select_file_groups_rejects_duplicate_runs(tmp_test_directory):
     _write_manifest(tmp_test_directory, "job-000001", 1)
     _write_manifest(tmp_test_directory, "job-000002", 1)
@@ -170,6 +208,39 @@ def test_check_manifest_rejects_unlisted_production_files(tmp_test_directory):
         check_manifest(manifest_path)
 
 
+def test_check_manifest_rejects_duplicate_output_entries(tmp_test_directory):
+    simtel_file = Path(tmp_test_directory) / "gamma_run000001.simtel.zst"
+    simtel_file.touch()
+    manifest = ProductionManifest(
+        path=Path(tmp_test_directory) / "manifest.yml",
+        data={
+            "schema_version": "1.0.0",
+            "product_type": "custom_product",
+            "status": "complete",
+            "configuration": {},
+            "files": {"sim_telarray": [simtel_file.name, simtel_file.name]},
+        },
+    )
+
+    with pytest.raises(ValueError, match="Duplicate output file listed"):
+        check_manifest(manifest)
+
+
+def test_check_manifest_accepts_non_simulation_product_manifest(tmp_test_directory):
+    manifest = ProductionManifest(
+        path=Path(tmp_test_directory) / "selection.yml",
+        data={
+            "schema_version": "1.0.0",
+            "product_type": "production_file_selection",
+            "status": "complete",
+            "configuration": {},
+            "files": {},
+        },
+    )
+
+    assert check_manifest(manifest) == {"valid": True, "unverifiable_fields": []}
+
+
 def test_inventory_production_files_discovers_nested_simulation_outputs(tmp_test_directory):
     job_directory = Path(tmp_test_directory)
     simtel_file = job_directory / "sim_telarray" / "run000001" / "gamma_run000001.simtel.zst"
@@ -181,6 +252,8 @@ def test_inventory_production_files_discovers_nested_simulation_outputs(tmp_test
     simtel_file.touch()
     log_file.touch()
     reduced_file.touch()
+    (job_directory / "trigger.trigger_histograms.hdf5").touch()
+    (job_directory / "unrecognized.txt").touch()
 
     assert inventory_production_files(job_directory) == {
         "reduced_event_data": ["sim_telarray/run000001/gamma_run000001.reduced_event_data.hdf5"],
@@ -193,6 +266,44 @@ def test_embedded_metadata_matches_in_memory_and_serialized_quantities():
     assert _embedded_metadata_matches(0 * u.deg, "0.0")
     assert _embedded_metadata_matches({"value": 20.0, "unit": "deg"}, "20")
     assert not _embedded_metadata_matches(20 * u.deg, "21")
+    assert _embedded_metadata_matches("Gamma", "gamma")
+
+
+def test_check_manifest_compares_embedded_simtel_metadata(tmp_test_directory, mocker):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    mocker.patch(
+        "simtools.production_configuration.production_file_selection.read_sim_telarray_metadata",
+        return_value=({"primary": "gamma", "zenith": "20 deg"}, None),
+    )
+
+    result = check_manifest(manifest_path)
+
+    assert "primary" not in result["unverifiable_fields"]
+    assert "zenith_angle" not in result["unverifiable_fields"]
+
+
+def test_compare_simtel_metadata_skips_configuration_fields_without_metadata(mocker):
+    manifest = ProductionManifest(
+        path=Path("manifest.yml"),
+        data={"configuration": {"primary": "gamma"}},
+    )
+    mocker.patch(
+        "simtools.production_configuration.production_file_selection.read_sim_telarray_metadata",
+        return_value=({"primary": "gamma"}, None),
+    )
+
+    assert _compare_simtel_metadata(Path("file.simtel"), manifest, ["primary"]) == []
+
+
+def test_check_manifest_rejects_mismatched_embedded_simtel_metadata(tmp_test_directory, mocker):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    mocker.patch(
+        "simtools.production_configuration.production_file_selection.read_sim_telarray_metadata",
+        return_value=({"primary": "proton"}, None),
+    )
+
+    with pytest.raises(ValueError, match=r"configuration\.primary"):
+        check_manifest(manifest_path)
 
 
 def test_validate_required_production_outputs_rejects_incomplete_job(tmp_test_directory):
@@ -202,3 +313,202 @@ def test_validate_required_production_outputs_rejects_incomplete_job(tmp_test_di
             "corsika_sim_telarray",
             tmp_test_directory,
         )
+
+
+def test_validate_required_production_outputs_accepts_required_output(tmp_test_directory):
+    validate_required_production_outputs(
+        {"corsika": ["shower.corsika.zst"]}, "corsika", tmp_test_directory
+    )
+
+
+def test_stable_configuration_hash_is_deterministic_and_short():
+    configuration = {"zenith_angle": {"value": 20.0, "unit": "deg"}}
+
+    first_hash = stable_configuration_hash(configuration)
+    second_hash = stable_configuration_hash({"zenith_angle": {"unit": "deg", "value": 20.0}})
+
+    assert first_hash == second_hash
+    assert len(first_hash) == 8
+    assert stable_configuration_hash(configuration, length=12) != first_hash
+
+
+def test_find_manifests_rejects_missing_production_path(tmp_test_directory):
+    with pytest.raises(FileNotFoundError, match="Production path not found"):
+        find_manifests(Path(tmp_test_directory) / "missing")
+
+
+def test_discover_product_manifests_filters_invalid_and_other_products(tmp_test_directory, mocker):
+    paths = [Path(tmp_test_directory) / name for name in ("keep.yml", "skip.yml", "invalid.yml")]
+    for path in paths:
+        path.touch()
+    data = {
+        "keep.yml": {
+            "schema_version": "1.0.0",
+            "product_type": "custom_product",
+            "status": "complete",
+            "configuration": {},
+            "files": {},
+        },
+        "skip.yml": {"product_type": "other_product"},
+        "invalid.yml": ["not a mapping"],
+    }
+    mocker.patch(
+        "simtools.production_configuration.production_file_selection.ascii_handler.collect_data_from_file",
+        side_effect=lambda path: data[Path(path).name],
+    )
+
+    result = discover_product_manifests(tmp_test_directory, "custom_product")
+
+    assert [manifest.path.name for manifest in result] == ["keep.yml"]
+
+
+def test_discover_product_manifests_rejects_missing_production_path(tmp_test_directory):
+    with pytest.raises(FileNotFoundError, match="Production path not found"):
+        discover_product_manifests(Path(tmp_test_directory) / "missing", "custom_product")
+
+
+def test_group_selected_files_rejects_missing_file_type(tmp_test_directory):
+    manifest_path = _write_manifest(tmp_test_directory, "job-000001", 1)
+    manifest = load_manifest(manifest_path)
+
+    with pytest.raises(ValueError, match="lists no files"):
+        group_selected_files([manifest], file_type="corsika")
+
+
+def test_write_selection_file_and_summary(tmp_test_directory):
+    group = ProductionFileGroup(
+        configuration={"primary": "gamma"},
+        run_numbers=[1, 3],
+        file_paths=[Path("job-000001/file.simtel.zst")],
+        missing_run_numbers=[2],
+    )
+    result = {
+        "metadata_files_read": 3,
+        "matching_jobs": 2,
+        "configuration_groups": 1,
+        "groups": [group],
+    }
+    output_file = Path(tmp_test_directory) / "selection.yml"
+
+    write_selection_file(result, output_file)
+
+    assert "Missing runs: 2" in selection_summary(result)
+    assert collect_data_from_file(output_file)["groups"][0]["files"] == [
+        "job-000001/file.simtel.zst"
+    ]
+
+
+def test_normalize_for_comparison_handles_quantities_and_sequences():
+    assert normalize_for_comparison(1 * u.m) == (1.0, "m")
+    assert normalize_for_comparison([1 * u.m, (2 * u.s,)]) == ((1.0, "m"), ((2.0, "s"),))
+
+
+def test_filter_manifests_supports_unqualified_configuration_keys():
+    manifest = ProductionManifest(
+        path=Path("manifest.yml"),
+        data={"configuration": {"primary": "gamma"}},
+    )
+
+    assert filter_manifests([manifest], ["primary=gamma"]) == [manifest]
+    assert _get_dotted_value({"configuration": {}}, "configuration.primary") is None
+    assert not filter_manifests([manifest], ["missing=value"])
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (None, "expected a mapping"),
+        ({}, "missing 'schema_version'"),
+        (
+            {
+                "schema_version": "9.9.9",
+                "product_type": "custom",
+                "status": "complete",
+                "configuration": {},
+                "files": {},
+            },
+            "Unsupported production metadata schema",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "product_type": "custom",
+                "status": "running",
+                "configuration": {},
+                "files": {},
+            },
+            "not complete",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "product_type": "custom",
+                "status": "complete",
+                "configuration": [],
+                "files": {},
+            },
+            "configuration is not a mapping",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "product_type": "simulate_prod_job",
+                "status": "complete",
+                "configuration": {},
+                "files": {},
+            },
+            "configuration.run_number",
+        ),
+        (
+            {
+                "schema_version": "1.0.0",
+                "product_type": "custom",
+                "status": "complete",
+                "configuration": {},
+                "files": [],
+            },
+            "files is not a mapping",
+        ),
+    ],
+)
+def test_validate_manifest_structure_rejects_malformed_data(data, message, tmp_test_directory):
+    with pytest.raises(ValueError, match=message):
+        _validate_manifest_structure(data, Path(tmp_test_directory) / "manifest.yml")
+
+
+@pytest.mark.parametrize("selection", ["missing_separator", "=value"])
+def test_parse_selection_rejects_invalid_syntax(selection):
+    with pytest.raises(ValueError, match="Selection"):
+        _parse_selection(selection)
+
+
+def test_quantity_selection_rejects_invalid_expected_quantity():
+    assert not _quantity_matches({"value": 1, "unit": "m"}, "not-a-quantity")
+
+
+def test_manifest_path_and_file_suffix_validation(tmp_test_directory):
+    with pytest.raises(ValueError, match="must be relative"):
+        _resolve_relative_manifest_path(tmp_test_directory, "/absolute/file.simtel.zst")
+    with pytest.raises(ValueError, match="suffix is inconsistent"):
+        _validate_file_type(Path(tmp_test_directory) / "file.txt", "sim_telarray", "manifest.yml")
+
+
+def test_filename_run_number_validation_allows_unencoded_names_and_rejects_mismatch():
+    no_run_manifest = ProductionManifest(Path("manifest.yml"), {"configuration": {}})
+    _validate_filename_run_number(Path("output.simtel"), no_run_manifest)
+    run_manifest = ProductionManifest(Path("manifest.yml"), {"configuration": {"run_number": 2}})
+
+    with pytest.raises(ValueError, match="Run number mismatch"):
+        _validate_filename_run_number(Path("gamma_run000001.simtel"), run_manifest)
+
+
+def test_production_file_type_and_quantity_helpers():
+    assert _production_file_type(Path("file.simtel.zst")) == "sim_telarray"
+    assert _production_file_type(Path("file.txt")) is None
+    assert _quantity_matches({"value": 100, "unit": "GeV"}, "0.1 TeV")
+
+
+def test_empty_selection_summary_has_no_missing_runs():
+    result = {"metadata_files_read": 0, "matching_jobs": 0, "configuration_groups": 0, "groups": []}
+    assert selection_summary(result).endswith("Missing runs: none")
+    assert _missing_run_numbers([]) == []

--- a/tests/unit_tests/production_configuration/test_production_metadata.py
+++ b/tests/unit_tests/production_configuration/test_production_metadata.py
@@ -109,6 +109,24 @@ def test_write_manifests_rejects_missing_job_directory(mocker, tmp_test_director
         production_metadata._write_manifests(Path(tmp_test_directory), "job-grid.ecsv", {})
 
 
+def test_write_manifests_supports_zero_based_job_directories(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    job_directory = production_path / "job-000000"
+    job_directory.mkdir()
+    (job_directory / "gamma_run000001.simtel.zst").touch()
+    mocker.patch(
+        "simtools.production_configuration.production_metadata.read_job_grid",
+        return_value=([_job_grid_row()], {"site": "North", "simulation_software": "sim_telarray"}),
+    )
+    write_file = mocker.patch(
+        "simtools.production_configuration.production_metadata.write_data_to_file"
+    )
+
+    production_metadata._write_manifests(production_path, "job-grid.ecsv", {"overwrite": False})
+
+    assert write_file.call_args.args[1] == job_directory / "simulate_prod_job_metadata.yml"
+
+
 def test_write_manifests_requires_overwrite_for_existing_manifest(mocker, tmp_test_directory):
     production_path = Path(tmp_test_directory)
     job_directory = production_path / "job-000001"

--- a/tests/unit_tests/production_configuration/test_production_metadata.py
+++ b/tests/unit_tests/production_configuration/test_production_metadata.py
@@ -1,0 +1,161 @@
+"""Tests for production metadata backfill and validation workflows."""
+
+from pathlib import Path
+
+import astropy.units as u
+import pytest
+
+from simtools.production_configuration import production_metadata
+
+
+def _job_grid_row():
+    """Return one complete authoritative job-grid row."""
+    return {
+        "run_number": 1,
+        "primary": "gamma",
+        "azimuth_angle": 180 * u.deg,
+        "zenith_angle": 20 * u.deg,
+        "energy_min": 0.03 * u.TeV,
+        "energy_max": 300 * u.TeV,
+        "cores_per_shower": 10,
+        "core_scatter_max": 500 * u.m,
+        "view_cone_min": 0 * u.deg,
+        "view_cone_max": 10 * u.deg,
+        "showers_per_run": 100,
+        "model_version": "7.0.0",
+        "array_layout_name": "CTAO-North-Alpha",
+        "corsika_le_interaction": "urqmd",
+        "corsika_he_interaction": "qgs3",
+    }
+
+
+def test_check_existing_manifests_reports_missing_job_manifest(tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    with pytest.raises(FileNotFoundError, match="No production job directories"):
+        production_metadata._check_existing_manifests(production_path)
+
+    (production_path / "job-000001").mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Missing production metadata manifest"):
+        production_metadata._check_existing_manifests(production_path)
+
+
+def test_write_production_metadata_dispatches_check_and_write_modes(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    mock_check = mocker.patch(
+        "simtools.production_configuration.production_metadata._check_existing_manifests"
+    )
+    mock_write = mocker.patch(
+        "simtools.production_configuration.production_metadata._write_manifests"
+    )
+
+    production_metadata.write_production_metadata(
+        {"production_path": str(production_path), "check": True}
+    )
+    production_metadata.write_production_metadata(
+        {"production_path": str(production_path), "job_grid_file": "job-grid.ecsv"}
+    )
+
+    mock_check.assert_called_once_with(production_path)
+    mock_write.assert_called_once_with(production_path, "job-grid.ecsv", mocker.ANY)
+
+
+def test_check_existing_manifests_validates_each_manifest(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    job_directory = production_path / "job-000001"
+    job_directory.mkdir()
+    manifest_path = job_directory / production_metadata.SIMULATE_PROD_JOB_METADATA
+    manifest_path.touch()
+    mock_check = mocker.patch(
+        "simtools.production_configuration.production_metadata.check_manifest"
+    )
+
+    production_metadata._check_existing_manifests(production_path)
+
+    mock_check.assert_called_once_with(manifest_path)
+
+
+def test_write_manifests_does_not_mark_incomplete_job_complete(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    (production_path / "job-000001").mkdir()
+    mocker.patch(
+        "simtools.production_configuration.production_metadata.read_job_grid",
+        return_value=(
+            [_job_grid_row()],
+            {"site": "North", "simulation_software": "corsika_sim_telarray"},
+        ),
+    )
+    write_file = mocker.patch(
+        "simtools.production_configuration.production_metadata.write_data_to_file"
+    )
+
+    with pytest.raises(ValueError, match="Incomplete production job"):
+        production_metadata._write_manifests(
+            production_path,
+            "job-grid.ecsv",
+            {"overwrite": False},
+        )
+
+    write_file.assert_not_called()
+
+
+def test_write_manifests_rejects_missing_job_directory(mocker, tmp_test_directory):
+    mocker.patch(
+        "simtools.production_configuration.production_metadata.read_job_grid",
+        return_value=([_job_grid_row()], {}),
+    )
+
+    with pytest.raises(FileNotFoundError, match="Production job directory not found"):
+        production_metadata._write_manifests(Path(tmp_test_directory), "job-grid.ecsv", {})
+
+
+def test_write_manifests_requires_overwrite_for_existing_manifest(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    job_directory = production_path / "job-000001"
+    job_directory.mkdir()
+    (job_directory / production_metadata.SIMULATE_PROD_JOB_METADATA).touch()
+    mocker.patch(
+        "simtools.production_configuration.production_metadata.read_job_grid",
+        return_value=([_job_grid_row()], {}),
+    )
+
+    with pytest.raises(FileExistsError, match="Use --overwrite"):
+        production_metadata._write_manifests(production_path, "job-grid.ecsv", {})
+
+
+def test_write_manifests_omits_unknown_catalog_and_atmosphere_values(mocker, tmp_test_directory):
+    production_path = Path(tmp_test_directory)
+    job_directory = production_path / "job-000001"
+    job_directory.mkdir()
+    (job_directory / "gamma_run000001.simtel.zst").touch()
+    mocker.patch(
+        "simtools.production_configuration.production_metadata.read_job_grid",
+        return_value=(
+            [_job_grid_row()],
+            {"site": "North", "simulation_software": "corsika_sim_telarray"},
+        ),
+    )
+    write_file = mocker.patch(
+        "simtools.production_configuration.production_metadata.write_data_to_file"
+    )
+
+    production_metadata._write_manifests(
+        production_path,
+        "job-grid.ecsv",
+        {"overwrite": False},
+    )
+
+    manifest = write_file.call_args.args[0]
+    assert "sct" not in manifest["catalog_metadata"]
+    assert manifest["configuration"]["atmosphere"] == {}
+
+
+def test_backfilled_atmosphere_and_configuration_validation(tmp_test_directory):
+    assert production_metadata._backfilled_atmosphere_configuration(
+        {"curved_atmosphere_min_zenith_angle": 70 * u.deg}
+    ) == {"curved_atmosphere_min_zenith_angle": 70 * u.deg}
+
+    with pytest.raises(ValueError, match="primary"):
+        production_metadata._validate_resolved_configuration({}, "job-grid.ecsv")
+    with pytest.raises(FileNotFoundError, match="Production path not found"):
+        production_metadata._job_directories(Path(tmp_test_directory) / "missing")

--- a/tests/unit_tests/production_configuration/test_trigger_histograms.py
+++ b/tests/unit_tests/production_configuration/test_trigger_histograms.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import astropy.units as u
 import h5py
@@ -7,6 +8,7 @@ import pytest
 from astropy.table import Table
 
 from simtools.io import table_handler
+from simtools.io.ascii_handler import collect_data_from_file
 from simtools.production_configuration.trigger_histograms import (
     TRIGGER_HISTOGRAM_BINS_TABLE,
     TRIGGER_HISTOGRAM_DENSE_GROUP,
@@ -19,10 +21,13 @@ from simtools.production_configuration.trigger_histograms import (
     _execute_production_job,
     _format_trigger_histogram_inspection,
     _get_plot_directory_name,
+    _group_output_stem,
+    _relative_to_directory,
     _use_readable_inline_array_names,
     _write_dense_histogram_payload,
     _write_directory_group_job,
     _write_directory_products,
+    _write_trigger_histogram_metadata,
     discover_event_data_groups,
     inspect_trigger_histogram_file,
     load_event_data_histograms,
@@ -392,6 +397,72 @@ def test_write_directory_group_job_uses_local_inner_execution(mocker):
     assert inner_args["backend"] == "local"
     assert inner_args["backend_config"] is None
     assert inner_args["max_workers"] == 1
+
+
+def test_trigger_histogram_metadata_uses_portable_paths_and_resolved_array_selection(
+    tmp_test_directory,
+):
+    base_directory = Path(tmp_test_directory)
+    input_file = base_directory / "grid-output" / "job-000001" / "gamma.hdf5"
+    output_file = base_directory / "trigger_histograms" / "gamma.trigger_histograms.hdf5"
+    input_file.parent.mkdir(parents=True)
+    output_file.parent.mkdir()
+    input_file.touch()
+    output_file.touch()
+
+    _write_trigger_histogram_metadata(
+        {
+            "energy_bins_per_decade": 10,
+            "angular_distance_bin_width": 0.5 * u.deg,
+            "core_distance_bin_width": 20 * u.m,
+            "minimum_triggered_telescopes": 2,
+        },
+        output_file,
+        {
+            "configuration": {"primary": "gamma"},
+            "run_numbers": [1],
+            "input_files": [input_file],
+            "array_selection": [{"array_name": "CTAO-North-Alpha", "telescope_ids": ["LSTN-01"]}],
+        },
+    )
+
+    metadata = collect_data_from_file(output_file.with_suffix(".yml"))
+    assert metadata["input_files"]["reduced_event_data"] == ["../grid-output/job-000001/gamma.hdf5"]
+    assert metadata["array_selection"][0]["array_name"] == "CTAO-North-Alpha"
+
+
+def test_group_output_stem_changes_with_histogram_settings_and_array_selection():
+    group = SimpleNamespace(
+        configuration={
+            "primary": "gamma",
+            "zenith_angle": {"value": 20.0, "unit": "deg"},
+            "corsika_he_interaction": "qgs3",
+        }
+    )
+    first = _group_output_stem(
+        group,
+        {
+            "histogram_settings": {"minimum_triggered_telescopes": 2},
+            "array_selection": [{"array_name": "alpha", "telescope_ids": ["LSTN-01"]}],
+        },
+    )
+    second = _group_output_stem(
+        group,
+        {
+            "histogram_settings": {"minimum_triggered_telescopes": 3},
+            "array_selection": [{"array_name": "alpha", "telescope_ids": ["LSTN-01"]}],
+        },
+    )
+
+    assert first != second
+
+
+def test_relative_to_directory_handles_sibling_directories(tmp_test_directory):
+    base_directory = Path(tmp_test_directory)
+    path = base_directory / "grid-output" / "job-000001" / "file.hdf5"
+    directory = base_directory / "trigger_histograms"
+
+    assert _relative_to_directory(path, directory) == "../grid-output/job-000001/file.hdf5"
 
 
 def test_write_trigger_histograms_dispatches_one_job_per_pattern(mocker, tmp_path):

--- a/tests/unit_tests/production_configuration/test_trigger_histograms.py
+++ b/tests/unit_tests/production_configuration/test_trigger_histograms.py
@@ -23,6 +23,7 @@ from simtools.production_configuration.trigger_histograms import (
     _get_plot_directory_name,
     _group_output_stem,
     _relative_to_directory,
+    _resolve_group_telescope_configs,
     _use_readable_inline_array_names,
     _write_dense_histogram_payload,
     _write_directory_group_job,
@@ -463,6 +464,44 @@ def test_relative_to_directory_handles_sibling_directories(tmp_test_directory):
     directory = base_directory / "trigger_histograms"
 
     assert _relative_to_directory(path, directory) == "../grid-output/job-000001/file.hdf5"
+
+
+def test_production_group_telescope_configs_come_from_metadata(mocker):
+    resolve = mocker.patch(
+        "simtools.production_configuration.trigger_histograms._resolve_telescope_configs",
+        return_value=[{"array_name": "CTAO-North-Alpha", "telescope_ids": ["LSTN-01"]}],
+    )
+
+    _resolve_group_telescope_configs(
+        {},
+        {
+            "site": "North",
+            "model_version": "7.0.0",
+            "array_layout_name": "CTAO-North-Alpha",
+        },
+    )
+
+    resolved_args = resolve.call_args.args[0]
+    assert resolved_args["site"] == "North"
+    assert resolved_args["model_version"] == ["7.0.0"]
+    assert resolved_args["array_layout_name"] == ["CTAO-North-Alpha"]
+
+
+def test_production_group_telescope_configs_reject_mismatched_layout():
+    with pytest.raises(ValueError, match="does not match selected production metadata"):
+        _resolve_group_telescope_configs(
+            {"array_layout_name": ["CTAO-North-Beta"]},
+            {
+                "site": "North",
+                "model_version": "7.0.0",
+                "array_layout_name": "CTAO-North-Alpha",
+            },
+        )
+
+
+def test_production_metadata_histograms_reject_non_event_data_file_types():
+    with pytest.raises(ValueError, match="requires file_type='reduced_event_data'"):
+        write_trigger_histograms({"production_path": "production", "file_type": "sim_telarray"})
 
 
 def test_write_trigger_histograms_dispatches_one_job_per_pattern(mocker, tmp_path):


### PR DESCRIPTION
Goal is to simplify the production use case when executed e.g., on a local cluster (as we do a lot on DESY for testing). This is especially important for complex production with a N-dim grid in zenith, azimuth, nsb, interaction models, fixed energies, etc.

## Metadata improvement

Each job writes a metadata file with details on production (including all simulation parameters, interaction models, relevant files)

The metadata is written at the end of each production step.

To write or check an existing production:

```
python src/simtools/applications/write_production_metadata.py \
   --production_path <production path> \
   --job_grid_file <my job grid file> \
  --overwrite / --check
```

## Filter for e.g. filling histograms

Filters are regular command-line arguments:

```
 212 │ 
 213 │ Examples:
 214 │ 
 215 │ ```bash
 216 │ --select configuration.corsika_he_interaction=qgs3
 217 │ --select configuration.corsika_he_interaction=epos
 218 │ --select configuration.zenith_angle="20 deg"
 219 │ --select configuration.primary=gamma
 220 │ ```
```

Allow `--select` to be repeated. All filters are combined with logical AND.

As an example, for epos at 20 degrees:

```bash
simtools-write-trigger-histograms \
  --production_path /data/prod7/grid-output \
  --select configuration.corsika_he_interaction=epos \
  --select configuration.zenith_angle="20 deg" \
  --file_type reduced_event_data \
  --output_path /data/prod7/trigger_histograms
```
