### PR TITLE
Reduce number of trigger to `CORSIKA` and `sim_telarray` build CI.

### DIFF
--- a/.github/workflows/build-corsika7.yml
+++ b/.github/workflows/build-corsika7.yml
@@ -11,9 +11,6 @@ on:
   pull_request:
     paths:
       - docker/Dockerfile-corsika7
-      - dependency_versions.yml
-      - src/simtools/applications/dependency_versions.py
-      - src/simtools/dependency_versions.py
       - docker/validate_corsika7_build.sh
       - .github/workflows/build-corsika7.yml
   schedule:

--- a/.github/workflows/build-sim_telarray.yml
+++ b/.github/workflows/build-sim_telarray.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     paths:
       - docker/Dockerfile-simtel_array
-      - dependency_versions.yml
-      - src/simtools/applications/dependency_versions.py
-      - src/simtools/dependency_versions.py
       - .github/workflows/build-sim_telarray.yml
   schedule:
     - cron: '0 0 1 * *'  # Every 1st day of the month at 00:00 UTC (build only)

--- a/docs/changes/2504.maintenance.md
+++ b/docs/changes/2504.maintenance.md
@@ -1,0 +1,1 @@
+Reduce number of trigger to build-CI for `CORSIKA` and `sim_telarray`.


### PR DESCRIPTION
These CIs are computational intensive and need hardly every updating. Running too much in the past weeks, and mostly due to unrelated changes. Try to reduce the triggers.