### PR TITLE
Adds process-level accounting to simulation production execution.

### DIFF
--- a/docs/changes/2496.feature.md
+++ b/docs/changes/2496.feature.md
@@ -1,1 +1,2 @@
 Improve simulation production metadata and accessing of production files in file-based systems.
+Production runs now retain per-process resource records for CORSIKA, multipipe, and sim_telarray.

--- a/docs/changes/2512.feature.md
+++ b/docs/changes/2512.feature.md
@@ -1,0 +1,1 @@
+Adds process-level accounting to simulation production execution.

--- a/docs/source/api-reference/job_execution.md
+++ b/docs/source/api-reference/job_execution.md
@@ -12,6 +12,13 @@ This is mostly used for small productions during the validation or verification 
    :members:
 ```
 
+(process-accounting)=
+
+```{eval-rst}
+.. automodule:: job_execution.process_accounting
+   :members:
+```
+
 (execution)=
 
 ```{eval-rst}

--- a/src/simtools/job_execution/process_accounting.py
+++ b/src/simtools/job_execution/process_accounting.py
@@ -1,0 +1,323 @@
+"""Run one process while recording its directly attributable resource use."""
+
+import argparse
+import gzip
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import threading
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def build_accounting_command(
+    command,
+    output_path,
+    role,
+    run_id,
+    model_version=None,
+    log_file=None,
+    input_file=None,
+):
+    """Build a command that records resource use for one executable.
+
+    The returned command preserves the executable's stdin unless ``input_file``
+    is supplied. This is important for sim_telarray consumers of an eventIO
+    stream.
+
+    Parameters
+    ----------
+    command : list[str | pathlib.Path]
+        Executable and arguments to run.
+    output_path : str or pathlib.Path
+        JSON resource-record output path.
+    role : str
+        Process role, such as ``"corsika"`` or ``"sim_telarray"``.
+    run_id : int or str
+        Production run identifier.
+    model_version : str, optional
+        Simulation-model version associated with this process.
+    log_file : str or pathlib.Path, optional
+        Gzip-compressed combined stdout and stderr log file.
+    input_file : str or pathlib.Path, optional
+        File connected to the child's stdin.
+
+    Returns
+    -------
+    list[str]
+        Command invoking this module with the supplied process command.
+    """
+    accounting_command = [
+        sys.executable,
+        "-m",
+        "simtools.job_execution.process_accounting",
+        "--output",
+        str(output_path),
+        "--role",
+        role,
+        "--run-id",
+        str(run_id),
+    ]
+    if model_version:
+        accounting_command.extend(["--model-version", str(model_version)])
+    if log_file:
+        accounting_command.extend(["--log-file", str(log_file)])
+    if input_file:
+        accounting_command.extend(["--input-file", str(input_file)])
+    return [*accounting_command, "--", *(str(value) for value in command)]
+
+
+def run_and_record(
+    command,
+    output_path,
+    role,
+    run_id,
+    model_version=None,
+    log_file=None,
+    input_file=None,
+    env=None,
+):
+    """Run a process and write a JSON resource record for its direct PID.
+
+    On Linux, user CPU time, system CPU time, and peak resident memory are
+    sampled from ``/proc/<pid>``. Other platforms still produce a record with
+    wall-clock duration and clearly identify unavailable measurements.
+
+    Parameters
+    ----------
+    command : list[str | pathlib.Path]
+        Executable and arguments to run.
+    output_path : str or pathlib.Path
+        JSON resource-record output path.
+    role : str
+        Process role.
+    run_id : int or str
+        Production run identifier.
+    model_version : str, optional
+        Simulation-model version associated with this process.
+    log_file : str or pathlib.Path, optional
+        Gzip-compressed combined stdout and stderr log file.
+    input_file : str or pathlib.Path, optional
+        File connected to the child's stdin.
+    env : dict, optional
+        Environment overrides for the child process.
+
+    Returns
+    -------
+    int
+        Child-process return code.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    start_time = datetime.now(UTC)
+    start_clock = time.perf_counter()
+    process, opened_files, log_writer = _start_process(command, log_file, input_file, env)
+    log_thread = _start_log_writer(process, log_writer)
+    cpu_times = None
+    peak_rss_bytes = None
+    try:
+        while process.poll() is None:
+            cpu_times, peak_rss_bytes = _update_measurements(process.pid, cpu_times, peak_rss_bytes)
+            time.sleep(0.05)
+        cpu_times, peak_rss_bytes = _update_measurements(process.pid, cpu_times, peak_rss_bytes)
+        return_code = process.wait()
+    finally:
+        if log_thread:
+            log_thread.join()
+            process.stdout.close()
+        for opened_file in opened_files:
+            opened_file.close()
+
+    record = _build_record(
+        command,
+        role,
+        run_id,
+        model_version,
+        process.pid,
+        start_time,
+        datetime.now(UTC),
+        time.perf_counter() - start_clock,
+        cpu_times,
+        peak_rss_bytes,
+        return_code,
+    )
+    output_path.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return return_code
+
+
+def _start_process(command, log_file, input_file, env):
+    """Start the child process and return it with files needing closure."""
+    opened_files = []
+    stdin = None
+    stdout = None
+    stderr = None
+    if input_file:
+        stdin = Path(input_file).open("rb")  # pylint: disable=consider-using-with
+        opened_files.append(stdin)
+    if log_file:
+        log_path = Path(log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_writer = gzip.open(log_path, "wb")  # pylint: disable=consider-using-with
+        opened_files.append(log_writer)
+        stdout = subprocess.PIPE
+        stderr = subprocess.STDOUT
+    else:
+        log_writer = None
+    try:
+        # The process and streams must remain open until the monitoring loop completes.
+        # pylint: disable=consider-using-with
+        process = subprocess.Popen(
+            [str(value) for value in command],
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            env=_build_environment(env),
+        )
+        # pylint: enable=consider-using-with
+    except BaseException:
+        for opened_file in opened_files:
+            opened_file.close()
+        raise
+    return process, opened_files, log_writer
+
+
+def _start_log_writer(process, log_writer):
+    """Copy combined child output to a gzip log without buffering it in memory."""
+    if log_writer is None:
+        return None
+    log_thread = threading.Thread(target=_copy_process_output, args=(process.stdout, log_writer))
+    log_thread.start()
+    return log_thread
+
+
+def _copy_process_output(process_output, log_writer):
+    """Copy one child-process output stream to its compressed log file."""
+    while chunk := process_output.read(1024 * 1024):
+        log_writer.write(chunk)
+
+
+def _build_environment(env):
+    """Return the inherited process environment with optional overrides."""
+    if env is None:
+        return None
+    process_env = os.environ.copy()
+    process_env.update(env)
+    return process_env
+
+
+def _update_measurements(pid, cpu_times, peak_rss_bytes):
+    """Read the latest direct-child CPU and resident-memory measurements."""
+    sample = _read_linux_process_sample(pid)
+    if sample is None:
+        return cpu_times, peak_rss_bytes
+    sampled_cpu_times, sampled_rss = sample
+    if sampled_rss is not None:
+        peak_rss_bytes = max(peak_rss_bytes or 0, sampled_rss)
+    return sampled_cpu_times, peak_rss_bytes
+
+
+def _read_linux_process_sample(pid):
+    """Read CPU and resident-memory data for one PID from Linux procfs."""
+    if platform.system() != "Linux":
+        return None
+    try:
+        stat_fields = (
+            Path(f"/proc/{pid}/stat").read_text(encoding="utf-8").rsplit(")", 1)[1].split()
+        )
+        status = Path(f"/proc/{pid}/status").read_text(encoding="utf-8")
+    except FileNotFoundError, IndexError, PermissionError:
+        return None
+    clock_ticks = os.sysconf(os.sysconf_names["SC_CLK_TCK"])
+    cpu_times = {
+        "user_seconds": int(stat_fields[11]) / clock_ticks,
+        "system_seconds": int(stat_fields[12]) / clock_ticks,
+    }
+    return cpu_times, _read_peak_rss_bytes(status)
+
+
+def _read_peak_rss_bytes(status):
+    """Return the Linux peak resident set size in bytes from a status payload."""
+    current_rss = None
+    for line in status.splitlines():
+        if line.startswith("VmHWM:"):
+            return int(line.split()[1]) * 1024
+        if line.startswith("VmRSS:"):
+            current_rss = int(line.split()[1]) * 1024
+    return current_rss
+
+
+def _build_record(
+    command,
+    role,
+    run_id,
+    model_version,
+    pid,
+    start_time,
+    end_time,
+    wall_time_seconds,
+    cpu_times,
+    peak_rss_bytes,
+    return_code,
+):
+    """Build one JSON-serializable resource record."""
+    return {
+        "schema_name": "process_resource_record",
+        "schema_version": "1.0.0",
+        "run_id": str(run_id),
+        "role": role,
+        "model_version": model_version,
+        "argv": [str(value) for value in command],
+        "pid": pid,
+        "start_time": start_time.isoformat(),
+        "end_time": end_time.isoformat(),
+        "wall_time_seconds": wall_time_seconds,
+        "user_cpu_seconds": None if cpu_times is None else cpu_times["user_seconds"],
+        "system_cpu_seconds": None if cpu_times is None else cpu_times["system_seconds"],
+        "peak_rss_bytes": peak_rss_bytes,
+        "return_code": return_code,
+        "signal": None if return_code >= 0 else signal.Signals(-return_code).name,
+        "measurement_method": "linux_procfs_direct_pid"
+        if platform.system() == "Linux"
+        else "wall_clock_only",
+        "platform": platform.platform(),
+    }
+
+
+def _parse_command_line_arguments():
+    """Parse process-accounting command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--role", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--model-version")
+    parser.add_argument("--log-file")
+    parser.add_argument("--input-file")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if arguments.command[:1] == ["--"]:
+        arguments.command = arguments.command[1:]
+    if not arguments.command:
+        parser.error("an executable command is required after '--'")
+    return arguments
+
+
+def main():
+    """Run the requested command and return its exit status."""
+    arguments = _parse_command_line_arguments()
+    return run_and_record(
+        arguments.command,
+        arguments.output,
+        arguments.role,
+        arguments.run_id,
+        model_version=arguments.model_version,
+        log_file=arguments.log_file,
+        input_file=arguments.input_file,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/simtools/runners/corsika_runner.py
+++ b/src/simtools/runners/corsika_runner.py
@@ -1,9 +1,11 @@
 """Generate run scripts and directories for CORSIKA simulations."""
 
 import logging
+import shlex
 from pathlib import Path
 
 from simtools import settings
+from simtools.job_execution.process_accounting import build_accounting_command
 from simtools.runners.runner_services import RunnerServices
 
 
@@ -101,10 +103,11 @@ class CorsikaRunner:
 
     def _export_run_script(self, run_number, sub_script, corsika_run_dir, extra_commands):
         """Export CORSIKA run script."""
-        corsika_log_file = self.runner_service.get_file_name(
-            "corsika_log", run_number=run_number
-        ).with_suffix("")  # remove .gz from log file
+        corsika_log_file = self.runner_service.get_file_name("corsika_log", run_number=run_number)
         corsika_input = self.runner_service.get_file_name("corsika_input", run_number=run_number)
+        resources_file = self.runner_service.get_file_name(
+            "corsika_resources", run_number=run_number
+        )
         sub_script = Path(sub_script)
         with open(sub_script, "w", encoding="utf-8") as file:
             file.write("#!/usr/bin/env bash\n")
@@ -120,12 +123,17 @@ class CorsikaRunner:
             file.write('mkdir -p "$CORSIKA_DATA"\n')
             file.write('cd "$CORSIKA_DATA" || exit 2\n')
 
-            file.write("\n# Running corsika\n")
-            file.write(
-                f"{self._corsika_executable()} < {corsika_input} > {corsika_log_file} 2>&1\n"
+            accounting_command = build_accounting_command(
+                [self._corsika_executable()],
+                resources_file,
+                "corsika",
+                run_number,
+                model_version=self.corsika_config.array_model.model_version,
+                log_file=corsika_log_file,
+                input_file=corsika_input,
             )
-            file.write("\n# Cleanup\n")
-            file.write(f"gzip {corsika_log_file}\n")
+            file.write("\n# Running corsika\n")
+            file.write(shlex.join(accounting_command) + "\n")
 
     def get_resources(self, runtime=None):
         """Return computing resources used."""

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -1,10 +1,12 @@
 """Run simulations with CORSIKA and pipe it to sim_telarray using the multipipe functionality."""
 
 import logging
+import shlex
 import stat
 
 import simtools.utils.general as gen
 from simtools import settings
+from simtools.job_execution.process_accounting import build_accounting_command
 from simtools.runners import corsika_runner, runner_services, simtel_runner
 from simtools.simtel.simulator_array import SimulatorArray
 
@@ -114,10 +116,21 @@ class CorsikaSimtelRunner:
                     run_number=run_number,
                     input_file="-",  # instruct sim_telarray to take input from stdout
                 )
+                resources_file = simulator_array.runner_service.get_file_name(
+                    file_type="sim_telarray_resources", run_number=run_number
+                )
+                accounting_command = build_accounting_command(
+                    run_command,
+                    resources_file,
+                    "sim_telarray",
+                    run_number,
+                    model_version=simulator_array.corsika_config.array_model.model_version,
+                    log_file=log_file,
+                )
                 file.write(
                     f"{simtel_runner.sim_telarray_env_as_string()} "
-                    + " ".join(run_command)
-                    + f" | gzip > {log_file} 2>&1\n"
+                    + shlex.join(accounting_command)
+                    + "\n"
                 )
                 file.write("\n")
 
@@ -145,11 +158,20 @@ class CorsikaSimtelRunner:
             "multi_pipe_script", run_number=run_number
         )
         with open(multipipe_script, "w", encoding="utf-8") as file:
