### PR TITLE
Add simtools-prod-test image

### DIFF
--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -3,28 +3,16 @@ name: CI-integrationtests
 
 permissions: {}
 
-env:
-  CLONE_ATTEMPTS: 2
-  GIT_HTTP_CONNECT_TIMEOUT: 20
-  GIT_HTTP_LOW_SPEED_LIMIT: 1000
-  GIT_HTTP_LOW_SPEED_TIME: 30
-  RETRY_SLEEP_SECONDS: 60
-
 on:
   workflow_dispatch:
-    inputs:
-      simulation_model_branch:
-        description: 'Simulation model branch'
-        required: false
-        type: string
-        default: 'main'
+    inputs: {}
   workflow_call:
     inputs:
       container_image:
         description: 'Container image to use for tests'
         required: false
         type: string
-        default: 'ghcr.io/gammasim/simtools-dev:latest'
+        default: 'ghcr.io/gammasim/simtools-prod-tests:latest'
       model_versions:
         description: 'Model versions to test'
         required: false
@@ -85,219 +73,6 @@ jobs:
           print(f"Verified packaged dependency catalog: {expected}")
           PY
 
-  prepare_interaction_tables:
-    name: download CORSIKA interaction tables
-    runs-on: ubuntu-latest
-    env:
-      IT_NAME: "corsika7-interaction-tables"
-      # For testing, overwrite CORSIKA_TABLES with branch name
-      # CORSIKA_TABLES: "main"
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-
-      - name: Install dependency exporter prerequisites
-        run: python -m pip install packaging pyyaml
-
-      - name: Read CORSIKA interaction tables version
-        id: interaction_table_version
-        run: |
-          CORSIKA_TABLES=$(python src/simtools/applications/dependency_versions.py \
-            --format github-output | sed -n 's/^corsika_tables_tag=//p')
-          test -n "$CORSIKA_TABLES"
-          echo "CORSIKA_TABLES=$CORSIKA_TABLES" >> "$GITHUB_ENV"
-          echo "version=$CORSIKA_TABLES" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached CORSIKA interaction tables
-        id: restore_interaction_tables
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
-        with:
-          path: ${{ env.IT_NAME }}
-          key: corsika-interaction-tables-${{ steps.interaction_table_version.outputs.version }}
-          restore-keys: |
-            corsika-interaction-tables-${{ steps.interaction_table_version.outputs.version }}-
-
-      - name: Clone CORSIKA interaction tables (exclude QGSJet tables)
-        run: |
-          REPO_URL=https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simulation_software/${IT_NAME}
-          export GIT_LFS_SKIP_SMUDGE=1  # disable automatic downloading of all LFS files
-
-          CLONE_DIR="${IT_NAME}-clone"
-          CACHE_DIR="$IT_NAME"
-          rm -rf "$CLONE_DIR"
-          CLONE_SUCCESS=false
-
-          for attempt in $(seq 1 "$CLONE_ATTEMPTS"); do
-            if git \
-              -c "http.connectTimeout=$GIT_HTTP_CONNECT_TIMEOUT" \
-              -c "http.lowSpeedLimit=$GIT_HTTP_LOW_SPEED_LIMIT" \
-              -c "http.lowSpeedTime=$GIT_HTTP_LOW_SPEED_TIME" \
-              clone --depth 1 --branch "$CORSIKA_TABLES" "$REPO_URL" "$CLONE_DIR"
-            then
-              git lfs install
-              if ! (cd "$CLONE_DIR" && git lfs pull --exclude="interaction-tables/qgsdat-II-04,interaction-tables/qgsdat-III"); then
-                echo "git lfs pull failed; will retry and/or fall back to the cache."
-                rm -rf "$CLONE_DIR"
-                continue
-              fi
-              rm -rf "$CACHE_DIR"
-              mv "$CLONE_DIR" "$CACHE_DIR"
-              echo "Successfully cloned CORSIKA interaction tables $CORSIKA_TABLES."
-              CLONE_SUCCESS=true
-              break
-            fi
-
-            rm -rf "$CLONE_DIR"
-            if [[ "$attempt" -lt "$CLONE_ATTEMPTS" ]]; then
-              echo "Clone attempt $attempt failed. Retrying in $RETRY_SLEEP_SECONDS seconds..."
-              sleep "$RETRY_SLEEP_SECONDS"
-            fi
-          done
-
-          if [ "$CLONE_SUCCESS" = false ] && [ ! -d "$CACHE_DIR" ]; then
-            echo "Failed to clone CORSIKA interaction tables $CORSIKA_TABLES and no cache is available."
-            exit 1
-          fi
-
-          if [ "$CLONE_SUCCESS" = false ]; then
-            echo "GitLab clone failed; using cached CORSIKA interaction tables $CORSIKA_TABLES."
-          fi
-
-      - name: Save cached CORSIKA interaction tables
-        if: steps.restore_interaction_tables.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
-        with:
-          path: ${{ env.IT_NAME }}
-          key: corsika-interaction-tables-${{ steps.interaction_table_version.outputs.version }}
-
-      - name: Upload CORSIKA interaction tables
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        with:
-          name: corsika-interaction-tables
-          path: ${{ env.IT_NAME }}
-          if-no-files-found: error
-          retention-days: 30
-
-  prepare_simulation_models:
-    name: download simulation models
-    runs-on: ubuntu-latest
-    env:
-      SIM_MODELS_REPO: "https://gitlab.cta-observatory.org/cta-science/simulations/simulation-model/simulation-models.git"
-
-    defaults:
-      run:
-        shell: bash -leo pipefail {0}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-
-      - name: Export dependency environment
-        run: |
-          python -m pip install pyyaml
-          python src/simtools/applications/dependency_versions.py --format env >> "$GITHUB_ENV"
-
-      - name: Determine simulation model branch
-        id: simulation_model_branch
-        env:
-          HEAD_REF: ${{ github.head_ref }}
-          REF_NAME: ${{ github.ref_name }}
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_BRANCH: ${{ github.event.inputs.simulation_model_branch }}
-        run: |
-          BRANCH="main"
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_BRANCH" ]; then
-            BRANCH="$INPUT_BRANCH"
-          fi
-          CURRENT_REF="$REF_NAME"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            CURRENT_REF="$HEAD_REF"
-          fi
-          if [[ "$CURRENT_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]*$ ]]; then
-            echo "Detected RC version branch: $CURRENT_REF - setting branch to $SIMTOOLS_DB_SIMULATION_MODEL_TAG"
-            if [[ ! "$SIMTOOLS_DB_SIMULATION_MODEL_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
-              echo "SIMTOOLS_DB_SIMULATION_MODEL_TAG must be a v-prefixed release tag."
-              exit 1
-            fi
-            BRANCH="$SIMTOOLS_DB_SIMULATION_MODEL_TAG"
-          fi
-          echo "SIMTOOLS_DB_SIMULATION_MODEL_BRANCH=$BRANCH" >> "$GITHUB_ENV"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached simulation models repository
-        # if: github.event_name != 'schedule'
-        id: restore_simulation_models
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
-        with:
-          path: simulation-models.git
-          key: simulation-models-git-${{ steps.simulation_model_branch.outputs.branch }}
-          restore-keys: |
-            simulation-models-git-${{ steps.simulation_model_branch.outputs.branch }}-
-
-      - name: Clone simulation models repository
-        # if: github.event_name != 'schedule'
-        run: |
-          CLONE_DIR="simulation-models.git-clone"
-          CACHE_DIR="simulation-models.git"
-          rm -rf "$CLONE_DIR"
-          CLONE_SUCCESS=false
-
-          for attempt in $(seq 1 "$CLONE_ATTEMPTS"); do
-            if git \
-              -c "http.connectTimeout=$GIT_HTTP_CONNECT_TIMEOUT" \
-              -c "http.lowSpeedLimit=$GIT_HTTP_LOW_SPEED_LIMIT" \
-              -c "http.lowSpeedTime=$GIT_HTTP_LOW_SPEED_TIME" \
-              clone --bare --depth 1 --branch "$SIMTOOLS_DB_SIMULATION_MODEL_BRANCH" \
-                "$SIM_MODELS_REPO" "$CLONE_DIR"
-            then
-              rm -rf "$CACHE_DIR"
-              mv "$CLONE_DIR" "$CACHE_DIR"
-              echo "Successfully cloned simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
-              CLONE_SUCCESS=true
-              break
-            fi
-
-            rm -rf "$CLONE_DIR"
-            if [[ "$attempt" -lt "$CLONE_ATTEMPTS" ]]; then
-              echo "Clone attempt $attempt failed. Retrying in $RETRY_SLEEP_SECONDS seconds..."
-              sleep "$RETRY_SLEEP_SECONDS"
-            fi
-          done
-
-          if [ "$CLONE_SUCCESS" = false ] && [ ! -d "$CACHE_DIR" ]; then
-            echo "Failed to clone simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH and no cache is available."
-            exit 1
-          fi
-
-          if [ "$CLONE_SUCCESS" = false ]; then
-            echo "GitLab clone failed; using cached simulation models revision $SIMTOOLS_DB_SIMULATION_MODEL_BRANCH."
-          fi
-
-          git --git-dir="$CACHE_DIR" rev-parse --verify HEAD
-
-
-      - name: Save cached simulation models repository
-        if: steps.restore_simulation_models.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6
-        with:
-          path: simulation-models.git
-          key: simulation-models-git-${{ steps.simulation_model_branch.outputs.branch }}
-
-      - name: Package simulation models repository
-        run: |
-          (
-            cd simulation-models.git
-            python -m zipfile -c ../simulation-models.git.zip .
-          )
-
-      - name: Upload simulation models repository
-        # if: github.event_name != 'schedule'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
-        with:
-          name: simulation-models-repo
-          path: simulation-models.git.zip
-          if-no-files-found: error
-          retention-days: 30
-
   prepare_test_resources:
     name: download test resources
     runs-on: ubuntu-latest
@@ -340,18 +115,15 @@ jobs:
           retention-days: 30
 
   integration_tests:
-    needs: [prepare_interaction_tables, prepare_simulation_models, prepare_test_resources]
+    needs: [prepare_test_resources]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     container:
-      image: ${{ inputs.container_image || 'ghcr.io/gammasim/simtools-dev:latest' }}
+      image: ${{ inputs.container_image || 'ghcr.io/gammasim/simtools-prod-tests:latest' }}
       options: --user 0
     env:
-      CONTAINER_IMAGE: ${{ inputs.container_image || 'ghcr.io/gammasim/simtools-dev:latest' }}
-      IT_NAME: "corsika7-interaction-tables"
-      SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH: ${{ github.workspace }}/corsika7-interaction-tables/interaction-tables
-      SIMULATION_MODELS_GIT_PATH: ${{ github.workspace }}/simulation-models.git
+      CONTAINER_IMAGE: ${{ inputs.container_image || 'ghcr.io/gammasim/simtools-prod-tests:latest' }}
 
     services:
       mongodb:
@@ -401,8 +173,8 @@ jobs:
         run: |
           {
             if [ "${{ matrix.model_source }}" = "git" ]; then
-              echo "SIMTOOLS_SIMULATION_MODELS_GIT_PATH=$SIMULATION_MODELS_GIT_PATH"
-              echo "SIMTOOLS_SIMULATION_MODELS_GIT_REVISION=HEAD"
+              echo "SIMTOOLS_SIMULATION_MODELS_GIT_PATH=$SIMTOOLS_SIMULATION_MODELS_GIT_PATH"
+              echo "SIMTOOLS_SIMULATION_MODELS_GIT_REVISION=$SIMTOOLS_SIMULATION_MODELS_GIT_REVISION"
             else
               echo "SIMTOOLS_DB_SERVER=mongodb"
               echo "SIMTOOLS_DB_API_USER=api"
@@ -416,59 +188,23 @@ jobs:
             echo "SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH=$SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH"
           } | tee .env >> "$GITHUB_ENV"
 
-      - name: Download CORSIKA interaction tables
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: corsika-interaction-tables
-          path: ${{ env.SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH }}/..
-
-      - name: Verify CORSIKA interaction tables
-        run: |
-          if ! test -f "$SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH/manifest.yaml"; then
-            echo "Interaction-table directory:"
-            ls -la "$SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH" || true
-            echo "Interaction-table parent directory:"
-            ls -la "$SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH/.." || true
-            exit 1
-          fi
-
-      - name: Download simulation models repository
-        # if: github.event_name != 'schedule'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
-        with:
-          name: simulation-models-repo
-          path: ${{ github.workspace }}
-
-      - name: Extract and verify simulation models repository
-        run: |
-          mkdir "$SIMULATION_MODELS_GIT_PATH"
-          python -m zipfile -t "$GITHUB_WORKSPACE/simulation-models.git.zip"
-          python -m zipfile -e "$GITHUB_WORKSPACE/simulation-models.git.zip" \
-            "$SIMULATION_MODELS_GIT_PATH"
-          git --git-dir="$SIMULATION_MODELS_GIT_PATH" rev-parse --verify HEAD
-
       - name: Extend PATH (sim_telarray)
         run: |
           [ -n "$SIMTOOLS_SIM_TELARRAY_PATH" ] && echo "$SIMTOOLS_SIM_TELARRAY_PATH" >> "$GITHUB_PATH"
 
-      - name: Install Python dependencies (prod container)
-        if: contains(inputs.container_image, 'simtools-prod')
-        run: |
-          pip install --no-cache-dir pygit2 pymongo pytest pytest-cov pytest-mock pytest-requirements pytest-xdist pytest-retry
-
-      - name: Install resource benchmark dependency (prod container)
-        if: ${{ inputs.benchmark && contains(inputs.container_image, 'simtools-prod') }}
-        run: pip install --no-cache-dir psutil
+      - name: Install current simtools checkout (production test image)
+        if: contains(env.CONTAINER_IMAGE, 'simtools-prod')
+        run: pip install --no-cache-dir --no-deps -e .
 
       - name: Install Python dependencies (dev container)
-        if: ${{ !contains(inputs.container_image, 'simtools-prod') }}
+        if: ${{ !contains(env.CONTAINER_IMAGE, 'simtools-prod') }}
         run: |
           pip install --no-cache-dir -e '.[tests,dev,doc,mongodb]'
 
       - name: Upload data to MongoDB
         if: matrix.model_source == 'mongodb'
         run: |
-          git clone --local "$SIMULATION_MODELS_GIT_PATH" "$GITHUB_WORKSPACE/simulation-models"
+          git clone --local "$SIMTOOLS_SIMULATION_MODELS_GIT_PATH" "$GITHUB_WORKSPACE/simulation-models"
           simtools-db-upload-model-repository \
             --db_simulation_model "$SIMTOOLS_DB_SIMULATION_MODEL" \
             --db_simulation_model_tag "$SIMTOOLS_DB_SIMULATION_MODEL_TAG" \
@@ -484,7 +220,7 @@ jobs:
               unset "$variable"
             done
             MODEL_SOURCE_ARGS=(
-              --simulation_models_git_path="$SIMULATION_MODELS_GIT_PATH"
+              --simulation_models_git_path="$SIMTOOLS_SIMULATION_MODELS_GIT_PATH"
               --simulation_models_git_revision="$SIMTOOLS_SIMULATION_MODELS_GIT_REVISION"
             )
           fi

--- a/.github/workflows/CI-integrationtests.yml
+++ b/.github/workflows/CI-integrationtests.yml
@@ -190,7 +190,9 @@ jobs:
 
       - name: Extend PATH (sim_telarray)
         run: |
-          [ -n "$SIMTOOLS_SIM_TELARRAY_PATH" ] && echo "$SIMTOOLS_SIM_TELARRAY_PATH" >> "$GITHUB_PATH"
+          if [ -n "$SIMTOOLS_SIM_TELARRAY_PATH" ]; then
+            echo "$SIMTOOLS_SIM_TELARRAY_PATH" >> "$GITHUB_PATH"
+          fi
 
       - name: Install current simtools checkout (production test image)
         if: contains(env.CONTAINER_IMAGE, 'simtools-prod')

--- a/.github/workflows/build-simtools-prod-tests.yml
+++ b/.github/workflows/build-simtools-prod-tests.yml
@@ -16,12 +16,18 @@ on:
         type: string
   schedule:
     - cron: "0 2 * * 0"
+  pull_request:
+    paths:
+      - ".github/workflows/build-simtools-prod-tests.yml"
+      - "docker/Dockerfile-simtools-prod-tests"
+      - "dependency_versions.yml"
 
 permissions: {}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-simtools-prod-tests.yml
+++ b/.github/workflows/build-simtools-prod-tests.yml
@@ -125,6 +125,8 @@ jobs:
   integration-tests:
     needs: build
     if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
     uses: ./.github/workflows/CI-integrationtests.yml
     with:
       container_image: ${{ needs.build.outputs.image }}

--- a/.github/workflows/build-simtools-prod-tests.yml
+++ b/.github/workflows/build-simtools-prod-tests.yml
@@ -1,0 +1,126 @@
+---
+name: build-simtools-prod-tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      prod_image:
+        description: "Published simtools-prod image used as the base"
+        required: false
+        default: "ghcr.io/gammasim/simtools-prod:latest"
+        type: string
+      simulation_model_ref:
+        description: "simulation-models branch or tag"
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "0 2 * * 0"
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+
+      - name: Install catalog reader
+        run: python -m pip install pyyaml
+
+      - name: Read test-data versions
+        id: catalog
+        run: |
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          from pathlib import Path
+          import yaml
+
+          catalog = yaml.safe_load(Path("dependency_versions.yml").read_text())
+          model = catalog["model-database"]
+          print(f"model_ref={model['default-tag']}")
+          print(f"model_repository={model['repository-url']}")
+          print(f"tables_tag={catalog['corsika-interaction-tables']['tag']}")
+          PY
+
+      - name: Prepare simulation models
+        id: models
+        env:
+          MODEL_REF: ${{ inputs.simulation_model_ref || steps.catalog.outputs.model_ref }}
+          MODEL_REPOSITORY: ${{ steps.catalog.outputs.model_repository }}
+        run: |
+          mkdir -p test-data
+          git clone --bare --depth 1 --branch "$MODEL_REF" "$MODEL_REPOSITORY" \
+            test-data/simulation-models.git
+          revision=$(git --git-dir=test-data/simulation-models.git rev-parse HEAD)
+          echo "revision=$revision" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare CORSIKA interaction tables
+        env:
+          TABLES_TAG: ${{ steps.catalog.outputs.tables_tag }}
+        run: |
+          export GIT_LFS_SKIP_SMUDGE=1
+          git clone --depth 1 --branch "$TABLES_TAG" \
+            https://gitlab.cta-observatory.org/cta-computing/dpps/simpipe/simulation_software/corsika7-interaction-tables.git \
+            test-data/corsika7-interaction-tables
+          git -C test-data/corsika7-interaction-tables lfs install
+          git -C test-data/corsika7-interaction-tables lfs pull \
+            --exclude="interaction-tables/qgsdat-II-04,interaction-tables/qgsdat-III"
+          rm -rf test-data/corsika7-interaction-tables/.git
+
+      - name: Set image tag
+        id: image
+        env:
+          MODEL_REVISION: ${{ steps.models.outputs.revision }}
+          MODEL_REF_INPUT: ${{ inputs.simulation_model_ref }}
+        run: |
+          tag="models-${MODEL_REVISION:0:12}-${GITHUB_SHA:0:7}"
+          image="ghcr.io/gammasim/simtools-prod-tests:$tag"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          if [ -z "$MODEL_REF_INPUT" ]; then
+            echo "latest=ghcr.io/gammasim/simtools-prod-tests:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e  # v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push test image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64/v8
+          build-args: |
+            PROD_IMAGE=${{ inputs.prod_image || 'ghcr.io/gammasim/simtools-prod:latest' }}
+            SIMULATION_MODELS_GIT_REVISION=${{ steps.models.outputs.revision }}
+            CORSIKA_TABLES_TAG=${{ steps.catalog.outputs.tables_tag }}
+          push: true
+          file: ./docker/Dockerfile-simtools-prod-tests
+          tags: |
+            ${{ steps.image.outputs.image }}
+            ${{ steps.image.outputs.latest }}
+          cache-from: type=gha,scope=simtools-prod-tests
+          cache-to: type=gha,mode=min,scope=simtools-prod-tests
+
+  integration-tests:
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/CI-integrationtests.yml
+    with:
+      container_image: ${{ needs.build.outputs.image }}
+      model_versions: '["7.0.0"]'
+      runner_labels: '["ubuntu-latest","ubuntu-24.04-arm"]'

--- a/.github/workflows/build-simtools-prod-tests.yml
+++ b/.github/workflows/build-simtools-prod-tests.yml
@@ -16,6 +16,21 @@ on:
         type: string
   schedule:
     - cron: "0 2 * * 0"
+  workflow_call:
+    inputs:
+      prod_image:
+        description: "Published simtools-prod image used as the base"
+        required: true
+        type: string
+      simulation_model_ref:
+        description: "simulation-models branch or tag"
+        required: false
+        default: ""
+        type: string
+    outputs:
+      image:
+        description: "Immutable test image reference"
+        value: ${{ jobs.build.outputs.image }}
   pull_request:
     paths:
       - ".github/workflows/build-simtools-prod-tests.yml"

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -156,14 +156,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=simtools-prod-${{ matrix.corsika_build_id }}-${{ matrix.simtel_tag }}-${{ matrix.avx_flag }}
           cache-to: type=gha,mode=min,scope=simtools-prod-${{ matrix.corsika_build_id }}-${{ matrix.simtel_tag }}-${{ matrix.avx_flag }}
-
-  test-simtools-prod:
-    permissions:
-      contents: read
-    needs: build-simtools-prod
-    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","generic"]'), github.event.inputs.avx_flag || 'all')) }}
-    uses: ./.github/workflows/CI-integrationtests.yml
-    with:
-      container_image: ghcr.io/gammasim/simtools-prod:${{ needs.build-simtools-prod.outputs.generic_tag }}
-      model_versions: '["7.0.0"]'
-      runner_labels: '["ubuntu-latest","ubuntu-24.04-arm"]'

--- a/.github/workflows/build-simtools-prod.yml
+++ b/.github/workflows/build-simtools-prod.yml
@@ -156,3 +156,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=simtools-prod-${{ matrix.corsika_build_id }}-${{ matrix.simtel_tag }}-${{ matrix.avx_flag }}
           cache-to: type=gha,mode=min,scope=simtools-prod-${{ matrix.corsika_build_id }}-${{ matrix.simtel_tag }}-${{ matrix.avx_flag }}
+
+  test-simtools-prod:
+    permissions:
+      contents: read
+    needs: [build-simtools-prod, build-simtools-prod-tests]
+    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","generic"]'), github.event.inputs.avx_flag || 'all')) }}
+    uses: ./.github/workflows/CI-integrationtests.yml
+    with:
+      container_image: ${{ needs.build-simtools-prod-tests.outputs.image }}
+      model_versions: '["7.0.0"]'
+      runner_labels: '["ubuntu-latest","ubuntu-24.04-arm"]'
+
+  build-simtools-prod-tests:
+    needs: build-simtools-prod
+    if: ${{ (github.event_name == 'release' || github.event_name == 'workflow_dispatch' || (startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc'))) && (github.event_name != 'workflow_dispatch' || contains(fromJSON('["all","generic"]'), github.event.inputs.avx_flag || 'all')) }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-simtools-prod-tests.yml
+    with:
+      prod_image: ghcr.io/gammasim/simtools-prod:${{ needs.build-simtools-prod.outputs.generic_tag }}

--- a/docker/Dockerfile-simtools-prod-tests
+++ b/docker/Dockerfile-simtools-prod-tests
@@ -11,16 +11,26 @@ ARG CONTAINER_UID="1000"
 ARG CONTAINER_GID="1000"
 
 USER 0:0
-COPY test-data/corsika7-interaction-tables /opt/simtools/test-data/corsika7-interaction-tables
-COPY test-data/simulation-models.git /opt/simtools/test-data/simulation-models.git
+COPY test-data/corsika7-interaction-tables \
+     /opt/simtools/test-data/corsika7-interaction-tables
+COPY test-data/simulation-models.git \
+     /opt/simtools/test-data/simulation-models.git
 
-RUN test -f /opt/simtools/test-data/corsika7-interaction-tables/interaction-tables/manifest.yaml && \
-    test "$(git --git-dir=/opt/simtools/test-data/simulation-models.git rev-parse HEAD)" = "${SIMULATION_MODELS_GIT_REVISION}" && \
+RUN test -f \
+      /opt/simtools/test-data/corsika7-interaction-tables/interaction-tables/manifest.yaml && \
+    model_revision="$(git \
+      --git-dir=/opt/simtools/test-data/simulation-models.git \
+      rev-parse HEAD)" && \
+    test "$model_revision" = "${SIMULATION_MODELS_GIT_REVISION}" && \
     . /workdir/env/bin/activate && \
-    pip install --no-cache-dir pygit2 pytest pytest-cov pytest-mock pytest-requirements pytest-xdist pytest-retry psutil && \
+    pip install --no-cache-dir \
+      pygit2 psutil pytest pytest-cov pytest-mock pytest-requirements pytest-retry pytest-xdist && \
     chown -R "${CONTAINER_UID}:${CONTAINER_GID}" /opt/simtools/test-data
 
-ENV SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH="/opt/simtools/test-data/corsika7-interaction-tables/interaction-tables"
+ENV SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH="/opt/simtools/test-data/\
+corsika7-interaction-tables/interaction-tables"
+ENV SIMTOOLS_SIM_TELARRAY_PATH="/workdir/simulation_software/sim_telarray"
+ENV SIMTOOLS_CORSIKA_PATH="/workdir/simulation_software/corsika7"
 ENV SIMTOOLS_SIMULATION_MODELS_GIT_PATH="/opt/simtools/test-data/simulation-models.git"
 ENV SIMTOOLS_SIMULATION_MODELS_GIT_REVISION=${SIMULATION_MODELS_GIT_REVISION}
 

--- a/docker/Dockerfile-simtools-prod-tests
+++ b/docker/Dockerfile-simtools-prod-tests
@@ -1,4 +1,7 @@
 # Test-data overlay for a published simtools production image.
+# hadolint global ignore=DL3013
+# Test tooling is installed from the current package indexes, as in the CI
+# workflow; the production image remains pinned independently.
 ARG PROD_IMAGE
 FROM ${PROD_IMAGE}
 

--- a/docker/Dockerfile-simtools-prod-tests
+++ b/docker/Dockerfile-simtools-prod-tests
@@ -1,0 +1,27 @@
+# Test-data overlay for a published simtools production image.
+ARG PROD_IMAGE
+FROM ${PROD_IMAGE}
+
+ARG SIMULATION_MODELS_GIT_REVISION
+ARG CORSIKA_TABLES_TAG
+ARG CONTAINER_UID="1000"
+ARG CONTAINER_GID="1000"
+
+USER 0:0
+COPY test-data/corsika7-interaction-tables /opt/simtools/test-data/corsika7-interaction-tables
+COPY test-data/simulation-models.git /opt/simtools/test-data/simulation-models.git
+
+RUN test -f /opt/simtools/test-data/corsika7-interaction-tables/interaction-tables/manifest.yaml && \
+    test "$(git --git-dir=/opt/simtools/test-data/simulation-models.git rev-parse HEAD)" = "${SIMULATION_MODELS_GIT_REVISION}" && \
+    . /workdir/env/bin/activate && \
+    pip install --no-cache-dir pygit2 pytest pytest-cov pytest-mock pytest-requirements pytest-xdist pytest-retry psutil && \
+    chown -R "${CONTAINER_UID}:${CONTAINER_GID}" /opt/simtools/test-data
+
+ENV SIMTOOLS_CORSIKA_INTERACTION_TABLE_PATH="/opt/simtools/test-data/corsika7-interaction-tables/interaction-tables"
+ENV SIMTOOLS_SIMULATION_MODELS_GIT_PATH="/opt/simtools/test-data/simulation-models.git"
+ENV SIMTOOLS_SIMULATION_MODELS_GIT_REVISION=${SIMULATION_MODELS_GIT_REVISION}
+
+LABEL org.gammasim.simtools.simulation-model-revision="${SIMULATION_MODELS_GIT_REVISION}" \
+      org.gammasim.simtools.corsika-interaction-tables-tag="${CORSIKA_TABLES_TAG}"
+
+USER ${CONTAINER_UID}:${CONTAINER_GID}


### PR DESCRIPTION
Add a generation pipeline for a testing image to avoid frequently failing integration tests due to failing gitlab connections.

This is the 'normal' simtools-prod image with the following additions:

- added simulation-models
- added interaction tables

This image will be used in the CI-integration test.