### PR TITLE
Azimuth setting for integration tests (not set to North or South)

### DIFF
--- a/docs/changes/2510.maintenance.md
+++ b/docs/changes/2510.maintenance.md
@@ -1,0 +1,1 @@
+Change azimuth of simulation-prod integration test to a value not being North or South.

--- a/docs/changes/2510.maintenance.md
+++ b/docs/changes/2510.maintenance.md
@@ -1,1 +1,1 @@
-Change azimuth of simulation-prod integration test to a value not being North or South.
+Change azimuth of the simulation-prod integration test to a value that is neither North nor South.

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
@@ -11,7 +11,7 @@ applications:
       by_version:
         <7.0.0: alpha
         '>=7.0.0': CTAO-South-Alpha
-    azimuth_angle: South
+    azimuth_angle: 85.
     core_scatter: 5 700 m
     corsika_seeds:
     - 534
@@ -43,11 +43,11 @@ applications:
   integration_tests:
   - test_outputs:
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.simtel.log.gz
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.simtel.log.gz
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.hdata.zst
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.hdata.zst
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.simtel.zst
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.simtel.zst
       validations:
       - type: simtel
         event:
@@ -64,17 +64,17 @@ applications:
             - 0
             - 50
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.reduced_event_data.hdf5
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.reduced_event_data.hdf5
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.corsika.zst
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.0.2_multiple_model_versions.corsika.zst
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.simtel.log.gz
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.simtel.log.gz
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.hdata.zst
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.hdata.zst
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.simtel.zst
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.simtel.zst
     - path_descriptor: grid_output_path
-      file: gamma_run000001_za20deg_azm180deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.reduced_event_data.hdf5
+      file: gamma_run000001_za20deg_azm085deg_South_CTAO-South-Alpha_6.1_multiple_model_versions.reduced_event_data.hdf5
   test_name: gamma_20_deg_multiple_model_versions
 schema_name: application_workflow.metaschema
 schema_version: 0.5.0

--- a/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
+++ b/tests/integration_tests/config/simulate_prod_gamma_20_deg_south_multiple_model_versions.yml
@@ -11,7 +11,7 @@ applications:
       by_version:
         <7.0.0: alpha
         '>=7.0.0': CTAO-South-Alpha
-    azimuth_angle: 85.
+    azimuth_angle: 85.0
     core_scatter: 5 700 m
     corsika_seeds:
     - 534


### PR DESCRIPTION
Closes #2491

Note that the integration test include a check for photons on the camera in sim-telarray