-            multipipe_command = settings.config.sim_telarray_path.joinpath(
-                f"bin/multipipe_corsika -c {multipipe_file} {self.sequential} "
-                "|| echo 'Fan-out failed'"
+            multipipe_command = [
+                settings.config.sim_telarray_path / "bin/multipipe_corsika",
+                "-c",
+                multipipe_file,
+            ]
+            if self.sequential:
+                multipipe_command.append(self.sequential)
+            accounting_command = build_accounting_command(
+                multipipe_command,
+                self.runner_service.get_file_name("multi_pipe_resources", run_number=run_number),
+                "multipipe",
+                run_number,
             )
-            file.write(f"{multipipe_command}")
+            file.write(shlex.join(accounting_command) + " || echo 'Fan-out failed'")
 
         multipipe_script.chmod(multipipe_script.stat().st_mode | stat.S_IEXEC)
 

--- a/src/simtools/runners/corsika_simtel_runner.py
+++ b/src/simtools/runners/corsika_simtel_runner.py
@@ -170,6 +170,7 @@ class CorsikaSimtelRunner:
                 self.runner_service.get_file_name("multi_pipe_resources", run_number=run_number),
                 "multipipe",
                 run_number,
+                model_version=self.base_corsika_config.array_model.model_version,
             )
             file.write(shlex.join(accounting_command) + " || echo 'Fan-out failed'")
 
