### PR TITLE
Do not initialize simulation model reader when generating test resources

### DIFF
--- a/docs/changes/2525.bugfix.md
+++ b/docs/changes/2525.bugfix.md
@@ -1,0 +1,1 @@
+Do not initialize simulation model reader when generating test resources.

--- a/src/simtools/applications/resources_test_generate.py
+++ b/src/simtools/applications/resources_test_generate.py
@@ -50,6 +50,7 @@ APPLICATION = ApplicationDefinition.for_module(
     arguments=(*_ARGUMENTS,),
     setup_io_handler=False,
     resolve_sim_software_executables=False,
+    initialize_model_reader=False,
 )
 
 

--- a/tests/unit_tests/applications/test_resources_test_generate.py
+++ b/tests/unit_tests/applications/test_resources_test_generate.py
@@ -1,0 +1,8 @@
+"""Tests for the resource-generation application."""
+
+from simtools.applications import resources_test_generate
+
+
+def test_application_does_not_initialize_model_reader():
+    """Resource orchestration must not require MongoDB during startup."""
+    assert resources_test_generate.APPLICATION.initialize_model_reader is False


### PR DESCRIPTION
Should fix the failing CI in simtools-tests: https://github.com/gammasim/simtools-tests/actions/runs/34477291127/job/102871063387

(rule: if we don't need a simulation model reader, don't try to initialize it)