### PR TITLE
Matplotlib issue when running random-order unit tests.

### DIFF
--- a/src/simtools/production_configuration/derive_corsika_limits.py
+++ b/src/simtools/production_configuration/derive_corsika_limits.py
@@ -544,7 +544,7 @@ def _resolve_trigger_histogram_files(trigger_histogram_file):
     """
     if any(character in trigger_histogram_file for character in "*?["):
         try:
-            return [str(path) for path in resolve_file_patterns(trigger_histogram_file)]
+            return [str(path) for path in sorted(resolve_file_patterns(trigger_histogram_file))]
         except FileNotFoundError as exc:
             raise ValueError(
                 f"No trigger-histogram files matched pattern '{trigger_histogram_file}'."

--- a/src/simtools/visualization/plot_simtel_event_histograms.py
+++ b/src/simtools/visualization/plot_simtel_event_histograms.py
@@ -853,7 +853,12 @@ def _add_lines(ax, lines):
         curve_x = np.asarray(curve.get("x", []), dtype=float).ravel()
         curve_y = np.asarray(curve.get("y", []), dtype=float).ravel()
         if curve_x.size and curve_x.size == curve_y.size:
-            curve_params = {"color": "r", "linestyle": "--", "linewidth": 1.0}
+            curve_params = {
+                "color": "r",
+                "linestyle": "--",
+                "linewidth": 1.0,
+                "marker": "None",
+            }
             if curve_x.size == 1:
                 curve_params.update(marker="o", markersize=3.0)
             ax.plot(curve_x, curve_y, **curve_params)

--- a/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
+++ b/tests/unit_tests/visualization/test_plot_simtel_event_histograms.py
@@ -979,8 +979,9 @@ def test_create_2d_plot_renders_single_point_limit_curve(tmp_test_directory):
 def test_add_lines_handles_multi_point_and_malformed_limit_curves():
     fig, ax = plt.subplots()
 
-    _add_lines(ax, {"curve": {"x": [100.0, 200.0], "y": [1.0, 2.0]}})
-    _add_lines(ax, {"curve": {"x": [100.0], "y": [1.0, 2.0]}})
+    with plt.rc_context({"lines.marker": "o"}):
+        _add_lines(ax, {"curve": {"x": [100.0, 200.0], "y": [1.0, 2.0]}})
+        _add_lines(ax, {"curve": {"x": [100.0], "y": [1.0, 2.0]}})
 
     assert len(ax.lines) == 1
     assert ax.lines[0].get_marker() == "None"


### PR DESCRIPTION
Matplotlib’s global lines.marker setting leaking between randomized tests.

Should fix (does locally): https://github.com/gammasim/simtools/actions/runs/33827210119/job/100882418428