@@ -202,14 +203,22 @@ class CorsikaSimtelRunner:
             self.file_list.update(self.corsika_runner.file_list)
 
         for simulator_array in self.simulator_array:
-            _tmp_list = simulator_array.file_list
-            for key, data in _tmp_list.items():
-                if key in self.file_list:
-                    # in case of multiple sim_telarray instances, make list of files
-                    if not isinstance(self.file_list[key], list):
-                        self.file_list[key] = [self.file_list[key]]
-                    self.file_list[key].append(data)
-                else:
-                    self.file_list[key] = [data]
+            self._merge_runner_file_list(simulator_array.file_list)
 
         return self.file_list
+
+    def _merge_runner_file_list(self, runner_file_list):
+        """Merge one simulator-array file list into the combined file list."""
+        for key, data in runner_file_list.items():
+            if not isinstance(data, list):
+                data = [data]
+            if key in self.file_list:
+                self._append_runner_files(key, data)
+            else:
+                self.file_list[key] = data
+
+    def _append_runner_files(self, key, data):
+        """Append runner files, normalizing an existing single path to a list."""
+        if not isinstance(self.file_list[key], list):
+            self.file_list[key] = [self.file_list[key]]
+        self.file_list[key].extend(data)

--- a/src/simtools/runners/runner_services.py
+++ b/src/simtools/runners/runner_services.py
@@ -22,6 +22,10 @@ FILES_AND_PATHS = {
         "suffix": ".corsika.log.gz",
         "sub_dir_type": "run_number",
     },
