### PR TITLE
Git backend for simulation models reader

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -228,7 +228,7 @@ jobs:
         id: restore_simulation_models
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
-          path: simulation-models
+          path: simulation-models.git
           key: simulation-models-${{ steps.simulation_model_branch.outputs.branch }}
           restore-keys: |
             simulation-models-${{ steps.simulation_model_branch.outputs.branch }}-
@@ -236,8 +236,8 @@ jobs:
       - name: Clone simulation models repository
         # if: github.event_name != 'schedule'
         run: |
-          CLONE_DIR="simulation-models-clone"
-          CACHE_DIR="simulation-models"
+          CLONE_DIR="simulation-models.git-clone"
+          CACHE_DIR="simulation-models.git"
           rm -rf "$CLONE_DIR"
           CLONE_SUCCESS=false
 
@@ -246,11 +246,12 @@ jobs:
               -c "http.connectTimeout=$GIT_HTTP_CONNECT_TIMEOUT" \
               -c "http.lowSpeedLimit=$GIT_HTTP_LOW_SPEED_LIMIT" \
               -c "http.lowSpeedTime=$GIT_HTTP_LOW_SPEED_TIME" \
-              clone --depth 1 --branch "$SIMTOOLS_DB_SIMULATION_MODEL_BRANCH" "$SIM_MODELS_REPO" "$CLONE_DIR"
+              clone --bare --depth 1 --branch "$SIMTOOLS_DB_SIMULATION_MODEL_BRANCH" \
+                "$SIM_MODELS_REPO" "$CLONE_DIR"
             then
               rm -rf "$CACHE_DIR"
               mv "$CLONE_DIR" "$CACHE_DIR"
-              echo "Successfully cloned simulation models branch $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
+              echo "Successfully cloned simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
               CLONE_SUCCESS=true
               break
             fi
@@ -263,12 +264,12 @@ jobs:
           done
 
           if [ "$CLONE_SUCCESS" = false ] && [ ! -d "$CACHE_DIR" ]; then
-            echo "Failed to clone simulation models branch $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH and no cache is available."
+            echo "Failed to clone simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH and no cache is available."
             exit 1
           fi
 
           if [ "$CLONE_SUCCESS" = false ]; then
-            echo "GitLab clone failed; using cached simulation models branch $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
+            echo "GitLab clone failed; using cached simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
           fi
 
 
@@ -276,7 +277,7 @@ jobs:
         if: steps.restore_simulation_models.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
         with:
-          path: simulation-models
+          path: simulation-models.git
           key: simulation-models-${{ steps.simulation_model_branch.outputs.branch }}
 
       - name: Upload simulation models repository
@@ -284,7 +285,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: simulation-models-repo
-          path: simulation-models
+          path: simulation-models.git
           if-no-files-found: error
           retention-days: 30
 
@@ -341,7 +342,7 @@ jobs:
       CONTAINER_IMAGE: ${{ inputs.container_image || 'ghcr.io/gammasim/simtools-dev:latest' }}
       IT_NAME: "corsika7-interaction-tables"
       SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH: ${{ github.workspace }}/corsika7-interaction-tables/interaction-tables
-      SIMULATION_MODELS_PATH: ../simulation-models
+      SIMULATION_MODELS_GIT_PATH: ../simulation-models.git
 
     strategy:
       fail-fast: false