+    "corsika_resources": {
+        "suffix": ".corsika.resources.json",
+        "sub_dir_type": "run_number",
+    },
     # Generic iact output
     "iact_output": {
         "suffix": ".iact.gz",
@@ -44,6 +48,10 @@ FILES_AND_PATHS = {
         "suffix": ".reduced_event_data.hdf5",
         "sub_dir_type": "run_number",
     },
+    "sim_telarray_resources": {
+        "suffix": ".simtel.resources.json",
+        "sub_dir_type": "run_number",
+    },
     # light_emission
     "light_emission_log": {
         "suffix": ".light_emission.log.gz",
@@ -56,6 +64,10 @@ FILES_AND_PATHS = {
     },
     "multi_pipe_script": {
         "suffix": ".multi_pipe.sh",
+        "sub_dir_type": "run_number",
+    },
+    "multi_pipe_resources": {
+        "suffix": ".multipipe.resources.json",
         "sub_dir_type": "run_number",
     },
     # job submission

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -1,5 +1,6 @@
 """Simulation runner for array simulations."""
 
+import shlex
 from pathlib import Path
 
 from simtools import settings
@@ -64,20 +65,33 @@ class SimulatorArray(SimtelRunner):
                     file.write(f"{line}\n")
                 file.write("# End of extras\n\n")
 
-            for _ in range(self.runs_per_set):
-                resources_file = self.runner_service.get_file_name(
-                    file_type="sim_telarray_resources", run_number=run_number
-                )
+            resources_file = self.runner_service.get_file_name(
+                file_type="sim_telarray_resources", run_number=run_number
+            )
+            resource_files = []
+            for run_index in range(self.runs_per_set):
+                process_resources_file = resources_file
+                if self.runs_per_set > 1:
+                    process_resources_file = resources_file.with_name(
+                        f"{resources_file.stem}.part{run_index + 1:04d}{resources_file.suffix}"
+                    )
+                resource_files.append(process_resources_file)
                 accounting_command = build_accounting_command(
                     command,
-                    resources_file,
+                    process_resources_file,
                     "sim_telarray",
                     run_number,
                     model_version=self.corsika_config.array_model.model_version,
                     log_file=log_file,
                     input_file=corsika_file,
                 )
-                file.write(f"{sim_telarray_env_as_string()} " + " ".join(accounting_command) + "\n")
+                file.write(f"{sim_telarray_env_as_string()} {shlex.join(accounting_command)}\n")
+
+            if self.file_list is None:
+                self.file_list = {}
+            self.file_list["sim_telarray_resources"] = (
+                resource_files[0] if len(resource_files) == 1 else resource_files
+            )
 
     def make_run_command(self, run_number=None, input_file=None):
         """

--- a/src/simtools/simtel/simulator_array.py
+++ b/src/simtools/simtel/simulator_array.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from simtools import settings
 from simtools.io import io_handler
+from simtools.job_execution.process_accounting import build_accounting_command
 from simtools.runners.simtel_runner import SimtelRunner, sim_telarray_env_as_string
 
 
@@ -64,11 +65,19 @@ class SimulatorArray(SimtelRunner):
                 file.write("# End of extras\n\n")
 
             for _ in range(self.runs_per_set):
-                file.write(
-                    f"{sim_telarray_env_as_string()} "
-                    + " ".join(command)
-                    + f" 2>&1 | gzip > {log_file}\n"
+                resources_file = self.runner_service.get_file_name(
+                    file_type="sim_telarray_resources", run_number=run_number
                 )
+                accounting_command = build_accounting_command(
+                    command,
+                    resources_file,
+                    "sim_telarray",
+                    run_number,
+                    model_version=self.corsika_config.array_model.model_version,
+                    log_file=log_file,
+                    input_file=corsika_file,
+                )
+                file.write(f"{sim_telarray_env_as_string()} " + " ".join(accounting_command) + "\n")
 
     def make_run_command(self, run_number=None, input_file=None):
         """

--- a/src/simtools/simulator.py
+++ b/src/simtools/simulator.py
@@ -688,6 +688,9 @@ class Simulator:
         simtools_log_file = general.get_simtools_log_file()
         histogram_files = general.ensure_list(self.get_files(file_type="sim_telarray_histogram"))
         corsika_log_files = general.ensure_list(self.get_files(file_type="corsika_log"))
+        resource_files = general.ensure_list(self.get_files(file_type="corsika_resources"))
+        resource_files += general.ensure_list(self.get_files(file_type="sim_telarray_resources"))
+        resource_files += general.ensure_list(self.get_files(file_type="multi_pipe_resources"))
         corsika_output_files = (
             general.ensure_list(self.get_files(file_type="corsika_output"))
             if settings.config.args.get("save_corsika_output")
@@ -706,7 +709,7 @@ class Simulator:
         )
         directory_for_grid_upload.mkdir(parents=True, exist_ok=True)
 
-        files_to_copy = log_files + histogram_files + corsika_log_files
+        files_to_copy = log_files + histogram_files + corsika_log_files + resource_files
         for model in self.array_models:
             files_to_copy += general.ensure_list(model.pack_model_files())
 

--- a/tests/unit_tests/job_execution/test_process_accounting.py
+++ b/tests/unit_tests/job_execution/test_process_accounting.py
@@ -1,0 +1,155 @@
+"""Unit tests for direct child-process resource accounting."""
+
+import gzip
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from simtools.job_execution import process_accounting
+
+
+def test_build_accounting_command_includes_optional_arguments(tmp_test_directory):
+    command = process_accounting.build_accounting_command(
+        ["simulation executable", "--option"],
+        tmp_test_directory / "resources.json",
+        "sim_telarray",
+        12,
+        model_version="7.0.0",
+        log_file=tmp_test_directory / "simulation.log.gz",
+        input_file=tmp_test_directory / "input.eventio",
+    )
+
+    assert command[:3] == [sys.executable, "-m", "simtools.job_execution.process_accounting"]
+    assert command[-3:] == ["--", "simulation executable", "--option"]
+    assert "--model-version" in command
+    assert "--log-file" in command
+    assert "--input-file" in command
+
+
+def test_build_accounting_command_without_optional_arguments(tmp_test_directory):
+    command = process_accounting.build_accounting_command(
+        ["simulation"], tmp_test_directory / "resources.json", "corsika", 1
+    )
+
+    assert "--model-version" not in command
+    assert "--log-file" not in command
+    assert "--input-file" not in command
+
+
+def test_run_and_record_writes_direct_process_record(tmp_test_directory):
+    input_file = tmp_test_directory / "input.txt"
+    input_file.write_text("eventio input", encoding="utf-8")
+    output_file = tmp_test_directory / "resources.json"
+    log_file = tmp_test_directory / "simulation.log.gz"
+
+    return_code = process_accounting.run_and_record(
+        [sys.executable, "-c", "import sys; print(sys.stdin.read())"],
+        output_file,
+        "corsika",
+        5,
+        model_version="7.0.0",
+        log_file=log_file,
+        input_file=input_file,
+    )
+
+    record = json.loads(output_file.read_text(encoding="utf-8"))
+    assert return_code == 0
+    assert record["role"] == "corsika"
+    assert record["run_id"] == "5"
+    assert record["model_version"] == "7.0.0"
+    assert record["return_code"] == 0
+    assert record["signal"] is None
+    assert record["wall_time_seconds"] > 0
+    assert record["measurement_method"] in {"linux_procfs_direct_pid", "wall_clock_only"}
+    with gzip.open(log_file, "rt", encoding="utf-8") as handle:
+        assert handle.read() == "eventio input\n"
+
+
+def test_run_and_record_records_failing_process(tmp_test_directory):
+    output_file = tmp_test_directory / "resources.json"
+
+    return_code = process_accounting.run_and_record(
+        [sys.executable, "-c", "raise SystemExit(3)"], output_file, "multipipe", 9
+    )
+
+    record = json.loads(output_file.read_text(encoding="utf-8"))
+    assert return_code == 3
+    assert record["return_code"] == 3
+    assert record["signal"] is None
+
+
+def test_run_and_record_accepts_environment_without_log_file(tmp_test_directory):
+    output_file = tmp_test_directory / "resources.json"
+
+    return_code = process_accounting.run_and_record(
+        [sys.executable, "-c", "import os; assert os.environ['SIMTOOLS_TEST_VALUE'] == 'set'"],
+        output_file,
+        "sim_telarray",
+        8,
+        env={"SIMTOOLS_TEST_VALUE": "set"},
+    )
+
+    assert return_code == 0
+    assert json.loads(output_file.read_text(encoding="utf-8"))["role"] == "sim_telarray"
+
+
+def test_read_linux_process_sample_handles_unavailable_process(mocker):
+    mocker.patch("simtools.job_execution.process_accounting.platform.system", return_value="Linux")
+    mocker.patch.object(Path, "read_text", side_effect=FileNotFoundError)
+
+    assert process_accounting._read_linux_process_sample(12) is None
+
+
+def test_read_linux_process_sample_skips_non_linux_platform(mocker):
+    mocker.patch("simtools.job_execution.process_accounting.platform.system", return_value="Darwin")
+
+    assert process_accounting._read_linux_process_sample(12) is None
+
+
+def test_read_peak_rss_bytes_prefers_peak_value():
+    status = "VmRSS:\t12 kB\nVmHWM:\t25 kB\n"
+
+    assert process_accounting._read_peak_rss_bytes(status) == 25 * 1024
+
+
+def test_read_peak_rss_bytes_returns_none_without_memory_data():
+    assert process_accounting._read_peak_rss_bytes("Name:\tsimulation\n") is None
+
+
+def test_start_process_closes_opened_files_on_error(tmp_test_directory, mocker):
+    input_file = Path(tmp_test_directory) / "input.eventio"
+    input_file.write_bytes(b"eventio")
+    mocker.patch(
+        "simtools.job_execution.process_accounting.subprocess.Popen",
+        side_effect=FileNotFoundError("simulation not found"),
+    )
+
+    with pytest.raises(FileNotFoundError, match="simulation not found"):
+        process_accounting._start_process(["simulation"], None, input_file, None)
+
+
+def test_main_requires_executable(mocker):
+    mocker.patch.object(
+        sys, "argv", ["process_accounting", "--output", "x", "--role", "x", "--run-id", "1"]
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        process_accounting.main()
+
+
+def test_main_runs_requested_command(mocker):
+    mocker.patch.object(
+        sys,
+        "argv",
+        ["process_accounting", "--output", "x", "--role", "corsika", "--run-id", "1", "--", "run"],
+    )
+    run_and_record = mocker.patch(
+        "simtools.job_execution.process_accounting.run_and_record", return_value=7
+    )
+
+    assert process_accounting.main() == 7
+    run_and_record.assert_called_once_with(
+        ["run"], "x", "corsika", "1", model_version=None, log_file=None, input_file=None
+    )

--- a/tests/unit_tests/runners/test_corsika_simtel_runner.py
+++ b/tests/unit_tests/runners/test_corsika_simtel_runner.py
@@ -59,6 +59,22 @@ def test_get_resources(corsika_simtel_runner, mocker):
     get_resources.assert_called_once_with(runtime=2.5)
 
 
+def test_update_file_list_flattens_repeated_resource_files(corsika_simtel_runner, mocker):
+    corsika_simtel_runner.file_list = {}
+    corsika_simtel_runner.corsika_runner.file_list = {}
+    first_array = mocker.Mock(file_list={"sim_telarray_resources": ["first", "second"]})
+    second_array = mocker.Mock(file_list={"sim_telarray_resources": "third"})
+    corsika_simtel_runner.simulator_array = [first_array, second_array]
+
+    corsika_simtel_runner.update_file_list_from_runners()
+
+    assert corsika_simtel_runner.file_list["sim_telarray_resources"] == [
+        "first",
+        "second",
+        "third",
+    ]
+
+
 def test_prepare_run(corsika_simtel_runner, tmp_path):
     # prepare_run now requires sub_script parameter and doesn't return the script path
     script_path = tmp_path / "test_script.sh"
@@ -88,6 +104,10 @@ def test_export_multipipe_script(corsika_simtel_runner, simtel_command, show_all
     with open(script) as f:
         script_content = f.read()
         assert simtel_command in script_content
+        assert (
+            f"--model-version {corsika_simtel_runner.base_corsika_config.array_model.model_version}"
+            in script_content
+        )
         assert "-C telescope_theta=20" in script_content
         assert "-C telescope_phi=0" in script_content
         assert show_all in script_content

--- a/tests/unit_tests/simtel/test_simulator_array.py
+++ b/tests/unit_tests/simtel/test_simulator_array.py
@@ -47,13 +47,13 @@ def test_prepare_run(simtel_runner, tmp_path, mocker):
     )
 
     # Check script content
-    content = sub_script.read_text()
+    content = sub_script.read_text(encoding="utf-8")
     assert "#!/usr/bin/env bash" in content
     assert "set -e" in content
     assert "set -o pipefail" in content
     assert "export TEST_VAR=1" in content
     assert "echo 'extra command'" in content
-    assert "echo 'test command'" in content
+    assert "test command" in content
 
 
 def test_prepare_run_no_extra_commands(simtel_runner, tmp_path, mocker):
@@ -62,9 +62,26 @@ def test_prepare_run_no_extra_commands(simtel_runner, tmp_path, mocker):
     sub_script = tmp_path / "simple_script.sh"
     simtel_runner.prepare_run(run_number=1, sub_script=sub_script, corsika_file="test.corsika")
 
-    content = sub_script.read_text()
+    content = sub_script.read_text(encoding="utf-8")
     assert "# Writing extras" not in content
     assert "sim_telarray command" in content
+
+
+def test_prepare_run_keeps_resource_record_for_each_run(simtel_runner, tmp_test_directory, mocker):
+    mocker.patch.object(simtel_runner, "make_run_command", return_value=["sim_telarray", "command"])
+    simtel_runner.file_list = {}
+    simtel_runner.runs_per_set = 2
+    sub_script = tmp_test_directory / "repeated_script.sh"
+
+    simtel_runner.prepare_run(run_number=1, sub_script=sub_script, corsika_file="input.corsika")
+
+    resource_files = simtel_runner.file_list["sim_telarray_resources"]
+    assert len(resource_files) == 2
+    assert resource_files[0] != resource_files[1]
+    content = sub_script.read_text(encoding="utf-8")
+    assert content.count("process_accounting") == 2
+    assert str(resource_files[0]) in content
+    assert str(resource_files[1]) in content
 
 
 def test_make_run_command_calibration_simulation(simtel_runner, mocker):

--- a/tests/unit_tests/test_simulator.py
+++ b/tests/unit_tests/test_simulator.py
@@ -241,6 +241,8 @@ def test_pack_for_register(array_simulator, mocker, model_version, caplog, tmp_t
     corsika_log_file = source_dir / f"corsika_{model_version}.log.gz"
     with gzip.open(corsika_log_file, "wt", encoding="utf-8") as handle:
         handle.write("corsika")
+    resource_file = source_dir / f"corsika_{model_version}.resources.json"
+    resource_file.write_text("{}", encoding="utf-8")
     model_archive = source_dir / f"model_files_{model_version}.tar.gz"
     model_archive.write_text("model", encoding="utf-8")
     simtools_log_file = source_dir / "simtools.log"
@@ -251,6 +253,7 @@ def test_pack_for_register(array_simulator, mocker, model_version, caplog, tmp_t
         "sim_telarray_log": [str(log_file)],
         "sim_telarray_histogram": [str(histogram_file)],
         "corsika_log": [str(corsika_log_file)],
+        "corsika_resources": [str(resource_file)],
         "sim_telarray_event_data": [],
     }
     mocker.patch.object(
@@ -277,6 +280,7 @@ def test_pack_for_register(array_simulator, mocker, model_version, caplog, tmp_t
         directory_for_grid_upload / corsika_log_file.name, "rt", encoding="utf-8"
     ) as handle:
         assert handle.read() == "corsika"
+    assert (directory_for_grid_upload / resource_file.name).read_text(encoding="utf-8") == "{}"
     assert (directory_for_grid_upload / model_archive.name).read_text(encoding="utf-8") == "model"
     assert not output_file.exists()
     assert (directory_for_grid_upload / output_file.name).read_text(encoding="utf-8") == "output"


### PR DESCRIPTION
  CORSIKA, multipipe, and sim_telarray executions are now launched through a shared accounting wrapper. Each process produces a JSON resource record containing:

  - role and run ID
  - model version where available
  - command arguments and PID
  - start/end timestamps
  - wall time
  - user/system CPU time
  - peak RSS memory
  - return code and signal
  - measurement platform/method

  New output files are created:

  - *.corsika.resources.json
  - *.multipipe.resources.json
  - *.simtel.resources.json

  These resource files are also included by pack_for_register() in grid-upload packages.

Example for CORSIKA:

```
cat simtools-grid-output/gamma_run000001_za20deg_azm085deg_South_alpha_6.0.2_multiple_model_versions.corsika.resources.json
{
  "argv": [
    "/workdir/simulation_software/corsika7/corsika_epos_urqmd_flat"
  ],
  "end_time": "2026-09-07T09:51:26.075421+00:00",
  "measurement_method": "linux_procfs_direct_pid",
  "model_version": "6.0.2",
  "peak_rss_bytes": 168611840,
  "pid": 52014,
  "platform": "Linux-5.14.0-687.39.1.el9_8.x86_64-x86_64-with-glibc2.34",
  "return_code": 0,
  "role": "corsika",
  "run_id": "1",
  "schema_name": "process_resource_record",
  "schema_version": "1.0.0",
  "signal": null,
  "start_time": "2026-09-07T09:50:59.641713+00:00",
  "system_cpu_seconds": 0.03,
  "user_cpu_seconds": 3.55,
  "wall_time_seconds": 26.433708888012916
}
```

Example for sim_telarray:

```
cat simtools-grid-output/gamma_run000001_za20deg_azm085deg_South_alpha_6.0.2_multiple_model_versions.simtel.resources.json 
{
  "argv": [
    "/workdir/simulation_software/sim_telarray/bin/sim_telarray",
    "-c",
    "/cephfs/users/maierg/CTA/simpipe/simtools-dev2/simtools-output/model/run000001/6.0.2/CTAO-South-alpha.cfg",
    "-I/cephfs/users/maierg/CTA/simpipe/simtools-dev2/simtools-output/model/run000001/6.0.2",
    "-C",
    "histogram_file=/cephfs/users/maierg/CTA/simpipe/simtools-dev2/simtools-output/sim_telarray/run000001/gamma_run000001_za20deg_azm085deg_South_alpha_6.0.2_multiple_model_versions.hdata.zst",
    "-C",
    "random_state=none",
    "-C",
    "output_file=/cephfs/users/maierg/CTA/simpipe/simtools-dev2/simtools-output/sim_telarray/run000001/gamma_run000001_za20deg_azm085deg_South_alpha_6.0.2_multiple_model_versions.simtel.zst",
    "-C",
    "random_seed=1745,290",
    "-C",
    "telescope_theta=20.0",
    "-C",
    "telescope_phi=85.0",
    "-C",
    "power_law=2.5",
    "-C",
    "show=all",
    "-"
  ],
  "end_time": "2026-09-07T09:51:25.660575+00:00",
  "measurement_method": "linux_procfs_direct_pid",
  "model_version": "6.0.2",
  "peak_rss_bytes": 464338944,
  "pid": 52049,
  "platform": "Linux-5.14.0-687.39.1.el9_8.x86_64-x86_64-with-glibc2.34",
  "return_code": 0,
  "role": "sim_telarray",
  "run_id": "1",
  "schema_name": "process_resource_record",
  "schema_version": "1.0.0",
  "signal": null,
  "start_time": "2026-09-07T09:51:01.035885+00:00",
  "system_cpu_seconds": 0.16,
  "user_cpu_seconds": 7.95,
  "wall_time_seconds": 24.62469304096885
}
```