@@ -377,7 +378,8 @@ jobs:
       - name: Create runtime environment (.env)
         run: |
           {
-            echo "SIMTOOLS_SIMULATION_MODELS_PATH=$SIMULATION_MODELS_PATH"
+            echo "SIMTOOLS_SIMULATION_MODELS_GIT_PATH=$SIMULATION_MODELS_GIT_PATH"
+            echo "SIMTOOLS_SIMULATION_MODELS_GIT_REVISION=HEAD"
             echo "SIMTOOLS_SIM_TELARRAY_PATH=$SIMTOOLS_SIM_TELARRAY_PATH"
             echo "SIMTOOLS_CORSIKA_PATH=$SIMTOOLS_CORSIKA_PATH"
             echo "SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH=$SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH"
@@ -404,7 +406,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: simulation-models-repo
-          path: ../simulation-models
+          path: ../simulation-models.git
 
       - name: Extend PATH (sim_telarray)
         run: |
@@ -413,7 +415,7 @@ jobs:
       - name: Install Python dependencies (prod container)
         if: contains(inputs.container_image, 'simtools-prod')
         run: |
-          pip install --no-cache-dir pytest pytest-cov pytest-mock pytest-requirements pytest-xdist pytest-retry
+          pip install --no-cache-dir pygit2 pytest pytest-cov pytest-mock pytest-requirements pytest-xdist pytest-retry
 
       - name: Install resource benchmark dependency (prod container)
         if: ${{ inputs.benchmark && contains(inputs.container_image, 'simtools-prod') }}
@@ -422,7 +424,7 @@ jobs:
       - name: Install Python dependencies (dev container)
         if: ${{ !contains(inputs.container_image, 'simtools-prod') }}
         run: |
-          pip install --no-cache-dir -e '.[tests,dev,doc,mongodb]'
+          pip install --no-cache-dir -e '.[tests,dev,doc,git,mongodb]'
 
       - name: Integration tests
         shell: bash -l {0}
@@ -431,7 +433,10 @@ jobs:
           for variable in ${!SIMTOOLS_DB_@}; do
             unset "$variable"
           done
-          MODEL_SOURCE_ARGS=(--simulation_models_path="$SIMULATION_MODELS_PATH")
+          MODEL_SOURCE_ARGS=(
+            --simulation_models_git_path="$SIMULATION_MODELS_GIT_PATH"
+            --simulation_models_git_revision="$SIMTOOLS_SIMULATION_MODELS_GIT_REVISION"
+          )
           if [[ "${{ inputs.benchmark }}" == "true" ]]; then
             pytest --model_version=${{ matrix.model_version }} --color=yes \
               "${MODEL_SOURCE_ARGS[@]}" \

--- a/dependency_versions.yml
+++ b/dependency_versions.yml
@@ -23,6 +23,8 @@ corsika-interaction-tables:
 model-database:
   name: CTAO-Simulation-Model
   default-tag: v0.17.2
+  repository-url: https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models.git
+  git-revision: d889ef1cceb3ef5f0d908ee707055b0c7ff6d4bb
 simtools-tests:
   repository: gammasim/simtools-tests
   source-url: https://github.com/gammasim/simtools-tests.git

--- a/docs/source/api-reference/model_repository.md
+++ b/docs/source/api-reference/model_repository.md
@@ -19,6 +19,15 @@ parameters, production tables, and referenced files.
    :members:
 ```
 
+## Git backend and source
+
+```{eval-rst}
+.. automodule:: model_repository.git_backend
+   :members:
+.. automodule:: model_repository.git_model
+   :members:
+```
+
 ## application model-reader factory
 
 ```{eval-rst}

--- a/docs/source/api-reference/model_repository.md
+++ b/docs/source/api-reference/model_repository.md
@@ -28,6 +28,13 @@ parameters, production tables, and referenced files.
    :members:
 ```
 
+## parsing
+
+```{eval-rst}
+.. automodule:: model_repository.parsing
+   :members:
+```
+
 ## application model-reader factory
 
 ```{eval-rst}

--- a/docs/source/components/databases.md
+++ b/docs/source/components/databases.md
@@ -7,12 +7,20 @@ The simtools package can use MongoDB to store production tables and simulation m
 MongoDB support is optional: install it with `pip install 'gammasimtools[mongodb]'` when using
 database administration commands or the MongoDB model-reader fallback.
 
-Normal applications read from a checked-out simulation-model repository when
-`simulation_models_path` (or `SIMTOOLS_SIMULATION_MODELS_PATH`) is configured. If no repository
-path is configured, the existing MongoDB configuration is used as a fallback. This keeps database
-backed tests and established workflows working while making repository reads independent of
-MongoDB. Without the optional dependency, MongoDB-only commands and the no-path fallback fail
-with an installation hint.
+Normal applications can read from a checked-out simulation-model repository when
+`simulation_models_path` (or `SIMTOOLS_SIMULATION_MODELS_PATH`) is configured. They can also read
+directly from a local normal, bare, or mirror Git repository with
+`simulation_models_git_path` and `simulation_models_git_revision` (or the corresponding
+`SIMTOOLS_SIMULATION_MODELS_GIT_*` variables). The Git source resolves the revision to an
+immutable commit and reads production tables, parameters, and model files directly from blobs;
+it never creates a checkout. An explicitly configured filesystem path takes precedence over Git,
+and Git takes precedence over the MongoDB fallback. The Git source warms production tables and
+their referenced parameter JSON on first access, while large `Files/` payloads remain lazy.
+
+If no repository source is configured, the existing MongoDB configuration is used as a fallback.
+MongoDB support is optional: install it with `pip install 'gammasimtools[mongodb]'` when using
+database administration commands or the MongoDB model-reader fallback. Install the Git reader with
+`pip install 'gammasimtools[git]'`.
 
 ```{important}
 No direct write access to the simulation model database is allowed to general users.

--- a/docs/source/developer-guide/testing_integration.md
+++ b/docs/source/developer-guide/testing_integration.md
@@ -71,7 +71,8 @@ To run the integration tests without MongoDB, pass the directory containing
 ```bash
 pytest --no-cov -v \
   --model_version 7.0.0 \
-  --simulation_models_path ../simulation-models \
+  --simulation_models_git_path ../simulation-models.git \
+  --simulation_models_git_revision v0.17.2 \
   tests/integration_tests/test_applications_from_config.py
 ```
 
@@ -80,7 +81,8 @@ The integration harness passes the path to each application subprocess. To run o
 ```bash
 pytest --no-cov -vv \
   --model_version 7.0.0 \
-  --simulation_models_path ../simulation-models \
+  --simulation_models_git_path ../simulation-models.git \
+  --simulation_models_git_revision v0.17.2 \
   'tests/integration_tests/test_applications_from_config.py::test_applications_from_config[simtools-docs-produce-array-element-report_run]'
 ```
 

--- a/docs/source/user-guide/manage_simulation_models/simulation_models_database.md
+++ b/docs/source/user-guide/manage_simulation_models/simulation_models_database.md
@@ -4,23 +4,30 @@
 The following applications are for testing, maintenance or debugging the simulation model database and repository.
 Note that the remote primary production database is modified only by the simulation models GitLab CI.
 
-## Reading from files
+## Reading from files or Git blobs
 
-Applications can read the simulation model from a local directory instead of MongoDB:
+Applications that use `SimulationModelReader` can read the simulation model
+from a local directory instead of MongoDB with
+`--simulation_models_path /path/to/model-files`.
+
+The supplied path must contain `simulation-models/productions` and
+`simulation-models/model_parameters`. A local Git object store can be used when one shared
+repository should serve several model revisions without multiple checkouts:
 
 ```console
-simtools-db-get-parameter-from-db \
-    --simulation_models_path /path/to/model-files \
-    --parameter camera_body_diameter \
-    --parameter_version 1.0.0 \
-    --site North \
-    --telescope LSTN-design
+simtools-simulate-prod \
+    --simulation_models_git_path /path/to/simulation-models.git \
+    --simulation_models_git_revision v0.17.2 \
+    --model_version 6.0.2
 ```
 
-The supplied path must contain
-`simulation-models/productions` and `simulation-models/model_parameters`. When the option is set,
-the filesystem source takes precedence over MongoDB configuration. Production tables and referenced
-parameter files are cached for the process lifetime; unrelated parameter versions are not read.
+The Git path may point to a normal, bare, or mirror repository. The revision is resolved once to a
+full commit ID, which is retained in worker configuration. Production tables and all parameter JSON
+files referenced by a selected model version are loaded in batches and cached for the process
+lifetime. Large files below `model_parameters/Files` are read only when explicitly exported.
+
+An explicit filesystem path takes precedence over a Git path; configuring both is an error. If
+neither is configured, the MongoDB source remains the fallback.
 
 Filesystem access is read-only. Database inspection, index generation, uploads, and inserts
 require MongoDB and report an error if used with only `--simulation_models_path`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ optional-dependencies.doc = [
   "sphinx-design",
   "towncrier",
 ]
+optional-dependencies.git = [
+  "pygit2>=1.19",
+]
 optional-dependencies.htcondor = [
   "htcondor>=25.0.7; platform_system=='Linux'",
 ]

--- a/src/simtools/application/control.py
+++ b/src/simtools/application/control.py
@@ -226,7 +226,11 @@ def _initialize_runtime(
 
     model_reader = None
     if initialize_model_reader:
-        model_reader = create_model_reader(args_dict.get("simulation_models_path"))
+        model_reader = create_model_reader(
+            simulation_models_path=args_dict.get("simulation_models_path"),
+            simulation_models_git_path=args_dict.get("simulation_models_git_path"),
+            simulation_models_git_revision=args_dict.get("simulation_models_git_revision"),
+        )
         config.set_model_reader(model_reader)
         _resolve_model_version_to_latest_patch(args_dict, logger, model_reader)
     _version_info(args_dict, io_handler_instance, logger)

--- a/src/simtools/application/control.py
+++ b/src/simtools/application/control.py
@@ -10,7 +10,7 @@ from astropy.utils import iers
 
 import simtools.utils.general as gen
 from simtools import dependencies, version
-from simtools.application.model_reader import create_model_reader
+from simtools.application.model_reader import create_model_reader_from_configuration
 from simtools.io import io_handler
 from simtools.runners.simtools_runner import prepare_runtime_environment
 from simtools.settings import config
@@ -226,11 +226,7 @@ def _initialize_runtime(
 
     model_reader = None
     if initialize_model_reader:
-        model_reader = create_model_reader(
-            simulation_models_path=args_dict.get("simulation_models_path"),
-            simulation_models_git_path=args_dict.get("simulation_models_git_path"),
-            simulation_models_git_revision=args_dict.get("simulation_models_git_revision"),
-        )
+        model_reader = create_model_reader_from_configuration(args_dict)
         config.set_model_reader(model_reader)
         _resolve_model_version_to_latest_patch(args_dict, logger, model_reader)
     _version_info(args_dict, io_handler_instance, logger)

--- a/src/simtools/application/model_reader.py
+++ b/src/simtools/application/model_reader.py
@@ -72,6 +72,26 @@ def create_model_reader(
     return SimulationModelReader(MongoDBModelSource(database_handler))
 
 
+def create_model_reader_from_configuration(configuration):
+    """Create a model reader from an application or test configuration.
+
+    Parameters
+    ----------
+    configuration : dict
+        Mapping that may contain filesystem or Git model-source options.
+
+    Returns
+    -------
+    SimulationModelReader
+        Reader selected by the supplied source options.
+    """
+    return create_model_reader(
+        simulation_models_path=configuration.get("simulation_models_path"),
+        simulation_models_git_path=configuration.get("simulation_models_git_path"),
+        simulation_models_git_revision=configuration.get("simulation_models_git_revision"),
+    )
+
+
 def create_model_reader_from_source_config(source_config):
     """Recreate a model reader from a worker-serializable source configuration.
 
@@ -97,7 +117,7 @@ def create_model_reader_from_source_config(source_config):
         path = source_config.get("path")
         if not path:
             raise ValueError("Filesystem model source configuration requires a path.")
-        return create_model_reader(path)
+        return create_model_reader(simulation_models_path=path)
     if source_type == "git":
         repository = source_config.get("repository")
         commit = source_config.get("commit")

--- a/src/simtools/application/model_reader.py
+++ b/src/simtools/application/model_reader.py
@@ -2,12 +2,18 @@
 
 import os
 
+from simtools import dependency_versions
 from simtools.model_repository.reader import SimulationModelReader
 from simtools.settings import config
 
 
-def create_model_reader(simulation_models_path=None, database_handler=None):
-    """Create a reader for a filesystem or MongoDB model source.
+def create_model_reader(
+    simulation_models_path=None,
+    database_handler=None,
+    simulation_models_git_path=None,
+    simulation_models_git_revision=None,
+):
+    """Create a reader for a filesystem, Git, or MongoDB model source.
 
     Parameters
     ----------
@@ -17,17 +23,45 @@ def create_model_reader(simulation_models_path=None, database_handler=None):
         ``SIMTOOLS_SIMULATION_MODELS_PATH`` is used when set.
     database_handler : DatabaseHandler, optional
         Existing MongoDB handler to adapt when no filesystem path is supplied.
+    simulation_models_git_path : str or Path, optional
+        Local normal, bare, or mirror Git repository.
+    simulation_models_git_revision : str, optional
+        Git tag, ref, or commit. The model-database catalog tag is used when
+        the Git path is set and this value is omitted.
 
     Returns
     -------
     SimulationModelReader
         Reader backed by the selected source.
     """
-    if simulation_models_path is None and database_handler is None:
+    if simulation_models_path and simulation_models_git_path:
+        raise ValueError(
+            "Filesystem and Git simulation-model sources cannot be configured together."
+        )
+
+    if (
+        simulation_models_path is None
+        and simulation_models_git_path is None
+        and database_handler is None
+    ):
         simulation_models_path = os.getenv("SIMTOOLS_SIMULATION_MODELS_PATH")
+        simulation_models_git_path = os.getenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH")
+        simulation_models_git_revision = os.getenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION")
 
     if simulation_models_path:
         return SimulationModelReader.from_files(simulation_models_path)
+
+    if simulation_models_git_path:
+        revision = simulation_models_git_revision
+        if revision is None:
+            catalog = dependency_versions.load_dependency_catalog()
+            model = catalog["model-database"]
+            revision = model.get("git-revision") or model.get(
+                "default-tag", model.get("default-version")
+            )
+        if not revision:
+            raise ValueError("A Git simulation-model revision is required.")
+        return SimulationModelReader.from_git(simulation_models_git_path, revision)
 
     if database_handler is None:
         database_handler = _create_database_handler()
@@ -64,6 +98,15 @@ def create_model_reader_from_source_config(source_config):
         if not path:
             raise ValueError("Filesystem model source configuration requires a path.")
         return create_model_reader(path)
+    if source_type == "git":
+        repository = source_config.get("repository")
+        commit = source_config.get("commit")
+        if not repository or not commit:
+            raise ValueError("Git model source configuration requires repository and commit.")
+        return create_model_reader(
+            simulation_models_git_path=repository,
+            simulation_models_git_revision=commit,
+        )
     if source_type == "mongodb":
         database_handler = _create_database_handler()
         if source_config.get("name"):

--- a/src/simtools/applications/docs_produce_production_summary.py
+++ b/src/simtools/applications/docs_produce_production_summary.py
@@ -17,6 +17,7 @@ APPLICATION = ApplicationDefinition.for_module(
         *cli.OUTPUT_ARGUMENTS,
     ),
     initialize_output=True,
+    initialize_model_reader=False,
 )
 
 

--- a/src/simtools/configuration/arguments.py
+++ b/src/simtools/configuration/arguments.py
@@ -412,6 +412,22 @@ SIMULATION_MODELS_PATH = _argument(
     default=None,
 )
 
+SIMULATION_MODELS_GIT_PATH = _argument(
+    "simulation_models_git_path",
+    _MODEL_REPOSITORY_GROUP,
+    help="Path to a local normal, bare, or mirror Git repository containing simulation models.",
+    type=Path,
+    default=None,
+)
+
+SIMULATION_MODELS_GIT_REVISION = _argument(
+    "simulation_models_git_revision",
+    _MODEL_REPOSITORY_GROUP,
+    help="Git tag, ref, or commit to read from the simulation-model repository.",
+    type=str,
+    default=None,
+)
+
 DATABASE_NAME = _argument(
     "database_name",
     "application",
@@ -468,6 +484,8 @@ DB_SIMULATION_MODEL_TAG = _argument(
 
 DATABASE_ARGUMENTS = (
     SIMULATION_MODELS_PATH,
+    SIMULATION_MODELS_GIT_PATH,
+    SIMULATION_MODELS_GIT_REVISION,
     DB_API_USER,
     DB_API_PW,
     DB_API_PORT,

--- a/src/simtools/configuration/show_options.py
+++ b/src/simtools/configuration/show_options.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from simtools.application.model_reader import create_model_reader
+from simtools.application.model_reader import create_model_reader_from_configuration
 from simtools.configuration import defaults
 from simtools.corsika.build_options import get_installed_corsika_build_variants
 from simtools.corsika.primary_particle import PrimaryParticle
@@ -177,15 +177,7 @@ def _show_array_layout_names(args_dict):
 
 def _create_model_reader(args_dict):
     """Create a configured model reader for an option provider."""
-    git_path = args_dict.get("simulation_models_git_path")
-    git_revision = args_dict.get("simulation_models_git_revision")
-    if git_path is None and git_revision is None:
-        return create_model_reader(args_dict.get("simulation_models_path"))
-    return create_model_reader(
-        simulation_models_path=args_dict.get("simulation_models_path"),
-        simulation_models_git_path=git_path,
-        simulation_models_git_revision=git_revision,
-    )
+    return create_model_reader_from_configuration(args_dict)
 
 
 def _show_corsika_he_interaction(args_dict):

--- a/src/simtools/configuration/show_options.py
+++ b/src/simtools/configuration/show_options.py
@@ -141,8 +141,7 @@ def _show_sites(_args_dict):
 
 
 def _show_model_versions(args_dict):
-    simulation_models_path = args_dict.get("simulation_models_path")
-    model_reader = create_model_reader(simulation_models_path)
+    model_reader = _create_model_reader(args_dict)
     return ShowOptionsResult(
         option_name="model_version",
         values=tuple(model_reader.get_model_versions()),
@@ -151,8 +150,7 @@ def _show_model_versions(args_dict):
 
 def _show_array_layout_names(args_dict):
     model_version = _get_single_model_version(args_dict, "array_layout_name")
-    simulation_models_path = args_dict.get("simulation_models_path")
-    model_reader = create_model_reader(simulation_models_path)
+    model_reader = _create_model_reader(args_dict)
     site = args_dict.get("site")
     sites = [site] if site else sorted(names.site_names())
     grouped_values = {
@@ -174,6 +172,19 @@ def _show_array_layout_names(args_dict):
         option_name="array_layout_name",
         grouped_values=grouped_values,
         notes=("Provide --site to limit array layouts to one site.",),
+    )
+
+
+def _create_model_reader(args_dict):
+    """Create a configured model reader for an option provider."""
+    git_path = args_dict.get("simulation_models_git_path")
+    git_revision = args_dict.get("simulation_models_git_revision")
+    if git_path is None and git_revision is None:
+        return create_model_reader(args_dict.get("simulation_models_path"))
+    return create_model_reader(
+        simulation_models_path=args_dict.get("simulation_models_path"),
+        simulation_models_git_path=git_path,
+        simulation_models_git_revision=git_revision,
     )
 
 

--- a/src/simtools/dependency_versions.py
+++ b/src/simtools/dependency_versions.py
@@ -277,6 +277,13 @@ def _validate_model_and_test_components(catalog, schema_version):
             else "Invalid model database version."
         )
         raise ValueError(message)
+    model = catalog["model-database"]
+    if model.get("repository-url") is not None and not str(model["repository-url"]).startswith(
+        "https://"
+    ):
+        raise ValueError("Simulation-model repository URL must use HTTPS.")
+    if model.get("git-revision") is not None:
+        _validate_revision(model["git-revision"], "simulation-model repository")
     if schema_version in {"0.2.0", "0.3.0", "0.4.0"}:
         _validate_simtools_tests(catalog["simtools-tests"])
 

--- a/src/simtools/io/ascii_handler.py
+++ b/src/simtools/io/ascii_handler.py
@@ -1,5 +1,6 @@
 """Helper module for ASCII file operations."""
 
+import io
 import json
 import logging
 import os
@@ -46,6 +47,34 @@ def collect_data_from_file(file_name, yaml_document=None, test_resources_path=No
     # broad exception to catch all possible errors in reading the file
     except Exception as exc:  # pylint: disable=broad-except
         raise type(exc)(f"Failed to read file {file_name}: {exc}") from exc
+
+
+def collect_data_from_bytes(data, file_name, yaml_document=None):
+    """Collect JSON or YAML data from an in-memory byte string.
+
+    Parameters
+    ----------
+    data : bytes
+        UTF-8 encoded file contents.
+    file_name : str or pathlib.Path
+        Logical file name used to select the parser and report errors.
+    yaml_document : int, optional
+        YAML document index for multi-document YAML files.
+
+    Returns
+    -------
+    dict or list
+        Parsed file contents.
+    """
+    logical_name = str(file_name)
+    suffix = Path(logical_name).suffix.lower()
+    try:
+        text = data.decode("utf-8")
+        return _collect_data_from_different_file_types(
+            io.StringIO(text), logical_name, suffix, yaml_document
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        raise type(exc)(f"Failed to read file {logical_name}: {exc}") from exc
 
 
 def _resolve_configured_test_resource_paths(data, test_resources_path=None):

--- a/src/simtools/job_execution/worker.py
+++ b/src/simtools/job_execution/worker.py
@@ -62,7 +62,13 @@ def _initialize_runtime(job_spec):
         return
     config.load(job_spec.runtime_args, job_spec.runtime_db_config)
     config.set_model_reader(
-        create_model_reader(job_spec.runtime_args.get("simulation_models_path"))
+        create_model_reader(
+            simulation_models_path=job_spec.runtime_args.get("simulation_models_path"),
+            simulation_models_git_path=job_spec.runtime_args.get("simulation_models_git_path"),
+            simulation_models_git_revision=job_spec.runtime_args.get(
+                "simulation_models_git_revision"
+            ),
+        )
     )
     io_handler.IOHandler().set_paths(
         output_path=job_spec.runtime_args.get("output_path"),

--- a/src/simtools/job_execution/worker.py
+++ b/src/simtools/job_execution/worker.py
@@ -8,7 +8,7 @@ import subprocess
 import traceback
 from pathlib import Path
 
-from simtools.application.model_reader import create_model_reader
+from simtools.application.model_reader import create_model_reader_from_configuration
 from simtools.io import io_handler
 from simtools.job_execution.job import JobSpec
 from simtools.settings import config
@@ -61,15 +61,7 @@ def _initialize_runtime(job_spec):
     if job_spec.runtime_args is None:
         return
     config.load(job_spec.runtime_args, job_spec.runtime_db_config)
-    config.set_model_reader(
-        create_model_reader(
-            simulation_models_path=job_spec.runtime_args.get("simulation_models_path"),
-            simulation_models_git_path=job_spec.runtime_args.get("simulation_models_git_path"),
-            simulation_models_git_revision=job_spec.runtime_args.get(
-                "simulation_models_git_revision"
-            ),
-        )
-    )
+    config.set_model_reader(create_model_reader_from_configuration(job_spec.runtime_args))
     io_handler.IOHandler().set_paths(
         output_path=job_spec.runtime_args.get("output_path"),
         model_path=job_spec.runtime_args.get("model_path"),

--- a/src/simtools/model_repository/files.py
+++ b/src/simtools/model_repository/files.py
@@ -1,6 +1,7 @@
 """Read and combine production-table files from a model repository."""
 
 import logging
+from pathlib import Path
 
 from packaging.version import Version
 
@@ -44,9 +45,36 @@ def read_production_tables(model_path, collection_name=None, production_files=No
     return model_dict
 
 
+def read_production_tables_from_documents(model_version, documents, collection_name=None):
+    """Read and merge production tables from parsed repository documents.
+
+    ``documents`` contains ``(model_name, file_name, document)`` tuples.  The
+    representation is shared by filesystem and Git readers so that both
+    sources apply patch history and production-table merging identically.
+    """
+    model_dict = {}
+    for model_name, file_name, document in documents:
+        if collection_name and (
+            names.get_collection_name_from_array_element_name(Path(file_name).stem, False)
+            != collection_name
+        ):
+            continue
+        _merge_production_table(model_dict, Path(file_name).stem, model_name, document)
+
+    for table in model_dict.values():
+        table["model_version"] = model_version
+    _remove_deprecated_model_parameters(model_dict)
+    return model_dict
+
+
 def _read_production_table(model_dict, file, model_name):
     """Read one production-table JSON file into an aggregate."""
-    array_element = file.stem
+    parameter_dict = ascii_handler.collect_data_from_file(file_name=file)
+    _merge_production_table(model_dict, file.stem, model_name, parameter_dict)
+
+
+def _merge_production_table(model_dict, array_element, model_name, parameter_dict):
+    """Merge one parsed production-table document into an aggregate."""
     collection = names.get_collection_name_from_array_element_name(array_element, False)
     model_dict.setdefault(
         collection,
@@ -58,7 +86,6 @@ def _read_production_table(model_dict, file, model_name):
             "deprecated_parameters": [],
         },
     )
-    parameter_dict = ascii_handler.collect_data_from_file(file_name=file)
     if array_element in ("configuration_corsika", "configuration_sim_telarray"):
         model_dict[collection]["parameters"] = parameter_dict["parameters"]
     else:

--- a/src/simtools/model_repository/git_backend.py
+++ b/src/simtools/model_repository/git_backend.py
@@ -1,0 +1,125 @@
+"""Small, replaceable Git object-store adapter for simulation models."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path, PurePosixPath
+
+
+class GitModelSourceDependencyError(RuntimeError):
+    """Raised when the Git model source is selected without pygit2."""
+
+
+class GitObjectStore(ABC):
+    """Library-neutral interface used by ``GitModelSource``."""
+
+    @abstractmethod
+    def resolve_revision(self, revision):
+        """Resolve a ref or commit to a full commit ID."""
+
+    @abstractmethod
+    def iter_files(self, commit, prefix):
+        """Return file paths below ``prefix`` for ``commit``."""
+
+    @abstractmethod
+    def read_blob(self, commit, path):
+        """Return one blob as bytes."""
+
+    @abstractmethod
+    def open_blob(self, commit, path):
+        """Return a binary stream for one blob."""
+
+
+class Pygit2ObjectStore(GitObjectStore):
+    """Read objects from a local normal, bare, or mirror repository."""
+
+    def __init__(self, repository_path):
+        """Open a local Git repository without creating a working tree."""
+        try:
+            import pygit2  # pylint: disable=import-outside-toplevel
+        except ImportError as exc:
+            raise GitModelSourceDependencyError(
+                "The Git simulation-model source requires pygit2; "
+                "install simtools with the `git` extra."
+            ) from exc
+
+        self.repository_path = Path(repository_path).expanduser().resolve()
+        if not self.repository_path.exists():
+            raise FileNotFoundError(f"Git model repository does not exist: {self.repository_path}")
+        try:
+            self._repository = pygit2.Repository(str(self.repository_path))
+        except (KeyError, OSError, ValueError) as exc:
+            raise ValueError(
+                f"Not a readable Git model repository: {self.repository_path}"
+            ) from exc
+        self._pygit2 = pygit2
+
+    def resolve_revision(self, revision):
+        """Resolve a tag, ref, or SHA to a full commit SHA."""
+        try:
+            obj = self._repository.revparse_single(str(revision))
+            commit = obj.peel(self._pygit2.Commit)
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(
+                f"Git revision {revision!r} not found or does not identify a commit "
+                f"in {self.repository_path}"
+            ) from exc
+        return str(commit.id)
+
+    def _commit_tree(self, commit):
+        """Return the tree for a resolved commit."""
+        try:
+            return self._repository[str(commit)].tree
+        except (KeyError, ValueError, TypeError) as exc:
+            raise ValueError(f"Git commit {commit!r} not found in {self.repository_path}") from exc
+
+    def _tree_object(self, commit, path):
+        """Return a tree object by its POSIX repository path."""
+        obj = self._commit_tree(commit)
+        for part in PurePosixPath(path).parts:
+            try:
+                obj = obj[part]
+            except (KeyError, ValueError, TypeError) as exc:
+                raise FileNotFoundError(
+                    f"Git path {path!r} not found at commit {commit} in {self.repository_path}"
+                ) from exc
+        return obj
+
+    def iter_files(self, commit, prefix):
+        """Return sorted regular-file paths below a tree prefix."""
+        prefix = PurePosixPath(prefix)
+        tree = self._commit_tree(commit)
+        for part in prefix.parts:
+            try:
+                tree = tree[part]
+            except (KeyError, ValueError, TypeError) as exc:
+                raise FileNotFoundError(
+                    f"Git path {prefix!s} not found at commit {commit} in {self.repository_path}"
+                ) from exc
+        if tree.type_str != "tree":
+            raise ValueError(f"Git path is not a directory: {prefix}")
+        paths = []
+        self._append_files(tree, prefix, paths)
+        return sorted(paths)
+
+    def _append_files(self, tree, prefix, paths):
+        """Recursively collect paths from a tree."""
+        for obj in tree:
+            path = prefix / obj.name
+            if obj.type_str == "tree":
+                self._append_files(obj, path, paths)
+            elif obj.type_str == "blob":
+                paths.append(path.as_posix())
+
+    def _blob(self, commit, path):
+        """Return a blob object and provide a source-specific error."""
+        obj = self._tree_object(commit, path)
+        if obj.type_str != "blob":
+            raise ValueError(f"Git path is not a file: {path}")
+        return obj
+
+    def read_blob(self, commit, path):
+        """Read a blob into memory."""
+        return self._blob(commit, path).data
+
+    def open_blob(self, commit, path):
+        """Open a blob as a binary stream without materializing it in memory."""
+        return self._pygit2.BlobIO(self._blob(commit, path))

--- a/src/simtools/model_repository/git_backend.py
+++ b/src/simtools/model_repository/git_backend.py
@@ -76,12 +76,18 @@ class Pygit2ObjectStore(GitObjectStore):
         obj = self._commit_tree(commit)
         for part in PurePosixPath(path).parts:
             try:
-                obj = obj[part]
+                obj = self._dereference_tree_entry(obj[part])
             except (KeyError, ValueError, TypeError) as exc:
                 raise FileNotFoundError(
                     f"Git path {path!r} not found at commit {commit} in {self.repository_path}"
                 ) from exc
         return obj
+
+    def _dereference_tree_entry(self, entry):
+        """Return the Git object represented by a pygit2 tree entry."""
+        if hasattr(entry, "id"):
+            return self._repository[entry.id]
+        return entry
 
     def iter_files(self, commit, prefix):
         """Return sorted regular-file paths below a tree prefix."""
@@ -89,7 +95,7 @@ class Pygit2ObjectStore(GitObjectStore):
         tree = self._commit_tree(commit)
         for part in prefix.parts:
             try:
-                tree = tree[part]
+                tree = self._dereference_tree_entry(tree[part])
             except (KeyError, ValueError, TypeError) as exc:
                 raise FileNotFoundError(
                     f"Git path {prefix!s} not found at commit {commit} in {self.repository_path}"
@@ -105,7 +111,7 @@ class Pygit2ObjectStore(GitObjectStore):
         for obj in tree:
             path = prefix / obj.name
             if obj.type_str == "tree":
-                self._append_files(obj, path, paths)
+                self._append_files(self._dereference_tree_entry(obj), path, paths)
             elif obj.type_str == "blob":
                 paths.append(path.as_posix())
 

--- a/src/simtools/model_repository/git_model.py
+++ b/src/simtools/model_repository/git_model.py
@@ -1,0 +1,279 @@
+"""Read simulation models directly from Git blobs."""
+
+import logging
+import threading
+from copy import deepcopy
+from pathlib import Path, PurePosixPath
+from time import perf_counter
+
+from astropy.table import Table
+from packaging.version import Version
+
+from simtools.io import ascii_handler
+from simtools.model_repository import files
+from simtools.model_repository.git_backend import Pygit2ObjectStore
+from simtools.model_repository.parsing import normalize_model_parameter
+from simtools.utils import names
+
+logger = logging.getLogger(__name__)
+
+
+class GitModelSource:
+    """Read a fixed simulation-model revision from a local Git object store."""
+
+    def __init__(self, repository_path, revision, object_store=None):
+        """Open ``repository_path`` and resolve ``revision`` once."""
+        self.repository_path = Path(repository_path).expanduser().resolve()
+        self._object_store = object_store or Pygit2ObjectStore(self.repository_path)
+        self.commit = self._object_store.resolve_revision(revision)
+        self._model_versions = None
+        self._snapshots = {}
+        self._production_tables = {}
+        self._parameters = {}
+        self._lock = threading.RLock()
+
+    @property
+    def source_name(self):
+        """Return the repository and immutable revision used for reads."""
+        return f"{self.repository_path}@{self.commit}"
+
+    @property
+    def source_config(self):
+        """Return the serializable source selection for worker processes."""
+        return {
+            "type": "git",
+            "repository": str(self.repository_path),
+            "commit": self.commit,
+        }
+
+    def is_configured(self):
+        """Return whether the Git source was opened successfully."""
+        return True
+
+    def get_model_versions(self, collection_name="telescopes"):
+        """Return semantically sorted production versions."""
+        del collection_name
+        if self._model_versions is None:
+            prefix = PurePosixPath("simulation-models/productions")
+            versions = {
+                PurePosixPath(path).relative_to(prefix).parts[0]
+                for path in self._object_store.iter_files(self.commit, prefix.as_posix())
+                if len(PurePosixPath(path).relative_to(prefix).parts) > 1
+            }
+            self._model_versions = sorted(versions, key=Version)
+        return list(self._model_versions)
+
+    def _warm_model_version(self, model_version):
+        """Warm all production and referenced parameter data for a model version."""
+        model_version = str(model_version)
+        with self._lock:
+            if model_version in self._snapshots:
+                return
+            started = perf_counter()
+            documents = self._production_documents(model_version)
+            tables = files.read_production_tables_from_documents(model_version, documents)
+            parameter_paths = self._parameter_paths(tables)
+            self._read_parameter_paths(parameter_paths)
+            for collection, table in tables.items():
+                self._production_tables[(model_version, collection)] = table
+            self._snapshots[model_version] = True
+            logger.debug(
+                "Git model warm-up commit=%s model_version=%s production_blobs=%d "
+                "parameter_blobs=%d duration=%.3fs",
+                self.commit,
+                model_version,
+                len(documents),
+                len(parameter_paths),
+                perf_counter() - started,
+            )
+
+    def read_production_table(self, collection_name, model_version):
+        """Return an aggregated production table for a collection and version."""
+        model_version = str(model_version)
+        self._warm_model_version(model_version)
+        try:
+            return deepcopy(self._production_tables[(model_version, collection_name)])
+        except KeyError as exc:
+            raise ValueError(
+                f"No production table for {collection_name} in model version {model_version}"
+            ) from exc
+
+    def read_parameters(self, parameter_versions, collection_name, instrument=None, site=None):
+        """Read and normalize parameter blobs by name and version."""
+        instrument = self._get_parameter_instrument(
+            {"instrument": instrument, "site": site}, collection_name
+        )
+        paths = {
+            self._parameter_path(collection_name, instrument, parameter, version): (
+                parameter,
+                version,
+            )
+            for parameter, version in parameter_versions.items()
+        }
+        self._read_parameter_paths(paths)
+        parameters = []
+        for path, (parameter, _version) in paths.items():
+            if path not in self._parameters:
+                continue
+            parameter_data = self._parameters[path]
+            scope = names.get_model_parameter_scope(collection_name, instrument, parameter)
+            if self._matches_filters(parameter_data, scope, site):
+                parameters.append(deepcopy(parameter_data))
+        if not parameters:
+            raise ValueError(f"No parameters found for {collection_name}: {parameter_versions}")
+        return parameters
+
+    def _production_documents(self, model_version):
+        """Read all production JSON documents for a version and its patch history."""
+        model_prefix = PurePosixPath("simulation-models/productions") / model_version
+        files_in_version = self._object_store.iter_files(self.commit, model_prefix.as_posix())
+        model_names = [model_version]
+        info_path = model_prefix / "info.yml"
+        if info_path.as_posix() in files_in_version:
+            info = ascii_handler.collect_data_from_bytes(
+                self._object_store.read_blob(self.commit, info_path.as_posix()), info_path
+            )
+            if info.get("model_update") == "patch_update":
+                model_names.extend(info.get("model_version_history", []))
+        model_names = sorted(set(model_names), key=Version)
+        documents = []
+        for model_name in model_names:
+            prefix = PurePosixPath("simulation-models/productions") / model_name
+            for path in self._object_store.iter_files(self.commit, prefix.as_posix()):
+                if path.endswith(".json"):
+                    documents.append(
+                        (
+                            model_name,
+                            path,
+                            ascii_handler.collect_data_from_bytes(
+                                self._object_store.read_blob(self.commit, path), path
+                            ),
+                        )
+                    )
+        if not documents:
+            raise ValueError(f"Model version {model_version} not found in {self.source_name}")
+        return documents
+
+    @staticmethod
+    def _parameter_paths(tables):
+        """Return unique parameter paths referenced by production tables."""
+        paths = {}
+        for collection, table in tables.items():
+            for instrument, parameters in table.get("parameters", {}).items():
+                if not isinstance(parameters, dict):
+                    continue
+                for parameter, version in parameters.items():
+                    if not isinstance(version, str):
+                        continue
+                    path = GitModelSource._parameter_path(
+                        collection, instrument, parameter, version
+                    )
+                    paths[path] = (parameter, version)
+        return paths
+
+    def _read_parameter_paths(self, paths):
+        """Read all missing parameter paths in one source batch."""
+        for path in paths:
+            if path in self._parameters:
+                continue
+            try:
+                data = ascii_handler.collect_data_from_bytes(
+                    self._object_store.read_blob(self.commit, path), path
+                )
+            except FileNotFoundError:
+                continue
+            self._parameters[path] = normalize_model_parameter(data)
+
+    @staticmethod
+    def _get_parameter_instrument(query, collection_name):
+        """Resolve the instrument scope used for a parameter lookup."""
+        instrument = query.get("instrument")
+        if instrument:
+            return instrument
+        if collection_name == "sites" and query.get("site"):
+            return f"OBS-{query['site']}"
+        if collection_name in ("configuration_corsika", "configuration_sim_telarray"):
+            return "global"
+        raise ValueError(
+            f"Git lookup for collection {collection_name} requires an array element name"
+        )
+
+    @staticmethod
+    def _parameter_path(collection_name, instrument, parameter, parameter_version):
+        """Return a repository-relative parameter path."""
+        scope = names.get_model_parameter_scope(collection_name, instrument, parameter)
+        return (
+            PurePosixPath("simulation-models/model_parameters")
+            / scope
+            / parameter
+            / f"{parameter}-{parameter_version}.json"
+        ).as_posix()
+
+    @staticmethod
+    def _matches_filters(parameter_data, instrument, site):
+        """Return whether parameter metadata matches source filters."""
+        if instrument == "global":
+            instrument = None
+        if instrument and parameter_data.get("instrument") != instrument:
+            return False
+        parameter_sites = parameter_data.get("site")
+        if site and isinstance(parameter_sites, list):
+            return site in parameter_sites
+        if not site or parameter_sites == site:
+            return True
+        return instrument is None and parameter_sites is None
+
+    def export_model_files(self, parameters=None, file_names=None, dest=None):
+        """Stream referenced model files from Git into ``dest``."""
+        if dest is None:
+            raise ValueError("Destination path is required to export model files.")
+        names_to_export = file_names
+        if names_to_export is None:
+            names_to_export = [
+                parameter["value"]
+                for parameter in (parameters or {}).values()
+                if isinstance(parameter, dict) and parameter.get("file") and parameter.get("value")
+            ]
+        if isinstance(names_to_export, str):
+            names_to_export = [names_to_export]
+        destination = Path(dest)
+        destination.mkdir(parents=True, exist_ok=True)
+        exported = {}
+        for file_name in names_to_export:
+            source_path = self._safe_file_path(file_name)
+            target = destination / file_name
+            if target.exists():
+                exported[file_name] = "file exists"
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                with self._object_store.open_blob(self.commit, source_path) as source:
+                    with target.open("wb") as output:
+                        while chunk := source.read(1024 * 1024):
+                            output.write(chunk)
+            except FileNotFoundError as exc:
+                raise FileNotFoundError(
+                    f"Model file not found at commit {self.commit}: {source_path}"
+                ) from exc
+            exported[file_name] = "copied from Git"
+        return exported
+
+    @staticmethod
+    def _safe_file_path(file_name):
+        """Resolve a model file path below the repository Files directory."""
+        path = PurePosixPath(str(file_name))
+        files_root = PurePosixPath("simulation-models/model_parameters/Files")
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError(f"Model file path escapes model Files directory: {file_name}")
+        return (files_root / path).as_posix()
+
+    def get_ecsv_file_as_astropy_table(self, file_name):
+        """Read an ECSV model file from a Git blob."""
+        source_path = self._safe_file_path(file_name)
+        try:
+            with self._object_store.open_blob(self.commit, source_path) as source:
+                return Table.read(source, format="ascii.ecsv")
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(
+                f"Model file not found at commit {self.commit}: {source_path}"
+            ) from exc

--- a/src/simtools/model_repository/git_model.py
+++ b/src/simtools/model_repository/git_model.py
@@ -3,6 +3,7 @@
 import logging
 import threading
 from copy import deepcopy
+from io import BytesIO
 from pathlib import Path, PurePosixPath
 from time import perf_counter
 
@@ -272,8 +273,9 @@ class GitModelSource:
         """Read an ECSV model file from a Git blob."""
         source_path = self._safe_file_path(file_name)
         try:
-            with self._object_store.open_blob(self.commit, source_path) as source:
-                return Table.read(source, format="ascii.ecsv")
+            return Table.read(
+                BytesIO(self._object_store.read_blob(self.commit, source_path)), format="ascii.ecsv"
+            )
         except FileNotFoundError as exc:
             raise FileNotFoundError(
                 f"Model file not found at commit {self.commit}: {source_path}"

--- a/src/simtools/model_repository/git_model.py
+++ b/src/simtools/model_repository/git_model.py
@@ -16,6 +16,7 @@ from simtools.model_repository.parsing import normalize_model_parameter
 from simtools.utils import names
 
 logger = logging.getLogger(__name__)
+_PRODUCTIONS_PATH = PurePosixPath("simulation-models/productions")
 
 
 class GitModelSource:
@@ -54,7 +55,7 @@ class GitModelSource:
         """Return semantically sorted production versions."""
         del collection_name
         if self._model_versions is None:
-            prefix = PurePosixPath("simulation-models/productions")
+            prefix = _PRODUCTIONS_PATH
             versions = {
                 PurePosixPath(path).relative_to(prefix).parts[0]
                 for path in self._object_store.iter_files(self.commit, prefix.as_posix())
@@ -125,7 +126,7 @@ class GitModelSource:
 
     def _production_documents(self, model_version):
         """Read all production JSON documents for a version and its patch history."""
-        model_prefix = PurePosixPath("simulation-models/productions") / model_version
+        model_prefix = _PRODUCTIONS_PATH / model_version
         files_in_version = self._object_store.iter_files(self.commit, model_prefix.as_posix())
         model_names = [model_version]
         info_path = model_prefix / "info.yml"
@@ -138,7 +139,7 @@ class GitModelSource:
         model_names = sorted(set(model_names), key=Version)
         documents = []
         for model_name in model_names:
-            prefix = PurePosixPath("simulation-models/productions") / model_name
+            prefix = _PRODUCTIONS_PATH / model_name
             for path in self._object_store.iter_files(self.commit, prefix.as_posix()):
                 if path.endswith(".json"):
                     documents.append(

--- a/src/simtools/model_repository/parsing.py
+++ b/src/simtools/model_repository/parsing.py
@@ -1,0 +1,16 @@
+"""Parsing helpers shared by simulation-model sources."""
+
+from simtools.utils import value_conversion
+
+
+def normalize_model_parameter(data):
+    """Normalize the value and unit fields of a model-parameter document."""
+    data = dict(data)
+    data["value"], _ = value_conversion.split_value_and_unit(
+        data["value"], "int" in data.get("type", "float")
+    )
+    data["value"], base_unit, _ = value_conversion.get_value_unit_type(
+        value=data["value"], unit_str=data.get("unit")
+    )
+    data["unit"] = value_conversion.normalize_model_parameter_unit(data["value"], base_unit)
+    return data

--- a/src/simtools/model_repository/reader.py
+++ b/src/simtools/model_repository/reader.py
@@ -10,8 +10,9 @@ from packaging.version import Version
 from simtools import settings
 from simtools.io import ascii_handler
 from simtools.model_repository import files
+from simtools.model_repository.parsing import normalize_model_parameter
 from simtools.simtel import simtel_table_reader
-from simtools.utils import names, value_conversion
+from simtools.utils import names
 from simtools.version import resolve_version_to_latest_patch
 
 
@@ -174,13 +175,7 @@ class FileSystemModelSource:
         key = str(parameter_path)
         if key not in self._parameters:
             data = ascii_handler.collect_data_from_file(file_name=parameter_path)
-            data["value"], _ = value_conversion.split_value_and_unit(
-                data["value"], "int" in data.get("type", "float")
-            )
-            data["value"], base_unit, _ = value_conversion.get_value_unit_type(
-                value=data["value"], unit_str=data.get("unit")
-            )
-            data["unit"] = value_conversion.normalize_model_parameter_unit(data["value"], base_unit)
+            data = normalize_model_parameter(data)
             self._parameters[key] = data
         return deepcopy(self._parameters[key])
 
@@ -254,6 +249,15 @@ class SimulationModelReader:
     def from_files(cls, simulation_models_path):
         """Create a reader for a checked-out model repository."""
         return cls(FileSystemModelSource(simulation_models_path))
+
+    @classmethod
+    def from_git(cls, repository_path, revision, object_store=None):
+        """Create a reader for one immutable revision of a Git repository."""
+        from simtools.model_repository.git_model import (  # pylint: disable=import-outside-toplevel
+            GitModelSource,
+        )
+
+        return cls(GitModelSource(repository_path, revision, object_store=object_store))
 
     @property
     def source_name(self):

--- a/src/simtools/schemas/dependency_versions.schema.yml
+++ b/src/simtools/schemas/dependency_versions.schema.yml
@@ -404,6 +404,8 @@ properties:
     properties:
       name: {type: string, minLength: 1}
       default-tag: {"$ref": "#/definitions/tag"}
+      repository-url: {type: string, pattern: "^https://"}
+      git-revision: {"$ref": "#/definitions/revision"}
   simtools-tests:
     type: object
     additionalProperties: false

--- a/src/simtools/testing/output_validation/model_parameters.py
+++ b/src/simtools/testing/output_validation/model_parameters.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from simtools.application.model_reader import create_model_reader
+from simtools.application.model_reader import create_model_reader_from_configuration
 from simtools.io import ascii_handler
 from simtools.testing.output_validation.reference import _compare_values
 from simtools.utils import general
@@ -19,16 +19,7 @@ def validate(path, rule, configuration, model_reader=None):
     """
     parameter_name = rule["reference_parameter_name"]
     if model_reader is None:
-        git_path = configuration.get("simulation_models_git_path")
-        git_revision = configuration.get("simulation_models_git_revision")
-        if git_path is None and git_revision is None:
-            model_reader = create_model_reader(configuration.get("simulation_models_path"))
-        else:
-            model_reader = create_model_reader(
-                simulation_models_path=configuration.get("simulation_models_path"),
-                simulation_models_git_path=git_path,
-                simulation_models_git_revision=git_revision,
-            )
+        model_reader = create_model_reader_from_configuration(configuration)
     reference = model_reader.get_model_parameter(
         parameter=parameter_name,
         site=configuration.get("site"),

--- a/src/simtools/testing/output_validation/model_parameters.py
+++ b/src/simtools/testing/output_validation/model_parameters.py
@@ -19,7 +19,16 @@ def validate(path, rule, configuration, model_reader=None):
     """
     parameter_name = rule["reference_parameter_name"]
     if model_reader is None:
-        model_reader = create_model_reader(configuration.get("simulation_models_path"))
+        git_path = configuration.get("simulation_models_git_path")
+        git_revision = configuration.get("simulation_models_git_revision")
+        if git_path is None and git_revision is None:
+            model_reader = create_model_reader(configuration.get("simulation_models_path"))
+        else:
+            model_reader = create_model_reader(
+                simulation_models_path=configuration.get("simulation_models_path"),
+                simulation_models_git_path=git_path,
+                simulation_models_git_revision=git_revision,
+            )
     reference = model_reader.get_model_parameter(
         parameter=parameter_name,
         site=configuration.get("site"),

--- a/src/simtools/testing/output_validation/runner.py
+++ b/src/simtools/testing/output_validation/runner.py
@@ -1,6 +1,6 @@
 """Orchestration of integration-test output validation."""
 
-from simtools.application.model_reader import create_model_reader
+from simtools.application.model_reader import create_model_reader_from_configuration
 from simtools.testing.output_validation.artifacts import OutputArtifact
 from simtools.testing.output_validation.registry import run_validator
 
@@ -60,13 +60,5 @@ def _validate_rule(artifact, rule, configuration, context):
 
 
 def _create_model_reader(configuration):
-    """Create a reader while retaining the compact legacy call shape."""
-    git_path = configuration.get("simulation_models_git_path")
-    git_revision = configuration.get("simulation_models_git_revision")
-    if git_path is None and git_revision is None:
-        return create_model_reader(configuration.get("simulation_models_path"))
-    return create_model_reader(
-        simulation_models_path=configuration.get("simulation_models_path"),
-        simulation_models_git_path=git_path,
-        simulation_models_git_revision=git_revision,
-    )
+    """Create a reader for model-parameter output validation."""
+    return create_model_reader_from_configuration(configuration)

--- a/src/simtools/testing/output_validation/runner.py
+++ b/src/simtools/testing/output_validation/runner.py
@@ -55,5 +55,18 @@ def _validate_descriptor(descriptor, configuration, active_versions, context):
 def _validate_rule(artifact, rule, configuration, context):
     """Run one validation rule, creating a shared model reader if needed."""
     if rule["type"] == "model_parameter" and context["model_reader"] is None:
-        context["model_reader"] = create_model_reader(configuration.get("simulation_models_path"))
+        context["model_reader"] = _create_model_reader(configuration)
     run_validator(artifact, rule, context)
+
+
+def _create_model_reader(configuration):
+    """Create a reader while retaining the compact legacy call shape."""
+    git_path = configuration.get("simulation_models_git_path")
+    git_revision = configuration.get("simulation_models_git_revision")
+    if git_path is None and git_revision is None:
+        return create_model_reader(configuration.get("simulation_models_path"))
+    return create_model_reader(
+        simulation_models_path=configuration.get("simulation_models_path"),
+        simulation_models_git_path=git_path,
+        simulation_models_git_revision=git_revision,
+    )

--- a/tests/integration_tests/config/db_get_array_layouts_from_db_layout_list.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_layout_list.yml
@@ -15,6 +15,7 @@ applications:
     output_file: array_layout_south_ground_from_list.ecsv
     output_path: simtools-output
     site: South
+  requires_mongodb: true
   test_name: layout_list
 schema_name: application_workflow.metaschema
 schema_version: 0.5.0

--- a/tests/integration_tests/config/db_get_array_layouts_from_db_layout_name.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_layout_name.yml
@@ -12,6 +12,7 @@ applications:
         ">=7.0.0": CTAO-North-Alpha
     model_version: 6.0.2
     site: North
+  requires_mongodb: true
   test_name: layout_name
 schema_name: application_workflow.metaschema
 schema_version: 0.5.0

--- a/tests/integration_tests/config/db_get_array_layouts_from_db_layout_with_calibration_flag.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_layout_with_calibration_flag.yml
@@ -17,6 +17,7 @@ applications:
     output_path: simtools-output
     site: South
   model_version_use_current: true
+  requires_mongodb: true
   test_name: layout_with_calibration_flag
 schema_name: application_workflow.metaschema
 schema_version: 0.5.0

--- a/tests/integration_tests/config/db_get_array_layouts_from_db_list_arrays.yml
+++ b/tests/integration_tests/config/db_get_array_layouts_from_db_list_arrays.yml
@@ -8,6 +8,7 @@ applications:
     list_available_layouts: true
     model_version: 6.0.2
     site: North
+  requires_mongodb: true
   test_name: list_arrays
 schema_name: application_workflow.metaschema
 schema_version: 0.5.0

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -18,6 +18,18 @@ def pytest_addoption(parser):
         default=None,
         help="Read simulation models from files at this path.",
     )
+    parser.addoption(
+        "--simulation_models_git_path",
+        action="store",
+        default=None,
+        help="Read simulation models from a local Git repository at this path.",
+    )
+    parser.addoption(
+        "--simulation_models_git_revision",
+        action="store",
+        default=None,
+        help="Git revision used for the simulation-model reader.",
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -14,18 +14,37 @@ from simtools.testing import configuration, helpers, log_inspector, validate_out
 logger = logging.getLogger()
 
 
-def _get_simulation_models_path(config, request, simtools_root_path):
-    """Return the configured model path or skip MongoDB-only applications."""
+def _get_simulation_model_source(config, request, simtools_root_path):
+    """Return the configured model source or skip MongoDB-only applications."""
     simulation_models_path = request.config.getoption("simulation_models_path", default=None)
-    if not simulation_models_path:
-        return None
+    git_path = request.config.getoption("simulation_models_git_path", default=None)
+    git_revision = request.config.getoption("simulation_models_git_revision", default=None)
+    if not simulation_models_path and not git_path:
+        return None, None
     if config.get("requires_mongodb"):
         pytest.skip(f"{config['application']} requires MongoDB")
 
-    simulation_models_path = Path(simulation_models_path)
-    if not simulation_models_path.is_absolute():
-        simulation_models_path = Path(simtools_root_path) / simulation_models_path
-    return simulation_models_path.resolve()
+    if simulation_models_path:
+        simulation_models_path = Path(simulation_models_path)
+        if not simulation_models_path.is_absolute():
+            simulation_models_path = Path(simtools_root_path) / simulation_models_path
+        return simulation_models_path.resolve(), None
+
+    git_path = Path(git_path)
+    if not git_path.is_absolute():
+        git_path = Path(simtools_root_path) / git_path
+    return None, (git_path.resolve(), git_revision)
+
+
+def _set_simulation_model_source_env(monkeypatch, simulation_models_path, git_source):
+    """Set environment variables for the selected simulation-model source."""
+    if simulation_models_path:
+        monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_PATH", str(simulation_models_path))
+    if git_source:
+        git_path, git_revision = git_source
+        monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", str(git_path))
+        if git_revision:
+            monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION", git_revision)
 
 
 def pytest_generate_tests(metafunc):
@@ -83,9 +102,10 @@ def test_applications_from_config(
     if tmp_config.get("skip_integration_test"):
         pytest.skip(tmp_config["skip_integration_test"])
 
-    simulation_models_path = _get_simulation_models_path(tmp_config, request, simtools_root_path)
-    if simulation_models_path:
-        monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_PATH", str(simulation_models_path))
+    simulation_models_path, git_source = _get_simulation_model_source(
+        tmp_config, request, simtools_root_path
+    )
+    _set_simulation_model_source_env(monkeypatch, simulation_models_path, git_source)
 
     logger.info(f"Test configuration from config file: {tmp_config}")
     logger.info(f"Model version: {model_version}")
@@ -134,17 +154,36 @@ def test_applications_from_config(
     )
 
 
-def test_get_simulation_models_path(tmp_test_directory, mocker):
+def test_get_simulation_model_source_from_filesystem(tmp_test_directory, mocker):
     """Resolve a relative simulation-model path against the simtools root."""
     request = mocker.MagicMock()
     request.config.getoption.return_value = "../simulation-models"
     root_path = Path(tmp_test_directory) / "simtools"
 
-    path = _get_simulation_models_path(
+    path, git_source = _get_simulation_model_source(
         {"application": "simtools-simulate-prod"}, request, root_path
     )
 
     assert path == (root_path / "../simulation-models").resolve()
+    assert git_source is None
+
+
+def test_get_simulation_model_source_from_git(tmp_test_directory, mocker):
+    """Resolve Git source options and preserve their requested revision."""
+    request = mocker.MagicMock()
+    options = {
+        "simulation_models_path": None,
+        "simulation_models_git_path": "../simulation-models.git",
+        "simulation_models_git_revision": "HEAD",
+    }
+    request.config.getoption.side_effect = lambda option, default=None: options.get(option, default)
+
+    path, git_source = _get_simulation_model_source(
+        {"application": "simtools-simulate-prod"}, request, tmp_test_directory
+    )
+
+    assert path is None
+    assert git_source == ((Path(tmp_test_directory) / "../simulation-models.git").resolve(), "HEAD")
 
 
 def test_mongodb_only_application_is_skipped(tmp_test_directory, mocker):
@@ -154,17 +193,14 @@ def test_mongodb_only_application_is_skipped(tmp_test_directory, mocker):
     config = {"application": "simtools-mongodb-operation", "requires_mongodb": True}
 
     with pytest.raises(pytest.skip.Exception, match="simtools-mongodb-operation requires MongoDB"):
-        _get_simulation_models_path(config, request, tmp_test_directory)
+        _get_simulation_model_source(config, request, tmp_test_directory)
 
 
-def test_get_simulation_models_path_is_optional(tmp_test_directory, mocker):
+def test_get_simulation_model_source_is_optional(tmp_test_directory, mocker):
     """Leave integration tests unchanged when no filesystem path is configured."""
     request = mocker.MagicMock()
     request.config.getoption.return_value = None
 
-    assert (
-        _get_simulation_models_path(
-            {"application": "simtools-simulate-prod"}, request, tmp_test_directory
-        )
-        is None
-    )
+    assert _get_simulation_model_source(
+        {"application": "simtools-simulate-prod"}, request, tmp_test_directory
+    ) == (None, None)

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -12,6 +12,37 @@ import pytest
 from simtools.testing import configuration, helpers, log_inspector, validate_output
 
 logger = logging.getLogger()
+_MONGODB_ENVIRONMENT = (
+    "SIMTOOLS_DB_SERVER",
+    "SIMTOOLS_DB_API_USER",
+    "SIMTOOLS_DB_API_PW",
+    "SIMTOOLS_DB_API_PORT",
+    "SIMTOOLS_DB_SIMULATION_MODEL",
+)
+_MONGODB_MODEL_TAG_ENVIRONMENT = (
+    "SIMTOOLS_DB_SIMULATION_MODEL_TAG",
+    "SIMTOOLS_DB_SIMULATION_MODEL_VERSION",
+)
+
+
+def _is_mongodb_application(config):
+    """Return whether an integration application requires MongoDB."""
+    return config.get("requires_mongodb") or config["application"].startswith("simtools-db-")
+
+
+def _has_mongodb_configuration(configuration=None):
+    """Return whether required MongoDB settings are available to the application."""
+    configuration = configuration or {}
+    values = [
+        configuration.get(variable.removeprefix("SIMTOOLS_").lower()) or os.environ.get(variable)
+        for variable in _MONGODB_ENVIRONMENT
+    ]
+    model_tag = (
+        configuration.get("db_simulation_model_tag")
+        or configuration.get("db_simulation_model_version")
+        or next((os.environ.get(variable) for variable in _MONGODB_MODEL_TAG_ENVIRONMENT), None)
+    )
+    return all(values) and bool(model_tag)
 
 
 def _get_simulation_model_source(config, request, simtools_root_path):
@@ -21,7 +52,7 @@ def _get_simulation_model_source(config, request, simtools_root_path):
     git_revision = request.config.getoption("simulation_models_git_revision", default=None)
     if not simulation_models_path and not git_path:
         return None, None
-    if config.get("requires_mongodb"):
+    if _is_mongodb_application(config):
         pytest.skip(f"{config['application']} requires MongoDB")
 
     if simulation_models_path:
@@ -101,6 +132,10 @@ def test_applications_from_config(
 
     if tmp_config.get("skip_integration_test"):
         pytest.skip(tmp_config["skip_integration_test"])
+    if _is_mongodb_application(tmp_config) and not _has_mongodb_configuration(
+        tmp_config.get("configuration")
+    ):
+        pytest.skip(f"{tmp_config['application']} requires MongoDB configuration")
 
     simulation_models_path, git_source = _get_simulation_model_source(
         tmp_config, request, simtools_root_path
@@ -194,6 +229,48 @@ def test_mongodb_only_application_is_skipped(tmp_test_directory, mocker):
 
     with pytest.raises(pytest.skip.Exception, match="simtools-mongodb-operation requires MongoDB"):
         _get_simulation_model_source(config, request, tmp_test_directory)
+
+
+def test_database_application_is_skipped_without_metadata(tmp_test_directory, mocker):
+    """Recognize database applications even when old configs lack metadata."""
+    request = mocker.MagicMock()
+    options = {
+        "simulation_models_path": None,
+        "simulation_models_git_path": "models.git",
+        "simulation_models_git_revision": "HEAD",
+    }
+    request.config.getoption.side_effect = lambda option, default=None: options.get(option, default)
+
+    with pytest.raises(
+        pytest.skip.Exception, match="simtools-db-get-array-layouts-from-db requires MongoDB"
+    ):
+        _get_simulation_model_source(
+            {"application": "simtools-db-get-array-layouts-from-db"},
+            request,
+            tmp_test_directory,
+        )
+
+
+def test_database_application_is_skipped_without_database_configuration(
+    tmp_test_directory, mocker, monkeypatch
+):
+    """Avoid launching DB applications when the test environment has no DB settings."""
+    request = mocker.MagicMock()
+    request.config.getoption.return_value = None
+    for variable in _MONGODB_ENVIRONMENT:
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(
+        pytest.skip.Exception,
+        match="simtools-db-get-file-from-db requires MongoDB configuration",
+    ):
+        test_applications_from_config(
+            tmp_test_directory,
+            {"application": "simtools-db-get-file-from-db"},
+            request,
+            tmp_test_directory,
+            monkeypatch,
+        )
 
 
 def test_get_simulation_model_source_is_optional(tmp_test_directory, mocker):

--- a/tests/integration_tests/test_applications_from_config.py
+++ b/tests/integration_tests/test_applications_from_config.py
@@ -2,6 +2,7 @@
 # Integration tests for applications from config file
 
 import copy
+import importlib
 import logging
 import os
 import subprocess
@@ -51,6 +52,10 @@ def _get_simulation_model_source(config, request, simtools_root_path):
     git_path = request.config.getoption("simulation_models_git_path", default=None)
     git_revision = request.config.getoption("simulation_models_git_revision", default=None)
     if not simulation_models_path and not git_path:
+        simulation_models_path = os.environ.get("SIMTOOLS_SIMULATION_MODELS_PATH")
+        git_path = os.environ.get("SIMTOOLS_SIMULATION_MODELS_GIT_PATH")
+        git_revision = os.environ.get("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION")
+    if not simulation_models_path and not git_path:
         return None, None
     if _is_mongodb_application(config):
         pytest.skip(f"{config['application']} requires MongoDB")
@@ -70,12 +75,53 @@ def _get_simulation_model_source(config, request, simtools_root_path):
 def _set_simulation_model_source_env(monkeypatch, simulation_models_path, git_source):
     """Set environment variables for the selected simulation-model source."""
     if simulation_models_path:
+        monkeypatch.delenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", raising=False)
+        monkeypatch.delenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION", raising=False)
         monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_PATH", str(simulation_models_path))
     if git_source:
         git_path, git_revision = git_source
+        monkeypatch.delenv("SIMTOOLS_SIMULATION_MODELS_PATH", raising=False)
         monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", str(git_path))
         if git_revision:
             monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION", git_revision)
+
+
+def _get_model_source_arguments(application):
+    """Return the model-source argument names accepted by an application."""
+    module_name = "simtools.applications." + application.removeprefix("simtools-").replace("-", "_")
+    try:
+        definition = importlib.import_module(module_name).APPLICATION
+    except ImportError, AttributeError:
+        return set()
+    return {argument.name for argument in definition.all_arguments}
+
+
+def _set_simulation_model_source_configuration(config, simulation_models_path, git_source):
+    """Replace a workflow's configured source with the selected test source.
+
+    The model-source options are only written to workflows of applications using
+    the standard model-source arguments. Applications defining
+    ``simulation_models_path`` as an application-specific argument are not
+    modified; they read the selected source from the environment variables set
+    by ``_set_simulation_model_source_env``.
+    """
+    if not simulation_models_path and not git_source:
+        return
+    source_config = config.get("configuration")
+    if source_config is None:  # e.g. 'auto-no_config' tests running without any argument
+        return
+    if "simulation_models_git_path" not in _get_model_source_arguments(config["application"]):
+        return
+    source_config.pop("simulation_models_path", None)
+    source_config.pop("simulation_models_git_path", None)
+    source_config.pop("simulation_models_git_revision", None)
+    if simulation_models_path:
+        source_config["simulation_models_path"] = str(simulation_models_path)
+        return
+    git_path, git_revision = git_source
+    source_config["simulation_models_git_path"] = str(git_path)
+    if git_revision:
+        source_config["simulation_models_git_revision"] = git_revision
 
 
 def pytest_generate_tests(metafunc):
@@ -141,6 +187,7 @@ def test_applications_from_config(
         tmp_config, request, simtools_root_path
     )
     _set_simulation_model_source_env(monkeypatch, simulation_models_path, git_source)
+    _set_simulation_model_source_configuration(tmp_config, simulation_models_path, git_source)
 
     logger.info(f"Test configuration from config file: {tmp_config}")
     logger.info(f"Model version: {model_version}")
@@ -221,6 +268,166 @@ def test_get_simulation_model_source_from_git(tmp_test_directory, mocker):
     assert git_source == ((Path(tmp_test_directory) / "../simulation-models.git").resolve(), "HEAD")
 
 
+def test_get_simulation_model_source_from_git_environment(tmp_test_directory, mocker, monkeypatch):
+    """Use the Git source configured in .env when no command-line option is given."""
+    request = mocker.MagicMock()
+    request.config.getoption.return_value = None
+    monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", "../simulation-models.git")
+    monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION", "6.0.2")
+
+    path, git_source = _get_simulation_model_source(
+        {"application": "simtools-simulate-prod"}, request, tmp_test_directory
+    )
+
+    assert path is None
+    assert git_source == (
+        (Path(tmp_test_directory) / "../simulation-models.git").resolve(),
+        "6.0.2",
+    )
+
+
+def test_git_source_replaces_filesystem_source_in_workflow_configuration(
+    tmp_test_directory, mocker
+):
+    """A selected Git source overrides a filesystem source embedded in a workflow."""
+    mocker.patch(
+        "tests.integration_tests.test_applications_from_config._get_model_source_arguments",
+        return_value={
+            "simulation_models_path",
+            "simulation_models_git_path",
+            "simulation_models_git_revision",
+        },
+    )
+    config = {
+        "application": "simtools-simulate-prod",
+        "configuration": {
+            "simulation_models_path": "../simulation-models",
+            "simulation_models_git_revision": "old-revision",
+        },
+    }
+
+    _set_simulation_model_source_configuration(
+        config,
+        None,
+        ((Path(tmp_test_directory) / "models.git").resolve(), "7.0.0"),
+    )
+
+    assert config["configuration"] == {
+        "simulation_models_git_path": str((Path(tmp_test_directory) / "models.git").resolve()),
+        "simulation_models_git_revision": "7.0.0",
+    }
+
+
+def test_unsupported_application_does_not_receive_model_source_configuration(
+    tmp_test_directory, mocker
+):
+    """Do not write model-source options into workflows that reject those arguments."""
+    mocker.patch(
+        "tests.integration_tests.test_applications_from_config._get_model_source_arguments",
+        return_value=set(),
+    )
+    config = {"application": "simtools-derive-photon-electron-spectrum", "configuration": {}}
+
+    _set_simulation_model_source_configuration(
+        config,
+        None,
+        ((Path(tmp_test_directory) / "models.git").resolve(), "7.0.0"),
+    )
+
+    assert config["configuration"] == {}
+
+
+def test_filesystem_source_supported_arguments_only(tmp_test_directory, mocker):
+    """Inject a filesystem source only for applications using the model-source arguments."""
+    mocker.patch(
+        "tests.integration_tests.test_applications_from_config._get_model_source_arguments",
+        return_value={"simulation_models_path", "simulation_models_git_path"},
+    )
+    config = {"application": "simtools-simulate-prod", "configuration": {}}
+
+    _set_simulation_model_source_configuration(
+        config,
+        Path(tmp_test_directory) / "simulation-models",
+        None,
+    )
+
+    assert config["configuration"] == {
+        "simulation_models_path": str(Path(tmp_test_directory) / "simulation-models")
+    }
+
+
+def test_application_specific_model_path_is_not_overridden(tmp_test_directory, mocker):
+    """Leave an application-specific ``simulation_models_path`` argument untouched."""
+    mocker.patch(
+        "tests.integration_tests.test_applications_from_config._get_model_source_arguments",
+        return_value={"simulation_models_path"},
+    )
+    config = {
+        "application": "simtools-docs-produce-production-summary",
+        "configuration": {"simulation_models_path": "../simulation-models"},
+    }
+
+    _set_simulation_model_source_configuration(
+        config,
+        None,
+        ((Path(tmp_test_directory) / "models.git").resolve(), "7.0.0"),
+    )
+
+    assert config["configuration"] == {"simulation_models_path": "../simulation-models"}
+
+
+def test_git_source_replaces_stale_revision(tmp_test_directory, mocker):
+    """Replace a stale Git revision when injecting a Git source."""
+    mocker.patch(
+        "tests.integration_tests.test_applications_from_config._get_model_source_arguments",
+        return_value={"simulation_models_git_path", "simulation_models_git_revision"},
+    )
+    config = {
+        "application": "simtools-simulate-prod",
+        "configuration": {"simulation_models_git_revision": "old-revision"},
+    }
+
+    _set_simulation_model_source_configuration(
+        config,
+        None,
+        ((Path(tmp_test_directory) / "models.git").resolve(), "7.0.0"),
+    )
+
+    assert config["configuration"] == {
+        "simulation_models_git_path": str((Path(tmp_test_directory) / "models.git").resolve()),
+        "simulation_models_git_revision": "7.0.0",
+    }
+
+
+def test_git_source_does_not_skip_application_with_model_path_argument(
+    tmp_test_directory, mocker, monkeypatch
+):
+    """Run workflows using an application-specific model path also for a Git source."""
+    request = mocker.MagicMock()
+    options = {
+        "simulation_models_path": None,
+        "simulation_models_git_path": "models.git",
+        "simulation_models_git_revision": "HEAD",
+    }
+    request.config.getoption.side_effect = lambda option, default=None: options.get(option, default)
+    config = {
+        "application": "simtools-docs-produce-production-summary",
+        "test_name": "run",
+        "configuration": {"simulation_models_path": "../simulation-models"},
+    }
+    run = mocker.patch("subprocess.run")
+    run.return_value = mocker.MagicMock(returncode=0, stdout="", stderr="")
+    validate = mocker.patch("simtools.testing.validate_output.validate_application_output")
+
+    test_applications_from_config(
+        tmp_test_directory, config, request, Path(tmp_test_directory), monkeypatch
+    )
+
+    assert run.called
+    validate.assert_called_once()
+    assert config["configuration"]["simulation_models_path"] == "../simulation-models"
+
+
 def test_mongodb_only_application_is_skipped(tmp_test_directory, mocker):
     """Skip MongoDB-only applications when filesystem model access is selected."""
     request = mocker.MagicMock()
@@ -273,10 +480,12 @@ def test_database_application_is_skipped_without_database_configuration(
         )
 
 
-def test_get_simulation_model_source_is_optional(tmp_test_directory, mocker):
+def test_get_simulation_model_source_is_optional(tmp_test_directory, mocker, monkeypatch):
     """Leave integration tests unchanged when no filesystem path is configured."""
     request = mocker.MagicMock()
     request.config.getoption.return_value = None
+    monkeypatch.delenv("SIMTOOLS_SIMULATION_MODELS_PATH", raising=False)
+    monkeypatch.delenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", raising=False)
 
     assert _get_simulation_model_source(
         {"application": "simtools-simulate-prod"}, request, tmp_test_directory

--- a/tests/unit_tests/application/test_control.py
+++ b/tests/unit_tests/application/test_control.py
@@ -166,7 +166,9 @@ def test_initialize_runtime_without_io_handler():
 
 def test_initialize_runtime_without_model_reader(mocker):
     """Write-only applications do not require a checked-out model repository."""
-    model_reader = mocker.patch("simtools.application.control.create_model_reader")
+    model_reader = mocker.patch(
+        "simtools.application.control.create_model_reader_from_configuration"
+    )
     app_context = _initialize_runtime(
         {"log_level": "info"}, {}, setup_io_handler=False, initialize_model_reader=False
     )

--- a/tests/unit_tests/application/test_model_reader.py
+++ b/tests/unit_tests/application/test_model_reader.py
@@ -7,6 +7,7 @@ import pytest
 
 from simtools.application.model_reader import (
     create_model_reader,
+    create_model_reader_from_configuration,
     create_model_reader_from_source_config,
     require_model_reader,
 )
@@ -91,6 +92,23 @@ def test_create_model_reader_uses_catalog_git_revision(catalog_model, mocker):
     from_git.assert_called_once_with("models.git", next(iter(catalog_model.values())))
 
 
+def test_create_model_reader_from_configuration_forwards_all_source_options(mocker):
+    """Configuration-based callers share the same source-selection path."""
+    reader = Mock()
+    create_reader = mocker.patch(
+        "simtools.application.model_reader.create_model_reader", return_value=reader
+    )
+    configuration = {
+        "simulation_models_path": "/models",
+        "simulation_models_git_path": "/models.git",
+        "simulation_models_git_revision": "commit",
+    }
+
+    assert create_model_reader_from_configuration(configuration) is reader
+
+    create_reader.assert_called_once_with(**configuration)
+
+
 def test_create_model_reader_rejects_catalog_without_git_revision(mocker):
     """A Git source cannot start when the catalog has no usable revision."""
     mocker.patch(
@@ -169,7 +187,7 @@ def test_create_model_reader_from_source_config_uses_filesystem_path(mocker):
         create_model_reader_from_source_config({"type": "filesystem", "path": "models"}) is reader
     )
 
-    create_reader.assert_called_once_with("models")
+    create_reader.assert_called_once_with(simulation_models_path="models")
 
 
 def test_create_model_reader_from_source_config_allows_unnamed_mongodb(mocker):

--- a/tests/unit_tests/application/test_model_reader.py
+++ b/tests/unit_tests/application/test_model_reader.py
@@ -10,6 +10,7 @@ from simtools.application.model_reader import (
     create_model_reader_from_source_config,
     require_model_reader,
 )
+from simtools.model_repository.reader import SimulationModelReader
 from simtools.settings import config
 
 
@@ -54,6 +55,30 @@ def test_create_model_reader_uses_environment_path(monkeypatch, tmp_test_directo
     assert reader.source_name == str(root.resolve())
 
 
+def test_create_model_reader_selects_git_source(monkeypatch, mocker, tmp_test_directory):
+    """A Git path and revision select the Git source without MongoDB."""
+    git_path = Path(tmp_test_directory) / "models.git"
+    git_reader = Mock()
+    from_git = mocker.patch.object(SimulationModelReader, "from_git", return_value=git_reader)
+    monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_PATH", str(git_path))
+    monkeypatch.setenv("SIMTOOLS_SIMULATION_MODELS_GIT_REVISION", "v1")
+    database_handler = mocker.patch("simtools.db.db_handler.DatabaseHandler")
+
+    assert create_model_reader() is git_reader
+    from_git.assert_called_once_with(str(git_path), "v1")
+    database_handler.assert_not_called()
+
+
+def test_create_model_reader_rejects_two_repository_sources(tmp_test_directory):
+    """Filesystem and Git sources cannot be selected simultaneously."""
+    with pytest.raises(ValueError, match="cannot be configured together"):
+        create_model_reader(
+            simulation_models_path=tmp_test_directory,
+            simulation_models_git_path=tmp_test_directory,
+            simulation_models_git_revision="v1",
+        )
+
+
 def test_create_model_reader_from_source_config_preserves_mongodb_name(mocker):
     """Worker source reconstruction keeps the selected MongoDB name."""
     handler = Mock()
@@ -64,6 +89,19 @@ def test_create_model_reader_from_source_config_preserves_mongodb_name(mocker):
 
     assert handler.db_name == "worker-db"
     assert reader.source_name == "worker-db"
+
+
+def test_create_model_reader_from_source_config_reopens_git_revision(mocker):
+    """Workers reconstruct Git readers from the serialized commit."""
+    reader = Mock()
+    from_git = mocker.patch.object(SimulationModelReader, "from_git", return_value=reader)
+
+    result = create_model_reader_from_source_config(
+        {"type": "git", "repository": "/models.git", "commit": "a" * 40}
+    )
+
+    assert result is reader
+    from_git.assert_called_once_with("/models.git", "a" * 40)
 
 
 def test_require_model_reader_prefers_explicit_reader():

--- a/tests/unit_tests/application/test_model_reader.py
+++ b/tests/unit_tests/application/test_model_reader.py
@@ -70,6 +70,38 @@ def test_create_model_reader_selects_git_source(monkeypatch, mocker, tmp_test_di
     database_handler.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "catalog_model",
+    [
+        {"git-revision": "a" * 40},
+        {"default-tag": "v1.2.3"},
+        {"default-version": "1.2.3"},
+    ],
+)
+def test_create_model_reader_uses_catalog_git_revision(catalog_model, mocker):
+    """A missing Git revision falls back through the dependency catalog."""
+    mocker.patch(
+        "simtools.application.model_reader.dependency_versions.load_dependency_catalog",
+        return_value={"model-database": catalog_model},
+    )
+    from_git = mocker.patch.object(SimulationModelReader, "from_git", return_value=Mock())
+
+    create_model_reader(simulation_models_git_path="models.git")
+
+    from_git.assert_called_once_with("models.git", next(iter(catalog_model.values())))
+
+
+def test_create_model_reader_rejects_catalog_without_git_revision(mocker):
+    """A Git source cannot start when the catalog has no usable revision."""
+    mocker.patch(
+        "simtools.application.model_reader.dependency_versions.load_dependency_catalog",
+        return_value={"model-database": {}},
+    )
+
+    with pytest.raises(ValueError, match="Git simulation-model revision is required"):
+        create_model_reader(simulation_models_git_path="models.git")
+
+
 def test_create_model_reader_rejects_two_repository_sources(tmp_test_directory):
     """Filesystem and Git sources cannot be selected simultaneously."""
     with pytest.raises(ValueError, match="cannot be configured together"):
@@ -103,6 +135,13 @@ def test_create_model_reader_from_source_config_reopens_git_revision(mocker):
 
     assert result is reader
     from_git.assert_called_once_with("/models.git", "a" * 40)
+
+
+@pytest.mark.parametrize("source_config", [{"type": "git"}, {"type": "git", "repository": "repo"}])
+def test_create_model_reader_from_source_config_rejects_incomplete_git_config(source_config):
+    """Worker Git configurations must include both repository and commit."""
+    with pytest.raises(ValueError, match="requires repository and commit"):
+        create_model_reader_from_source_config(source_config)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/configuration/test_show_options.py
+++ b/tests/unit_tests/configuration/test_show_options.py
@@ -131,6 +131,28 @@ def test_show_model_versions_uses_selected_reader(monkeypatch):
     assert result.values == ("7.0.0", "7.1.0")
 
 
+def test_show_model_versions_uses_configured_git_source(mocker):
+    """Git source options are forwarded before runtime initialization."""
+    reader = mocker.Mock()
+    reader.get_model_versions.return_value = ["7.0.0"]
+    create_reader = mocker.patch.object(show_options, "create_model_reader", return_value=reader)
+
+    result = show_options.resolve_show_options(
+        {
+            "show_options": "model_version",
+            "simulation_models_git_path": "/models.git",
+            "simulation_models_git_revision": "v1",
+        }
+    )
+
+    assert result.values == ("7.0.0",)
+    create_reader.assert_called_once_with(
+        simulation_models_path=None,
+        simulation_models_git_path="/models.git",
+        simulation_models_git_revision="v1",
+    )
+
+
 def test_show_array_layout_names_groups_all_sites(monkeypatch):
     class FakeSiteModel:
         def __init__(self, site, model_version, model_reader):

--- a/tests/unit_tests/configuration/test_show_options.py
+++ b/tests/unit_tests/configuration/test_show_options.py
@@ -124,7 +124,9 @@ def test_show_model_versions_uses_selected_reader(monkeypatch):
         def get_model_versions(self):
             return ["7.0.0", "7.1.0"]
 
-    monkeypatch.setattr(show_options, "create_model_reader", lambda *_: FakeModelReader())
+    monkeypatch.setattr(
+        show_options, "create_model_reader_from_configuration", lambda *_: FakeModelReader()
+    )
 
     result = show_options.resolve_show_options({"show_options": "model_version"})
 
@@ -135,7 +137,9 @@ def test_show_model_versions_uses_configured_git_source(mocker):
     """Git source options are forwarded before runtime initialization."""
     reader = mocker.Mock()
     reader.get_model_versions.return_value = ["7.0.0"]
-    create_reader = mocker.patch.object(show_options, "create_model_reader", return_value=reader)
+    create_reader = mocker.patch.object(
+        show_options, "create_model_reader_from_configuration", return_value=reader
+    )
 
     result = show_options.resolve_show_options(
         {
@@ -147,9 +151,11 @@ def test_show_model_versions_uses_configured_git_source(mocker):
 
     assert result.values == ("7.0.0",)
     create_reader.assert_called_once_with(
-        simulation_models_path=None,
-        simulation_models_git_path="/models.git",
-        simulation_models_git_revision="v1",
+        {
+            "show_options": "model_version",
+            "simulation_models_git_path": "/models.git",
+            "simulation_models_git_revision": "v1",
+        }
     )
 
 

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -586,12 +586,17 @@ def patch_database_handler(request, mocker, simtools_settings):
 
     previous_model_reader = settings.config.model_reader
     settings.config.set_model_reader(mock_model_reader)
-    mocker.patch("simtools.application.control.create_model_reader", return_value=mock_model_reader)
     mocker.patch(
-        "simtools.configuration.show_options.create_model_reader", return_value=mock_model_reader
+        "simtools.application.control.create_model_reader_from_configuration",
+        return_value=mock_model_reader,
     )
     mocker.patch(
-        "simtools.job_execution.worker.create_model_reader", return_value=mock_model_reader
+        "simtools.configuration.show_options.create_model_reader_from_configuration",
+        return_value=mock_model_reader,
+    )
+    mocker.patch(
+        "simtools.job_execution.worker.create_model_reader_from_configuration",
+        return_value=mock_model_reader,
     )
     yield
     settings.config.set_model_reader(previous_model_reader)

--- a/tests/unit_tests/model_repository/test_git_backend.py
+++ b/tests/unit_tests/model_repository/test_git_backend.py
@@ -1,0 +1,153 @@
+"""Tests for the pygit2 object-store adapter."""
+
+import io
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from simtools.model_repository.git_backend import (
+    GitModelSourceDependencyError,
+    Pygit2ObjectStore,
+)
+
+
+class _Node:
+    """Minimal pygit2 tree or blob object."""
+
+    def __init__(self, name, type_str, children=None, data=None):
+        self.name = name
+        self.type_str = type_str
+        self.children = children or {}
+        self.data = data
+
+    def __getitem__(self, name):
+        return self.children[name]
+
+    def __iter__(self):
+        return iter(self.children.values())
+
+
+class _Repository:
+    """Minimal pygit2 repository object."""
+
+    def __init__(self, commit, tree):
+        self.commit = commit
+        self.tree = tree
+
+    def revparse_single(self, _):
+        """Return a revision object that resolves to the configured commit."""
+        return SimpleNamespace(peel=lambda _: self.commit)
+
+    def __getitem__(self, _):
+        return SimpleNamespace(tree=self.tree)
+
+
+def _install_pygit2(monkeypatch, repository):
+    """Install a minimal pygit2 substitute and return the resolved commit."""
+    pygit2 = SimpleNamespace(
+        Commit=object(),
+        Repository=lambda _: repository,
+        BlobIO=lambda blob: io.BytesIO(blob.data),
+    )
+    monkeypatch.setitem(sys.modules, "pygit2", pygit2)
+
+
+def test_pygit2_object_store_requires_optional_dependency(monkeypatch, tmp_test_directory):
+    """Selecting a Git source explains how to install its dependency."""
+    monkeypatch.setitem(sys.modules, "pygit2", None)
+
+    with pytest.raises(
+        GitModelSourceDependencyError, match="install simtools with the `git` extra"
+    ):
+        Pygit2ObjectStore(tmp_test_directory)
+
+
+def test_pygit2_object_store_rejects_missing_repository(monkeypatch, tmp_test_directory):
+    """A nonexistent repository path fails before opening pygit2."""
+    _install_pygit2(monkeypatch, repository=None)
+
+    with pytest.raises(FileNotFoundError, match="Git model repository does not exist"):
+        Pygit2ObjectStore(tmp_test_directory / "missing.git")
+
+
+def test_pygit2_object_store_rejects_unreadable_repository(monkeypatch, tmp_test_directory):
+    """A path that pygit2 cannot open reports a readable error."""
+    pygit2 = SimpleNamespace(
+        Commit=object(),
+        Repository=lambda _: (_ for _ in ()).throw(OSError("invalid repository")),
+        BlobIO=lambda blob: io.BytesIO(blob.data),
+    )
+    monkeypatch.setitem(sys.modules, "pygit2", pygit2)
+
+    with pytest.raises(ValueError, match="Not a readable Git model repository"):
+        Pygit2ObjectStore(tmp_test_directory)
+
+
+def test_pygit2_object_store_reads_tree_blobs(monkeypatch, tmp_test_directory):
+    """Resolve revisions and read recursively discovered blob objects."""
+    blob = _Node("model.json", "blob", data=b"{}")
+    nested_blob = _Node("nested.json", "blob", data=b"[]")
+    nested_tree = _Node("nested", "tree", {"nested.json": nested_blob})
+    models_tree = _Node("models", "tree", {"model.json": blob, "nested": nested_tree})
+    root_tree = _Node("", "tree", {"models": models_tree})
+    commit = SimpleNamespace(id="a" * 40)
+    repository = _Repository(commit, root_tree)
+    _install_pygit2(monkeypatch, repository)
+    store = Pygit2ObjectStore(tmp_test_directory)
+
+    resolved = store.resolve_revision("v1")
+
+    assert resolved == "a" * 40
+    assert store.iter_files(resolved, "models") == [
+        "models/model.json",
+        "models/nested/nested.json",
+    ]
+    assert store.read_blob(resolved, "models/model.json") == b"{}"
+    assert store.open_blob(resolved, "models/nested/nested.json").read() == b"[]"
+
+
+def test_pygit2_object_store_reports_invalid_paths(monkeypatch, tmp_test_directory):
+    """Missing and non-file paths provide source-specific errors."""
+    tree = _Node("models", "tree")
+    root_tree = _Node("", "tree", {"models": tree})
+    repository = _Repository(SimpleNamespace(id="a" * 40), root_tree)
+    _install_pygit2(monkeypatch, repository)
+    store = Pygit2ObjectStore(tmp_test_directory)
+
+    with pytest.raises(FileNotFoundError, match="Git path missing"):
+        store.iter_files("a" * 40, "missing")
+    with pytest.raises(ValueError, match="Git path is not a file"):
+        store.read_blob("a" * 40, "models")
+
+
+def test_pygit2_object_store_reports_invalid_revisions_and_commits(
+    monkeypatch, mocker, tmp_test_directory
+):
+    """Invalid revisions and commits report source-specific errors."""
+    root_tree = _Node("", "tree")
+    repository = _Repository(SimpleNamespace(id="a" * 40), root_tree)
+    _install_pygit2(monkeypatch, repository)
+    store = Pygit2ObjectStore(tmp_test_directory)
+    mocker.patch.object(repository, "revparse_single", side_effect=KeyError)
+
+    with pytest.raises(ValueError, match="Git revision 'missing' not found"):
+        store.resolve_revision("missing")
+
+    mocker.patch.object(_Repository, "__getitem__", side_effect=KeyError)
+    with pytest.raises(ValueError, match="Git commit 'b"):
+        store.iter_files("b" * 40, "models")
+
+
+def test_pygit2_object_store_reports_missing_or_file_prefix(monkeypatch, tmp_test_directory):
+    """Directory and blob APIs reject paths of the wrong kind."""
+    blob = _Node("model.json", "blob", data=b"{}")
+    root_tree = _Node("", "tree", {"model.json": blob})
+    repository = _Repository(SimpleNamespace(id="a" * 40), root_tree)
+    _install_pygit2(monkeypatch, repository)
+    store = Pygit2ObjectStore(tmp_test_directory)
+
+    with pytest.raises(ValueError, match="Git path is not a directory"):
+        store.iter_files("a" * 40, "model.json")
+    with pytest.raises(FileNotFoundError, match="Git path 'missing'"):
+        store.read_blob("a" * 40, "missing")

--- a/tests/unit_tests/model_repository/test_git_backend.py
+++ b/tests/unit_tests/model_repository/test_git_backend.py
@@ -28,19 +28,31 @@ class _Node:
         return iter(self.children.values())
 
 
+class _TreeEntry:
+    """Minimal pygit2 tree entry referring to a separate Git object."""
+
+    def __init__(self, name, type_str, identifier):
+        self.name = name
+        self.type_str = type_str
+        self.id = identifier
+
+
 class _Repository:
     """Minimal pygit2 repository object."""
 
-    def __init__(self, commit, tree):
+    def __init__(self, commit, tree, objects=None):
         self.commit = commit
         self.tree = tree
+        self.objects = objects or {}
 
     def revparse_single(self, _):
         """Return a revision object that resolves to the configured commit."""
         return SimpleNamespace(peel=lambda _: self.commit)
 
-    def __getitem__(self, _):
-        return SimpleNamespace(tree=self.tree)
+    def __getitem__(self, identifier):
+        if identifier == str(self.commit.id):
+            return SimpleNamespace(tree=self.tree)
+        return self.objects[identifier]
 
 
 def _raise_invalid_repository(_):
@@ -90,14 +102,34 @@ def test_pygit2_object_store_rejects_unreadable_repository(monkeypatch, tmp_test
 
 
 def test_pygit2_object_store_reads_tree_blobs(monkeypatch, tmp_test_directory):
-    """Resolve revisions and read recursively discovered blob objects."""
+    """Resolve revisions and read recursively discovered pygit2 tree entries."""
     blob = _Node("model.json", "blob", data=b"{}")
     nested_blob = _Node("nested.json", "blob", data=b"[]")
-    nested_tree = _Node("nested", "tree", {"nested.json": nested_blob})
-    models_tree = _Node("models", "tree", {"model.json": blob, "nested": nested_tree})
-    root_tree = _Node("", "tree", {"models": models_tree})
+    nested_tree = _Node(
+        "nested",
+        "tree",
+        {"nested.json": _TreeEntry("nested.json", "blob", "nested-blob")},
+    )
+    models_tree = _Node(
+        "models",
+        "tree",
+        {
+            "model.json": _TreeEntry("model.json", "blob", "model-blob"),
+            "nested": _TreeEntry("nested", "tree", "nested-tree"),
+        },
+    )
+    root_tree = _Node("", "tree", {"models": _TreeEntry("models", "tree", "models-tree")})
     commit = SimpleNamespace(id="a" * 40)
-    repository = _Repository(commit, root_tree)
+    repository = _Repository(
+        commit,
+        root_tree,
+        {
+            "model-blob": blob,
+            "models-tree": models_tree,
+            "nested-blob": nested_blob,
+            "nested-tree": nested_tree,
+        },
+    )
     _install_pygit2(monkeypatch, repository)
     store = Pygit2ObjectStore(tmp_test_directory)
 

--- a/tests/unit_tests/model_repository/test_git_backend.py
+++ b/tests/unit_tests/model_repository/test_git_backend.py
@@ -43,6 +43,11 @@ class _Repository:
         return SimpleNamespace(tree=self.tree)
 
 
+def _raise_invalid_repository(_):
+    """Raise the repository-open error used by the invalid-repository test."""
+    raise OSError("invalid repository")
+
+
 def _install_pygit2(monkeypatch, repository):
     """Install a minimal pygit2 substitute and return the resolved commit."""
     pygit2 = SimpleNamespace(
@@ -75,7 +80,7 @@ def test_pygit2_object_store_rejects_unreadable_repository(monkeypatch, tmp_test
     """A path that pygit2 cannot open reports a readable error."""
     pygit2 = SimpleNamespace(
         Commit=object(),
-        Repository=lambda _: (_ for _ in ()).throw(OSError("invalid repository")),
+        Repository=_raise_invalid_repository,
         BlobIO=lambda blob: io.BytesIO(blob.data),
     )
     monkeypatch.setitem(sys.modules, "pygit2", pygit2)

--- a/tests/unit_tests/model_repository/test_git_model.py
+++ b/tests/unit_tests/model_repository/test_git_model.py
@@ -247,11 +247,13 @@ def test_git_source_reads_ecsv_and_rejects_invalid_file_paths(tmp_test_directory
     source = GitModelSource(Path(str(tmp_test_directory)) / "models.git", "v1", object_store=store)
 
     assert source.get_ecsv_file_as_astropy_table(file_name)["value"].tolist() == [1, 2]
+    assert store.reads == [path]
     with pytest.raises(ValueError, match="escapes model Files"):
         source.get_ecsv_file_as_astropy_table("../values.ecsv")
-    mocker.patch.object(store, "open_blob", side_effect=FileNotFoundError)
+    missing = mocker.patch.object(store, "read_blob", side_effect=FileNotFoundError)
     with pytest.raises(FileNotFoundError, match="Model file not found at commit"):
         source.get_ecsv_file_as_astropy_table(file_name)
+    missing.assert_called_once()
 
 
 def test_git_source_preloads_tables_and_parameters_once(tmp_test_directory):

--- a/tests/unit_tests/model_repository/test_git_model.py
+++ b/tests/unit_tests/model_repository/test_git_model.py
@@ -1,0 +1,133 @@
+"""Tests for the Git-blob simulation-model source."""
+
+import io
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from simtools.model_repository.git_backend import GitObjectStore
+from simtools.model_repository.git_model import GitModelSource
+from simtools.model_repository.reader import SimulationModelReader
+
+
+class MemoryObjectStore(GitObjectStore):
+    """Tiny object store used to test source behavior without Git or a network."""
+
+    def __init__(self, objects):
+        self.objects = objects
+        self.reads = []
+        self.list_calls = []
+
+    def resolve_revision(self, revision):
+        assert revision == "v1"
+        return "a" * 40
+
+    def iter_files(self, commit, prefix):
+        self.list_calls.append(prefix)
+        prefix = prefix.rstrip("/") + "/"
+        return sorted(path for path in self.objects if path.startswith(prefix))
+
+    def read_blob(self, commit, path):
+        self.reads.append(path)
+        return self.objects[path]
+
+    def open_blob(self, commit, path):
+        self.reads.append(path)
+        return io.BytesIO(self.objects[path])
+
+
+def _json(value):
+    """Encode a test document as a Git blob."""
+    return json.dumps(value).encode()
+
+
+def _parameter(instrument, value):
+    """Return a model parameter document."""
+    return _json(
+        {
+            "file": False,
+            "instrument": instrument,
+            "parameter": "camera_body_diameter",
+            "parameter_version": "1.0.0",
+            "site": "North",
+            "type": "float64",
+            "unit": None,
+            "value": value,
+        }
+    )
+
+
+def test_git_source_preloads_tables_and_parameters_once(tmp_test_directory):
+    """A model version warm-up reads all production and referenced blobs once."""
+    objects = {
+        "simulation-models/productions/1.0.0/LSTN-design.json": _json(
+            {"parameters": {"LSTN-design": {"camera_body_diameter": "1.0.0"}}}
+        ),
+        "simulation-models/productions/1.0.0/LSTN-01.json": _json(
+            {
+                "parameters": {"LSTN-01": {"camera_body_diameter": "1.0.0"}},
+                "design_model": {"LSTN-01": "LSTN-design"},
+            }
+        ),
+        "simulation-models/model_parameters/LSTN-design/camera_body_diameter/"
+        "camera_body_diameter-1.0.0.json": _parameter("LSTN-design", 348.0),
+        "simulation-models/model_parameters/LSTN-01/camera_body_diameter/"
+        "camera_body_diameter-1.0.0.json": _parameter("LSTN-01", 350.0),
+    }
+    store = MemoryObjectStore(objects)
+    repository = Path(str(tmp_test_directory)) / "models.git"
+    source = GitModelSource(repository, "v1", object_store=store)
+    reader = SimulationModelReader(source)
+
+    first = reader.get_model_parameters("North", "LSTN-01", "telescopes", "1.0.0")
+    reads_after_first = list(store.reads)
+    second = reader.get_model_parameters("North", "LSTN-01", "telescopes", "1.0.0")
+
+    assert first["camera_body_diameter"]["value"] == pytest.approx(350.0)
+    assert second == first
+    assert store.reads == reads_after_first
+    assert sorted(path for path in store.reads if path.endswith(".json")) == sorted(objects)
+    assert source.source_config == {
+        "type": "git",
+        "repository": str(repository.resolve()),
+        "commit": "a" * 40,
+    }
+
+
+def test_pygit2_source_reads_normal_and_bare_repositories(tmp_test_directory):
+    """The pygit2 adapter reads the same immutable data from both repository forms."""
+    pytest.importorskip("pygit2")
+    repository = Path(str(tmp_test_directory)) / "models"
+    objects = {
+        "simulation-models/productions/1.0.0/LSTN-design.json": _json(
+            {"parameters": {"LSTN-design": {"camera_body_diameter": "1.0.0"}}}
+        ),
+        "simulation-models/model_parameters/LSTN-design/camera_body_diameter/"
+        "camera_body_diameter-1.0.0.json": _parameter("LSTN-design", 348.0),
+    }
+    for relative_path, data in objects.items():
+        path = repository / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(data)
+    _run_git("init", repository)
+    _run_git("-C", repository, "config", "user.email", "tests@example.invalid")
+    _run_git("-C", repository, "config", "user.name", "simtools tests")
+    _run_git("-C", repository, "add", ".")
+    _run_git("-C", repository, "commit", "-m", "model")
+    _run_git("-C", repository, "tag", "v1")
+    bare_repository = Path(str(tmp_test_directory)) / "models.git"
+    _run_git("clone", "--bare", repository, bare_repository)
+
+    for source_path in (repository, bare_repository):
+        reader = SimulationModelReader.from_git(source_path, "v1")
+        assert reader.get_model_versions() == ["1.0.0"]
+        assert reader.get_model_parameters("North", "LSTN-design", "telescopes", "1.0.0")[
+            "camera_body_diameter"
+        ]["value"] == pytest.approx(348.0)
+
+
+def _run_git(*args):
+    """Run a local Git command used to construct a disposable repository."""
+    subprocess.run(["git", *map(str, args)], check=True, capture_output=True, text=True)

--- a/tests/unit_tests/model_repository/test_git_model.py
+++ b/tests/unit_tests/model_repository/test_git_model.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from astropy.table import Table
 
 from simtools.model_repository.git_backend import GitObjectStore
 from simtools.model_repository.git_model import GitModelSource
@@ -57,6 +58,200 @@ def _parameter(instrument, value):
             "value": value,
         }
     )
+
+
+def test_git_source_exposes_metadata_and_reports_missing_tables(tmp_test_directory):
+    """The Git source exposes its immutable identity and table errors."""
+    objects = {
+        "simulation-models/productions/1.0.0/LSTN-design.json": _json(
+            {"parameters": {"LSTN-design": {}}}
+        )
+    }
+    repository = Path(str(tmp_test_directory)) / "models.git"
+    source = GitModelSource(repository, "v1", object_store=MemoryObjectStore(objects))
+
+    assert source.source_name == f"{repository.resolve()}@{'a' * 40}"
+    assert source.is_configured() is True
+    assert source.get_model_versions("sites") == ["1.0.0"]
+    with pytest.raises(ValueError, match="No production table for sites"):
+        source.read_production_table("sites", "1.0.0")
+
+
+def test_git_source_reads_patch_history_and_ignores_non_json_files(tmp_test_directory):
+    """Patch production documents are combined in version order."""
+    objects = {
+        "simulation-models/productions/1.0.0/LSTN-design.json": _json(
+            {"parameters": {"LSTN-design": {}}}
+        ),
+        "simulation-models/productions/1.1.0/info.yml": (
+            b"model_update: patch_update\nmodel_version_history:\n  - 1.0.0\n"
+        ),
+        "simulation-models/productions/1.1.0/LSTN-01.json": _json(
+            {"parameters": {"LSTN-01": {}}, "design_model": {"LSTN-01": "LSTN-design"}}
+        ),
+        "simulation-models/productions/1.1.0/README.txt": b"not a production table",
+    }
+    source = GitModelSource(
+        Path(str(tmp_test_directory)) / "models.git", "v1", object_store=MemoryObjectStore(objects)
+    )
+
+    documents = source._production_documents("1.1.0")
+
+    assert [(model, path) for model, path, _ in documents] == [
+        ("1.0.0", "simulation-models/productions/1.0.0/LSTN-design.json"),
+        ("1.1.0", "simulation-models/productions/1.1.0/LSTN-01.json"),
+    ]
+
+    empty_source = GitModelSource(
+        Path(str(tmp_test_directory)) / "empty.git", "v1", object_store=MemoryObjectStore({})
+    )
+    with pytest.raises(ValueError, match=r"Model version 2\.0\.0 not found"):
+        empty_source._production_documents("2.0.0")
+
+
+def test_git_source_collects_parameter_paths_and_handles_missing_values():
+    """Parameter warm-up indexes only dictionary string references."""
+    tables = {
+        "telescopes": {
+            "parameters": {
+                "LSTN-01": {"camera_body_diameter": "1.0.0", "ignored": 1},
+                "invalid": "not a mapping",
+            }
+        }
+    }
+
+    paths = GitModelSource._parameter_paths(tables)
+
+    expected_path = GitModelSource._parameter_path(
+        "telescopes", "LSTN-01", "camera_body_diameter", "1.0.0"
+    )
+    assert paths == {expected_path: ("camera_body_diameter", "1.0.0")}
+
+
+def test_git_source_reads_and_filters_parameters(tmp_test_directory, mocker):
+    """Parameter reads normalize data, cache blobs, and filter metadata."""
+    path = GitModelSource._parameter_path("telescopes", "LSTN-01", "camera_body_diameter", "1.0.0")
+    store = MemoryObjectStore({path: _parameter("LSTN-01", 350.0)})
+    source = GitModelSource(Path(str(tmp_test_directory)) / "models.git", "v1", object_store=store)
+
+    parameters = source.read_parameters(
+        {"camera_body_diameter": "1.0.0"},
+        "telescopes",
+        instrument="LSTN-01",
+        site="North",
+    )
+    assert parameters[0]["value"] == pytest.approx(350.0)
+    source.read_parameters(
+        {"camera_body_diameter": "1.0.0"},
+        "telescopes",
+        instrument="LSTN-01",
+        site="North",
+    )
+    assert store.reads.count(path) == 1
+
+    source._parameters[path]["site"] = "South"
+    with pytest.raises(ValueError, match="No parameters found"):
+        source.read_parameters(
+            {"camera_body_diameter": "1.0.0"},
+            "telescopes",
+            instrument="LSTN-01",
+            site="North",
+        )
+
+    missing = GitModelSource(
+        Path(str(tmp_test_directory)) / "missing.git", "v1", object_store=MemoryObjectStore({})
+    )
+    mocker.patch.object(missing._object_store, "read_blob", side_effect=FileNotFoundError)
+    with pytest.raises(ValueError, match="No parameters found"):
+        missing.read_parameters(
+            {"camera_body_diameter": "1.0.0"},
+            "telescopes",
+            instrument="LSTN-01",
+            site="North",
+        )
+
+
+@pytest.mark.parametrize(
+    ("query", "collection", "expected"),
+    [
+        ({"instrument": "LSTN-01"}, "telescopes", "LSTN-01"),
+        ({"site": "North"}, "sites", "OBS-North"),
+        ({}, "configuration_corsika", "global"),
+        ({}, "configuration_sim_telarray", "global"),
+    ],
+)
+def test_git_source_resolves_parameter_instruments(query, collection, expected):
+    """Git parameter lookups resolve element, site, and global scopes."""
+    assert GitModelSource._get_parameter_instrument(query, collection) == expected
+
+
+def test_git_source_rejects_ambiguous_parameter_instrument():
+    """Non-global collections require an explicit element scope."""
+    with pytest.raises(ValueError, match="requires an array element name"):
+        GitModelSource._get_parameter_instrument({}, "telescopes")
+
+
+@pytest.mark.parametrize(
+    ("data", "instrument", "site", "expected"),
+    [
+        ({"instrument": "LSTN-01", "site": "North"}, "LSTN-01", "North", True),
+        ({"instrument": "MSTN-01", "site": "North"}, "LSTN-01", "North", False),
+        ({"instrument": "LSTN-01", "site": ["North", "South"]}, "LSTN-01", "South", True),
+        ({"instrument": "LSTN-01", "site": "North"}, "LSTN-01", "South", False),
+        ({"instrument": None, "site": None}, "global", "North", True),
+    ],
+)
+def test_git_source_matches_parameter_filters(data, instrument, site, expected):
+    """Git parameter filters handle scalar, list, and global metadata."""
+    assert GitModelSource._matches_filters(data, instrument, site) is expected
+
+
+def test_git_source_exports_files_lazily_and_safely(tmp_test_directory, mocker):
+    """Git files are streamed on demand and cannot escape the Files directory."""
+    objects = {
+        "simulation-models/model_parameters/Files/nested/model.dat": b"model",
+        "simulation-models/model_parameters/Files/other.dat": b"other",
+    }
+    store = MemoryObjectStore(objects)
+    source = GitModelSource(Path(str(tmp_test_directory)) / "models.git", "v1", object_store=store)
+    destination = Path(str(tmp_test_directory)) / "exported"
+
+    assert source.export_model_files(file_names="nested/model.dat", dest=destination) == {
+        "nested/model.dat": "copied from Git"
+    }
+    assert (destination / "nested/model.dat").read_bytes() == b"model"
+    assert source.export_model_files(file_names="nested/model.dat", dest=destination) == {
+        "nested/model.dat": "file exists"
+    }
+    assert source.export_model_files(
+        parameters={"selected": {"file": True, "value": "other.dat"}}, dest=destination
+    ) == {"other.dat": "copied from Git"}
+    with pytest.raises(ValueError, match="escapes model Files"):
+        source.export_model_files(file_names="../model.dat", dest=destination)
+    with pytest.raises(ValueError, match="Destination path is required"):
+        source.export_model_files(file_names="other.dat")
+
+    missing = mocker.patch.object(store, "open_blob", side_effect=FileNotFoundError)
+    with pytest.raises(FileNotFoundError, match="Model file not found at commit"):
+        source.export_model_files(file_names="missing.dat", dest=destination)
+    missing.assert_called_once()
+
+
+def test_git_source_reads_ecsv_and_rejects_invalid_file_paths(tmp_test_directory, mocker):
+    """ECSV blobs are read as tables and missing blobs get a useful error."""
+    buffer = io.StringIO()
+    Table({"value": [1, 2]}).write(buffer, format="ascii.ecsv")
+    file_name = "values.ecsv"
+    path = f"simulation-models/model_parameters/Files/{file_name}"
+    store = MemoryObjectStore({path: buffer.getvalue().encode()})
+    source = GitModelSource(Path(str(tmp_test_directory)) / "models.git", "v1", object_store=store)
+
+    assert source.get_ecsv_file_as_astropy_table(file_name)["value"].tolist() == [1, 2]
+    with pytest.raises(ValueError, match="escapes model Files"):
+        source.get_ecsv_file_as_astropy_table("../values.ecsv")
+    mocker.patch.object(store, "open_blob", side_effect=FileNotFoundError)
+    with pytest.raises(FileNotFoundError, match="Model file not found at commit"):
+        source.get_ecsv_file_as_astropy_table(file_name)
 
 
 def test_git_source_preloads_tables_and_parameters_once(tmp_test_directory):

--- a/tests/unit_tests/model_repository/test_parsing.py
+++ b/tests/unit_tests/model_repository/test_parsing.py
@@ -1,0 +1,38 @@
+"""Tests for model-parameter parsing helpers."""
+
+import pytest
+
+from simtools.model_repository import parsing
+
+
+@pytest.mark.parametrize(
+    ("parameter_type", "is_integer"),
+    [("int64", True), ("float64", False), ("", False)],
+)
+def test_normalize_model_parameter_normalizes_value_and_unit(mocker, parameter_type, is_integer):
+    """Normalize a copy while preserving the input document."""
+    split = mocker.patch.object(
+        parsing.value_conversion, "split_value_and_unit", return_value=(42, "cm")
+    )
+    get_value = mocker.patch.object(
+        parsing.value_conversion, "get_value_unit_type", return_value=(42, "m", "float")
+    )
+    normalize_unit = mocker.patch.object(
+        parsing.value_conversion, "normalize_model_parameter_unit", return_value="m"
+    )
+    data = {"unit": "cm", "value": "42 cm"}
+    if parameter_type:
+        data["type"] = parameter_type
+
+    result = parsing.normalize_model_parameter(data)
+
+    expected = {"unit": "m", "value": 42}
+    original = {"unit": "cm", "value": "42 cm"}
+    if parameter_type:
+        expected["type"] = parameter_type
+        original["type"] = parameter_type
+    assert result == expected
+    assert data == original
+    split.assert_called_once_with("42 cm", is_integer)
+    get_value.assert_called_once_with(value=42, unit_str="cm")
+    normalize_unit.assert_called_once_with(42, "m")

--- a/tests/unit_tests/model_repository/test_reader.py
+++ b/tests/unit_tests/model_repository/test_reader.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from astropy.table import Table
 
 from simtools.application.model_reader import create_model_reader
 from simtools.model_repository import files as repository_files
@@ -155,6 +156,153 @@ def test_filesystem_source_rejects_missing_repository(tmp_test_directory):
     """A missing repository fails with a useful path error."""
     with pytest.raises(FileNotFoundError, match="Simulation models path does not exist"):
         FileSystemModelSource(Path(tmp_test_directory) / "missing")
+
+
+def test_filesystem_source_rejects_incomplete_repository(tmp_test_directory):
+    """A repository must contain both model directory trees."""
+    root = Path(tmp_test_directory) / "models"
+    (root / "simulation-models/productions").mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError, match="Expected simulation models directory"):
+        FileSystemModelSource(root)
+
+
+def test_filesystem_source_caches_versions_and_validates_tables(model_repository, mocker):
+    """Version and production-table reads are cached and validate their keys."""
+    source = FileSystemModelSource(model_repository)
+    source.get_model_versions()
+    (model_repository / "simulation-models/productions/9.0.0").mkdir()
+    assert source.get_model_versions() == ["1.0.0"]
+
+    source.read_production_table("telescopes", "1.0.0")
+    read_tables = mocker.spy(repository_files, "read_production_tables")
+    source.read_production_table("telescopes", "1.0.0")
+    read_tables.assert_not_called()
+
+    with pytest.raises(ValueError, match=r"Model version 2\.0\.0 not found"):
+        source.read_production_table("telescopes", "2.0.0")
+    with pytest.raises(ValueError, match="No production table for sites"):
+        source.read_production_table("sites", "1.0.0")
+
+
+@pytest.mark.parametrize(
+    ("query", "collection", "expected_instrument"),
+    [
+        ({"instrument": "LSTN-01"}, "telescopes", "LSTN-01"),
+        ({"site": "North"}, "sites", "OBS-North"),
+        ({"site": "North"}, "configuration_corsika", "global"),
+        ({"site": "North"}, "configuration_sim_telarray", "global"),
+    ],
+)
+def test_filesystem_source_resolves_parameter_scopes(query, collection, expected_instrument):
+    """Filesystem queries use the same scopes as the database source."""
+    assert FileSystemModelSource._get_parameter_instrument(query, collection) == expected_instrument
+
+
+def test_filesystem_source_rejects_ambiguous_parameter_scope():
+    """An element scope is required for non-global filesystem collections."""
+    with pytest.raises(ValueError, match="requires an array element name"):
+        FileSystemModelSource._get_parameter_instrument({}, "telescopes")
+
+
+def test_filesystem_source_queries_and_filters_parameters(model_repository):
+    """Queries support OR clauses and reject missing or mismatched parameters."""
+    source = FileSystemModelSource(model_repository)
+    query = {
+        "instrument": "LSTN-01",
+        "site": "North",
+        "$or": [
+            {"parameter": "missing", "parameter_version": "1.0.0"},
+            {"parameter": "camera_body_diameter", "parameter_version": "2.0.0"},
+        ],
+    }
+    result = source.query_model_parameters(query, "telescopes")
+    assert result[0]["value"] == pytest.approx(350.0)
+
+    with pytest.raises(ValueError, match="No parameters found"):
+        source.query_model_parameters(
+            {
+                "instrument": "LSTN-01",
+                "parameter": "camera_body_diameter",
+                "parameter_version": "2.0.0",
+                "site": "South",
+            },
+            "telescopes",
+        )
+
+    with pytest.raises(ValueError, match="No parameters found"):
+        source.read_parameters(
+            {"missing": "1.0.0"}, "telescopes", instrument="LSTN-01", site="North"
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "instrument", "site", "matches"),
+    [
+        ({"instrument": "LSTN-01", "site": "North"}, "LSTN-01", "North", True),
+        ({"instrument": "MSTN-01", "site": "North"}, "LSTN-01", "North", False),
+        ({"instrument": "LSTN-01", "site": ["North", "South"]}, "LSTN-01", "South", True),
+        ({"instrument": "LSTN-01", "site": "North"}, "LSTN-01", "South", False),
+        ({"instrument": None, "site": None}, "global", "North", True),
+    ],
+)
+def test_filesystem_source_matches_parameter_filters(data, instrument, site, matches):
+    """Instrument and site filters handle scalar, list, and global metadata."""
+    assert FileSystemModelSource._matches_filters(data, instrument, site) is matches
+
+
+def test_filesystem_source_exports_files_and_rejects_unsafe_paths(
+    model_repository, tmp_test_directory
+):
+    """Referenced files are copied once and cannot escape the Files directory."""
+    files_path = model_repository / "simulation-models/model_parameters/Files"
+    (files_path / "nested/model.dat").parent.mkdir(parents=True)
+    (files_path / "nested/model.dat").write_bytes(b"model")
+    destination = Path(tmp_test_directory) / "exported"
+    source = FileSystemModelSource(model_repository)
+
+    assert source.export_model_files(file_names="nested/model.dat", dest=destination) == {
+        "nested/model.dat": "copied from filesystem"
+    }
+    assert source.export_model_files(file_names="nested/model.dat", dest=destination) == {
+        "nested/model.dat": "file exists"
+    }
+    with pytest.raises(ValueError, match="escapes model Files"):
+        source.export_model_files(file_names="../model.dat", dest=destination)
+    with pytest.raises(FileNotFoundError, match="Model file not found"):
+        source.export_model_files(file_names="missing.dat", dest=destination)
+    with pytest.raises(ValueError, match="Destination path is required"):
+        source.export_model_files(file_names="nested/model.dat")
+
+
+def test_filesystem_source_exports_parameter_file_values(model_repository, tmp_test_directory):
+    """File-valued parameters are selected when file names are omitted."""
+    files_path = model_repository / "simulation-models/model_parameters/Files"
+    files_path.mkdir(parents=True, exist_ok=True)
+    (files_path / "model.dat").write_bytes(b"model")
+    destination = Path(tmp_test_directory) / "exported"
+    source = FileSystemModelSource(model_repository)
+
+    result = source.export_model_files(
+        parameters={"file": {"file": True, "value": "model.dat"}}, dest=destination
+    )
+    assert result == {"model.dat": "copied from filesystem"}
+
+
+def test_filesystem_source_reads_ecsv_and_rejects_missing_file(
+    model_repository, tmp_test_directory
+):
+    """ECSV model files are exposed as Astropy tables."""
+    files_path = model_repository / "simulation-models/model_parameters/Files"
+    files_path.mkdir(parents=True, exist_ok=True)
+    Table({"value": [1, 2]}).write(files_path / "values.ecsv", format="ascii.ecsv")
+    source = FileSystemModelSource(model_repository)
+
+    assert source.get_ecsv_file_as_astropy_table("values.ecsv")["value"].tolist() == [1, 2]
+    with pytest.raises(FileNotFoundError, match="Model file not found"):
+        source.get_ecsv_file_as_astropy_table("missing.ecsv")
+    with pytest.raises(ValueError, match="escapes model Files"):
+        source.get_ecsv_file_as_astropy_table("../values.ecsv")
 
 
 def test_model_repository_import_does_not_load_database_modules():
@@ -381,3 +529,96 @@ def test_reader_facade_covers_all_version_and_export_paths(mocker):
     )
     assert reader.export_model_files.call_count == 2
     read_table.assert_called_once_with("p", Path("output") / "p.dat")
+
+
+def test_reader_facade_delegates_git_source_and_optional_source_config(mocker):
+    """Git construction and source metadata are exposed by the facade."""
+    git_source = Mock(source_name="models@commit", source_config={"type": "git"})
+    git_class = mocker.patch(
+        "simtools.model_repository.git_model.GitModelSource", return_value=git_source
+    )
+
+    reader = SimulationModelReader.from_git("models.git", "abc", object_store="store")
+
+    git_class.assert_called_once_with("models.git", "abc", object_store="store")
+    assert reader.source_name == "models@commit"
+    assert reader.source_config == {"type": "git"}
+
+    source_without_config = Mock(spec=["source_name", "is_configured"])
+    assert SimulationModelReader(source_without_config).source_config is None
+
+
+def test_reader_facade_handles_value_errors_across_model_versions():
+    """Unavailable model versions are skipped during aggregate reads."""
+    source = Mock()
+    source.get_model_versions.return_value = ["1.0.0"]
+    reader = SimulationModelReader(source)
+    reader.get_model_parameters = Mock(side_effect=ValueError("not available"))
+
+    assert (
+        reader.get_model_parameters_for_all_model_versions("North", "LSTN-01", "telescopes") == {}
+    )
+
+
+def test_reader_facade_selects_all_array_element_scope_branches(mocker):
+    """Scope selection handles global, design, and concrete requests."""
+    source = Mock()
+    source.read_production_table.return_value = {
+        "model_version": "1.0.0",
+        "design_model": {"LSTN-01": "LSTN-design"},
+    }
+    reader = SimulationModelReader(source)
+    simtel_scopes = mocker.patch.object(
+        reader, "_get_sim_telarray_array_element_list", return_value=["global"]
+    )
+
+    assert reader._get_array_element_list(None, None, {}, "configuration_corsika") == ["global"]
+    assert reader._get_array_element_list("LSTN-01", "North", {}, "configuration_sim_telarray") == [
+        "global"
+    ]
+    simtel_scopes.assert_called_once()
+    assert reader._get_array_element_list("LSTN-design", None, {}, "telescopes") == ["LSTN-design"]
+    assert reader._get_array_element_list(
+        "LSTN-01", None, source.read_production_table.return_value, "telescopes"
+    ) == [
+        "LSTN-design",
+        "LSTN-01",
+    ]
+
+
+def test_reader_simtel_scope_lookup_supports_fallback_and_wraps_errors(mocker):
+    """Concrete sim_telarray scopes use design data or configured fallbacks."""
+    source = Mock()
+    source.read_production_table.return_value = {"design_model": {"LSTN-01": "LSTN-design"}}
+    reader = SimulationModelReader(source)
+    args = {"ignore_missing_design_model": False}
+    mocker.patch.object(reader_module.settings.config, "_args", new=args)
+
+    assert reader._get_sim_telarray_array_element_list("LSTN-01", {"model_version": "1.0.0"}) == [
+        "global",
+        "LSTN-design",
+        "LSTN-01",
+    ]
+    assert reader._get_sim_telarray_array_element_list("global", {}) == ["global"]
+    assert reader._get_sim_telarray_array_element_list("LSTN-design", {}) == [
+        "global",
+        "LSTN-design",
+    ]
+
+    source.read_production_table.return_value = {"design_model": {}}
+    args["ignore_missing_design_model"] = True
+    assert reader._get_sim_telarray_array_element_list("LSTN-01", {"model_version": "1.0.0"}) == [
+        "global",
+        "LSTN-01",
+        "LSTN-01",
+        "LSTN-design",
+    ]
+
+    scopes = mocker.patch.object(
+        reader_module.names,
+        "get_sim_telarray_parameter_scopes",
+        side_effect=KeyError("missing"),
+    )
+    with pytest.raises(KeyError, match="Failed to generate array element list"):
+        reader._get_sim_telarray_array_element_list(None, {})
+    scopes.assert_called_once()

--- a/tests/unit_tests/testing/output_validation/test_model_parameters.py
+++ b/tests/unit_tests/testing/output_validation/test_model_parameters.py
@@ -12,7 +12,7 @@ def test_validate_model_parameter_reports_mismatch(tmp_test_directory, mocker):
     """Report when a generated parameter differs from its model reference."""
     output = Path(tmp_test_directory) / "parameter.json"
     output.write_text(json.dumps({"value": [1.0, 2.0]}), encoding="utf-8")
-    model_reader = mocker.patch.object(model_parameters, "create_model_reader")
+    model_reader = mocker.patch.object(model_parameters, "create_model_reader_from_configuration")
     model_reader.return_value.get_model_parameter.return_value = {
         "parameter": {"value": [1.0, 3.0]}
     }
@@ -42,7 +42,7 @@ def test_validate_model_parameter_applies_scaling(tmp_test_directory, mocker):
     """Compare a generated parameter with a scaled model reference."""
     output = Path(tmp_test_directory) / "parameter.json"
     output.write_text(json.dumps({"value": [1.0, 2.0]}), encoding="utf-8")
-    model_reader = mocker.patch.object(model_parameters, "create_model_reader")
+    model_reader = mocker.patch.object(model_parameters, "create_model_reader_from_configuration")
     model_reader.return_value.get_model_parameter.return_value = {
         "parameter": {"value": [2.0, 4.0]}
     }
@@ -60,7 +60,7 @@ def test_validate_model_parameter_reuses_explicit_reader(tmp_test_directory, moc
     output.write_text(json.dumps({"value": 1.0}), encoding="utf-8")
     model_reader = mocker.Mock()
     model_reader.get_model_parameter.return_value = {"parameter": {"value": 1.0}}
-    create_reader = mocker.patch.object(model_parameters, "create_model_reader")
+    create_reader = mocker.patch.object(model_parameters, "create_model_reader_from_configuration")
 
     model_parameters.validate(
         output,
@@ -76,7 +76,7 @@ def test_validate_model_parameter_rejects_unscalable_value(tmp_test_directory, m
     """Report when a generated value cannot be scaled numerically."""
     output = Path(tmp_test_directory) / "parameter.json"
     output.write_text(json.dumps({"value": {"invalid": 1}}), encoding="utf-8")
-    model_reader = mocker.patch.object(model_parameters, "create_model_reader")
+    model_reader = mocker.patch.object(model_parameters, "create_model_reader_from_configuration")
     model_reader.return_value.get_model_parameter.return_value = {"parameter": {"value": 2.0}}
 
     with pytest.raises(AssertionError, match="cannot be scaled"):

--- a/tests/unit_tests/testing/output_validation/test_runner.py
+++ b/tests/unit_tests/testing/output_validation/test_runner.py
@@ -69,7 +69,9 @@ def test_runner_creates_one_reader_for_model_validations(tmp_test_directory, moc
     output = Path(tmp_test_directory) / "result.json"
     output.touch()
     reader = mocker.Mock()
-    create_reader = mocker.patch.object(runner, "create_model_reader", return_value=reader)
+    create_reader = mocker.patch.object(
+        runner, "create_model_reader_from_configuration", return_value=reader
+    )
     dispatch = mocker.patch.object(runner, "run_validator")
     config = {
         "configuration": {},
@@ -92,7 +94,7 @@ def test_runner_creates_one_reader_for_model_validations(tmp_test_directory, moc
 
     runner.validate_application_output(config)
 
-    create_reader.assert_called_once_with(None)
+    create_reader.assert_called_once_with(config["configuration"])
     assert all(
         call.args[2]["configuration"] is config["configuration"] for call in dispatch.call_args_list
     )


### PR DESCRIPTION
Add a third read-only simulation model source alongside filesystem and MongoDB:

```text
SimulationModelReader
├── FileSystemModelSource
├── MongoDBModelSource
└── GitModelSource
```

`GitModelSource` will open a local Git repository object database through
`pygit2`, resolve one immutable Git revision, and read production tables,
parameter JSON, and referenced files directly from Git blobs.
